### PR TITLE
docs: refrescar CLAUDE.md + project docs para monorepo edge/central

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,28 +1,72 @@
 <system_prompt>
 <role>
-You are an Elite Senior Data Engineer and Python Expert. Your primary focus is on Clean Architecture, highly readable code, and bulletproof testing. We will be pair programming.
+Elite Senior Data Engineer & Python expert. Pair-programming contributor on
+a multi-tenant CNES/SUS data reconciliation engine. Clean Architecture,
+strict testing discipline, no speculative features.
 </role>
 
 <project_context>
-Mission-critical data extraction and reconciliation pipeline. Reconciliation Rule Engine cross-referencing local Firebird DB, HR systems, and BigQuery national data for public health compliance (CNPJ `55.293.427/0001-17`).
+Distributed data platform for Brazilian public-health workforce data. Edge
+agents extract raw data from municipal databases (Firebird CNES, SIHD),
+upload Parquet to object storage (MinIO), and a central worker persists to
+a multi-tenant Postgres Gold schema. Audit rules are applied downstream by
+an external service — out of scope for this repo.
+
+Pilot: Presidente Epitácio/SP (IBGE 354130, CNPJ 55.293.427/0001-17).
+Architecture ready for multi-municipality via per-tenant isolation
+(TenantMiddleware + Postgres RLS). Not yet in production.
+
+Active sources: CNES (Firebird local + BigQuery nacional + DATASUS API),
+SIHD hospitalar. Roadmap: BPA, Esus PEC, HR PIS→CPF cross-walking.
 </project_context>
 
 <project_architecture>
+Monorepo uv workspace. 2 shared packages + 4 apps.
 
-- **Ingestion:** cnes_client (Firebird/fdb cursor), hr_client (.xlsx/.csv), web_client (DATASUS HTTP), adapters → canonical schemas via PEP 544 Protocols
-- **Transform:** transformer.py — CPF cleaning, ISO 8601 dates, dedup (RQ-002, RQ-003)
-- **Analyze:** rules_engine.py — 11 audit rules (RQ-003-B, RQ-005–011, Ghost Payroll, Missing Registration). evolution_tracker.py — JSON snapshots
-- **Export:** csv_exporter (BR CSV `;` sep, utf-8-sig), report_generator (Excel/openpyxl, multi-sheet)
+- **Packages (shared libraries):**
+  - `cnes_domain` — Ports/Protocols (PEP 544), pipeline primitives
+    (`CircuitBreaker`), row mappers, transformer, extraction models,
+    tenant ContextVar. Zero infra dependencies.
+  - `cnes_infra` — Concrete adapters: Postgres storage (repositories,
+    job_queue, landing, RLS, schema), MinIO object_storage,
+    Firebird/HR/DATASUS/BigQuery ingestion clients, Alembic migrations,
+    OTel telemetry.
+
+- **Apps (deployables):**
+  - `dump_agent` — **Edge Agent**. Daemon near the source (municipal
+    Firebird or SIHD). Extracts raw → Parquet streaming gzip → MinIO
+    via presigned URL issued by central API.
+  - `central_api` — FastAPI. Job orchestration, presigned URL minting,
+    tenant middleware, health/admin/jobs routes, lease reaper.
+  - `data_processor` — Async worker. Pulls queued jobs, downloads Parquet,
+    runs transformer + row mappers, upserts Gold schema, manages
+    idempotency via `fontes` JSONB merge.
+  - `cnes_db_migrator` — Alembic init-container for Kubernetes.
+
+- **Data flow:** `[Edge: FB/SIHD] → dump_agent → MinIO (raw Parquet) →
+  central_api (queue) → data_processor (transform + upsert) →
+  Postgres Gold (dim_*, fato_*, RLS) → [External audit — out of scope]`
+
+- **Deploy target:** Kubernetes. Central apps (api + processor + init
+  migrator) + on-prem edge agents (Windows Service / systemd). Local dev
+  via `docker-compose.yml`; perf fixtures via `docker-compose.perf.yml`.
 </project_architecture>
 
 <resources>
-- **Data Dictionary:** `docs/data-dictionary-firebird-bigquery.md` — Firebird schema, BigQuery schema, audit rules. CRITICAL: Consult BEFORE writing SQL, extraction logic, or mock DataFrames.
-- **Skills/Agents Guide:** `.claude/skills/skill-authoring/SKILL.md` — Read only when creating or modifying skills/agents/commands.
+- **Monorepo architecture diagram + contracts:** `docs/architecture.md`
+- **Roadmap:** `docs/roadmap.md` — BPA, Esus PEC, HR, rules service
+- **Data dictionaries (CONSULTAR antes de escrever SQL/mocks):**
+  - `docs/data-dictionary-firebird-bigquery.md` — CNES local + nacional
+  - `docs/data-dictionary-cnes.md` — schema canônico Gold
+  - `docs/data-dictionary-sihd-hospital.md` — SIHD / AIH
+- **Per-app/package docs:** `apps/<app>/CLAUDE.md`,
+  `packages/<pkg>/CLAUDE.md` — abrir ao editar dentro daquele diretório.
+- **Perf tests:** `docs/perf-testing.md` — 5 tiers (micro/macro/stress/soak/spike).
+- **Narrativa histórica:** `docs/project-context.md`
 </resources>
 
 <engineering_and_quality_rules>
-
-## Hard Limits (non-negotiable — refactor before committing)
+## Hard Limits (non-negotiable)
 
 | Metric | Limit |
 |---|---|
@@ -32,276 +76,109 @@ Mission-critical data extraction and reconciliation pipeline. Reconciliation Rul
 | File length | ≤ 500 lines |
 | Parameters | ≤ 4 |
 | Nesting depth | ≤ 3 levels |
+| CLAUDE.md length | ≤ 200 lines per file |
 
 ## Critical Rules
 
-- Build only what was explicitly requested. No speculative features, no premature abstractions.
+- Build only what was requested. No speculative features, no premature abstractions.
 - Read before writing. Never assume file contents from memory.
-- Verify after every change: lint → tests → self-review.
-- Name tests by behavior: `test_rejeita_cpf_invalido`, not `test_validate`.
-- Mock at the boundary (DB connection, HTTP client). Never deep inside code under test.
+- Verify every change: `ruff check .` → `pytest` → self-review.
+- Test names describe behavior in Portuguese: `test_rejeita_cpf_invalido`.
+- Mock at boundary (DB / HTTP / object store). Never deep inside code under test.
 - Parameterized queries only. No string interpolation into SQL, ever.
 - Commit format: `<type>(<scope>): <description>`. Never commit directly to `main`.
-- CLAUDE.md files ≤ 200 lines. Move detailed specs to referenced files.
-
+- Every bug fix ships with a regression test proven to fail pre-fix.
+- Tenant isolation: every Postgres query passes through `set_tenant_id()`; never bypass RLS.
+- Adding a new app in `apps/` → create `apps/<app>/CLAUDE.md` in the same PR.
+- Adding a new package in `packages/` → create `packages/<pkg>/CLAUDE.md` in the same PR.
 </engineering_and_quality_rules>
 
 <token_efficiency>
-THESE RULES APPLY TO ALL CODE, LOGS, AND RESPONSES GENERATED:
-
 CODE:
+- Zero inline comments. Code self-documents via names + types.
+- "Why" comments only for non-obvious workarounds/business rules.
+- Public docstrings: Args/Returns/Raises, ≤ 6 lines, no prose.
+- Private functions: no docstring.
+- Module docstring: 1 line max.
+- Specific imports (`from X import Y`). Zero dead code, zero commented-out code.
+- Error messages: `key=value`, no prose.
 
-- Zero inline/block comments. Code must self-document via names + types.
-- Only exception: single-line "why" comments for non-obvious workarounds/business rules.
-- Docstrings ONLY on public functions/classes. Format: Args/Returns/Raises, no prose. Max 6 lines.
-- Private functions: NO docstring. Name + type hints = documentation.
-- Module docstring: ONE line max.
-- No dead code, no commented-out code, no unused imports.
-- Specific imports (`from X import Y`) over module imports.
-- Compact error messages: key=value style, no prose.
+VISUAL: zero ASCII art, banners, decorative lines, emoji — anywhere.
 
-VISUAL:
+LOGGING: `logger.info("action key=%s other=%d", a, b)`. One line per event.
 
-- Zero ASCII art, separators, box-drawing, banners, or decorative lines anywhere.
-- Zero emoji in code, logs, or comments.
-- Use blank lines and code structure for organization, not visual markers.
-
-LOGGING:
-
-- Structured key=value format: `logger.info("action key=%s", val)`
-- No prose sentences, no decorative log lines, no banners.
-- One log line per event. No multi-line log blocks for a single event.
-
-AI RESPONSES:
-
-- Start with action/code. No preamble ("Sure!", "Great question!", "I understand...")
-- Surgical edits over full rewrites. Describe ONLY what changed.
-- No post-task summary. Test output = summary.
-- Telegraphic explanations: "Switched to cursor — fdb LEFT JOIN bug" not paragraphs
+AI RESPONSES: start with action. Surgical edits, no preamble, no post-summary.
 </token_efficiency>
 
 <response_format>
