### PR TITLE
ci(ruff): excluir plugins .claude/ + corrigir lint remanescente

### DIFF
--- a/apps/central_api/tests/test_app.py
+++ b/apps/central_api/tests/test_app.py
@@ -19,18 +19,18 @@ def _make_app():
         return create_app()
 
 
-@pytest.fixture()
+@pytest.fixture
 def app():
     return _make_app()
 
 
-@pytest.fixture()
+@pytest.fixture
 def client(app):
     with TestClient(app, raise_server_exceptions=True) as c:
         yield c
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_engine():
     engine = MagicMock(spec=Engine)
     con = MagicMock()
@@ -40,7 +40,7 @@ def mock_engine():
     return engine
 
 
-@pytest.fixture()
+@pytest.fixture
 def client_with_engine(app, mock_engine):
     from central_api.deps import get_engine
     app.dependency_overrides[get_engine] = lambda: mock_engine
@@ -49,7 +49,7 @@ def client_with_engine(app, mock_engine):
     app.dependency_overrides.clear()
 
 
-@pytest.fixture()
+@pytest.fixture
 def failing_engine():
     engine = MagicMock(spec=Engine)
     engine.connect.side_effect = Exception("db_down")
@@ -363,7 +363,8 @@ class TestLeaseReaperLoop:
     @pytest.mark.asyncio
     async def test_reaper_loop_registra_leases_reaped(self):
         import asyncio
-        from central_api.deps import _lease_reaper_loop, _REAPER_INTERVAL
+
+        from central_api.deps import _lease_reaper_loop
         engine = MagicMock()
         call_count = 0
 
@@ -384,11 +385,10 @@ class TestLeaseReaperLoop:
     @pytest.mark.asyncio
     async def test_reaper_loop_captura_excecao(self):
         import asyncio
-        from unittest.mock import AsyncMock
+
         import central_api.deps as deps_mod
 
         engine = MagicMock()
-        original_interval = deps_mod._REAPER_INTERVAL
 
         with patch.object(deps_mod, "_REAPER_INTERVAL", 0.01):
             with patch(

--- a/apps/cnes_db_migrator/tests/test_run.py
+++ b/apps/cnes_db_migrator/tests/test_run.py
@@ -1,5 +1,4 @@
 """Testes unitários do cnes_db_migrator."""
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/apps/data_processor/tests/adapters/test_cnes_nacional_adapter.py
+++ b/apps/data_processor/tests/adapters/test_cnes_nacional_adapter.py
@@ -1,5 +1,4 @@
 """Testes do CnesNacionalAdapter."""
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import polars as pl
@@ -241,8 +240,8 @@ class TestSihdLocalAdapter:
         })
 
     def test_renomeia_colunas_raw_para_canonico(self):
-        from data_processor.adapters.sihd_local_adapter import SihdLocalAdapter
         from cnes_domain.contracts.sihd_columns import SCHEMA_AIH
+        from data_processor.adapters.sihd_local_adapter import SihdLocalAdapter
         df = SihdLocalAdapter(self._make_raw_aihs()).listar_aihs()
         assert "NUM_AIH" in df.columns
         assert "AH_NUM_AIH" not in df.columns

--- a/apps/data_processor/tests/test_data_processor_main.py
+++ b/apps/data_processor/tests/test_data_processor_main.py
@@ -72,6 +72,7 @@ class TestMain:
     @pytest.mark.asyncio
     async def test_main_executa_run_processor(self, tmp_path, monkeypatch):
         import sys
+
         from cnes_infra import config as infra_config
         monkeypatch.setattr(infra_config, "LOGS_DIR", tmp_path)
         monkeypatch.setattr(
@@ -82,12 +83,11 @@ class TestMain:
         with (
             patch("data_processor.main._setup_logging"),
             patch("data_processor.main.init_telemetry"),
-            patch("data_processor.main.create_engine") as mock_engine,
-            patch("data_processor.main._create_storage") as mock_storage,
+            patch("data_processor.main.create_engine"),
+            patch("data_processor.main._create_storage"),
             patch("data_processor.main.run_processor") as mock_run,
         ):
             mock_run.return_value = None
-            import asyncio
             mock_run.side_effect = None
 
             async def _fake_run(*a, **kw):

--- a/apps/data_processor/tests/test_processor.py
+++ b/apps/data_processor/tests/test_processor.py
@@ -226,7 +226,9 @@ class TestProcessJobSihd:
         mock_download,
     ):
         import uuid
+
         import polars as pl
+
         from cnes_infra.storage.job_queue import Job
         from data_processor.processor import process_job
 

--- a/apps/dump_agent/tests/test_platform_runtime.py
+++ b/apps/dump_agent/tests/test_platform_runtime.py
@@ -155,6 +155,7 @@ class TestWindowsHandler:
 
     def test_handler_chama_callback(self):
         import threading
+
         from dump_agent import platform_runtime as pr
         called = threading.Event()
         pr._temp_dirs.clear()
@@ -191,6 +192,7 @@ class TestWindowsHandler:
 class TestInstallWindowsHandlerPortable:
     def test_registra_handler_via_mock(self, monkeypatch):
         from unittest.mock import MagicMock
+
         from dump_agent import platform_runtime as pr
         fake_kernel32 = MagicMock()
         fake_kernel32.SetConsoleCtrlHandler.return_value = 1
@@ -202,6 +204,7 @@ class TestInstallWindowsHandlerPortable:
 
     def test_levanta_quando_set_console_ctrl_handler_falha(self, monkeypatch):
         from unittest.mock import MagicMock
