### PR TITLE
feat(dump-agent-go): Plan C — cutover + runbooks + deprecation

### DIFF
--- a/apps/central_api/src/central_api/app.py
+++ b/apps/central_api/src/central_api/app.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 
 from central_api.deps import lifespan
 from central_api.middleware import TenantMiddleware
-from central_api.routes import admin, health, jobs
+from central_api.routes import admin, agents, health, jobs
 from cnes_infra.telemetry import init_telemetry
 
 init_telemetry("central-api")
@@ -21,4 +21,5 @@ def create_app() -> FastAPI:
     app.include_router(jobs.router, prefix="/api/v1")
     app.include_router(health.router, prefix="/api/v1")
     app.include_router(admin.router, prefix="/api/v1")
+    app.include_router(agents.router, prefix="/api/v1")
     return app

--- a/apps/central_api/src/central_api/repositories/agent_status_repo.py
+++ b/apps/central_api/src/central_api/repositories/agent_status_repo.py
@@ -1,0 +1,58 @@
+"""Repositório de status agregado de agents por tenant."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from cnes_domain.tenant import set_tenant_id
+
+
+@dataclass
+class AgentStatus:
+    tenant_id: str
+    last_seen: datetime | None
+    agent_version: str | None
+    machine_id: str | None
+    jobs_completed_7d: int
+    jobs_failed_7d: int
+
+
+_SQL = text(
+    """
+    SELECT
+        MAX(j.heartbeat_at) AS last_seen,
+        MAX(j.agent_version) AS agent_version,
+        MAX(j.machine_id) AS machine_id,
+        SUM(CASE WHEN j.status IN ('COMPLETED','DONE') THEN 1 ELSE 0 END) AS completed,
+        SUM(CASE WHEN j.status IN ('FAILED','DEAD_LETTER') THEN 1 ELSE 0 END) AS failed
+    FROM queue.jobs j
+    WHERE j.tenant_id = :tenant
+      AND j.created_at >= NOW() - INTERVAL '7 days'
+    """
+)
+
+
+def query_agent_status(engine: Engine, *, tenant_id: str) -> AgentStatus:
+    """Agrega métricas recentes para o tenant."""
+    set_tenant_id(tenant_id)
+    with engine.connect() as conn:
+        row = conn.execute(_SQL, {"tenant": tenant_id}).mappings().one_or_none()
+    if row is None:
+        return AgentStatus(
+            tenant_id=tenant_id,
+            last_seen=None,
+            agent_version=None,
+            machine_id=None,
+            jobs_completed_7d=0,
+            jobs_failed_7d=0,
+        )
+    return AgentStatus(
+        tenant_id=tenant_id,
+        last_seen=row["last_seen"],
+        agent_version=row["agent_version"],
+        machine_id=row["machine_id"],
+        jobs_completed_7d=int(row["completed"] or 0),
+        jobs_failed_7d=int(row["failed"] or 0),
+    )

--- a/apps/central_api/src/central_api/routes/agents.py
+++ b/apps/central_api/src/central_api/routes/agents.py
@@ -1,0 +1,39 @@
+"""Rota de status agregado de agents por tenant."""
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.engine import Engine
+
+from central_api.deps import get_engine
+from central_api.repositories.agent_status_repo import query_agent_status
+
+router = APIRouter(tags=["agents"])
+
+
+class AgentStatusResponse(BaseModel):
+    tenant_id: str
+    last_seen: str | None
+    agent_version: str | None
+    machine_id: str | None
+    jobs_completed_7d: int
+    jobs_failed_7d: int
+
+
+@router.get("/agents/status", response_model=AgentStatusResponse)
+def get_agent_status(
+    tenant_id: str = Query(..., pattern=r"^\d{6}$"),
+    x_tenant_id: str = Header(..., alias="X-Tenant-Id"),
+    engine: Engine = Depends(get_engine),
+) -> AgentStatusResponse:
+    """Retorna status agregado do agent do tenant."""
+    if tenant_id != x_tenant_id:
+        raise HTTPException(status_code=403, detail="tenant_mismatch")
+    status = query_agent_status(engine, tenant_id=tenant_id)
+    return AgentStatusResponse(
+        tenant_id=status.tenant_id,
+        last_seen=status.last_seen.isoformat() if status.last_seen else None,
+        agent_version=status.agent_version,
+        machine_id=status.machine_id,
+        jobs_completed_7d=status.jobs_completed_7d,
+        jobs_failed_7d=status.jobs_failed_7d,
+    )

--- a/apps/central_api/tests/repositories/conftest.py
+++ b/apps/central_api/tests/repositories/conftest.py
@@ -1,0 +1,31 @@
+"""Fixtures para testes de repositories — engine Postgres + migrations."""
+
+import os
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+_PG_URL = os.getenv(
+    "PG_TEST_URL",
+    "postgresql+psycopg://cnesdata:cnesdata_test@localhost:5433/cnesdata_test",
+)
+
+
+@pytest.fixture(scope="session")
+def pg_engine():
+    engine = create_engine(_PG_URL)
+    try:
+        with engine.connect() as con:
+            con.execute(text("SELECT 1"))
+    except Exception:
+        pytest.skip(
+            f"postgres indisponível em {_PG_URL}; rode 'docker compose up -d' primeiro",
+        )
+    cfg = Config()
+    cfg.set_main_option("script_location", "cnes_infra:alembic")
+    cfg.set_main_option("sqlalchemy.url", _PG_URL)
+    command.upgrade(cfg, "head")
+    yield engine
+    engine.dispose()

--- a/apps/central_api/tests/repositories/test_agent_status_repo.py
+++ b/apps/central_api/tests/repositories/test_agent_status_repo.py
@@ -1,0 +1,28 @@
+"""Teste do agent_status_repo."""
+
+import pytest
+
+from central_api.repositories.agent_status_repo import (
+    AgentStatus,
+    query_agent_status,
+)
+
+pytestmark = pytest.mark.postgres
+
+
+def test_query_agent_status_vazio_retorna_zeros(pg_engine) -> None:
+    status = query_agent_status(pg_engine, tenant_id="999999")
+    assert isinstance(status, AgentStatus)
+    assert status.tenant_id == "999999"
+    assert status.jobs_completed_7d == 0
+    assert status.jobs_failed_7d == 0
+    assert status.last_seen is None
+    assert status.agent_version is None
+
+
+def test_query_agent_status_agrega_completed_e_failed(pg_engine) -> None:
+    status = query_agent_status(pg_engine, tenant_id="354130")
+    assert isinstance(status, AgentStatus)
+    assert status.tenant_id == "354130"
+    assert status.jobs_completed_7d >= 0
+    assert status.jobs_failed_7d >= 0

--- a/apps/central_api/tests/routes/test_agents.py
+++ b/apps/central_api/tests/routes/test_agents.py
@@ -1,0 +1,141 @@
+"""Teste da rota GET /api/v1/agents/status."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.engine import Engine
+
+from central_api.repositories.agent_status_repo import AgentStatus
+
+
+def _make_app():
+    with (
+        patch("central_api.app.init_telemetry"),
+        patch("central_api.deps.install_rls_listener"),
+        patch("central_api.deps.instrument_engine"),
+        patch("central_api.deps.create_engine"),
+        patch("central_api.deps.reap_expired_leases", return_value=0),
+    ):
+        from central_api.app import create_app
+        return create_app()
+
+
+@pytest.fixture
+def app():
+    return _make_app()
+
+
+@pytest.fixture
+def mock_engine():
+    return MagicMock(spec=Engine)
+
+
+@pytest.fixture
+def client(app, mock_engine):
+    from central_api.deps import get_engine
+    app.dependency_overrides[get_engine] = lambda: mock_engine
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _status(tenant_id: str = "354130", **overrides) -> AgentStatus:
+    base = {
+        "tenant_id": tenant_id,
+        "last_seen": None,
+        "agent_version": None,
+        "machine_id": None,
+        "jobs_completed_7d": 0,
+        "jobs_failed_7d": 0,
+    }
+    base.update(overrides)
+    return AgentStatus(**base)
+
+
+class TestAgentsStatusEndpoint:
+    def test_retorna_json_com_campos_esperados(self, client):
+        with patch(
+            "central_api.routes.agents.query_agent_status",
+            return_value=_status(
+                tenant_id="354130",
+                last_seen=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+                agent_version="0.1.0",
+                machine_id="agent-01",
+                jobs_completed_7d=7,
+                jobs_failed_7d=2,
+            ),
+        ):
+            resp = client.get(
+                "/api/v1/agents/status",
+                params={"tenant_id": "354130"},
+                headers={"X-Tenant-Id": "354130"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["tenant_id"] == "354130"
+        assert body["agent_version"] == "0.1.0"
+        assert body["machine_id"] == "agent-01"
+        assert body["jobs_completed_7d"] == 7
+        assert body["jobs_failed_7d"] == 2
+        assert body["last_seen"].startswith("2026-04-20")
+
+    def test_retorna_zeros_quando_sem_historico(self, client):
+        with patch(
+            "central_api.routes.agents.query_agent_status",
+            return_value=_status(tenant_id="354130"),
+        ):
+            resp = client.get(
+                "/api/v1/agents/status",
+                params={"tenant_id": "354130"},
+                headers={"X-Tenant-Id": "354130"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["jobs_completed_7d"] == 0
+        assert body["jobs_failed_7d"] == 0
+        assert body["last_seen"] is None
+        assert body["agent_version"] is None
+        assert body["machine_id"] is None
+
+    def test_rejeita_tenant_mismatch(self, client):
+        with patch(
+            "central_api.routes.agents.query_agent_status",
+            return_value=_status(tenant_id="354130"),
+        ):
+            resp = client.get(
+                "/api/v1/agents/status",
+                params={"tenant_id": "999999"},
+                headers={"X-Tenant-Id": "354130"},
+            )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "tenant_mismatch"
+
+    def test_valida_formato_tenant_query(self, client):
+        resp = client.get(
+            "/api/v1/agents/status",
+            params={"tenant_id": "abc"},
+            headers={"X-Tenant-Id": "abc"},
+        )
+        assert resp.status_code == 422
+
+    def test_exige_header_x_tenant_id(self, client):
+        resp = client.get(
+            "/api/v1/agents/status",
+            params={"tenant_id": "354130"},
+        )
+        assert resp.status_code == 422
+
+    def test_passa_tenant_id_para_repo(self, client):
+        with patch(
+            "central_api.routes.agents.query_agent_status",
+            return_value=_status(tenant_id="354130"),
+        ) as mock_query:
+            client.get(
+                "/api/v1/agents/status",
+                params={"tenant_id": "354130"},
+                headers={"X-Tenant-Id": "354130"},
+            )
+        assert mock_query.call_count == 1
+        assert mock_query.call_args.kwargs == {"tenant_id": "354130"}

--- a/apps/dump_agent/CLAUDE.md
+++ b/apps/dump_agent/CLAUDE.md
@@ -1,5 +1,14 @@
 # dump_agent — Edge Agent
 
+> **⚠️ DEPRECATED — Em processo de migração para Go**
+>
+> Este app (`dump_agent` Python) entrará em modo **manutenção** após conclusão
+> da Fase B do cutover (ver `docs/runbooks/dumpagent-cutover.md`). Desenvolvimento
+> ativo acontece em `apps/dump_agent_go/`. Após cutover, apenas bug-fixes
+> críticos são aceitos aqui. Previsão de remoção: 3 meses após início da Fase D.
+>
+> Ver `docs/runbooks/dumpagent-deprecation-python.md`.
+
 ## Executive Summary
 
 Daemon assíncrono que roda **próximo à fonte de dados** (máquina do município

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -27,6 +27,65 @@
         "title": "AcquireJobRequest",
         "type": "object"
       },
+      "AgentStatusResponse": {
+        "properties": {
+          "agent_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Version"
+          },
+          "jobs_completed_7d": {
+            "title": "Jobs Completed 7D",
+            "type": "integer"
+          },
+          "jobs_failed_7d": {
+            "title": "Jobs Failed 7D",
+            "type": "integer"
+          },
+          "last_seen": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen"
+          },
+          "machine_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Machine Id"
+          },
+          "tenant_id": {
+            "title": "Tenant Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tenant_id",
+          "last_seen",
+          "agent_version",
+          "machine_id",
+          "jobs_completed_7d",
+          "jobs_failed_7d"
+        ],
+        "title": "AgentStatusResponse",
+        "type": "object"
+      },
       "CompleteUploadRequest": {
         "properties": {
           "machine_id": {
@@ -307,6 +366,59 @@
         "summary": "Reap Leases",
         "tags": [
           "admin"
+        ]
+      }
+    },
+    "/api/v1/agents/status": {
+      "get": {
+        "description": "Retorna status agregado do agent do tenant.",
+        "operationId": "get_agent_status_api_v1_agents_status_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "pattern": "^\\d{6}$",
+              "title": "Tenant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Tenant-Id",
+            "required": true,
+            "schema": {
+              "title": "X-Tenant-Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Agent Status",
+        "tags": [
+          "agents"
         ]
       }
     },

--- a/docs/runbooks/dumpagent-cutover.md
+++ b/docs/runbooks/dumpagent-cutover.md
@@ -1,0 +1,196 @@
+# dumpagent Cutover — Python → Go
+
+## Visão Geral
+
+Processo em 4 fases. Cada fase deve ser concluída e validada antes da próxima.
+
+```
+Fase A (1 sem)   Fase B (1-2 sem)   Fase C (3-4 sem)   Fase D (3 meses)
+───────────────  ────────────────   ─────────────────  ──────────────
+Shadow mode      Go ativo PE        Rollout tenants    Python deprecation
+(PE apenas)      Python parado      manuais            manutenção → remove
+```
+
+## Checklist pré-cutover (aplicar a cada tenant)
+
+- [ ] NTP sync verificado (`w32tm /query /status`, skew < 1min). Ver `edge-ntp-setup.md`.
+- [ ] Versão Go baixada do bucket + SHA256 validado
+- [ ] AV whitelist aplicado se ambiente tem AV restritivo
+- [ ] `CnesDumpAgent_Backup\` populado com última versão Python (para rollback)
+- [ ] Runbook `dumpagent-install-windows.md` revisado pelo operador local
+- [ ] Runbook `dumpagent-rollback.md` disponível e impresso/salvo offline
+- [ ] Janela de observação de 1h combinada com central
+
+---
+
+## Fase A — Shadow mode em PE (1 semana)
+
+### A.1 — Deploy shadow
+
+Na máquina do piloto PE (já com Python rodando normalmente):
+
+```powershell
+# baixar dumpagent-shadow do bucket (mesma versão stable)
+Expand-Archive .\dumpagent-v0.1.0-shadow.zip "C:\Program Files\CnesAgentShadow"
+```
+
+### A.2 — Configurar shadow
+
+`C:\Program Files\CnesAgentShadow\config.env`:
+
+```env
+# copiar da config Python + adicionar:
+DUMP_SHADOW_MODE=true
+DUMP_SHADOW_DIR=C:\ProgramData\CnesAgent\shadow
+```
+
+### A.3 — Executar shadow em foreground
+
+```powershell
+cd "C:\Program Files\CnesAgentShadow"
+.\dumpagent.exe run --verbose
+```
+
+Deixar rodando em parallel ao Python (lock não conflita porque são serviços
+distintos — considerar renomear para `CnesDumpAgentShadow` se conflitar).
+
+**Importante:** shadow NÃO chama CompleteJob — portanto o Python completa
+o mesmo job, fila não bloqueia.
+
+### A.4 — Comparar
+
+Diariamente:
+
+```powershell
+# para cada parquet shadow gerado:
+Get-ChildItem "C:\ProgramData\CnesAgent\shadow\*.parquet.gz" | ForEach-Object {
+    $job_id = $_.BaseName -replace '\.parquet$', ''
+    $python_baseline = "C:\CnesAgent\production_output\$job_id.parquet"
+    python scripts\shadow_diff.py --python $python_baseline --go $_.FullName
+}
+```
+
+Registrar resultados em planilha/doc:
+- jobs comparados
+- diffs identificados (row count, byte count, field-level)
+- encoding issues (§10.1.1 spec)
+
+### A.5 — Critério de saída Fase A
+
+- [ ] 100 jobs consecutivos com `shadow_diff` retornando `identical=True`
+- [ ] Fixtures sujas de encoding testadas (ao menos 3 rows com char WIN1252
+      corrompido preservadas via `SanitizeString`)
+- [ ] Zero crashes do shadow por 7 dias
+- [ ] Aprovação da equipe central para avançar
+
+## Fase B — Go ativo em PE (1-2 semanas)
+
+### B.1 — Parar Python
+
+```powershell
+Stop-Service CnesDumpAgent
+```
+
+### B.2 — Desinstalar Python
+
+Opcional — manter instalação como fallback local para rollback rápido:
+
+```powershell
+# backup antes de desinstalar
+Copy-Item "C:\Program Files\CnesAgentPy" "C:\CnesAgent_Backup\" -Recurse
+pip uninstall dump-agent -y
+# ou remove pasta se PyInstaller
+```
+
+### B.3 — Instalar Go
+
+Seguir `dumpagent-install-windows.md`.
+
+### B.4 — Observação 14 dias
+
+Operador central monitora diariamente via `/agents/status`:
+
+```bash
+curl -H "X-Tenant-Id: 354130" "https://api.cnesdata.gov.br/api/v1/agents/status?tenant_id=354130"
+```
+
+Métricas-alvo:
+- `jobs_completed_7d` ≥ histórico Python (±10%)
+- `jobs_failed_7d` ≤ 2 × histórico Python
+- `last_seen` < 15min atrás
+- `agent_version` inicia com `v0.1`
+
+### B.5 — Critério de saída Fase B
+
+- [ ] 14 dias sem rollback
+- [ ] Fail rate estável
+- [ ] Zero encoding issues reportados
+- [ ] Zero clock skew incidents
+
+---
+
+## Fase C — Rollout multi-tenant (3-4 semanas)
+
+Replicar Fase B para os demais tenants, 1-2 por semana:
+
+1. Operador do tenant recebe link presigned + runbook install
+2. Executar shadow local 48h (mini-Fase A)
+3. Cutover com janela pré-agendada
+4. 7 dias de observação antes de marcar "estável"
+
+Taxa-alvo: 80% dos tenants migrados em 4 semanas.
+
+### C.1 — Critério de saída Fase C
+
+- [ ] ≥80% tenants migrados
+- [ ] PE completou 30+ dias em Go
+- [ ] Fail rate global Go ≤ fail rate global Python (baseline)
+
+---
+
+## Fase D — Deprecation Python (3 meses)
+
+### D.1 — Banner DEPRECATED
+
+Editar `apps/dump_agent/CLAUDE.md` adicionando no topo:
+
+```markdown
+> **⚠️ DEPRECATED — Migração Go em andamento**
+>
+> `dump_agent` Python está em modo manutenção desde `<data>`. Nova feature
+> development acontece em `apps/dump_agent_go/`. Este app será removido em
+> `<data + 3 meses>`. Bug-fixes críticos ainda aceitos.
+```
+
+### D.2 — Travar PRs não-críticos
+
+Adicionar label `dumpagent-py-legacy` + GitHub CODEOWNERS para exigir
+aprovação sênior em mudanças.
+
+### D.3 — Tag final Python
+
+Após 3 meses:
+
+```bash
+git tag dumpagent-py-v<N.M.P>-final
+git push origin dumpagent-py-v<N.M.P>-final
+```
+
+### D.4 — Remoção
+
+PR final:
+
+```bash
+git rm -r apps/dump_agent/
+git commit -m "chore: remove apps/dump_agent (Python) após cutover completo"
+```
+
+Preservar `dumpagent-py-v<N.M.P>-final` para referência arqueológica.
+
+---
+
+## Contatos
+
+- Operação central: `<nome>` — <email>
+- Escalation: `<nome sênior>` — <phone>
+- Grupo Telegram: `<link>`

--- a/docs/runbooks/dumpagent-deprecation-python.md
+++ b/docs/runbooks/dumpagent-deprecation-python.md
@@ -1,0 +1,57 @@
+# dumpagent Python — Deprecation Timeline
+
+## Status
+
+- **Iniciado:** `<data Fase D>`
+- **Modo:** Manutenção (bug-fixes críticos apenas)
+- **Remoção do repo:** `<data Fase D + 3 meses>`
+- **Tag final:** `dumpagent-py-v<N.M.P>-final`
+
+## Bug-fixes críticos aceitos
+
+| Categoria | Exemplo |
+|---|---|
+| Segurança | CVE em dependência ativa |
+| Data integrity | Extrator retorna rows corrompidas silenciosamente |
+| Regressão pós-cutover | Tenant ainda em Python impactado por mudança incompatível no central |
+
+## Não aceitos
+
+- Features novas
+- Refactor
+- Dep updates sem motivação de segurança
+- Melhorias de performance
+- Mudança de schema
+
+## Processo para tenant ainda em Python
+
+Se algum tenant não migrou:
+
+1. Investigar motivo (técnico, político, treinamento)
+2. Escalar para gerente ops antes do prazo de 3 meses
+3. Se razão técnica (hw muito antigo p/ Go): documentar + extender prazo
+   case-by-case
+4. Se razão política (município não autoriza): escalar para diretoria
+
+## Remoção
+
+Antes de deletar:
+
+- [ ] Zero tenants reportando uso via `/agents/status?agent_version=py*`
+- [ ] Tag `dumpagent-py-v<N.M.P>-final` empurrada para origin
+- [ ] Bucket releases ainda tem ZIP Python (para rollback de emergência
+  caso-limite, retido por 12 meses após remoção)
+- [ ] CLAUDE.md global atualizado (remoção do `dump_agent/` Python)
+
+Comando:
+
+```bash
+git checkout -b chore/remove-dumpagent-python
+git rm -r apps/dump_agent/
+git commit -m "chore: remove apps/dump_agent (Python) após cutover completo
+(veja tag dumpagent-py-v<N.M.P>-final para referência histórica)"
+git push origin chore/remove-dumpagent-python
+gh pr create --title "chore: remove legacy Python dumpagent"
+```
+
+Merge apenas com aprovação de 2 reviewers sêniores.

--- a/docs/runbooks/dumpagent-rollback.md
+++ b/docs/runbooks/dumpagent-rollback.md
@@ -1,0 +1,111 @@
+# dumpagent Rollback — Go → Python
+
+## Quando executar
+
+- Taxa de `FailJob(retryable=false)` Go > 20% em janela 1h após cutover
+- Corrupção de Parquet detectada (diff shadow > 0 em produção)
+- Crash-loop do service (panic threshold atingido)
+- Decisão operacional em coordenação com central
+
+## Tempo estimado
+
+15 min por máquina. Sem downtime significativo — Python retoma fila do mesmo ponto.
+
+## Pré-requisitos
+
+- Acesso admin à máquina
+- ZIP da última versão Python salvo localmente em `C:\CnesAgent_Backup\`
+- Senha Firebird + caminho CNES.GDB preservados
+
+## Procedimento
+
+### 1. Parar serviço Go
+
+```powershell
+Stop-Service CnesDumpAgent -Force
+# aguarda até 30s para SCM reportar STOPPED
+Get-Service CnesDumpAgent
+```
+
+Confirmar `Status: Stopped`.
+
+### 2. Desinstalar serviço Go
+
+```powershell
+cd "C:\Program Files\CnesAgent"
+.\dumpagent.exe uninstall
+```
+
+Output esperado: `uninstalled service=CnesDumpAgent`.
+
+### 3. Reinstalar Python
+
+Opção A — wheel instalado via pip:
+
+```powershell
+# Se pip + Python ainda presentes:
+pip install dump-agent==<ultima_py_stable>
+# ou:
+pip install C:\CnesAgent_Backup\dump_agent-<versao>-py3-none-any.whl
+```
+
+Opção B — PyInstaller frozen (recomendado se pip foi removido):
+
+```powershell
+Expand-Archive "C:\CnesAgent_Backup\dump_agent_py-<versao>.zip" "C:\Program Files\CnesAgentPy"
+```
+
+### 4. Configurar env Python
+
+Criar `C:\Program Files\CnesAgentPy\.env` com mesmas vars da instalação Go
+(TENANT_ID, DB_HOST, DB_PATH, DB_PASSWORD etc).
+
+### 5. Reinstalar serviço Python
+
+Windows com NSSM (mecanismo usado pelo Python):
+
+```powershell
+# nssm.exe baixado previamente em C:\CnesAgent_Backup\
+C:\CnesAgent_Backup\nssm.exe install CnesDumpAgent `
+  "C:\Python313\python.exe" "-m dump_agent.main"
+C:\CnesAgent_Backup\nssm.exe set CnesDumpAgent AppDirectory "C:\Program Files\CnesAgentPy"
+C:\CnesAgent_Backup\nssm.exe set CnesDumpAgent AppEnvironmentExtra (Get-Content "C:\Program Files\CnesAgentPy\.env" -Raw)
+```
+
+Ou se instalação original usa outro método (InstallAnywhere etc), seguir
+documentação do instalador original.
+
+### 6. Iniciar Python
+
+```powershell
+Start-Service CnesDumpAgent
+Get-Content "$env:LOCALAPPDATA\CnesAgent\logs\dump_agent.log" -Tail 30
+```
+
+Procurar por boot Python esperado (formato `YYYY-MM-DD HH:MM:SS INFO ...`).
+
+### 7. Notificar central
+
+Via e-mail / Telegram para operador central:
+- Tenant rolled back: `PE/354130`
+- Timestamp: `<ISO8601>`
+- Motivo resumido
+- Versão Python ativa
+
+### 8. Preservar logs Go para post-mortem
+
+```powershell
+$backup = "C:\CnesAgent_Backup\rollback-$(Get-Date -Format 'yyyyMMdd-HHmm')"
+New-Item -ItemType Directory $backup -Force
+Copy-Item "$env:LOCALAPPDATA\CnesAgent\logs\*" $backup -Recurse
+Copy-Item "$env:LOCALAPPDATA\CnesAgent\CLOCK_FATAL.txt" $backup -ErrorAction SilentlyContinue
+```
+
+Upload para central para análise.
+
+## Verificação pós-rollback
+
+- [ ] `Get-Service CnesDumpAgent` → Running
+- [ ] Últimos logs mostram `worker_started` Python
+- [ ] Próximos 30min: pelo menos 1 job completed no central dashboard
+- [ ] `central_api` dashboard /agents/status retorna `agent_version` Python

--- a/docs/runbooks/edge-ntp-setup.md
+++ b/docs/runbooks/edge-ntp-setup.md
@@ -1,0 +1,80 @@
+# NTP Sync em Edge Machines
+
+## Por quê
+
+Clock drift > 5min invalida presigned URLs (HTTP 403 `RequestTimeTooSkewed`).
+Skew > 60min trava o dumpagent (`CLOCK_FATAL.txt` escrito em boot).
+
+## Windows
+
+### Verificar status atual
+
+```powershell
+w32tm /query /status
+```
+
+Campos importantes:
+- `Last Successful Sync Time:` — deve ser < 24h
+- `Source:` — servidor NTP atualmente em uso
+
+### Resync manual
+
+```powershell
+Stop-Service w32time
+w32tm /unregister; w32tm /register
+Start-Service w32time
+w32tm /resync /force
+```
+
+### Configurar time server
+
+Para domínios internos:
+
+```powershell
+w32tm /config /manualpeerlist:"ntp.cnesdata.gov.br,0x8 br.pool.ntp.org,0x8" `
+  /syncfromflags:manual /reliable:yes /update
+Restart-Service w32time
+```
+
+Verificar skew após resync:
+
+```powershell
+w32tm /monitor /computers:br.pool.ntp.org
+```
+
+## Linux (systemd)
+
+```bash
+sudo timedatectl set-ntp true
+sudo systemctl restart systemd-timesyncd
+timedatectl status
+```
+
+Ou com chrony:
+
+```bash
+sudo apt install chrony
+sudo systemctl enable --now chrony
+chronyc sources
+```
+
+## Verificação pós-setup
+
+```powershell
+# Windows
+w32tm /stripchart /computer:br.pool.ntp.org /samples:3 /dataonly
+# Esperado: offset < 1s
+```
+
+```bash
+# Linux
+chronyc tracking
+```
+
+## Troubleshooting
+
+| Sintoma | Causa | Ação |
+|---|---|---|
+| `CLOCK_FATAL.txt` presente | Skew > 60min | `w32tm /resync /force`, reiniciar dumpagent |
+| Upload falha 403 silencioso | Skew 5-60min | Resync NTP + retry automático |
+| NTP resync falha | Firewall bloqueia UDP 123 | Liberar porta 123 para NTP server |

--- a/packages/cnes_infra/src/cnes_infra/alembic/versions/009_add_agent_version_to_jobs.py
+++ b/packages/cnes_infra/src/cnes_infra/alembic/versions/009_add_agent_version_to_jobs.py
@@ -1,0 +1,28 @@
+"""add agent_version to queue.jobs.
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-04-21
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "009"
+down_revision: str = "008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:  # pragma: no cover - alembic migration
+    op.add_column(
+        "jobs",
+        sa.Column("agent_version", sa.String(length=50), nullable=True),
+        schema="queue",
+    )
+
+
+def downgrade() -> None:  # pragma: no cover - alembic migration
+    op.drop_column("jobs", "agent_version", schema="queue")

--- a/packages/cnes_infra/src/cnes_infra/storage/job_queue_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/storage/job_queue_schema.py
@@ -45,6 +45,7 @@ jobs = Table(
     ),
     Column("trace_context", JSONB),
     Column("machine_id", String(128)),
+    Column("agent_version", String(50)),
     Column("lease_expires_at", DateTime(timezone=True)),
     Column("heartbeat_at", DateTime(timezone=True)),
     Column(

--- a/scripts/gen_golden_fixtures.py
+++ b/scripts/gen_golden_fixtures.py
@@ -1,0 +1,94 @@
+"""Gera fixtures golden capturando output atual do dump_agent Python.
+
+Uso:
+    python scripts/gen_golden_fixtures.py --cod-municipio 354130 --output docs/fixtures/golden/
+
+Cada intent (profissionais, estabelecimentos, equipes, sihd_producao) produz
+par <intent>.parquet + <intent>.meta.json com metadata de query/params.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_extractor(intent: str) -> Callable[..., pl.DataFrame]:
+    from dump_agent.extractors.cnes_extractor import CnesExtractor
+    from dump_agent.extractors.sihd_extractor import SihdExtractor
+
+    if intent.startswith("cnes_"):
+        return CnesExtractor()
+    if intent.startswith("sihd_"):
+        return SihdExtractor()
+    raise ValueError(f"unknown intent={intent}")
+
+
+def capture_intent(intent: str, *, cod_municipio: str = "354130") -> pl.DataFrame:
+    extractor = _resolve_extractor(intent)
+    return extractor(cod_municipio=cod_municipio)  # type: ignore[operator]
+
+
+def write_fixture(
+    df: pl.DataFrame,
+    output_dir: Path,
+    intent: str,
+    *,
+    query: str,
+    params: tuple,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    parquet_path = output_dir / f"{intent}.parquet"
+    meta_path = output_dir / f"{intent}.meta.json"
+
+    df.write_parquet(parquet_path, compression="snappy")
+
+    sha = hashlib.sha256(parquet_path.read_bytes()).hexdigest()
+    meta = {
+        "intent": intent,
+        "row_count": df.height,
+        "columns": df.columns,
+        "sql_query": query,
+        "sql_params": list(params),
+        "sha256": sha,
+        "polars_version": pl.__version__,
+    }
+    meta_path.write_text(json.dumps(meta, indent=2, ensure_ascii=False), encoding="utf-8")
+    logger.info("fixture_written intent=%s rows=%d sha256=%s", intent, df.height, sha[:12])
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cod-municipio", default="354130")
+    parser.add_argument("--output", type=Path, default=Path("docs/fixtures/golden/"))
+    parser.add_argument(
+        "--intents",
+        nargs="+",
+        default=["cnes_profissionais", "cnes_estabelecimentos", "cnes_equipes", "sihd_producao"],
+    )
+    args = parser.parse_args()
+
+    for intent in args.intents:
+        try:
+            df = capture_intent(intent, cod_municipio=args.cod_municipio)
+        except Exception:
+            logger.exception("capture_failed intent=%s", intent)
+            return 1
+        write_fixture(df, args.output, intent, query="<captured>", params=(args.cod_municipio,))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen_golden_fixtures_test.py
+++ b/scripts/gen_golden_fixtures_test.py
@@ -1,0 +1,31 @@
+"""Teste do gerador de fixtures golden."""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import polars as pl
+
+from scripts.gen_golden_fixtures import capture_intent, write_fixture
+
+
+def test_write_fixture_cria_parquet_e_meta(tmp_path: Path) -> None:
+    df = pl.DataFrame({"cnes": ["0001"], "nome": ["UBS"]})
+    write_fixture(df, tmp_path, "cnes_estabelecimentos", query="SELECT *", params=("354130",))
+
+    parquet_path = tmp_path / "cnes_estabelecimentos.parquet"
+    meta_path = tmp_path / "cnes_estabelecimentos.meta.json"
+
+    assert parquet_path.exists()
+    assert meta_path.exists()
+
+    roundtrip = pl.read_parquet(parquet_path)
+    assert roundtrip.equals(df)
+
+
+def test_capture_intent_chama_extractor_mockado() -> None:
+    fake_extractor = MagicMock(return_value=pl.DataFrame({"x": [1]}))
+
+    with patch("scripts.gen_golden_fixtures._resolve_extractor", return_value=fake_extractor):
+        df = capture_intent("cnes_estabelecimentos", cod_municipio="354130")
+
+    assert fake_extractor.called
+    assert df.height == 1

--- a/scripts/shadow_diff.py
+++ b/scripts/shadow_diff.py
@@ -1,0 +1,91 @@
+"""Compara outputs Parquet Python↔Go row-a-row com normalização canônica.
+
+Uso:
+    python scripts/shadow_diff.py \\
+        --python docs/fixtures/golden/cnes_profissionais.parquet \\
+        --go /path/to/shadow/<job_id>.parquet.gz
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import io
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DiffResult:
+    identical: bool
+    diff_rows: int
+    summary: str
+
+
+def normalize_df(df: pl.DataFrame) -> pl.DataFrame:
+    """Ordena colunas alfabeticamente e rows por todas as colunas ASC."""
+    sorted_cols = sorted(df.columns)
+    return df.select(sorted_cols).sort(by=sorted_cols)
+
+
+def _load(path: Path) -> pl.DataFrame:
+    data = path.read_bytes()
+    if path.suffix == ".gz":
+        data = gzip.decompress(data)
+    return pl.read_parquet(io.BytesIO(data))
+
+
+def compare_parquets(a: Path, b: Path) -> DiffResult:
+    """Compara dois Parquets normalizados."""
+    df_a = normalize_df(_load(a))
+    df_b = normalize_df(_load(b))
+
+    if df_a.columns != df_b.columns:
+        return DiffResult(
+            identical=False, diff_rows=-1,
+            summary=f"column mismatch a={df_a.columns} b={df_b.columns}",
+        )
+    if df_a.height != df_b.height:
+        return DiffResult(
+            identical=False, diff_rows=abs(df_a.height - df_b.height),
+            summary=f"row count mismatch a={df_a.height} b={df_b.height}",
+        )
+
+    differ = df_a.with_row_index("__idx").join(
+        df_b.with_row_index("__idx"), on="__idx", suffix="_b", how="inner",
+    )
+    diff_count = 0
+    for col in df_a.columns:
+        diff_mask = differ[col] != differ[f"{col}_b"]
+        diff_count += int(diff_mask.sum() or 0)
+
+    if diff_count == 0:
+        return DiffResult(identical=True, diff_rows=0, summary="identical")
+    return DiffResult(
+        identical=False, diff_rows=diff_count,
+        summary=f"{diff_count} cell diffs",
+    )
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--python", type=Path, required=True)
+    parser.add_argument("--go", type=Path, required=True)
+    args = parser.parse_args()
+
+    result = compare_parquets(args.python, args.go)
+    logger.info(
+        "diff_result identical=%s diff=%d summary=%s",
+        result.identical, result.diff_rows, result.summary,
+    )
+    return 0 if result.identical else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shadow_diff_test.py
+++ b/scripts/shadow_diff_test.py
@@ -1,0 +1,37 @@
+"""Teste do shadow diff."""
+from pathlib import Path
+
+import polars as pl
+
+from scripts.shadow_diff import compare_parquets, normalize_df
+
+
+def test_normalize_df_ordena_canonicamente() -> None:
+    df = pl.DataFrame({"b": [2, 1], "a": ["y", "x"]})
+    norm = normalize_df(df)
+    assert norm.columns == sorted(df.columns)
+    # sorted por todas colunas ascending
+    assert norm.row(0) == ("x", 1)
+
+
+def test_compare_parquets_identicos(tmp_path: Path) -> None:
+    df = pl.DataFrame({"cnes": ["0001", "0002"], "nome": ["A", "B"]})
+    p1 = tmp_path / "a.parquet"
+    p2 = tmp_path / "b.parquet"
+    df.write_parquet(p1)
+    df.write_parquet(p2)
+    result = compare_parquets(p1, p2)
+    assert result.identical is True
+    assert result.diff_rows == 0
+
+
+def test_compare_parquets_difere(tmp_path: Path) -> None:
+    a = pl.DataFrame({"cnes": ["0001"], "nome": ["A"]})
+    b = pl.DataFrame({"cnes": ["0001"], "nome": ["B"]})
+    pa = tmp_path / "a.parquet"
+    pb = tmp_path / "b.parquet"
+    a.write_parquet(pa)
+    b.write_parquet(pb)
+    result = compare_parquets(pa, pb)
+    assert result.identical is False
+    assert result.diff_rows == 1


### PR DESCRIPTION
## Summary

Finaliza migração `dump_agent` Python → Go fornecendo:

- `scripts/gen_golden_fixtures.py` — captura Parquet canônico do extractor Python atual
- `scripts/shadow_diff.py` — comparador Python↔Go com normalização canônica (sort cols+rows)
- `central_api` endpoint `GET /api/v1/agents/status` + repository agregado (last_seen, agent_version, machine_id, jobs completed/failed 7d)
- Migração Alembic 009: `agent_version VARCHAR(50)` em `queue.jobs` (`machine_id` já existia)
- Runbooks operacionais completos:
  - `dumpagent-cutover.md` — fases A-D mestre
  - `dumpagent-rollback.md` — Go→Python 15min
  - `edge-ntp-setup.md` — NTP Windows+Linux
  - `dumpagent-deprecation-python.md` — timeline + remoção
- Banner DEPRECATED em `apps/dump_agent/CLAUDE.md` apontando para runbooks

## Commits (9)

| # | Sha | Resumo |
|---|---|---|
| 1 | 101b82f | tools(scripts): gen_golden_fixtures captura outputs Python canônicos |
| 2 | e614c99 | tools(scripts): shadow_diff compara Parquets Python↔Go normalizados |
| 3 | f1a7d4b | feat(central-api): agent_status_repo + migração jobs.agent_version |
| 4 | 085c322 | feat(central-api): endpoint GET /api/v1/agents/status + openapi regen |
| 5 | 03cebdb | docs(runbooks): edge NTP setup Windows + Linux |
| 6 | 1e94cef | docs(runbooks): dumpagent rollback Go→Python |
| 7 | 0ffdc1d | docs(runbooks): timeline + processo de deprecation do dumpagent Python |
| 8 | d461804 | docs(runbooks): cutover mestre Python→Go (fases A-D) |
| 9 | 5afc270 | chore(dump-agent): marcar Python app como DEPRECATED |

## Test plan

- [x] `pytest scripts/` — 5 tests (gen_golden_fixtures 2, shadow_diff 3) PASS
- [x] `pytest apps/central_api/tests/ -m "not postgres and not e2e"` — 39 PASS
- [x] `openapi.json` regenerado + drift check limpo (paths: 8 → 9)
- [x] `ruff check scripts/ apps/central_api/ packages/cnes_infra/src/cnes_infra/alembic/versions/009_*.py` — All checks passed
- [ ] CI verde (drift check + pytest packages/apps)
- [ ] Migração Alembic 009 aplica limpa em ambiente test (via CI)

## Defeitos de plan corrigidos inline

1. **Plan Task 4**: `public.jobs` → `queue.jobs` (schema real). `machine_id` já existia (Column String(128)) → só adicionar `agent_version` (String(50)).
2. **Plan Task 4**: `apps/cnes_db_migrator/alembic/versions/` → `packages/cnes_infra/src/cnes_infra/alembic/versions/`. Revision `"009"` (numérico curto) vs `"009_add_agent_version"` para match 007/008 style.
3. **Plan Task 4**: `get_db_session()/Session` não existe em central_api → usar `get_engine()`/`Engine` como jobs.py.
4. **Plan Task 5**: `APIRouter(prefix="/api/v1/agents")` duplicaria `/api/v1` — usar `prefix="/agents"` + `app.include_router(prefix="/api/v1")`.
5. **Plan Task 5**: `AgentStatus` dataclass como response_model → introduzir `AgentStatusResponse(BaseModel)` espelho.

## Task 2 (capture fixtures) deferida

Requer Firebird synthetic do piloto PE acessível em ambiente dev + FIREBIRD_DLL.
Plan texto original dizia executar manualmente fora do CI; como não temos FB PE sintético
neste pipeline, geração de fixtures reais fica como primeiro passo da Fase A
(operacional) do cutover.

## Execution timeline pós-merge

1. Semana 1 (Fase A): operador PE gera fixtures golden com script real + shadow mode
2. Semana 2-3 (Fase B): cutover PE com observação 14d via `/agents/status`
3. Semana 4-7 (Fase C): rollout restante municípios
4. Mês 3 (Fase D): banner formal + tag final Python + remoção eventual

## Spec 2 coverage end-to-end

Os 3 plans (A runtime, B service+release, C cutover) fecham cobertura completa da Spec 2 `docs/superpowers/specs/2026-04-20-dump-agent-go-migration-design.md` (§3-§10.1.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)