-Before writing any code, wrap analysis and TDD planning inside a `<thinking>` block. Output test code first, then implementation. Wait for input to begin.
+Before code: wrap analysis in `<thinking>`. Tests first, implementation second.
 </response_format>
 </system_prompt>
 
 ## Commands
 
 ```bash
-# Lint
-./venv/Scripts/ruff.exe check src/ tests/
+# Lint (global)
+.venv/Scripts/ruff.exe check .
 
-# Tests — unit only (fast)
-./venv/Scripts/python.exe -m pytest tests/ -m "not integration" -q --tb=short
+# Tests — rápidos (sem docker)
+.venv/Scripts/python.exe -m pytest -m "not integration and not postgres and not bigquery and not e2e and not stress and not soak and not spike and not windows_only" -q
 
-# Tests — single module
-./venv/Scripts/python.exe -m pytest tests/analysis/test_rules_engine.py -v
+# Tests — single package/app
+.venv/Scripts/python.exe -m pytest packages/cnes_domain -q
+.venv/Scripts/python.exe -m pytest apps/dump_agent -q
 
-# Tests — full suite
-./venv/Scripts/python.exe -m pytest tests/ -q --tb=short
+# Tests — integration (requer docker compose up -d postgres)
+.venv/Scripts/python.exe -m pytest -m postgres -q
 
-# Pipeline (requires .env configured)
-./venv/Scripts/python.exe src/main.py
+# Coverage gates
+.venv/Scripts/python.exe -m pytest packages/ --cov --cov-config=pyproject.toml   # 100% branch
+.venv/Scripts/python.exe -m pytest apps/   --cov --cov-config=.coveragerc        # 90% line
+
+# Perf micro (todo PR)
+.venv/Scripts/python.exe -m pytest tests/perf/micro -m perf_micro --benchmark-only
+
+# Rodar central_api localmente
+docker compose up -d postgres minio
+uv run uvicorn central_api.app:create_app --factory --reload
 ```
 
-## Environment (`.env` required)
+## Monorepo map
 
-| Variable | Required | Description |
+| Path | Type | Purpose |
 |---|---|---|
-| `DB_PATH` | yes | Path to CNES.GDB Firebird file |
-| `DB_PASSWORD` | yes | Firebird password |
-| `FIREBIRD_DLL` | yes | Path to `fbclient.dll` (64-bit) |
-| `COD_MUN_IBGE` | yes | 6-digit IBGE municipality code |
-| `ID_MUNICIPIO_IBGE7` | yes | 7-digit IBGE municipality code |
-| `CNPJ_MANTENEDORA` | yes | 14-digit CNPJ (no punctuation) |
-| `GCP_PROJECT_ID` | yes | BigQuery project ID |
-| `FOLHA_HR_PATH` | no | Path to HR payroll spreadsheet |
-| `DATASUS_AUTH_TOKEN` | no | Bearer token para apidadosabertos.saude.gov.br |
-| `OUTPUT_DIR` | no | Output dir (default: `data/processed`) |
-| `DB_HOST` | no | Firebird host (default: `localhost`) |
-| `DB_USER` | no | Firebird user (default: `SYSDBA`) |
+| `packages/cnes_domain/` | library | Ports, models, pipeline, processing — domain core |
+| `packages/cnes_infra/` | library | Storage, ingestion, telemetry, migrations |
+| `apps/dump_agent/` | edge daemon | Firebird/SIHD → Parquet → MinIO |
+| `apps/central_api/` | FastAPI | Job orchestration, presigned URLs, health |
+| `apps/data_processor/` | worker | Parquet → transform → Postgres Gold |
+| `apps/cnes_db_migrator/` | init-container | Alembic `upgrade head` |
+| `docs/` | documentation | Dictionaries, architecture, roadmap, perf |
+| `tests/perf/` | perf suite | micro / macro / stress / soak / spike tiers |
 
-## Module Map
+## Environment (minimum for any pytest)
 
