### PR TITLE
fix(rollout): shadow-e2e FB healthcheck brittle + --wait timeout

### DIFF
--- a/.github/workflows/shadow-e2e.yml
+++ b/.github/workflows/shadow-e2e.yml
@@ -43,7 +43,16 @@ jobs:
           pip install pytest polars faker dbfread
 
       - name: Start shadow containers
-        run: docker compose -f docker-compose.shadow.yml up -d --wait
+        run: |
+          docker compose -f docker-compose.shadow.yml up -d
+          for i in $(seq 1 30); do
+              if docker inspect --format='{{.State.Health.Status}}' cnesdata-minio-shadow-1 2>/dev/null | grep -q healthy; then
+                  echo "minio_ready"
+                  break
+              fi
+              sleep 2
+          done
+          sleep 10
 
       - name: Restore seed
         run: bash scripts/seed_restore.sh docs/fixtures/shadow-seed/

--- a/docker-compose.shadow.yml
+++ b/docker-compose.shadow.yml
@@ -9,10 +9,6 @@ services:
       - fb_shadow_data:/firebird/data
     ports:
       - "3051:3050"
-    healthcheck:
-      test: ["CMD-SHELL", "echo 'SELECT 1 FROM RDB$$DATABASE;' | isql-fb /firebird/data/shadow.fdb -u SYSDBA -p masterkey || exit 1"]
-      interval: 5s
-      retries: 20
 
   minio-shadow:
     image: minio/minio:latest


### PR DESCRIPTION
## Bug

Run 24732541823 (auto-trigger push merge PR #26) falhou após 1m45s:
\`\`\`
container cnesdata-firebird-shadow-1 is unhealthy
\`\`\`

Root cause: healthcheck em docker-compose.shadow.yml usa \`isql-fb\` + query RDB\$DATABASE que falha em jacobalberty/firebird:2.5-ss (cmd name differ + DB create race). Workflow step \`docker compose up -d --wait\` bloqueia até healthcheck pass, resultando em timeout.

## Fix

1. Remove healthcheck de firebird-shadow (deixa minio's que funciona)
2. Substitui \`up -d --wait\` por \`up -d\` + wait explícito no minio (via docker inspect) + sleep 10
3. seed_restore.sh já tem wait loop (30×1s via isql probe dentro do container) — handle real readiness

## Operational impact

- Watch loop counter SHADOW_GREEN_COUNT_DEVELOP resetou para 0 (expected — failure was counted)
- Pós-merge desta fix: próximo push-develop trigger (automático) + nightly acumulam counter
- 3-green sequence reinicia do zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)