+
         from dump_agent import platform_runtime as pr
         fake_kernel32 = MagicMock()
         fake_kernel32.SetConsoleCtrlHandler.return_value = 0
@@ -225,6 +228,7 @@ class TestWindowsMutexPortable:
 
     def test_levanta_quando_handle_invalido(self, monkeypatch):
         from unittest.mock import MagicMock
+
         from dump_agent import platform_runtime as pr
         fake_kernel32 = MagicMock()
         fake_kernel32.CreateMutexW.return_value = 0
@@ -292,8 +296,9 @@ class TestAcquireSingleInstanceLockPortable:
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only code")
 class TestWindowsMutexExitNoHandle:
     def test_exit_com_handle_none_nao_levanta(self):
-        from dump_agent import platform_runtime as pr
         from unittest.mock import MagicMock, patch
+
+        from dump_agent import platform_runtime as pr
         fake_kernel32 = MagicMock()
         fake_kernel32.CreateMutexW.return_value = 1
         import ctypes

--- a/apps/dump_agent/tests/worker/test_consumer_async.py
+++ b/apps/dump_agent/tests/worker/test_consumer_async.py
@@ -228,7 +228,6 @@ class TestRunWorkerTimingPaths:
         async def mock_acquire(url, mid):
             nonlocal call_count
             call_count += 1
-            return None
 
         stop_event = asyncio.Event()
         with (

--- a/packages/cnes_infra/tests/test_infra_config.py
+++ b/packages/cnes_infra/tests/test_infra_config.py
@@ -70,25 +70,29 @@ class TestLazyAttrs:
             _ = cfg.nao_existe
 
     def test_db_path_levanta_os_error_sem_env(self, monkeypatch):
-        monkeypatch.delenv("DB_PATH", raising=False)
         import cnes_infra.config as cfg
+        cfg._firebird_db_path.cache_clear()
+        monkeypatch.delenv("DB_PATH", raising=False)
         with pytest.raises(OSError):
             _ = cfg.DB_PATH
 
     def test_db_password_levanta_os_error_sem_env(self, monkeypatch):
-        monkeypatch.delenv("DB_PASSWORD", raising=False)
         import cnes_infra.config as cfg
+        cfg._firebird_db_password.cache_clear()
+        monkeypatch.delenv("DB_PASSWORD", raising=False)
         with pytest.raises(OSError):
             _ = cfg.DB_PASSWORD
 
     def test_firebird_dll_levanta_os_error_sem_env(self, monkeypatch):
-        monkeypatch.delenv("FIREBIRD_DLL", raising=False)
         import cnes_infra.config as cfg
+        cfg._firebird_dll.cache_clear()
+        monkeypatch.delenv("FIREBIRD_DLL", raising=False)
         with pytest.raises(OSError):
             _ = cfg.FIREBIRD_DLL
 
     def test_gcp_project_id_levanta_os_error_sem_env(self, monkeypatch):
-        monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
         import cnes_infra.config as cfg
+        cfg._gcp_project_id.cache_clear()
+        monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
         with pytest.raises(OSError):
             _ = cfg.GCP_PROJECT_ID

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,13 @@ markers = [
 [tool.ruff]
 line-length = 100
 target-version = "py313"
+extend-exclude = [
+    ".claude",
+    ".venv",
+    "fb_64",
+    "node_modules",
+    "packages/cnes_infra/src/cnes_infra/alembic/versions",
+]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary

Fix para `lint-test-coverage` que falhou após merge da Fase 3. Duas causas:

### 1. Ruff lintando plugins fora do escopo do projeto

`ruff check .` estava rodando em `.claude/skills/excalidraw-diagram/references/render_excalidraw.py` (arquivo de plugin instalado localmente via marketplace). 205 erros reportados, maioria sem relação com o código do projeto.

**Fix:** `pyproject.toml` `[tool.ruff]` agora tem `extend-exclude = [".claude", ".venv", "fb_64", "node_modules", "packages/cnes_infra/src/cnes_infra/alembic/versions"]`.

### 2. Violações legítimas remanescentes (25 erros no código do projeto)

Auto-fixáveis (22): I001 unsorted-imports, F401 unused-import, PT001 fixture-parens, PLR1711/RET501 return None — aplicadas via `ruff check --fix`.

Manuais (3): F841 unused `as mock_X` em `with patch(...) as mock_X` onde a binding não era lida. Simplificado para `with patch(...)` bare.

### 3. Flaky test de config isolado

`test_db_password_levanta_os_error_sem_env` (e 3 irmãos) falhavam em execução isolada. Raiz: `cnes_infra.config` chama `load_dotenv(override=False)` na importação; se a ordem era `monkeypatch.delenv` → `import cfg`, o `load_dotenv` repopulava a variável do `.env`.

**Fix:** reordenar `import cnes_infra.config` antes do `monkeypatch.delenv` + adicionar `cfg.<lazy>.cache_clear()` para cobrir também o caso de lru_cache populado por teste anterior na mesma sessão.

## Testes

| Check | Resultado |
|---|---|
| `ruff check .` | All checks passed! |
| `pytest` (all, sem integration) | 537 passed, 1 skipped |
| `pytest --cov-config=pyproject.toml --cov-fail-under=100` (core) | 100.00% branch |
| `pytest --cov-config=.coveragerc --cov-fail-under=90` (apps) | 97.85% line |
| Teste isolado `test_db_password_*` | PASS (era FAIL) |

## Test plan

- [ ] CI `lint-test-coverage` deve passar verde no PR
- [ ] Gates de cobertura permanecem em 100/90
- [ ] Nenhuma regressão em testes existentes