-| Path | Responsibility |
-|---|---|
-| `src/ingestion/cnes_client.py` | Firebird cursor queries (fdb) |
-| `src/ingestion/cnes_local_adapter.py` | Local CNES → canonical schema |
-| `src/ingestion/cnes_nacional_adapter.py` | National CNES (BigQuery) → canonical schema |
-| `src/ingestion/hr_client.py` | Payroll .xlsx/.csv parser |
-| `src/ingestion/web_client.py` | DATASUS HTTP fetcher |
-| `src/ingestion/schemas.py` | PEP 544 Protocols (canonical schema) |
-| `src/ingestion/db_client.py` | Firebird connection wrapper |
-| `src/ingestion/base.py` | Shared ingestion base |
-| `src/processing/transformer.py` | CPF cleaning, ISO dates, dedup |
-| `src/analysis/rules_engine.py` | 11 audit rules (RQ-003-B … RQ-011) |
-| `src/analysis/evolution_tracker.py` | Historical JSON snapshots |
-| `src/export/csv_exporter.py` | BR CSV (`;` sep, utf-8-sig) |
-| `src/export/report_generator.py` | Excel multi-sheet (openpyxl) |
-| `src/config.py` | Single source of truth for all config |
-| `src/main.py` | Pipeline entry point |
-
-## Key Database Tables
-
-> Full column schemas in `docs/data-dictionary-firebird-bigquery.md`. Consult before writing queries or mocks.
-
-| Table | Purpose |
-|---|---|
-| LFCES021 | Professional ↔ Establishment links (workload, CBO) |
-| LFCES004 | Establishments (CNES code, name, type, municipality) |
-| LFCES018 | Professionals (CPF, name) |
-| LFCES048 | Professional ↔ Team members |
-| LFCES060 | Health teams (INE, area, segment) |
-
-## Firebird Quirks
-
-- `pd.read_sql()` with LEFT JOIN fails error -501 → use manual cursor
-- ORDER BY positional references unsupported on system tables
-- `TRIM()` unavailable in `RDB$` system queries
-- Windows cp1252 encoding issues → reconfigure `sys.stdout`
-- `LFCES060.SEQ_EQUIPE` is national (6-7 digits); first 4 chars = `LFCES048.SEQ_EQUIPE` (local)
-- `CD_SEGMENT`/`DS_SEGMENT` return error -206 via alias in nested LEFT JOIN — recover in separate subquery
-
-## Conventions
-
-- No hardcoded paths or credentials — all via `config.py` + `.env`
-- No `print()` in production code — use `logging`
-- Data transformations work on `.copy()`, never mutate originals
-- DB connections closed in `finally` blocks
-- All user-facing strings and docstrings in Portuguese
-- Business logic in English; comments in Portuguese
-- Skip fb_64/* for context window, use fdb instead
-
-<!-- rtk-instructions v2 -->
-# RTK (Rust Token Killer) - Token-Optimized Commands
-
-## Golden Rule
-
-**Always prefix commands with `rtk`**. If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
-
-**Important**: Even in command chains with `&&`, use `rtk`:
-```bash
-# ❌ Wrong
-git add . && git commit -m "msg" && git push
-
-# ✅ Correct
-rtk git add . && rtk git commit -m "msg" && rtk git push
+```
+DB_URL=postgresql+psycopg://cnesdata:cnesdata_test@localhost:5433/cnesdata_test
+COD_MUN_IBGE=354130
+ID_MUNICIPIO_IBGE7=3541308
+CNPJ_MANTENEDORA=55293427000117
+COMPETENCIA_ANO=2026
+COMPETENCIA_MES=1
 ```
 
-## RTK Commands by Workflow
+Per-app env vars (MinIO, CENTRAL_API_URL, TENANT_ID, FIREBIRD_DLL, etc):
+ver `apps/<app>/CLAUDE.md`.
 
-### Build & Compile (80-90% savings)
-```bash
-rtk cargo build         # Cargo build output
-rtk cargo check         # Cargo check output
-rtk cargo clippy        # Clippy warnings grouped by file (80%)
-rtk tsc                 # TypeScript errors grouped by file/code (83%)
-rtk lint                # ESLint/Biome violations grouped (84%)
-rtk prettier --check    # Files needing format only (70%)
-rtk next build          # Next.js build with route metrics (87%)
-```
+## Global conventions
 
-### Test (90-99% savings)
-```bash
-rtk cargo test          # Cargo test failures only (90%)
-rtk vitest run          # Vitest failures only (99.5%)
-rtk playwright test     # Playwright failures only (94%)
-rtk test <cmd>          # Generic test wrapper - failures only
-```
+- No hardcoded paths/credentials — all via `cnes_infra.config` + `.env`.
+- No `print()` — use `logging` with structured `key=value`.
+- DataFrames: columns novas via `with_columns`; nunca mutar input in-place.
+- DB connections em `finally` ou context managers (UoW pattern).
+- UI strings e docstrings em Português. Code e comentários em Inglês.
+- Firebird só em `apps/dump_agent/` + `packages/cnes_infra/ingestion/` —
+  `central_api` e `data_processor` não tocam Firebird diretamente.
+- Tenant: sempre `cnes_domain.tenant.set_tenant_id()` antes de query Postgres.
 
-### Git (59-80% savings)
-```bash
-rtk git status          # Compact status
-rtk git log             # Compact log (works with all git flags)
-rtk git diff            # Compact diff (80%)
-rtk git show            # Compact show (80%)
-rtk git add             # Ultra-compact confirmations (59%)
-rtk git commit          # Ultra-compact confirmations (59%)
-rtk git push            # Ultra-compact confirmations
-rtk git pull            # Ultra-compact confirmations
-rtk git branch          # Compact branch list
-rtk git fetch           # Compact fetch
-rtk git stash           # Compact stash
-rtk git worktree        # Compact worktree
-```
-
-Note: Git passthrough works for ALL subcommands, even those not explicitly listed.
-
-### GitHub (26-87% savings)
-```bash
-rtk gh pr view <num>    # Compact PR view (87%)
-rtk gh pr checks        # Compact PR checks (79%)
-rtk gh run list         # Compact workflow runs (82%)
-rtk gh issue list       # Compact issue list (80%)
-rtk gh api              # Compact API responses (26%)
-```
-
-### JavaScript/TypeScript Tooling (70-90% savings)
-```bash
-rtk pnpm list           # Compact dependency tree (70%)
-rtk pnpm outdated       # Compact outdated packages (80%)
-rtk pnpm install        # Compact install output (90%)
-rtk npm run <script>    # Compact npm script output
-rtk npx <cmd>           # Compact npx command output
-rtk prisma              # Prisma without ASCII art (88%)
-```
-
-### Files & Search (60-75% savings)
-```bash
-rtk ls <path>           # Tree format, compact (65%)
-rtk read <file>         # Code reading with filtering (60%)
-rtk grep <pattern>      # Search grouped by file (75%)
-rtk find <pattern>      # Find grouped by directory (70%)
-```
-
-### Analysis & Debug (70-90% savings)
-```bash
-rtk err <cmd>           # Filter errors only from any command
-rtk log <file>          # Deduplicated logs with counts
-rtk json <file>         # JSON structure without values
-rtk deps                # Dependency overview
-rtk env                 # Environment variables compact
-rtk summary <cmd>       # Smart summary of command output
-rtk diff                # Ultra-compact diffs
-```
-
-### Infrastructure (85% savings)
-```bash
-rtk docker ps           # Compact container list
-rtk docker images       # Compact image list
-rtk docker logs <c>     # Deduplicated logs
-rtk kubectl get         # Compact resource list
-rtk kubectl logs        # Deduplicated pod logs
-```
-
-### Network (65-70% savings)
-```bash
-rtk curl <url>          # Compact HTTP responses (70%)
-rtk wget <url>          # Compact download output (65%)
-```
-
-### Meta Commands
-```bash
-rtk gain                # View token savings statistics
-rtk gain --history      # View command history with savings
-rtk discover            # Analyze Claude Code sessions for missed RTK usage
-rtk proxy <cmd>         # Run command without filtering (for debugging)
-rtk init                # Add RTK instructions to CLAUDE.md
-rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
-```
-
-## Token Savings Overview
-
-| Category | Commands | Typical Savings |
-|----------|----------|-----------------|
-| Tests | vitest, playwright, cargo test | 90-99% |
-| Build | next, tsc, lint, prettier | 70-87% |
-| Git | status, log, diff, add, commit | 59-80% |
-| GitHub | gh pr, gh run, gh issue | 26-87% |
-| Package Managers | pnpm, npm, npx | 70-90% |
-| Files | ls, read, grep, find | 60-75% |
-| Infrastructure | docker, kubectl | 85% |
-| Network | curl, wget | 65-70% |
-
-Overall average: **60-90% token reduction** on common development operations.
-<!-- /rtk-instructions -->
+> Para comandos RTK (Rust Token Killer), ver `~/.claude/CLAUDE.md` global.

--- a/apps/central_api/CLAUDE.md
+++ b/apps/central_api/CLAUDE.md
@@ -1,0 +1,90 @@
+# central_api — FastAPI ingestion + job orchestration
+
+## Executive Summary
+
+Servidor FastAPI que recebe requisições de `dump_agent` (poll de jobs,
+upload de artefatos, heartbeat) e de serviços administrativos (health,
+reap-leases). Emite URLs pré-assinadas MinIO, gerencia fila de jobs em
+Postgres com leases (reclama jobs expirados via background task), expõe
+OpenAPI em `/openapi.json`. Stateless em nível de request — toda persistência
+em Postgres; MinIO é conteúdo, não estado.
+
+## Role
+
+**Central orchestrator**. Único ponto de entrada HTTP do sistema.
+Horizontalmente escalável, com cuidado: reaper background task só deve rodar
+em 1 réplica (gate via env `ENABLE_REAPER`).
+
+## Functionalities
+
+- `GET /api/v1/system/health` — healthcheck + ping Postgres
+- `GET /api/v1/jobs/next` — próximo job para `(tenant_id, machine_id)` com lease
+- `POST /api/v1/jobs/{id}/heartbeat` — estende lease
+- `POST /api/v1/jobs/{id}/artifact` — emite presigned PUT MinIO
+- `POST /api/v1/jobs/{id}/complete` — marca job uploaded (processor pega depois)
+- `POST /api/v1/jobs/{id}/fail` — marca falha (retryable ou DLQ)
+- `POST /api/v1/admin/reap-leases` — libera jobs com lease expirado (admin)
+- `TenantMiddleware` — extrai `X-Tenant-Id` header e chama `set_tenant_id()`
+- Background task: `_lease_reaper_loop` (a cada `_REAPER_INTERVAL=60s`) no lifespan
+
+## Objectives
+
+- p99 de `/jobs/next` < 200ms (Postgres-only, sem I/O externo)
+- Zero cross-tenant leak (RLS + middleware + teste contratual)
+- Uptime 99.9% (single-replica inicialmente; rolling restart no k8s suporta)
+
+## Limitations
+
+- **Não executa jobs** — só orquestra (execução fica no `data_processor`)
+- **Não lê Firebird/SIHD direto** — todo dado chega via `dump_agent`
+- **Não processa Parquet** — só emite presigned URLs; MinIO armazena
+- **Sem auth próprio** — assume rede confiável (VPN municipal) ou gateway
+  externo (ingress com auth) na frente
+
+## Requirements
+
+**Runtime deps (apps/central_api/pyproject.toml):** `fastapi`, `uvicorn`,
+`sqlalchemy`, `psycopg`, `cnes_domain`, `cnes_infra` (`storage/*`, `telemetry`).
+
+**Env vars:**
+
+| Var | Obrigatória | Descrição |
+|---|---|---|
+| `DB_URL` | sim | Postgres URL (`postgresql+psycopg://...`) |
+| `MINIO_ENDPOINT` | sim | `host:port` MinIO (ex.: `minio:9000`) |
+| `MINIO_ACCESS_KEY` | sim | Credencial MinIO |
+| `MINIO_SECRET_KEY` | sim | Credencial MinIO |
+| `MINIO_BUCKET` | opcional | Default `cnesdata-landing` |
+| `MINIO_SECURE` | opcional | `true` para HTTPS (default `false`) |
+| `API_HOST` | opcional | Default `0.0.0.0` |
+| `API_PORT` | opcional | Default `8000` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | opcional | Tracing (se OTel SDK instalado) |
+| `ENABLE_REAPER` | opcional | `true` em 1 réplica para reaper rodar (futuro) |
+
+## Module Map
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `src/central_api/app.py` | `create_app()` factory — FastAPI + lifespan + middleware + routers |
+| `src/central_api/deps.py` | `get_engine()`, `lifespan`, `_lease_reaper_loop`, RLS listener install |
+| `src/central_api/middleware.py` | `TenantMiddleware` — extrai `X-Tenant-Id` header |
+| `src/central_api/routes/health.py` | `/api/v1/system/health` — ping DB |
+| `src/central_api/routes/jobs.py` | `/api/v1/jobs/*` — fila, artifact, heartbeat, complete, fail |
+| `src/central_api/routes/admin.py` | `/api/v1/admin/*` — reap-leases, ops |
+
+## Gotchas
+
+- **TenantMiddleware obrigatório:** toda request precisa de header
+  `X-Tenant-Id`. Sem ele, `set_tenant_id()` não é chamado e queries quebram
+  silenciosamente (RLS bloqueia). Exception: rotas de health podem ignorar
+  (mas hoje não fazem).
+- **Lease reaper é background task, não worker:** roda no mesmo processo do
+  uvicorn via `lifespan`. Em deploy k8s com 2+ réplicas, só 1 deve rodar
+  reaper — o padrão recomendado é flag `ENABLE_REAPER=true` em uma só
+  (atualmente todas rodam; limitação conhecida do single-replica dev).
+- **`test_smoke.py`** requer docker-compose completo (API + MinIO + DB) —
+  marcado `[e2e, postgres]` e pulado no filtro padrão de CI.
+- **RLS install:** `install_rls_listener(engine)` é chamado no lifespan.
+  Sem isso, queries via SQLAlchemy não setam `app.tenant_id` e RLS bloqueia
+  tudo. Teste de regressão: qualquer query em integration test deve passar
+  (se bloquear, listener não foi instalado).

--- a/apps/cnes_db_migrator/CLAUDE.md
+++ b/apps/cnes_db_migrator/CLAUDE.md
@@ -1,0 +1,64 @@
+# cnes_db_migrator — Alembic init-container
+
+## Executive Summary
+
+Runner mínimo que invoca `alembic upgrade head` antes de `central_api` e
+`data_processor` iniciarem. Desenhado como initContainer Kubernetes — roda
+uma vez por deploy, sai com código 0 em sucesso ou 1 em falha de migration.
+Zero estado próprio; toda configuração vem de env vars.
+
+## Role
+
+Boot-time DB migrator. Sem loop, sem persistência. Artefato único:
+container image minimalista.
+
+## Functionalities
+
+- `alembic -c alembic.ini upgrade head` contra `DB_URL` do env
+- Retry em falha de conexão transitória (até 30s) — espera Postgres subir
+- Exit 0 em sucesso, exit 1 em falha de migration
+
+## Objectives
+
+- Execução < 10s em deploy steady-state (migrations já aplicadas → no-op)
+- Zero race entre réplicas (Alembic file-level lock garante)
+- Imagem docker < 150MB (só Python + Alembic + deps + `cnes_infra`)
+
+## Limitations
+
+- **Não aplica data migrations complexas** — só schema DDL
+- **Não roda em prod contra DB de produção sem backup recente** (responsabilidade do operador)
+- **Não gera migrations** — só aplica existentes. `alembic revision --autogenerate` roda em dev local
+
+## Requirements
+
+**Runtime deps (apps/cnes_db_migrator/pyproject.toml):** `alembic`,
+`sqlalchemy`, `psycopg`, `cnes_infra` (por causa de `env.py` importar
+`cnes_infra.storage.schema`).
+
+**Env vars:**
+
+| Var | Obrigatória | Descrição |
+|---|---|---|
+| `DB_URL` | sim | Postgres URL (target do upgrade) |
+
+## Module Map
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `src/cnes_db_migrator/run.py` | CLI simples: `python -m cnes_db_migrator` invoca `command.upgrade(cfg, "head")` |
+| `packages/cnes_infra/alembic.ini` | Config Alembic (`script_location = src/cnes_infra/alembic`) |
+| `packages/cnes_infra/src/cnes_infra/alembic/env.py` | Env script com `_resolver_db_url` |
+| `packages/cnes_infra/src/cnes_infra/alembic/versions/*.py` | Migrations numeradas (omitidas em coverage) |
+
+## Gotchas
+
+- **`env.py._resolver_db_url`:** prefere `sqlalchemy.url` do Config (setado
+  por fixtures de teste via `cfg.set_main_option`) e cai em `DB_URL` env
+  var senão. Isso destrava testes sem precisar setar env global.
+- **Migration paths:** `script_location = src/cnes_infra/alembic` (relativo
+  a `packages/cnes_infra/` onde fica o `alembic.ini`). CLI precisa rodar
+  a partir de `packages/cnes_infra/` OU passar `-c packages/cnes_infra/alembic.ini`.
+- **Init-container em k8s:** configurar `restartPolicy: OnFailure` e
+  `backoffLimit: 3`. Timeout de 60s recomendado (primeiro boot após criar
+  DB pode levar até 20s com 6 migrations).

--- a/apps/data_processor/CLAUDE.md
+++ b/apps/data_processor/CLAUDE.md
@@ -1,0 +1,94 @@
+# data_processor — Transform & persist worker
+
+## Executive Summary
+
+Worker assíncrono que consome jobs da fila do `central_api`, baixa Parquet
+gzip do MinIO, aplica transformações canônicas (CPF zero-pad + strip
+pontuação, dedup, flags de carga horária) via
+`cnes_domain.processing.transformer`, e persiste no schema Gold Postgres
+(`dim_estabelecimento`, `dim_profissional`, `fato_vinculo`) com upsert
+idempotente e merge JSONB de `fontes` para suportar múltiplas origens
+sobre a mesma chave (LOCAL, NACIONAL, WEB).
+
+## Role
+
+**Central worker**. Stateless entre jobs; estado inteiramente em Postgres.
+Horizontalmente escalável — múltiplas réplicas puxam da mesma fila sem
+colisão (lease-based).
+
+## Functionalities
+
+- Poll de jobs via HTTP ao `central_api` (mesmo endpoint do `dump_agent`,
+  filtro por status `ready_to_process`)
+- Download streaming de Parquet gzip do MinIO via presigned GET
+- Roteamento por source (CNES / SIHD) via `adapters/*_adapter.py`
+- Aplicação de `transformar()` (clean CPF, pad, RQ-002 filter, `ALERTA_CH` flag)
+- Mapeamento raw → canonical via `row_mapper.mapear_*`
+- Upsert idempotente (`ON CONFLICT DO UPDATE` com merge JSONB `fontes || EXCLUDED.fontes`)
+- `CircuitBreaker` em chamadas MinIO e `central_api` (backoff exp capado)
+
+## Objectives
+
+- Throughput ≥ 10k rows/s no upsert (gate do stress test)
+- Idempotência total: N execuções do mesmo job = mesmo resultado no Gold
+- Zero perda de dados via DLQ (`job_queue` tabelas `public.job_retries`)
+
+## Limitations
+
+- **Não faz extract** — só consome Parquet pronto
+- **Não aplica regras de auditoria** — persiste dados canônicos; regras
+  rodam em serviço externo que consome Gold via SQL JOINs
+- **Não tem UI** — é daemon puro, monitorado via logs + OTel
+- **Não conecta ao Firebird** — totalmente desacoplado das fontes
+- **Não orquestra jobs** — só executa; `central_api` decide prioridade/fila
+
+## Requirements
+
+**Runtime deps (apps/data_processor/pyproject.toml):** `sqlalchemy`, `psycopg`,
+`polars`, `httpx`, `minio`, `cnes_domain`, `cnes_infra`.
+
+**Env vars:**
+
+| Var | Obrigatória | Descrição |
+|---|---|---|
+| `DB_URL` | sim | Postgres Gold (mesmo cluster do `central_api`) |
+| `CENTRAL_API_URL` | sim | Para polling da fila |
+| `MINIO_ENDPOINT` | sim | Host:port MinIO |
+| `MINIO_ACCESS_KEY` | sim | Credencial MinIO |
+| `MINIO_SECRET_KEY` | sim | Credencial MinIO |
+| `MINIO_BUCKET` | opcional | Default `cnesdata-landing` |
+| `TENANT_ID` | sim | Tenant do worker (1 worker = 1 tenant por enquanto) |
+| `WORKER_POLL_INTERVAL` | opcional | Default `5s` |
+
+## Module Map
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `src/data_processor/main.py` | Entrypoint async + `_setup_logging` + `_create_storage` + run_processor |
+| `src/data_processor/consumer.py` | Loop de pull de jobs do `central_api` |
+| `src/data_processor/processor.py` | Pipeline download → transform → upsert (`_persist_profissionais`, etc) |
+| `src/data_processor/config.py` | Config do worker (bucket, intervalos) |
+| `src/data_processor/adapters/cnes_local_adapter.py` | Parquet CNES raw → DataFrame canônico |
+| `src/data_processor/adapters/cnes_nacional_adapter.py` | Parquet BigQuery nacional → canônico |
+| `src/data_processor/adapters/sihd_local_adapter.py` | Parquet SIHD/AIH → canônico |
+
+## Gotchas
+
+- **`fontes` JSONB merge:** upsert usa `||` (idempotente para object).
+  Contrato fixo: `dict[str, bool]` ex.: `{"LOCAL": true, "WEB": true}`.
+  Se virar array, regressão `test_fontes_idempotency_integration` falha.
+- **`vinculo_repo` usa upsert, não plain INSERT** — fix aplicado em Fase 2.
+  Múltiplas fontes (LOCAL, NACIONAL) podem upsertar a mesma
+  `(tenant, cnes, cpf, competencia)` sem violar FK/PK.
+- **CircuitBreaker é sync + async, APIs separadas:** use `.call()` para
+  função síncrona, `.call_async()` para coroutine. Misturar dispara
+  `TypeError` explícito (evita falha silenciosa que motivou o fix original).
+- **Column names do BigQuery nacional** (confirmados empiricamente):
+  `cbo_2002` (não `id_cbo`), `indicador_atende_sus` inteiro 1/0 (não
+  `indicador_sus` string "S"/"N"). Ver `docs/data-dictionary-firebird-bigquery.md`.
+- **`set_tenant_id` obrigatório antes de qualquer query Postgres:** worker
+  chama `set_tenant_id(config.TENANT_ID)` no start de cada job. Sem isso,
+  RLS bloqueia e job falha com 0 rows.
+- **Streaming download gzip:** parquet baixado chunk a chunk via httpx
+  stream para evitar OOM em arquivos grandes. Marcado `# pragma: no cover`
+  nos fallbacks de tempfile.

--- a/apps/dump_agent/CLAUDE.md
+++ b/apps/dump_agent/CLAUDE.md
@@ -1,0 +1,106 @@
+# dump_agent — Edge Agent
+
+## Executive Summary
+
+Daemon assíncrono que roda **próximo à fonte de dados** (máquina do município
+com Firebird CNES, ou servidor hospitalar com SIHD) e faz ELT mínimo: extrai
+via cursor paginado, serializa para Parquet com streaming gzip, e faz upload
+incremental para MinIO via URL pré-assinada emitida pelo `central_api`.
+Stateless — não mantém estado além do Parquet local temporário.
+
+## Role
+
+**Edge Agent** no pattern edge/central. Implementação Python; cada município
+com Firebird precisa de 1 instância rodando (Windows Service ou systemd).
+Registra-se via `machine_id` estável e faz polling de jobs pendentes para
+seu tenant.
+
+## Functionalities
+
+- Polling de fila de jobs via `GET /api/v1/jobs/next` (long-poll + heartbeat)
+- Extração Firebird CNES (`CnesExtractor`) — 3 queries + merge em Python
+  devido bug -501 do LEFT JOIN via `fdb`
+- Extração SIHD hospitalar (`SihdExtractor`) — AIH + procedimentos
+- Streaming gzip → Parquet (sem carregar tudo em memória via `SpoolGuard`)
+- Upload multipart para MinIO via presigned PUT URL
+- Single-instance lock (mutex Windows `Global\CnesDumpAgent-<mid>` / fcntl POSIX)
+- Graceful shutdown (SIGTERM/SIGINT POSIX, Ctrl-Break Windows)
+- Jitter de startup (max 30min configurável) para evitar thundering-herd
+- Heartbeat periódico para estender lease do job no `central_api`
+
+## Objectives
+
+- ≥ 99% dos jobs completam sem intervenção humana
+- Latência extract → upload ≤ 10min para 100k rows
+- RSS estável em soak 30min (slope < 1 MB/min — gate de soak test)
+- Zero file descriptor leak (delta < 100 em 30min — gate de soak test)
+
+## Limitations
+
+- **Não aplica regras de negócio** — só extrai raw e entrega
+- **Não transforma dados** (exceto tipagem Polars) — transform fica no `data_processor`
+- **Não lê/escreve em Postgres Gold** — comunica só com `central_api` + MinIO
+- **Não funciona sem rede** para o `central_api` — sem modo offline
+- **Exige Firebird 2.5 embedded + `fbclient.dll` 64-bit** (via `FIREBIRD_DLL`)
+- Windows-only: requer SeCreateGlobalPrivilege para named mutex Global\
+
+## Requirements
+
+**Runtime deps (apps/dump_agent/pyproject.toml):** `fdb`, `polars`, `httpx`,
+`cnes_domain`, `cnes_infra` (client-side: `object_storage` + `ingestion/db_client`).
+
+**Env vars:**
+
+| Var | Obrigatória | Descrição |
+|---|---|---|
+| `CENTRAL_API_URL` | sim | Base URL do `central_api` (ex.: `https://api.cnesdata.gov.br`) |
+| `TENANT_ID` | sim | ID do município (IBGE 6-dígitos, ex.: `354130`) |
+| `DB_PATH` | sim (CNES) | Caminho para `CNES.GDB` |
+| `DB_PASSWORD` | sim (CNES) | Senha Firebird |
+| `FIREBIRD_DLL` | sim (CNES) | Path para `fbclient.dll` 64-bit |
+| `SIHD_DB_PATH` | sim (SIHD) | Caminho para DB SIHD |
+| `MACHINE_ID` | opcional | Override (senão gera UUID estável em `app_data_dir/machine_id`) |
+| `DUMP_MAX_JITTER_SECONDS` | opcional | Jitter de startup (default `1800`) |
+| `DUMP_LOGS_DIR` | opcional | Override do dir de logs (default `%LOCALAPPDATA%/CnesAgent/logs` ou `~/.local/state/cnes-agent/logs`) |
+
+**Infra:** acesso de rede ao `central_api` (HTTPS) e ao MinIO (via presigned URLs).
+
+## Module Map
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `src/dump_agent/main.py` | Entrypoint daemon — async loop + install_shutdown_handler |
+| `src/dump_agent/cli.py` | CLI (`--version`, `--help`) — não aceita flags de conexão |
+| `src/dump_agent/platform_runtime.py` | POSIX vs Win32: lock, signals, `logs_dir`, `fbclient_dll_path`, `resolve_machine_id` |
+| `src/dump_agent/io_guard.py` | `SpoolGuard(max_bytes)` — limite de bytes em disco para parquet temp |
+| `src/dump_agent/worker/consumer.py` | Loop de `_acquire_job` + `_execute_job` + `_heartbeat_loop` |
+| `src/dump_agent/worker/connection.py` | Factory `fdb.connect(charset="WIN1252")` |
+| `src/dump_agent/worker/streaming_executor.py` | Pipeline extract → parquet gzip → presigned upload |
+| `src/dump_agent/extractors/cnes_extractor.py` | 3 queries CNES + merge em `SEQ_EQUIPE` |
+| `src/dump_agent/extractors/sihd_extractor.py` | Extração SIHD / AIH |
+| `src/dump_agent/extractors/protocol.py` | `Extractor` Protocol (contrato do registry) |
+| `src/dump_agent/extractors/registry.py` | `intent → extractor` lookup dinâmico |
+
+## Gotchas
+
+- **Firebird LEFT JOIN -501:** `pd.read_sql` com LEFT JOIN a `LFCES060`
+  retorna NULLs silenciosamente. Workaround: 3 queries separadas + merge
+  Polars por prefixo de 4 chars em `SEQ_EQUIPE`. **NÃO simplificar para
+  1 query** — o teste de regressão só pega a falha em produção.
+- **WIN1252 encoding:** `fdb.connect(..., charset="WIN1252")` obrigatório.
+  Nomes acentuados (ex.: "Atenção Básica") precisam NFKD antes de merges
+  para não dar false-negative em cross-check com nacional.
+- **ORDER BY posicional** não suportado em tabelas `RDB$` do Firebird 2.5.
+- **Windows mutex:** `acquire_single_instance_lock()` usa named mutex
+  `Global\CnesDumpAgent-<machine_id>`. Requer `SeCreateGlobalPrivilege` —
+  em sessão limitada, cai para mutex local (apenas 1 sessão protegida).
+  POSIX usa `fcntl.flock` em lock file em `app_data_dir/.lock`.
+- **Frozen PyInstaller:** `fbclient_dll_path()` tem branch que lê de
+  `sys._MEIPASS`. Marcado `# pragma: no cover - frozen only`.
+- **PlatformRuntime dual-pragma:** blocos inteiros `if sys.platform == "win32"`
+  e `!= "win32"` têm `# pragma: no cover - windows_only` / `posix_only`.
+  Coverage é por plataforma — CI Linux cobre o bloco POSIX, rodar local
+  Windows cobre o Windows.
+- **Startup jitter:** `random.uniform(0, DUMP_MAX_JITTER_SECONDS)` antes do
+  primeiro poll. Em N edges, reduz pico de carga contra `central_api`.
+  **Não remover.**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,221 @@
+# CnesData — Arquitetura
+
+> Visão sistêmica do monorepo. Para contexto histórico/narrativa ver `docs/project-context.md`.
+> Para roadmap ver `docs/roadmap.md`.
+
+## Visão macro
+
+Plataforma distribuída edge/central para reconciliação de dados de saúde
+pública. Edge Agents (`dump_agent`) rodam próximo às fontes municipais
+(Firebird CNES, SIHD hospitalar), extraem Parquet raw e fazem upload via
+URL pré-assinada para MinIO. O `central_api` (FastAPI) orquestra jobs e
+emite presigned URLs. O `data_processor` (worker) consome jobs, baixa
+Parquet do MinIO, aplica transformações canônicas e persiste no schema
+Gold Postgres com isolamento por tenant (RLS). Regras de auditoria são
+aplicadas por serviço externo via SQL JOINs contra o Gold.
+
+## Data flow
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ EDGE (município)                                              │
+│                                                               │
+│  [Firebird CNES.GDB]        [SIHD DB]                         │
+│         │                      │                              │
+│         └──────┬───────────────┘                              │
+│                ▼                                              │
+│          dump_agent (daemon)                                  │
+│          - 3-query extraction + merge (CNES)                  │
+│          - streaming Parquet gzip                             │
+│          - single-instance lock                               │
+│                │                                              │
+│                │ HTTPS (long poll)                            │
+└────────────────┼──────────────────────────────────────────────┘
+                 │
+┌────────────────┼──────────────────────────────────────────────┐
+│ CENTRAL        ▼                                              │
+│         central_api (FastAPI)                                 │
+│          - /jobs/next (lease)                                 │
+│          - /jobs/{id}/artifact (presigned PUT)                │
+│          - /jobs/{id}/heartbeat                               │
+│          - /jobs/{id}/complete                                │
+│          - TenantMiddleware (X-Tenant-Id)                     │
+│          - lease reaper (background task)                     │
+│                │                                              │
+│       ┌────────┴────────┐                                     │
+│       ▼                 ▼                                     │
+│  [Postgres queue]   [MinIO]  ← presigned GET/PUT              │
+│       │                 ▲                                     │
+│       │                 │                                     │
+│       ▼                 │                                     │
+│   data_processor ───────┘                                     │
+│   - download Parquet                                          │
+│   - transform (CPF pipeline, dedup, CH flag)                  │
+│   - row_mapper (dim/fato)                                     │
+│   - upsert Postgres Gold (merge JSONB fontes)                 │
+│                │                                              │
+│                ▼                                              │
+│       [Postgres Gold]                                         │
+│        gold.dim_estabelecimento                               │
+│        gold.dim_profissional                                  │
+│        gold.fato_vinculo                                      │
+│        (RLS per tenant)                                       │
+│                │                                              │
+│                │ SQL JOINs                                    │
+│                ▼                                              │
+│       [Rules service — OUT OF SCOPE, repo externo]            │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## Contratos entre apps
+
+### Edge → Central (HTTPS)
+
+| Verb + Path | Payload | Response |
+|---|---|---|
+| `GET /api/v1/jobs/next?machine_id=<id>` | header `X-Tenant-Id` | `{job_id, intent, lease_until}` ou 204 |
+| `POST /api/v1/jobs/{id}/heartbeat` | `{}` | `{lease_until}` |
+| `POST /api/v1/jobs/{id}/artifact` | `{filename, size}` | `{presigned_url, object_key}` |
+| `POST /api/v1/jobs/{id}/complete` | `{object_key, rows}` | 204 |
+| `POST /api/v1/jobs/{id}/fail` | `{reason, retryable}` | 204 |
+
+### Central → MinIO
+
+- Presigned PUT URLs (validade: 1h) para upload de Parquet
+- Presigned GET URLs (validade: 1h) para download pelo `data_processor`
+- Bucket único: `cnesdata-landing` (configurável via `MINIO_BUCKET`)
+- Key convention: `<tenant_id>/<intent>/<competencia>/<job_id>.parquet.gz`
+
+### Processor → Central
+
+Mesmo pattern de polling dos edges — o processor consome da mesma fila,
+filtrando por `status=ready_to_process`.
+
+## Modelo de dados Gold
+
+```
+┌──────────────────────────────┐
+│ dim_estabelecimento          │
+├──────────────────────────────┤
+│ tenant_id     VARCHAR  PK    │
+│ cnes          VARCHAR  PK    │
+│ cnpj          VARCHAR        │
+│ nome_fantasia VARCHAR        │
+│ municipio     VARCHAR        │
+│ fontes        JSONB          │  ← {"LOCAL": true, "WEB": true}
+│ criado_em     TIMESTAMPTZ    │
+│ atualizado_em TIMESTAMPTZ    │
+└──────────────────────────────┘
+          │
+          │ 1:N
+          ▼
+┌──────────────────────────────┐         ┌──────────────────────────────┐
+│ fato_vinculo                 │         │ dim_profissional             │
+├──────────────────────────────┤         ├──────────────────────────────┤
+│ tenant_id   VARCHAR  PK      │ N:1 ────│ tenant_id VARCHAR PK         │
+│ cnes        VARCHAR  PK,FK   │         │ cpf       VARCHAR PK         │
+│ cpf         VARCHAR  PK,FK   │         │ cns       VARCHAR            │
+│ competencia VARCHAR  PK      │         │ nome      VARCHAR            │
+│ cbo         VARCHAR          │         │ fontes    JSONB              │
+│ ch_total    INTEGER          │         │ atualizado_em TIMESTAMPTZ    │
+│ alerta_ch   VARCHAR          │         └──────────────────────────────┘
+│ fontes      JSONB            │
+│ atualizado_em TIMESTAMPTZ    │
+└──────────────────────────────┘
+```
+
+Todas as tabelas têm Row-Level Security ativa. Queries sem `tenant_id` no
+contexto (via `set_tenant_id()` do `cnes_domain.tenant`) retornam vazio.
+
+## Fluxo de jobs (estados)
+
+```
+   ┌─────────┐       lease       ┌────────┐
+   │ pending ├──────────────────▶│ leased │
+   └────┬────┘                   └───┬────┘
+        │                            │
+        │ lease expired              │ heartbeat
+        │ (reaper)                   │
+        ◀────────────────────────────┤
+        │                            │
+        │                            │ complete
+        │                            ▼
+        │                      ┌──────────┐
+        │                      │ uploaded │
+        │                      └────┬─────┘
+        │                           │ processor picks
+        │                           ▼
+        │                   ┌─────────────┐
+        │                   │ processing  │
+        │                   └──────┬──────┘
+        │                          │
+        │                          │ success
+        │                          ▼
+        │                   ┌─────────────┐
+        │                   │ completed   │
+        │                   └─────────────┘
+        │
+        │ fail (retryable)
+        ▼
+   ┌─────────┐  exceeded retries  ┌─────────────┐
+   │ pending │ ──────────────────▶│ dead_letter │
+   └─────────┘                    └─────────────┘
+```
+
+Tabelas: `public.jobs` (fila), `public.job_retries`, `public.job_leases`.
+Reaper do `central_api` roda a cada `_REAPER_INTERVAL=60s` e volta leases
+expirados para `pending`.
+
+## Multi-tenancy
+
+Fluxo do `tenant_id` em cada request:
+
+```
+[Edge agent / client]
+    │  header: X-Tenant-Id: 354130
+    ▼
+[central_api.TenantMiddleware]
+    │  call: set_tenant_id("354130")   ← ContextVar
+    ▼
+[route handler]
+    │  usa cnes_domain.tenant.get_tenant_id() se precisa
+    ▼
+[repository / UoW]
+    │  SQLAlchemy executa com RLS ativo (via event listener)
+    │  Postgres injeta WHERE tenant_id = current_setting('app.tenant_id')
+    ▼
+[Postgres Gold]
+```
+
+Instalação do listener RLS: `cnes_infra.storage.rls.install_rls_listener(engine)`
+no bootstrap do engine (em `central_api.deps` e `data_processor.main`).
+
+## Observabilidade
+
+- **Logs:** structured `key=value` via `logging` stdlib (sem prose). Root
+  handler escreve em stdout (k8s) e `logs/` (local).
+- **Tracing:** OTel opcional — se `OTEL_EXPORTER_OTLP_ENDPOINT` setado,
+  `cnes_infra.telemetry.init_telemetry("<service>")` exporta spans.
+  Sem a env var, `tracer` é no-op (pragma no cover).
+- **Métricas:** via OTel quando ativo; senão, nenhuma coleta própria (k8s/prom
+  pode scrapar métricas do FastAPI via middleware se configurado).
+- **Health:** `GET /api/v1/system/health` retorna `{status: ok, db_connected: bool}`.
+
+## Deploy target
+
+Kubernetes. Layout planejado:
+
+```
+Namespace: cnesdata
+├── Deployment: central-api    (2+ réplicas, only 1 com ENABLE_REAPER=true)
+├── Deployment: data-processor (N réplicas, escala horizontal)
+├── StatefulSet: (ou Deployment) minio  (ou managed S3)
+├── StatefulSet: postgres     (managed preferencial)
+└── Jobs transitórios:
+    └── cnes-db-migrator (initContainer em pre-sync)
+
+Edge (on-prem):
+└── dump_agent como Windows Service (municípios) ou systemd (servidores Linux)
+```
+
+Ainda não está em produção. Dockerfiles existem em cada `apps/*/Dockerfile`.

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -1,6 +1,6 @@
 # CnesData — Project Context
 
-> Living document. Last updated: 2026-04-12.
+> Living document. Last updated: 2026-04-18.
 > Audience: the developer (Vinícius), colleagues who will run the pipeline,
 > and any future AI session that needs to understand this project deeply.
 
@@ -19,12 +19,15 @@ The output is a single Excel workbook with a summary dashboard and one tab per v
 
 ### Current Operational Mode vs. Target Architecture
 
-| Aspect | Current (CLI) | Target (API Engine) |
-|---|---|---|
-| Local data source | Direct Firebird connection | Parquet sent via HTTP by dump agent |
-| Trigger | Manual / Windows Task Scheduler | API call from dump agent or scheduler |
-| Multi-municipality | Config change per run | Multiple dump agents, one engine |
-| `--source` flag | `LOCAL` (default), `NACIONAL`, `AMBOS` | Same — source is declared, never inferred |
+**Current architecture (2026-04):** monorepo distribuído com 2 packages
+(`cnes_domain`, `cnes_infra`) e 4 apps (`dump_agent` edge, `central_api`
+FastAPI, `data_processor` worker, `cnes_db_migrator` init-container). Ver
+`docs/architecture.md` para diagrama completo e contratos.
+
+Migração concluída: a CLI monolítica `src/main.py` + `pipeline/orchestrator.py`
++ `rules_engine.py` + exporters Excel/CSV foram removidos. Extração, orquestração
+e persistência agora vivem em apps separados; regras de auditoria ficaram em
+serviço externo (fora deste repo) que consome o schema Gold via SQL JOINs.
 
 ---
 
@@ -103,32 +106,20 @@ Or, with the scheduled task, it runs unattended on the 15th of every month.
 
 ### Module Inventory
 
-| Module | Purpose | Tests |
-|---|---|---|
-| `cli.py` | argparse CLI (`--source`, `-c`, `-o`, `-v`) | ~15 |
-| `config.py` | .env reader, centralized configuration | 10 |
-| `main.py` | Pipeline entry point | 16+ |
-| `pipeline/orchestrator.py` | PipelineOrchestrator, StageSkipError, StageFatalError | — |
-| `pipeline/state.py` | PipelineState (target_source, DataFrames) | 8 |
-| `pipeline/stages/ingestao_local.py` | Parquet/Firebird → state | — |
-| `pipeline/stages/ingestao_nacional.py` | BigQuery → state (circuit breaker) | — |
-| `pipeline/stages/processamento.py` | Cleaning, dedup | — |
-| `pipeline/stages/exportacao.py` | PostgreSQL persistence, status derivation | 15 |
-| `ingestion/base.py` | PEP 544 Protocol definitions | 5 |
-| `ingestion/schemas.py` | Canonical column names (source of truth) | — |
-| `ingestion/cnes_client.py` | Firebird extraction (WIN1252, 3-query) | 15 |
-| `ingestion/cnes_local_adapter.py` | Firebird → canonical schema (NFKD) | 29 |
-| `ingestion/cnes_nacional_adapter.py` | BigQuery → canonical schema | 14 |
-| `ingestion/web_client.py` | BigQuery client via basedosdados | 17 |
-| `ingestion/hr_client.py` | HR spreadsheet parser (.xlsx/.csv) | 21 |
-| `processing/transformer.py` | Cleaning, RQ-002, RQ-003 | ~20 |
-| `storage/postgres_adapter.py` | PostgreSQL upsert by competência | — |
-
-**Total: 319+ unit tests passing.** Integration tests require live Firebird.
+Ver `apps/<app>/CLAUDE.md` e `packages/<pkg>/CLAUDE.md` para inventário
+de módulos atualizado. Arquivos do layout antigo (`src/cli.py`,
+`src/main.py`, `src/pipeline/orchestrator.py`, `src/ingestion/cnes_client.py`,
+etc.) foram removidos em 2026-04 com a migração para monorepo.
 
 ---
 
 ## 4. The 11 Audit Rules
+
+> **Histórico (2026-04):** a camada de regras de auditoria foi removida
+> deste repo. Regras RQ-* listadas abaixo são aplicadas por serviço externo
+> que consome o schema Gold (`gold.dim_estabelecimento`, `gold.dim_profissional`,
+> `gold.fato_vinculo`) via SQL JOINs. Documentação mantida aqui como
+> referência histórica.
 
 ### Local Rules (Firebird only)
 
@@ -192,16 +183,9 @@ Or, with the scheduled task, it runs unattended on the 15th of every month.
 
 ## 6. Where It's Headed (Near-Term Roadmap)
 
-These are concrete next steps, ordered by value:
-
-| Priority | Task | Status | Why |
-|---|---|---|---|
-| 1 | Data validation + 5 defect fixes | ✅ Done | CPF/CNES zero-padding, RQ-007/009 cascade false positives, COVEPE type 50 |
-| 2 | CBO enrichment (human-readable job titles) | ✅ Done | DESCRICAO_CBO column in all reports via NFCES026 |
-| 3 | "Double-Check" Nacional (cascade_resolver) | Removed | Audit layer removed 2026-04 — rules applied by separate service via PostgreSQL JOINs |
-| 4 | Gold layer Medallion (Postgres JSONB) | ✅ Done | Analytic persistence via Postgres: evolucao_metricas_mensais + auditoria_resultados |
-| 5 | HR Pre-processor (PIS→CPF crosswalk) | ✅ Done | scripts/hr_pre_processor.py via LFCES018 — 61% coverage (240/395) |
-| 6 | Evolution dashboard in Excel | Not started | Trend tab comparing snapshots month-over-month (needs 2+ runs) |
+Ver `docs/roadmap.md` — fonte única de prioridades. Resumo: CNES+SIHD
+ativos, multi-tenant pronto, perf tests prontos. Próximo: BPA, Esus PEC,
+HR PIS→CPF, rules service.
 
 ---
 
@@ -309,15 +293,24 @@ COMPETENCIA_MES=12
 
 If starting a new Claude Code or Claude session for this project:
 
-1. **Entry point:** `src/main.py` — everything flows from here.
-2. **Source of truth for columns:** `src/ingestion/schemas.py` — never reference raw Firebird or BigQuery column names in analysis code.
-3. **Source of truth for rules:** `docs/data-dictionary-firebird-bigquery.md` — every CBO, TIPO_UNIDADE, and rule definition is documented here.
-4. **Do not recreate:** `cnes_exporter.py` is deleted. The architecture is layered (ingestion → processing → analysis → export). No monolithic pipeline.
-5. **Test command:** `pytest tests/ -m "not integration" -v` — all 271+ tests should pass without Firebird or BigQuery.
-6. **CLI:** `python src/main.py --help` shows all options.
-7. **The Firebird LEFT JOIN bug is real** — do not try to simplify `cnes_client.py` back to a single query. It will silently return NULLs for all team data. The 3-query + Python merge approach is intentional and documented.
-8. **BigQuery column names are confirmed empirically** — the docs/data-dictionary-firebird-bigquery.md notes which columns were wrong in earlier iterations (e.g., `id_cbo` doesn't exist, `indicador_sus` doesn't exist). Trust the confirmed schema, not guesses.
-9. **CLI:** `python src/main.py --help` — pipeline accepts `-c YYYY-MM`, `--source {LOCAL,NACIONAL,AMBOS}` (default `LOCAL`), `-o OUTPUT_DIR`, `-v`/`--verbose`. `--skip-nacional` was removed in 2026-04 — use `--source LOCAL`.
-10. **CBO lookup:** `extrair_lookup_cbo(con)` returns `dict[str, str]` CBO→description from NFCES026. Passed as optional parameter to `transformar()` and `detectar_divergencia_cbo()`.
-11. **Zero-padding is intentional:** CPF gets `zfill(11)` and CNES gets `zfill(7)`. Firebird omits leading zeros. Do not remove these zfills.
-12. **RQ-009 cascade filter:** professionals from establishments already flagged by RQ-007 are excluded. Without this, 87% of RQ-009 results are false positives. See `cnes_excluir` parameter in `detectar_profissionais_ausentes_local()`.
+1. **Entry point por app:** `apps/<app>/src/<app>/main.py` (central_api:
+   `app.py`). Começar lendo `apps/<app>/CLAUDE.md` para executive summary
+   + funcionalidades + env vars.
+2. **Arquitetura macro:** `docs/architecture.md` — data flow edge→central,
+   contratos HTTP, modelo Gold, fluxo de jobs.
+3. **Source of truth para colunas:** `packages/cnes_domain/contracts/` —
+   nunca referencie raw Firebird ou BigQuery column names em código de domínio.
+4. **Source of truth para regras:** `docs/data-dictionary-firebird-bigquery.md`
+   (histórico — regras aplicadas por serviço externo agora).
+5. **Test command (rápido):**
+   `pytest -m "not integration and not postgres and not bigquery and not e2e and not stress and not soak and not spike" -q`
+   — todos devem passar sem docker.
+6. **Firebird LEFT JOIN bug é real** — não simplificar `CnesExtractor`
+   para 1 query. Ver `apps/dump_agent/CLAUDE.md` gotchas.
+7. **Multi-tenant obrigatório:** toda query Postgres passa por
+   `set_tenant_id()` via middleware (`central_api`) ou direto no worker
+   (`data_processor`).
+8. **Gold schema é canônico:** `dim_estabelecimento`, `dim_profissional`,
+   `fato_vinculo` com `fontes` JSONB-object. Multi-fonte via merge `||`.
+9. **Deploy target k8s** — não em produção ainda. Ver `docs/architecture.md`
+   seção "Deploy target".

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,44 @@
+# CnesData — Roadmap
+
+> Fonte única da verdade sobre prioridades. Atualizar ao fechar/abrir escopo.
+> Histórico detalhado em `docs/project-context.md`.
+
+## Now (em produção / ativo)
+
+| Item | Estado | Evidência |
+|---|---|---|
+| CNES local via Firebird | Ativo | `dump_agent` extractors + data_processor adapter |
+| CNES nacional via BigQuery | Ativo | `cnes_infra.ingestion.web_client` + data_processor adapter |
+| CNES via DATASUS API | Ativo | `cnes_infra.ingestion.cnes_oficial_web_adapter` |
+| SIHD hospitalar | Ativo | `dump_agent.extractors.sihd_extractor` + data_processor adapter |
+| Multi-tenant (RLS + Middleware) | Pronto, piloto PE/SP | `cnes_infra.storage.rls` + `central_api.middleware` |
+| Perf test pipeline (5 tiers) | Pronto | `tests/perf/{micro,macro,stress,soak,spike}/` + nightly workflow |
+| CI com gates duplos (100%/90%) | Pronto | `.github/workflows/ci.yml` |
+
+## Next (planejado, sem código ainda)
+
+| Item | Prioridade | Bloqueio / Pré-req |
+|---|---|---|
+| BPA (Boletim Produção Ambulatorial) | Alta | Formatos de arquivo + schema canônico |
+| Esus PEC (Prontuário Eletrônico Cidadão) | Alta | Acesso ao DB municipal varia; negociação política |
+| HR PIS→CPF cross-walking | Média | `scripts/hr_pre_processor.py` existia em iteração anterior (61% cobertura) — reativar/reescrever no monorepo |
+| Rules service (serviço externo) | Média | Repo separado; consome Gold via SQL JOINs |
+| Automated DATASUS submission check | Baixa | Alert quando competência local > BigQuery nacional por > 2 meses |
+
+## Later (conceitual — sem comprometimento de escopo)
+
+| Item | Motivação |
+|---|---|
+| Web dashboard (Streamlit/Metabase/custom) | Substituir relatórios Excel (removidos do escopo) para audiência > 3 pessoas |
+| Team-level audit | Audit de equipes ESF/EAP/ESB. Bloqueado por INE format gap (FB 10 chars vs BQ 18) |
+| Apps de fontes adicionais | SIGTAP, SIA-SUS, outros módulos DATASUS |
+| Integração Pro-Saúde / CNES-WEB | Validação em tempo real de envios ao DATASUS |
+
+## Removido definitivamente (2026-04)
+
+| Item | Razão |
+|---|---|
+| Camada de regras de auditoria (RQ-002 a RQ-011) | Movida para serviço externo que consome Gold via SQL JOINs |
+| Excel/CSV exporters (`csv_exporter`, `report_generator`) | Obsoleto com rules service externo; dashboards futuros substituem |
+| CLI monolítico `src/main.py` | Substituído por apps distribuídos (edge + central + processor) |
+| `pipeline/orchestrator.py` | Substituído por job queue em `central_api` + workers stateless |

--- a/packages/cnes_domain/CLAUDE.md
+++ b/packages/cnes_domain/CLAUDE.md
@@ -1,0 +1,69 @@
+# cnes_domain — Domain core (pure, zero-infra)
+
+## Executive Summary
+
+Biblioteca de tipos, protocolos e primitivas do domínio. **Zero dependências
+de infra** (nada de SQLAlchemy, MinIO, httpx, fdb). Define o contrato entre
+os 4 apps via PEP 544 Protocols e modelos Pydantic. É consumida por
+`cnes_infra` (implementações concretas) e direta ou indiretamente por todos
+os apps deployáveis.
+
+## Scope
+
+- **Ports (Protocols):** `ObjectStoragePort`, `UnitOfWork`,
+  `EstabelecimentoRepository`, `ProfissionalRepository`, `VinculoRepository`
+- **Models:** `ExtractionIntent`, `ExtractionParams`, request/response de API
+- **Contracts:** sets de colunas canônicas (CNES + SIHD)
+- **Pipeline primitives:** `CircuitBreaker` (sync + async, thread-safe)
+- **Processing:** `transformer.transformar()` (pipeline CPF),
+  `row_mapper` (raw→dims/fato)
+- **Tenant context:** `set_tenant_id()` / `get_tenant_id()` via ContextVar
+- **Competência:** parsing YYYY-MM + validação
+- **Observability:** `tracer` OTel (no-op se SDK não instalado)
+
+## Conventions
+
+- **Nada aqui pode importar de `cnes_infra`, `sqlalchemy`, `httpx`, `minio`, `fdb`**
+- Ports são Protocols (PEP 544), não ABCs — `@runtime_checkable` em
+  `object_storage.py` e `repository.py` para suporte a `isinstance`
+- Funções de processing recebem/retornam `polars.DataFrame`
+- 100% branch coverage é gate de CI para este pacote
+- `_LAZY_ATTRS` em `cnes_infra.config` não tem equivalente aqui — domínio
+  não lê env vars diretamente (receber via parâmetro)
+
+## Module Map
+
+| Path | Responsabilidade |
+|---|---|
+| `contracts/columns.py` | Colunas canônicas CNES (set + listas) |
+| `contracts/sihd_columns.py` | Colunas canônicas SIHD / AIH |
+| `contracts/schemas.py` | PEP 544 Protocols para DataFrames canônicos |
+| `models/api.py` | Pydantic: `JobCreate`, `JobStatus`, `LeaseResponse` etc. |
+| `models/extraction.py` | `ExtractionIntent` enum + `ExtractionParams` (regex CNES/IBGE) |
+| `pipeline/circuit_breaker.py` | Thread-safe CB com `call()` + `call_async()` |
+| `ports/object_storage.py` | `ObjectStoragePort` Protocol + `NullObjectStoragePort` |
+| `ports/repository.py` | 3 Repository Protocols runtime_checkable |
+| `ports/storage.py` | `UnitOfWork` + `NullUnitOfWork` + `NullStorage` |
+| `processing/transformer.py` | Pipeline CPF (strip_chars → replace_all \D → pad_start → RQ-002), flag CH zero |
+| `processing/row_mapper.py` | DataFrame → row dicts (`mapear_estabelecimentos`, `mapear_profissionais`, `mapear_vinculos`, `extrair_fonte`) |
+| `competencia.py` | YYYY-MM parsing + range |
+| `tenant.py` | ContextVar + `set_tenant_id` / `get_tenant_id` |
+| `observability.py` | `tracer` no-op ou wrapper OTel |
+| `config.py` | `validar_formato` (regex) + `_exigir` / `_exigir_inteiro` (usados por `cnes_infra`) |
+
+## Gotchas
+
+- **CircuitBreaker lock não cruza await:** usa `threading.Lock`. Seção
+  crítica pequena e não contém `await` — seguro em async.
+- **Backoff expoente capado em `_MAX_BACKOFF_EXPONENTE=30`:** evita
+  `OverflowError` quando `_falhas_consecutivas > 1023` (Python `2**N` para
+  float). Sem isso, o breaker quebra em cenários de contenção prolongada.
+- **Transformer CPF ordem:** `strip_chars → replace_all(r"\D", "") →
+  pad_start(11, "0") → _aplicar_rq002`. Pontuação é removida ANTES de pad.
+  Entrada `".-./"` vira `""` (filtrada por RQ-002 via sentinela).
+- **Tenant ContextVar:** herdada por tasks async via
+  `contextvars.copy_context()`. Se criar threads manuais, repassar o contexto
+  explicitamente.
+- **Protocol + `@runtime_checkable`:** só adicionar a decorator quando
+  precisa de `isinstance()` check. Custo em performance é desprezível mas
+  expõe atributos não-públicos em `dir()`.

--- a/packages/cnes_infra/CLAUDE.md
+++ b/packages/cnes_infra/CLAUDE.md
@@ -1,0 +1,80 @@
+# cnes_infra — Infra adapters (Postgres + MinIO + external APIs)
+
+## Executive Summary
+
+Implementações concretas dos Ports declarados em `cnes_domain`. Conecta a
+infra real (Postgres, MinIO, Firebird, HR spreadsheets, BigQuery, DATASUS
+API) e expõe repositories, storage clients e migrações Alembic. Depende de
+`cnes_domain`; apps deployáveis usam este pacote via DI pelos Ports — nunca
+importam classes concretas diretamente (exceto factories no bootstrap).
+
+## Scope
+
+- **Storage:** SQLAlchemy Core + repositórios (upsert idempotente),
+  job queue com leases, landing schema (raw), RLS policies, schema Gold
+- **Ingestion clients:** Firebird (`db_client`), HR (.xlsx/.csv com
+  encoding fallback), DATASUS API (`cnes_oficial_web_adapter`), BigQuery
+  (`web_client`)
+- **Alembic migrations:** schemas `gold`, `landing`, `public.jobs`.
+  Versions numeradas `001_*` a `006_*`
+- **Telemetry:** init OTel (opcional — pragmas no cover se SDK não instalado)
+- **Config:** `_exigir`, `_exigir_inteiro`, `_sanitizar_db_url`,
+  lazy lookups com `@lru_cache` (ex.: `DB_PASSWORD`, `FIREBIRD_DLL`)
+
+## Conventions
+
+- Todo repositório aceita `Connection` no construtor (UoW injection)
+- Upserts usam `ON CONFLICT DO UPDATE` + merge JSONB em `fontes`
+- Migrations são numeradas e **imutáveis após merge** — novo schema muda
+  requer nova migration
+- OTel é **opcional** — imports em try/except com `# pragma: no cover -
+  otel optional` quando aplicável
+- RLS policy install é idempotente (safe para rodar em cada boot)
+
+## Module Map
+
+| Path | Responsabilidade |
+|---|---|
+| `storage/schema.py` | `dim_estabelecimento` / `dim_profissional` / `fato_vinculo` (SQLAlchemy Core) |
+| `storage/landing.py` | `landing.raw_extractions` (histórico de Parquets recebidos) |
+| `storage/job_queue.py` | Fila + leases + DLQ + retry. Função `reap_expired_leases` |
+| `storage/rls.py` | Policies RLS + `install_rls_listener(engine)` (event hook SQLAlchemy) |
+| `storage/object_storage.py` | `MinioObjectStorage` implementa `ObjectStoragePort` |
+| `storage/repositories/unit_of_work.py` | `PostgresUnitOfWork` wrap SQLAlchemy Session |
+| `storage/repositories/estabelecimento_repo.py` | Upsert `dim_estabelecimento` com merge `fontes` |
+| `storage/repositories/profissional_repo.py` | Upsert `dim_profissional` com merge `fontes` |
+| `storage/repositories/vinculo_repo.py` | Upsert `fato_vinculo` — **usa INSERT ON CONFLICT, não plain INSERT** |
+| `ingestion/db_client.py` | `fdb.connect(charset="WIN1252")` wrapper |
+| `ingestion/hr_client.py` | Parser .xlsx/.csv com cp1252 fallback |
+| `ingestion/web_client.py` | BigQuery via `basedosdados` (OAuth browser flow) |
+| `ingestion/cnes_oficial_web_adapter.py` | DATASUS API protegido por `CircuitBreaker` |
+| `alembic.ini` | Config Alembic raiz do pacote |
+| `alembic/env.py` | `_resolver_db_url` — config override → `DB_URL` fallback |
+| `alembic/versions/*.py` | Migrations numeradas (omitidas em coverage) |
+| `telemetry.py` | `init_telemetry(service)` + `instrument_engine(engine)` |
+| `config.py` | `DB_URL`, `MINIO_*`, `API_*`, `COMPETENCIA_*`, `_LAZY_ATTRS` |
+
+## Gotchas
+
+- **`fontes` é JSONB-object, NÃO array:** `{"LOCAL": true, "WEB": true}`.
+  Upsert via `||` (merge raso) é idempotente. **Não migrar para array** sem
+  revisar semântica — regressão `test_fontes_idempotency` trava isso.
+- **Alembic script_location:** `src/cnes_infra/alembic` (relativo ao
+  `alembic.ini` em `packages/cnes_infra/`). CLI precisa rodar a partir de
+  `packages/cnes_infra/`.
+- **`_LAZY_ATTRS` com `@lru_cache`:** `_firebird_db_path`,
+  `_firebird_db_password`, `_firebird_dll`, `_gcp_project_id`. Testes que
+  mudam env precisam chamar `.cache_clear()` antes do access.
+- **`load_dotenv(override=False)`** no topo de `config.py` repopula env a
+  partir de `.env` em IMPORT time. Se `monkeypatch.delenv` rodar antes do
+  import, a env é restaurada silenciosamente. **Ordem correta:** importar
+  `cnes_infra.config` primeiro, depois `monkeypatch.delenv(...)`.
+- **`_resolver_db_url`** em `alembic/env.py` prefere `sqlalchemy.url` do
+  Config (setado por fixtures via `cfg.set_main_option`) e só cai em
+  `DB_URL` env var. Isso destrava testes sem precisar setar env global.
+- **Migration 006 (GIN index em `fontes`)** é necessária para queries de
+  volume por fonte. Não remover.
+- **`vinculo_repo.gravar` usa `INSERT ON CONFLICT DO UPDATE`:** múltiplas
+  fontes (LOCAL + NACIONAL) podem upsertar a mesma `(tenant, cnes, cpf,
+  competencia)` sem violar constraint. Troca para plain INSERT quebra o
+  fluxo multi-fonte.


### PR DESCRIPTION
## Summary

Atualiza toda a documentação CLAUDE.md/project-context para refletir o estado real do projeto — monorepo distribuído com 2 packages + 4 apps deployáveis, camada de regras de auditoria removida, multi-tenant pronto via RLS+TenantMiddleware, deploy target Kubernetes.

## O que entra (5 commits)

| # | SHA | Escopo |
|---|---|---|
| 1 | \`6a38dbd\` | \`docs/architecture.md\` (novo, 221L) + \`docs/roadmap.md\` (novo, 44L) |
| 2 | \`5f15cac\` | \`packages/cnes_domain/CLAUDE.md\` (69L) + \`packages/cnes_infra/CLAUDE.md\` (80L) |
| 3 | \`0b8f3a0\` | \`apps/dump_agent/CLAUDE.md\` (106L) + \`apps/central_api/CLAUDE.md\` (90L) + \`apps/data_processor/CLAUDE.md\` (94L) + \`apps/cnes_db_migrator/CLAUDE.md\` (64L) |
| 4 | \`6048cc3\` | \`CLAUDE.md\` root reescrito (184L) |
| 5 | \`0cd664a\` | \`docs/project-context.md\` atualizado (316L, redução de 7) |

## Estrutura da doc (nova convenção)

- **Root \`CLAUDE.md\`** (~180L): visão global, regras cross-cutting, mapa do monorepo, ponteiros
- **\`apps/<app>/CLAUDE.md\`** (~60-110L cada): template 8 seções — Executive Summary, Role, Functionalities, Objectives, Limitations, Requirements, Module Map, Gotchas
- **\`packages/<pkg>/CLAUDE.md\`** (~70-80L cada): template 5 seções — Exec Summary, Scope, Conventions, Module Map, Gotchas
- **\`docs/architecture.md\`**: data flow + contratos + Gold ER + fluxo de jobs + multi-tenancy
- **\`docs/roadmap.md\`**: fonte única de prioridades (Now/Next/Later/Removido)

Claude Code carrega automaticamente o CLAUDE.md do diretório em que está editando — hierarquia reduz overhead cognitivo.

## Conteúdo-chave atualizado

- **Paths corrigidos:** \`.venv/\` (com ponto), \`packages/\`+\`apps/\`, sem \`src/\`
- **Termo Edge Agent** introduzido como papel arquitetural do \`dump_agent\`
- **Multi-tenant** documentado (TenantMiddleware, set_tenant_id, RLS) como pronto, piloto PE/SP
- **Deploy k8s** documentado (ainda não em prod)
- **Regras de auditoria** marcadas out-of-scope (serviço externo consome Gold via SQL)
- **Fontes ativas:** CNES (Firebird+BigQuery+DATASUS API) + SIHD; roadmap: BPA, Esus PEC
- **Bloco RTK removido** (existe em \`~/.claude/CLAUDE.md\` global — duplicar violava limite de 200 linhas)
- **Referências mortas removidas:** \`src/main.py\`, \`rules_engine.py\`, \`csv_exporter\`, \`report_generator\`, \`pipeline/orchestrator\` (confirmado por grep em todos CLAUDE.md)

## Zero código tocado

Nenhum \`.py\` alterado. \`ruff check .\` limpo. Nenhum teste roda — é doc-only.

## Regras permanentes adicionadas

- Todo bug fix ship com regression test que falha pré-fix
- Tenant isolation sempre via \`set_tenant_id()\` antes de query Postgres
- **Novo app em \`apps/\` → \`apps/<app>/CLAUDE.md\` no mesmo PR**
- **Novo package em \`packages/\` → \`packages/<pkg>/CLAUDE.md\` no mesmo PR**

## Test plan

- [ ] \`ruff check .\` passa (sem Python mudou, não deveria regredir)
- [ ] Abrir \`apps/dump_agent/\` e ler CLAUDE.md → responder "o que faz este daemon?" em < 30s
- [ ] \`grep -E "src/main\.py|rules_engine\.py|csv_exporter|report_generator|pipeline/orchestrator" CLAUDE.md apps/*/CLAUDE.md packages/*/CLAUDE.md\` retorna vazio
- [ ] Todas CLAUDE.md ≤ 200 linhas