### PR TITLE
fix(ci): env do job adiciona COD_MUN_IBGE / ID_MUNICIPIO_IBGE7 / CNPJ_MANTENEDORA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       COMPETENCIA_ANO: "2026"
       COMPETENCIA_MES: "1"
       DISABLE_PANDERA_IMPORT_WARNING: "True"
+      COD_MUN_IBGE: "354130"
+      ID_MUNICIPIO_IBGE7: "3541308"
+      CNPJ_MANTENEDORA: "55293427000117"
     services:
       postgres:
         image: postgres:16-alpine


### PR DESCRIPTION
## Summary

CI step \`Test + coverage (core pkgs, branch 100)\` reprovava com 4 falhas em \`TestVariaveisEager\`:

\`\`\`
OSError: Variável de ambiente obrigatória 'COD_MUN_IBGE' não encontrada.
OSError: Variável de ambiente obrigatória 'CNPJ_MANTENEDORA' não encontrada.
\`\`\`

Cobertura não era o problema (log mostra \`Total coverage: 100.00%\`). O exit 1 vinha dos 4 testes que acessam atributos lazy de \`cnes_infra.config\` e comparam com valores específicos (\`\"354130\"\`, \`\"55293427000117\"\`) — vêm do \`.env\` local do dev.

## Fix

Adiciona 3 env vars ao bloco \`env:\` do job \`lint-test-coverage\` em \`.github/workflows/ci.yml\`:

\`\`\`yaml
COD_MUN_IBGE: \"354130\"
ID_MUNICIPIO_IBGE7: \"3541308\"
CNPJ_MANTENEDORA: \"55293427000117\"
\`\`\`

Valores batem com os asserts em \`packages/cnes_domain/tests/test_config.py:14,17\` e passam nos regexes de validação em \`packages/cnes_infra/src/cnes_infra/config.py\` (\`_RE_COD_MUN_6\`, \`_RE_IBGE7\`, \`_RE_CNPJ_14\`).

\`ID_MUNICIPIO_IBGE7\` adicionado preventivamente — hoje nenhum teste lazy-load ele, mas \`.env\` local tem e qualquer teste futuro que acesse \`config.ID_MUNICIPIO_IBGE7\` quebraria da mesma forma.

## Verificação

Local, com as envs replicadas:
\`\`\`
$ pytest packages/cnes_domain/tests/test_config.py::TestVariaveisEager -v
4 passed in 0.65s
\`\`\`

## Test plan

- [ ] Step \`Test + coverage (core pkgs, branch 100)\` passa verde
- [ ] Contagem final: \`340 passed, 4 skipped\` (era \`336 passed, 4 failed, 4 skipped\`)
- [ ] Step \`Test + coverage (apps, line 90)\` continua verde
- [ ] Gate de cobertura 100% branch mantido