### PR TITLE
fix(rollout): seed_restore detecta isql binary correto (jacobalberty image)

### DIFF
--- a/scripts/seed_restore.sh
+++ b/scripts/seed_restore.sh
@@ -23,17 +23,35 @@ if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER}$"; then
     exit 1
 fi
 
+# Descobre path do isql (jacobalberty image usa /usr/local/firebird/bin/isql;
+# outras imagens podem ter isql-fb no PATH)
+ISQL=$(docker exec "$CONTAINER" bash -c \
+    "command -v isql || command -v isql-fb || ls /usr/local/firebird/bin/isql 2>/dev/null" \
+    | tr -d '\r' | head -n1)
+if [ -z "$ISQL" ]; then
+    echo "isql_binary_not_found_in_container" >&2
+    exit 1
+fi
+echo "isql_path=$ISQL"
+
 # Aguarda FB estar pronto
 echo "waiting_for_firebird..."
-for i in $(seq 1 30); do
+ready=0
+for i in $(seq 1 60); do
     if docker exec "$CONTAINER" bash -c \
-        "echo 'SELECT 1 FROM RDB\$DATABASE;' | isql-fb ${DB_PATH} -u SYSDBA -p masterkey" \
+        "echo 'SELECT 1 FROM RDB\$DATABASE;' | $ISQL ${DB_PATH} -u SYSDBA -p masterkey" \
         >/dev/null 2>&1; then
-        echo "firebird_ready"
+        echo "firebird_ready_after=${i}s"
+        ready=1
         break
     fi
     sleep 1
 done
+if [ "$ready" -ne 1 ]; then
+    echo "firebird_not_ready_after_60s" >&2
+    docker logs "$CONTAINER" | tail -30 >&2
+    exit 1
+fi
 
 # Executa cada .sql em seed_dir na ordem alfabética
 shopt -s nullglob
@@ -43,7 +61,7 @@ for sql in "$SEED_DIR"/*.sql; do
     # Copia arquivo pro container temp + executa
     docker cp "$sql" "$CONTAINER:/tmp/$base"
     docker exec "$CONTAINER" bash -c \
-        "isql-fb ${DB_PATH} -u SYSDBA -p masterkey -i /tmp/$base"
+        "$ISQL ${DB_PATH} -u SYSDBA -p masterkey -i /tmp/$base"
     echo "executed=$base"
 done
 


### PR DESCRIPTION
## Bug

Run 24732930597 (post-fix #27 merge) falhou em:
\`\`\`
bash: line 1: isql-fb: command not found
exit 127
\`\`\`

Root cause: jacobalberty/firebird:2.5-ss não tem \`isql-fb\` (nome Debian/Ubuntu package). Image usa \`isql\` em \`/usr/local/firebird/bin/\`.

## Fix

- seed_restore.sh: detecta ISQL binary via cascade \`command -v isql || command -v isql-fb || /usr/local/firebird/bin/isql\`
- Wait loop extendido 30→60s
- Abort explícito com \`docker logs\` tail se FB não ready

## Shadow counter impact

SHADOW_GREEN_COUNT_DEVELOP resetou para 0 novamente. Loop reinicia no próximo push-develop/nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)