### PR TITLE
fix(ci): env vars de config + deps (duckdb/psutil) + marker e2e em test_smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   lint-test-coverage:
     runs-on: ubuntu-latest
+    env:
+      DB_URL: postgresql+psycopg://cnesdata:cnesdata_test@localhost:5433/cnesdata_test
+      PG_TEST_URL: postgresql+psycopg://cnesdata:cnesdata_test@localhost:5433/cnesdata_test
+      COMPETENCIA_ANO: "2026"
+      COMPETENCIA_MES: "1"
+      DISABLE_PANDERA_IMPORT_WARNING: "True"
     services:
       postgres:
         image: postgres:16-alpine
@@ -38,7 +44,7 @@ jobs:
           pip install -e apps/data_processor
           pip install -e apps/central_api
           pip install -e apps/cnes_db_migrator
-          pip install pytest pytest-cov pytest-asyncio pytest-benchmark hypothesis ruff
+          pip install pytest pytest-cov pytest-asyncio pytest-benchmark hypothesis ruff duckdb psutil
 
       - name: Lint
         run: ruff check .
@@ -47,9 +53,6 @@ jobs:
         run: |
           cd packages/cnes_infra
           alembic -c alembic.ini upgrade head
-        env:
-          DB_URL: postgresql+psycopg://cnesdata:cnesdata_test@localhost:5433/cnesdata_test
-          PG_TEST_URL: postgresql+psycopg://cnesdata:cnesdata_test@localhost:5433/cnesdata_test
 
       - name: Test + coverage (core pkgs, branch 100)
         run: |
@@ -58,8 +61,6 @@ jobs:
             -m "not bigquery and not e2e and not stress and not soak and not spike" \
             --cov --cov-config=pyproject.toml \
             --cov-report=term-missing
-        env:
-          PG_TEST_URL: postgresql+psycopg://cnesdata:cnesdata_test@localhost:5433/cnesdata_test
 
       - name: Test + coverage (apps, line 90)
         run: |

--- a/apps/central_api/tests/test_smoke.py
+++ b/apps/central_api/tests/test_smoke.py
@@ -5,7 +5,7 @@ import urllib.request
 
 import pytest
 
-pytestmark = pytest.mark.postgres
+pytestmark = [pytest.mark.e2e, pytest.mark.postgres]
 
 
 def test_health_retorna_ok(api_url):


### PR DESCRIPTION
## Summary

Sequência de fixes para o job \`Test + coverage (core pkgs, branch 100)\` que falhou após merge de #15. Três erros separados:

### 1. \`OSError: DB_URL não encontrada\`
A coleta de \`packages/cnes_domain/tests/test_config.py\` importa \`cnes_infra.config\`, que tem \`DB_URL: str = _sanitizar_db_url(_exigir(\"DB_URL\"))\` no topo do módulo. O env var só era exportado no step de migrations, não nos steps de pytest.

**Fix:** mover \`DB_URL\`, \`PG_TEST_URL\`, \`COMPETENCIA_ANO\`, \`COMPETENCIA_MES\` (todos obrigatórios por \`cnes_infra.config\`) para o nível do job. Herdam em todos os steps automaticamente; steps ficam mais enxutos.

### 2. \`ModuleNotFoundError: No module named 'duckdb'\`
\`packages/cnes_infra/tests/storage/test_dlq_schema.py\` importa duckdb. Esta lib foi adicionada como dev-dependency no pyproject em #12, mas o CI não lê \`[tool.uv.dev-dependencies]\` — usa \`pip install <lista explícita>\`.

**Fix:** adicionar \`duckdb\` e \`psutil\` (perf harnesses) à linha de \`pip install\` do CI.

### 3. \`test_smoke.py\` erra tentando subir docker compose
Os 3 testes em \`apps/central_api/tests/test_smoke.py\` requerem stack Docker completa (api, minio, postgres). Estavam marcados só como \`postgres\`, mas o CI só tem um Postgres service — sem api nem minio. O teste tenta \`docker compose up\` e colide com containers já rodando.

**Fix:** upgrade do marker para \`[e2e, postgres]\`. Filtros do CI já excluem \`e2e\`.

## Verificação local

Com as mesmas envs do CI:
- Core: \`371 passed, 6 warnings in 29.62s\` — 100% branch coverage
- Apps: \`190 passed, 8 skipped, 13 deselected\` — 97.85% line coverage, gate 90

## Test plan

- [ ] Job \`Run migrations\` passa verde (confirma fix do PR #15)
- [ ] Job \`Test + coverage (core)\` passa com --cov-fail-under=100 implícito via pyproject
- [ ] Job \`Test + coverage (apps)\` passa com --cov-fail-under=90 via .coveragerc
- [ ] 3 erros de test_smoke.py agora viram \"skipped\" em vez de \"error\"