### PR TITLE
fix(ci): alembic.ini + DB_URL no job de migração

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           cd packages/cnes_infra
           alembic -c alembic.ini upgrade head
         env:
+          DB_URL: postgresql+psycopg://cnesdata:cnesdata_test@localhost:5433/cnesdata_test
           PG_TEST_URL: postgresql+psycopg://cnesdata:cnesdata_test@localhost:5433/cnesdata_test
 
       - name: Test + coverage (core pkgs, branch 100)

--- a/packages/cnes_infra/alembic.ini
+++ b/packages/cnes_infra/alembic.ini
@@ -1,0 +1,39 @@
+[alembic]
+script_location = src/cnes_infra/alembic
+prepend_sys_path = .
+path_separator = os
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/packages/cnes_infra/src/cnes_infra/alembic/env.py
+++ b/packages/cnes_infra/src/cnes_infra/alembic/env.py
@@ -19,9 +19,16 @@ for md in (gold_metadata, landing_metadata, queue_metadata):
         table.tometadata(target_metadata)
 
 
+def _resolver_db_url() -> str:  # pragma: no cover - alembic CLI only
+    override = alembic_config.get_main_option("sqlalchemy.url")
+    if override:
+        return override
+    return app_config.DB_URL
+
+
 def run_migrations_offline() -> None:  # pragma: no cover - alembic CLI only
     context.configure(
-        url=app_config.DB_URL,
+        url=_resolver_db_url(),
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
@@ -31,7 +38,7 @@ def run_migrations_offline() -> None:  # pragma: no cover - alembic CLI only
 
 
 def run_migrations_online() -> None:  # pragma: no cover - alembic CLI only
-    connectable = create_engine(app_config.DB_URL, poolclass=pool.NullPool)
+    connectable = create_engine(_resolver_db_url(), poolclass=pool.NullPool)
     with connectable.connect() as connection:
         context.configure(
             connection=connection,


### PR DESCRIPTION
## Summary

Fix para o job 'Run migrations' do CI que falhou com:
\`\`\`
alembic -c alembic.ini upgrade head
FAILED: No 'script_location' key found in configuration.
\`\`\`

### Causa

\`packages/cnes_infra/alembic.ini\` nunca foi commitado. O workflow CI invocava \`alembic -c alembic.ini\` mas o arquivo não existia, então alembic caía em config vazia sem \`script_location\`.

Localmente os testes funcionavam porque os fixtures (\`tests/perf/conftest.py\`, \`tests/storage/conftest.py\`) constroem o \`Config\` programaticamente:
\`\`\`python
cfg = Config()
cfg.set_main_option("script_location", "cnes_infra:alembic")
cfg.set_main_option("sqlalchemy.url", _PG_URL)
\`\`\`
Mas o CI usava a CLI direta.

### Fix

1. **\`packages/cnes_infra/alembic.ini\`** criado com \`script_location = src/cnes_infra/alembic\` + loggers padrão.
2. **\`env.py\`** ganha helper \`_resolver_db_url\` — prefere \`sqlalchemy.url\` do Config (passado via \`cfg.set_main_option\` em testes) e cai em \`app_config.DB_URL\` no CLI. Isso destrava testes que passam URL customizada sem precisar setar \`DB_URL\` env antes de importar \`cnes_infra.config\`.
3. **\`ci.yml\`** exporta \`DB_URL\` além de \`PG_TEST_URL\` no job 'Run migrations' para que a CLI ache a URL de conexão.

### Verificação local

- \`alembic -c alembic.ini upgrade head\` executa OK apontando pro postgres de teste
- 4 testes \`test_fontes_idempotency\` (marker \`postgres\`) passam
- \`ruff check .\` limpo

## Test plan

- [ ] Job 'Run migrations' do CI passa verde
- [ ] Job 'Test + coverage' subsequentes continuam passando
- [ ] Gates de cobertura 100/90 mantidos