### PR TITLE
feat(contracts): Spec 1 — openapi.json canônico + CI drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,17 @@ jobs:
           pip install -e apps/batch_watcher
           pip install pytest pytest-cov pytest-asyncio pytest-benchmark hypothesis ruff duckdb psutil
 
+      - name: Verify openapi.json up-to-date
+        run: |
+          python scripts/gen_openapi.py --output /tmp/openapi_fresh.json
+          if ! diff -q docs/contracts/openapi.json /tmp/openapi_fresh.json > /dev/null; then
+            echo "::error::openapi.json drift detected"
+            echo "Run: python scripts/gen_openapi.py"
+            diff docs/contracts/openapi.json /tmp/openapi_fresh.json | head -50
+            exit 1
+          fi
+          echo "openapi.json is up-to-date"
+
       - name: Lint
         run: ruff check .
 

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -1,0 +1,614 @@
+{
+  "components": {
+    "schemas": {
+      "AcquireJobRequest": {
+        "properties": {
+          "machine_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Machine Id",
+            "type": "string"
+          },
+          "source_system": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source System"
+          }
+        },
+        "required": [
+          "machine_id"
+        ],
+        "title": "AcquireJobRequest",
+        "type": "object"
+      },
+      "CompleteUploadRequest": {
+        "properties": {
+          "machine_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Machine Id",
+            "type": "string"
+          },
+          "object_key": {
+            "minLength": 1,
+            "title": "Object Key",
+            "type": "string"
+          },
+          "size_bytes": {
+            "minimum": 0.0,
+            "title": "Size Bytes",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "machine_id",
+          "object_key",
+          "size_bytes"
+        ],
+        "title": "CompleteUploadRequest",
+        "type": "object"
+      },
+      "ExtractionIntent": {
+        "enum": [
+          "profissionais",
+          "estabelecimentos",
+          "equipes",
+          "sihd_producao"
+        ],
+        "title": "ExtractionIntent",
+        "type": "string"
+      },
+      "ExtractionParams": {
+        "additionalProperties": false,
+        "description": "Payload validado para jobs de extração.",
+        "properties": {
+          "cod_municipio": {
+            "pattern": "^\\d{6}$",
+            "title": "Cod Municipio",
+            "type": "string"
+          },
+          "competencia": {
+            "pattern": "^\\d{4}-(0[1-9]|1[0-2])$",
+            "title": "Competencia",
+            "type": "string"
+          },
+          "intent": {
+            "$ref": "#/components/schemas/ExtractionIntent"
+          }
+        },
+        "required": [
+          "intent",
+          "competencia",
+          "cod_municipio"
+        ],
+        "title": "ExtractionParams",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "HealthResponse": {
+        "properties": {
+          "db_connected": {
+            "title": "Db Connected",
+            "type": "boolean"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "db_connected",
+          "timestamp"
+        ],
+        "title": "HealthResponse",
+        "type": "object"
+      },
+      "HeartbeatRequest": {
+        "properties": {
+          "machine_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Machine Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "machine_id"
+        ],
+        "title": "HeartbeatRequest",
+        "type": "object"
+      },
+      "HeartbeatResponse": {
+        "properties": {
+          "lease_expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lease Expires At"
+          },
+          "renewed": {
+            "title": "Renewed",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "renewed"
+        ],
+        "title": "HeartbeatResponse",
+        "type": "object"
+      },
+      "JobStatusResponse": {
+        "properties": {
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "error_detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Detail"
+          },
+          "job_id": {
+            "title": "Job Id",
+            "type": "string"
+          },
+          "source_system": {
+            "title": "Source System",
+            "type": "string"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_id",
+          "status",
+          "source_system",
+          "tenant_id"
+        ],
+        "title": "JobStatusResponse",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "CnesData Processing Engine",
+    "version": "1.0.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/v1/admin/reap-leases": {
+      "post": {
+        "operationId": "reap_leases_api_v1_admin_reap_leases_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Reap Leases Api V1 Admin Reap Leases Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Reap Leases",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/api/v1/jobs/acquire": {
+      "post": {
+        "operationId": "acquire_job_api_v1_jobs_acquire_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcquireJobRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Acquire Job",
+        "tags": [
+          "jobs"
+        ]
+      }
+    },
+    "/api/v1/jobs/create": {
+      "post": {
+        "operationId": "create_extraction_job_api_v1_jobs_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExtractionParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Create Extraction Job Api V1 Jobs Create Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Extraction Job",
+        "tags": [
+          "jobs"
+        ]
+      }
+    },
+    "/api/v1/jobs/{job_id}": {
+      "get": {
+        "operationId": "get_job_status_api_v1_jobs__job_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Job Status",
+        "tags": [
+          "jobs"
+        ]
+      }
+    },
+    "/api/v1/jobs/{job_id}/complete-upload": {
+      "post": {
+        "operationId": "complete_upload_route_api_v1_jobs__job_id__complete_upload_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Complete Upload Route",
+        "tags": [
+          "jobs"
+        ]
+      }
+    },
+    "/api/v1/jobs/{job_id}/heartbeat": {
+      "post": {
+        "operationId": "heartbeat_api_v1_jobs__job_id__heartbeat_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HeartbeatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HeartbeatResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Heartbeat",
+        "tags": [
+          "jobs"
+        ]
+      }
+    },
+    "/api/v1/jobs/{job_id}/streaming": {
+      "post": {
+        "operationId": "start_streaming_api_v1_jobs__job_id__streaming_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HeartbeatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Start Streaming",
+        "tags": [
+          "jobs"
+        ]
+      }
+    },
+    "/api/v1/system/health": {
+      "get": {
+        "operationId": "health_check_api_v1_system_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health Check",
+        "tags": [
+          "sistema"
+        ]
+      }
+    }
+  }
+}

--- a/scripts/gen_openapi.py
+++ b/scripts/gen_openapi.py
@@ -1,0 +1,56 @@
+"""Gera docs/contracts/openapi.json a partir do central_api FastAPI app."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _bootstrap_env() -> None:
+    os.environ.setdefault("DB_URL", "postgresql+psycopg://user:pw@localhost/placeholder")
+    os.environ.setdefault("MINIO_ENDPOINT", "localhost:9000")
+    os.environ.setdefault("MINIO_ACCESS_KEY", "placeholder")
+    os.environ.setdefault("MINIO_SECRET_KEY", "placeholder")
+    os.environ.setdefault("MINIO_BUCKET", "placeholder")
+
+
+def generate(output_path: Path) -> int:
+    """Gera OpenAPI schema e escreve em output_path.
+
+    Args:
+        output_path: caminho do arquivo JSON de saída.
+
+    Returns:
+        Código de saída (0 em sucesso).
+    """
+    _bootstrap_env()
+    from central_api.app import create_app
+
+    app = create_app()
+    schema = app.openapi()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(schema, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    logger.info(
+        "openapi_written path=%s paths=%d", output_path, len(schema.get("paths", {})),
+    )
+    return 0
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, default=Path("docs/contracts/openapi.json"))
+    args = parser.parse_args()
+    return generate(args.output)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen_openapi_test.py
+++ b/scripts/gen_openapi_test.py
@@ -1,0 +1,36 @@
+"""Teste do gen_openapi."""
+import json
+from pathlib import Path
+
+from scripts.gen_openapi import generate
+
+
+def test_generate_escreve_json_valido(tmp_path: Path) -> None:
+    output = tmp_path / "openapi.json"
+    rc = generate(output)
+    assert rc == 0
+    assert output.exists()
+
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["openapi"].startswith("3.")
+    assert "info" in data
+    assert "paths" in data
+
+
+def test_generate_inclui_rotas_jobs(tmp_path: Path) -> None:
+    output = tmp_path / "openapi.json"
+    generate(output)
+    data = json.loads(output.read_text(encoding="utf-8"))
+    paths = data["paths"]
+
+    assert "/api/v1/jobs/acquire" in paths
+    assert "/api/v1/jobs/{job_id}/heartbeat" in paths
+    assert "/api/v1/jobs/{job_id}/complete-upload" in paths
+
+
+def test_generate_deterministico(tmp_path: Path) -> None:
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    generate(a)
+    generate(b)
+    assert a.read_bytes() == b.read_bytes(), "output must be byte-identical between runs"


### PR DESCRIPTION
## Summary

- `scripts/gen_openapi.py` emite `docs/contracts/openapi.json` a partir do FastAPI `central_api` (via `create_app().openapi()`)
- Commitado `docs/contracts/openapi.json` inicial com 8 paths `/api/v1/*` + 10 schemas
- CI workflow `.github/workflows/ci.yml` ganha step de drift check — PR que muda Pydantic sem regenerar openapi.json falha

## Test plan

- [x] `pytest scripts/gen_openapi_test.py` → 3 testes verdes (escreve JSON, inclui rotas, determinístico)
- [x] `ruff check scripts/` limpo
- [x] Gerador produz 8 paths `/api/v1/jobs/*` + admin + system/health
- [x] Drift check local: regenerar matches committed (\`diff -q\` exit 0)
- [ ] CI green incluindo novo drift step (a validar no PR)

## Habilita

Plan A \`dump_agent_go\` (30 tasks) consumir \`docs/contracts/openapi.json\` via \`oapi-codegen\` sem manutenção manual de clientes Go.

## Nota de defeito plan (corrigido)

Plan inicial esperava paths bare \`/jobs/acquire\`, mas router é mounted com \`prefix=\"/api/v1\"\` em \`create_app\`. Tests ajustados para \`/api/v1/jobs/*\`. Consumidor Go pega paths reais do openapi.json, sem impacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)