### PR TITLE
docs(gold): Spec B — Gold v2 schema + SIA/BPA introspection (docs only)

### DIFF
--- a/docs/data-dictionary-bpa.md
+++ b/docs/data-dictionary-bpa.md
@@ -1,0 +1,217 @@
+# Dicionário de Dados — BPA-Mag (BPAMAG.GDB)
+
+> **Status:** Preliminar — derivado de PDFs Datasus. Introspecção completa do
+> Firebird GDB está deferida (requer `fbclient.dll` 1.5.5, a ser extraído via
+> `Firebird-1.5.5.4926-3-Win32.exe` disponível em `http://sia.datasus.gov.br`).
+
+Fontes consultadas:
+
+- `E:/BPA/Layout_Exportacao_BPA.pdf` — layout dos arquivos de remessa TXT gerados
+  pelo BPA-Mag (cabeçalho + BPA-C + BPA-I).
+- `E:/BPA/Manual_Operacional_BPA.pdf` — manual operacional do BPA-Mag v1
+  (CGSI/DRAC/SAS/MS, set/2012).
+
+## Contexto operacional (Manual_Operacional_BPA.pdf)
+
+O **BPA-Mag** é o aplicativo de captação desktop (Windows, Firebird embarcado)
+utilizado pelos prestadores do SUS para registrar produção ambulatorial **sem
+exigência de autorização prévia** (procedimentos de atenção básica e média
+complexidade). Instituído pela Portaria GM/MS nº 545/1993, ampliado pela
+Portaria SAS/MS nº 709/2007 com a modalidade individualizada.
+
+- **Portaria GM/MS nº 545/1993** — institui o BPA substituindo a GAP (Guia
+  de Autorização Ambulatorial).
+- **Portaria SAS/MS nº 709/2007** — cria o BPA-I (individualizado), somando-se
+  à APAC e preservando o BPA-C para registro agregado.
+- **SIGTAP define o instrumento de registro** (§8): cada procedimento no SIGTAP
+  tem o atributo `Instrumento de Registro` com domínio {BPA Consolidado, BPA
+  Individualizado, APAC, RAAS}. O BPA-Mag só aceita procedimentos marcados como
+  BPA-C ou BPA-I.
+- **Atributos complementares relevantes** (extraídos do §8):
+  - `009 - Exige CNS` — torna CNS do paciente obrigatório em BPA-I.
+  - `012 - Exige idade no BPA (Consolidado)` — idade obrigatória em BPA-C.
+  - `021 - Não Exige CBO` — dispensa CBO do profissional.
+- **Arquivos de apoio importados mensalmente:**
+  - KIT SIA / BDSIA (`BDSIAaaaammv.exe`) — tabelas SIGTAP da competência.
+  - Equipes CAPTAÇÃO (do CNES) — mapeamento de equipes de atenção básica.
+
+## Layout de Exportação (Layout_Exportacao_BPA.pdf)
+
+O arquivo de remessa exportado pelo BPA-Mag é texto plano, posicional (layout
+fixo), ASCII, com terminador `CR+LF` por linha. Estrutura:
+
+```
+[CABEÇALHO — 132 bytes — 1 linha]
+[LINHAS BPA-C — 50 bytes cada]
+[LINHAS BPA-I — 352 bytes cada]
+```
+
+### CABEÇALHO (`cbc-*`) — 132 bytes
+
+| Seq | Campo | Ini | Fim | Tam | Tipo | Descrição |
+|---|---|---|---|---|---|---|
+| 1 | `cbc-hdr` | 001 | 002 | 2 | NUM | Indicador de linha (fixo `01`) |
+| 2 | `Cbc-hdr` | 003 | 007 | 5 | ALFA | Delimitador `#BPA#` |
+| 3 | `cbc-mvm` | 008 | 013 | 6 | NUM | Competência AAAAMM |
+| 4 | `cbc-lin` | 014 | 019 | 6 | NUM | Total de linhas BPA gravadas |
+| 5 | `cbc-flh` | 020 | 025 | 6 | NUM | Total de folhas BPA gravadas |
+| 6 | `cbc-smt-vrf` | 026 | 029 | 4 | NUM | Campo de controle (domínio 1111..2221, cálculo no final do PDF) |
+| 7 | `cbc-rsp` | 030 | 059 | 30 | ALFA | Nome do órgão de origem |
+| 8 | `cbc-sgl` | 060 | 065 | 6 | ALFA | Sigla do órgão de origem |
+| 9 | `cbc-cgccpf` | 066 | 079 | 14 | NUM | CGC/CPF do prestador |
+| 10 | `cbc-dst` | 080 | 119 | 40 | ALFA | Nome do órgão destino |
+| 11 | `cbc-dst-in` | 120 | 120 | 1 | ALFA | Indicador destino: `E` Estadual / `M` Municipal |
+| 12 | `cbc_versao` | 121 | 130 | 10 | ALFA | Versão do sistema (livre) |
+| 13 | `cbc-fim` | 131 | 132 | 2 | ALFA | `CR+LF` |
+
+### BPA-C — Boletim Consolidado (`prd-*`, ident=`02`) — 50 bytes
+
+| Seq | Campo | Ini | Fim | Tam | Tipo | Descrição |
+|---|---|---|---|---|---|---|
+| 1 | `prd-ident` | 001 | 002 | 2 | NUM | Fixo `02` |
+| 2 | `prd-cnes` | 003 | 009 | 7 | NUM | CNES + DV |
+| 3 | `prd-cmp` | 010 | 015 | 6 | NUM | Competência AAAAMM |
+| 4 | `Prd_cbo` | 016 | 021 | 6 | ALFA | CBO profissional |
+| 5 | `prd-flh` | 022 | 024 | 3 | NUM | Número da folha (001..999) |
+| 6 | `prd-seq` | 025 | 026 | 2 | NUM | Sequencial (01..20) |
+| 7 | `prd-pa` | 027 | 036 | 10 | NUM | Procedimento SIGTAP + DV |
+| 8 | `prd-ldade` | 037 | 039 | 3 | NUM | Idade (0..130) |
+| 9 | `prd-qt` | 040 | 045 | 6 | NUM | Quantidade |
+| 10 | `prd-org` | 046 | 048 | 3 | ALFA | Origem: `BPA`/`PNI`/`SIE`/`SIB`/`MIN`/`PAC`/`SCL`/`EXT` |
+| 11 | `prd-fim` | 049 | 050 | 2 | — | `CR+LF` |
+
+### BPA-I — Boletim Individualizado (`prd-*`, ident=`03`) — 352 bytes
+
+| Seq | Campo | Ini | Fim | Tam | Tipo | Descrição |
+|---|---|---|---|---|---|---|
+| 1 | `prd-ident` | 001 | 002 | 2 | NUM | Fixo `03` |
+| 2 | `prd-cnes` | 003 | 009 | 7 | NUM | CNES + DV |
+| 3 | `prd-cmp` | 010 | 015 | 6 | NUM | Competência AAAAMM |
+| 4 | `Prd_cnsmed` | 016 | 030 | 15 | NUM | CNS do profissional + DV |
+| 5 | `Prd_cbo` | 031 | 036 | 6 | ALFA | CBO profissional |
+| 6 | `Prd_dtaten` | 037 | 044 | 8 | NUM | Data atendimento AAAAMMDD |
+| 7 | `prd-flh` | 045 | 047 | 3 | NUM | Número da folha (001..999) |
+| 8 | `prd-seq` | 048 | 049 | 2 | NUM | Sequencial (01..99) |
+| 9 | `prd-pa` | 050 | 059 | 10 | NUM | Procedimento SIGTAP + DV |
+| 10 | `Prd-cnspac` | 060 | 074 | 15 | NUM | CNS do paciente (condicional ao procedimento) |
+| 11 | `Prd-sexo` | 075 | 075 | 1 | ALFA | `M` ou `F` |
+| 12 | `Prd-ibge` | 076 | 081 | 6 | NUM | IBGE município residência |
+| 13 | `Prd-cid` | 082 | 085 | 4 | ALFA | CID-10 |
+| 14 | `prd-ldade` | 086 | 088 | 3 | NUM | Idade (0..130) |
+| 15 | `prd-qt` | 089 | 094 | 6 | NUM | Quantidade |
+| 16 | `Prd-caten` | 095 | 096 | 2 | NUM | Caráter de atendimento |
+| 17 | `Prd-naut` | 097 | 109 | 13 | NUM | Número de autorização do estabelecimento |
+| 18 | `prd-org` | 110 | 112 | 3 | ALFA | Origem (mesmo domínio de BPA-C) |
+| 19 | `prd-nmpac` | 113 | 142 | 30 | ALFA | Nome do paciente |
+| 20 | `prd-dtnasc` | 143 | 150 | 8 | NUM | Data nascimento AAAAMMDD |
+| 21 | `prd-raca` | 151 | 152 | 2 | NUM | Raça/cor: `01` Branca, `02` Preta, `03` Parda, `04` Amarela, `05` Indígena, `99` Sem info |
+| 22 | `prd-etnia` | 153 | 156 | 4 | NUM | Etnia (obrigatório se raça=05, a partir de Out/2010) |
+| 23 | `prd-nac` | 157 | 159 | 3 | NUM | Nacionalidade |
+| 24 | `prd_srv` | 160 | 162 | 3 | NUM | Código do Serviço |
+| 25 | `prd_clf` | 163 | 165 | 3 | NUM | Código da Classificação |
+| 26 | `prd_equipe_Seq` | 166 | 173 | 8 | NUM | Sequencial da equipe |
+| 27 | `prd_equipe_Area` | 174 | 177 | 4 | NUM | Área da equipe |
+| 28 | `prd_cnpj` | 178 | 191 | 14 | NUM | CNPJ da empresa de manutenção/adaptação de OPM |
+| 29 | `prd_cep_pcnte` | 192 | 199 | 8 | NUM | CEP do paciente |
+| 30 | `prd_lograd_pcnte` | 200 | 202 | 3 | NUM | Código do logradouro |
+| 31 | `prd_end_pcnte` | 203 | 232 | 30 | ALFA | Endereço |
+| 32 | `prd_compl_pcnte` | 233 | 242 | 10 | ALFA | Complemento |
+| 33 | `prd_num_pcnte` | 243 | 247 | 5 | ALFA | Número |
+| 34 | `prd_bairro_pcnte` | 248 | 277 | 30 | ALFA | Bairro |
+| 35 | `prd_ddtel_pcnte` | 278 | 288 | 11 | NUM | Telefone |
+| 36 | `prd_email_pcnte` | 289 | 328 | 40 | ALFA | E-mail |
+| 37 | `prd_ine` | 329 | 338 | 10 | NUM | INE (identificação nacional de equipes, a partir de Ago/2015) |
+| 38 | `prd_cpf_pcnte` | 339 | 349 | 11 | NUM | CPF do indivíduo (condicional) |
+| 38 | `prd_situacao_rua` | 350 | 350 | 1 | ALFA | `N`/`S` pessoa em situação de rua (a partir de Dez/2024) |
+| 39 | `prd-fim` | 351 | 352 | 2 | — | `CR+LF` |
+
+> Obs.: A sequência `38` aparece duplicada no PDF — `prd_cpf_pcnte` e
+> `prd_situacao_rua` são campos distintos, a numeração é inconsistente no
+> documento original.
+
+### Regras adicionais (observação final do PDF)
+
+- **Cálculo do `cbc-smt-vrf` (campo de controle):**
+  1. Somar `procedimento + quantidade` de todas as linhas.
+  2. Obter resto da divisão por 1111.
+  3. Somar 1111 ao resto → resultado final.
+- **Identificação do paciente (BPA-I):** deve-se usar **apenas um** dos
+  documentos, CPF **ou** CNS. Se informado um, o outro deve ficar em branco.
+
+## Fluxos Operacionais (Manual_Operacional_BPA.pdf)
+
+Ordem canônica de operação do BPA-Mag em cada competência:
+
+1. **Instalação/configuração** — Firebird 1.5.5 + BPA-Mag (§2).
+2. **Preparação da competência** (§5) — cadastro de responsáveis, definição de
+   AAAAMM, importação de:
+   - Tabela SUS (SIGTAP) do KIT SIA — `BDSIAaaaammv.exe`;
+   - Equipes CAPTAÇÃO (do CNES) — quando houver ações de equipe.
+3. **Registro BPA-C** (§6) — inclusão de folhas consolidadas por
+   CNES/Mês/Ano/CBO/Idade/Quantidade.
+4. **Registro BPA-I** (§7) — folhas individualizadas por CNES + CNS
+   Profissional, com múltiplos atendimentos (CNS paciente, CID, sexo, idade,
+   quantidade, serviço/classificação, caráter de atendimento, número de
+   autorização opcional).
+5. **Exportação** (§9) — geração do TXT de remessa conforme layout acima,
+   encaminhado ao gestor estadual/municipal para ingestão no SIA.
+
+## Integração com Gold v2
+
+Mapeamento alvo (multi-tenant, pilot Presidente Epitácio):
+
+- **BPA-C (consolidado)** → `fato_producao_ambulatorial` com
+  `fonte_sistema = 'SIA_BPA_C'`. Sem `sk_paciente` (agregado). Chave natural
+  operacional: `(sk_estabelecimento, sk_competencia, sk_cbo, idade, sk_procedimento)`.
+- **BPA-I (individualizado)** → `fato_producao_ambulatorial` com
+  `fonte_sistema = 'SIA_BPA_I'`. Inclui `sk_paciente`, `dt_atendimento`,
+  `cid10`, `caracter_atendimento`, `num_autorizacao`.
+- **Dedup com SIA oficial (PA/AR/AB):** quando o município receber os `.dbc`
+  processados pelo SIA Nacional via DATASUS após a remessa, aplicar chave:
+  `(sk_estab, sk_prof, sk_procedimento, sk_competencia, dt_atendimento,
+  sk_paciente)` para casar registros BPA-I locais ↔ SIA centralizado. Usar
+  `fontes` JSONB (padrão do repo) para merge idempotente.
+- **Origem do registro** (`prd-org`) → coluna categórica
+  `origem_captacao` com domínio `{BPA, PNI, SIE, SIB, MIN, PAC, SCL, EXT}`.
+- **Raça/cor, etnia, nacionalidade** → já presentes em `dim_pessoa` v2;
+  preencher a partir dos campos `prd-raca`, `prd-etnia`, `prd-nac`.
+- **Equipe (INE + área + sequencial)** → `dim_equipe_sus` (nova dimensão
+  candidata) ou colunas desnormalizadas em `fato_producao_ambulatorial`.
+- **Endereço do paciente** → `dim_endereco` (CEP, logradouro, bairro,
+  telefone, e-mail) SCD2 para rastreio histórico.
+- **Campo de controle `cbc-smt-vrf`** → validação de integridade pós-ingestão
+  (recomputar e comparar); não persistir em Gold.
+
+## TODO: Introspecção completa do GDB
+
+Rodar quando `fbclient.dll` estiver disponível:
+
+```bash
+python scripts/introspect_bpa_gdb.py \
+  --gdb "E:/BPA/BPAMAG.GDB" \
+  --dll "<path>/fbclient.dll" \
+  --output docs/data-dictionary-bpa.md
+```
+
+Saídas esperadas da introspecção:
+
+- Lista completa de tabelas internas do BPA-Mag (cabeçalho, folhas, itens,
+  domínios, usuários, config).
+- Mapeamento campo ↔ atributo do layout TXT (muitas colunas GDB têm nomes
+  diferentes dos códigos do layout de export).
+- Constraints, domínios, triggers, stored procedures.
+- Contagens de linhas por tabela para dimensionamento de ingestão.
+
+## Arquivos de extração de PDF (gerados por `scripts/parse_datasus_pdfs.py`)
+
+Temporários já removidos após consolidação. Reexecutar se necessário:
+
+```bash
+.venv/Scripts/python.exe scripts/parse_datasus_pdfs.py \
+  --pdf "E:/BPA/Layout_Exportacao_BPA.pdf" \
+  --output docs/_tmp_bpa_layout.md
+
+.venv/Scripts/python.exe scripts/parse_datasus_pdfs.py \
+  --pdf "E:/BPA/Manual_Operacional_BPA.pdf" \
+  --output docs/_tmp_bpa_manual.md
+```

--- a/docs/data-dictionary-cnes.md
+++ b/docs/data-dictionary-cnes.md
@@ -3602,3 +3602,36 @@ RELAÇÃO DAS TABELAS DE DOMÍNIOS
 | CD\_HABILITACAO | VARCHAR(4) |  |  |  |  | Yes | NOT NULL |  |  |
 | DS\_HABILITACAO | VARCHAR(256) |  |  |  |  |  | NOT NULL |  |  |
 | TP\_HABILITACAO | CHAR(1) |  |  |  |  |  | NULL |  |  |
+
+---
+
+## §Gold v2 Mapping
+
+Mapeamento das tabelas técnicas CNES (LFCES*/NFCES*) para Gold v2
+(ver `docs/data-dictionary-gold-v2.md`):
+
+| Origem Firebird | → | Gold v2 | Observação |
+|---|---|---|---|
+| `LFCES018` (profissionais) | → | `dim_profissional` | CPF_PROF → cpf_hash (SHA256[:11]); NOME_PROF → nome; COD_CNS → cns |
+| `LFCES004` (estabelecimentos) | → | `dim_estabelecimento` | CNES → cnes; NOME_FANTA → nome; CNPJ_MANT → cnpj_mantenedora; TP_UNID_ID → tp_unid; CODMUNGEST → sk_municipio (via dim_municipio lookup) |
+| `LFCES021` (vínculos) | → | `fato_vinculo_cnes` | PROF_ID/UNIDADE_ID resolvidos para sk_*; CARGA_HORARIA_TOTAL → carga_horaria_sem; IND_VINC preservado; COD_CBO → sk_cbo |
+| `LFCES060` (equipes) | → | `fato_vinculo_cnes.sk_equipe` | SEQ_EQUIPE → sk_equipe; dim_equipe futuro |
+| `NFCES026` (CBO) | → | `dim_cbo` | COD_CBO → cod_cbo; sync periódico por competência |
+| `NFCES005` (municípios) | → | `dim_municipio` | COD_MUN → ibge6; reconciliação com CADMUN SIA |
+| `NFCES010` (tp unidade) | → | atributo `tp_unid` em `dim_estabelecimento` | SMALLINT, domínio estático |
+| `NFCES046` (tp equipe) | → | atributo em `dim_equipe` (futuro) | reservado |
+| `NFCES058` (IND_VINC subvínculos) | → | lookup estática; não reificada como dim | 6 dígitos, ref documental |
+
+### BigQuery nacional → Gold v2
+
+Mesmo mapeamento do CNES local; `fonte_sistema='CNES_NACIONAL'`. Reconciliação em
+`dim_profissional.fontes JSONB`: `{"CNES_LOCAL": true, "CNES_NACIONAL": true}`.
+
+### Ingestão (dump_agent_go existente)
+
+Intents atuais cobrem mapping acima:
+- `cnes_profissionais` — extract LFCES018 + LFCES021 join
+- `cnes_estabelecimentos` — extract LFCES004
+- `cnes_equipes` — extract LFCES060
+
+Mappers `data_processor` a criar (fora de escopo Spec B).

--- a/docs/data-dictionary-firebird-bigquery.md
+++ b/docs/data-dictionary-firebird-bigquery.md
@@ -542,3 +542,15 @@ ORDER BY prof.NOME_PROF, vinc.COD_CBO
 > `CD_SEGMENT` e `DS_SEGMENT` existem em `LFCES060` (confirmado via `RDB$`) mas retornam
 > erro `-206 Column unknown` quando acessados via alias curto em `LEFT JOIN` aninhado no Firebird.
 > Se necessário, recuperar em subquery separada após a carga principal.
+
+---
+
+## §Gold v2 Mapping
+
+Este dicionário descreve o **schema CNES parcial inferido** (Firebird local
+vs BigQuery nacional). A versão canônica desde Spec B (2026-04-21) é
+`docs/data-dictionary-cnes.md` — a seção Gold v2 Mapping oficial está lá.
+
+Mesmo mapeamento aplica aqui, com nota: tabelas nacionais BigQuery (versão
+derivada) são carregadas via `fonte_sistema='CNES_NACIONAL'`. Reconciliação
+em `dim_profissional.fontes JSONB` via merge idempotente.

--- a/docs/data-dictionary-gold-v2.md
+++ b/docs/data-dictionary-gold-v2.md
@@ -1,0 +1,645 @@
+# Dicionário de Dados — Gold Schema v2 (Proposta)
+
+- **Versão:** 2.0
+- **Data:** 2026-04-21
+- **Status:** Design docs-only — não implementado
+- **Autor:** Claude (co-design com Vinícius Andre, session 2026-04-21)
+- **Spec de referência:** `docs/superpowers/specs/2026-04-21-gold-schema-refactor-sia-bpa-design.md`
+
+Dicionários correlatos (fontes que alimentam Gold v2):
+
+- `docs/data-dictionary-cnes.md` — CNES Firebird local (LFCES*) + nacional (NFCES*)
+- `docs/data-dictionary-firebird-bigquery.md` — CNES BigQuery nacional
+- `docs/data-dictionary-sihd-hospital.md` — SIHD2 local (TB_AIH/TB_HAIH/TB_PA/TB_HPA)
+- `docs/data-dictionary-sia.md` — SIASUS DBFs (105 arquivos introspectados)
+- `docs/data-dictionary-bpa.md` — BPA-Mag (BPAMAG.GDB + layout TXT exportação)
+
+---
+
+## 1. Visão geral
+
+Gold v2 adota **star schema híbrido** em duas camadas:
+
+1. **`landing.raw_extractions`** — evidência imutável de auditoria. Cada
+   extração (Parquet em MinIO) registrada com `sha256`, `row_count`,
+   `schema_version`, `extracao_ts`, `job_id`, `fonte_sistema`.
+2. **`gold.*`** — star schema compacto (7 dims + 4 fatos + 1 view
+   materializada). Surrogate keys `INT4`, valores em centavos `BIGINT`,
+   partitioning por `sk_competencia`.
+
+Garantias de auditabilidade: todo fato carrega `fonte_sistema`, `job_id`,
+`extracao_ts` — rastreamento reverso até Parquet raw em MinIO via
+`landing.raw_extractions.object_key`.
+
+Byte budget: redução ~65% vs Gold atual (UUID(16) → INT4(4) em chaves,
+JSONB redundante removido de fatos, tipos nativos compactos — `SMALLINT`,
+`CHAR(N)`, `DATE` onde não há componente temporal).
+
+Multi-tenant: `landing.tenant_id CHAR(6)` IBGE6. Em `gold.*` isolamento
+via `set_tenant_id()` ContextVar + RLS Postgres sobre `sk_municipio`.
+
+---
+
+## 2. Layer `landing`
+
+### 2.1 `landing.raw_extractions`
+
+```sql
+CREATE SCHEMA IF NOT EXISTS landing;
+
+CREATE TABLE landing.raw_extractions (
+    id              UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    job_id          UUID          NOT NULL,
+    fonte_sistema   TEXT          NOT NULL,
+    tenant_id       CHAR(6)       NOT NULL,
+    competencia     INT4          NOT NULL,
+    tipo_extracao   TEXT          NOT NULL,
+    object_key      TEXT          NOT NULL,
+    row_count       INT4          NOT NULL,
+    sha256          CHAR(64)      NOT NULL,
+    schema_version  SMALLINT      NOT NULL,
+    extracao_ts     TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    ingested_ts     TIMESTAMPTZ,
+    CONSTRAINT uniq_source_comp UNIQUE (fonte_sistema, tenant_id, competencia, tipo_extracao),
+    CONSTRAINT chk_fonte_sistema CHECK (fonte_sistema IN (
+        'CNES_LOCAL', 'CNES_NACIONAL', 'SIHD',
+        'SIA_APA', 'SIA_BPI', 'BPA_C', 'BPA_I'
+    )),
+    CONSTRAINT chk_competencia_yyyymm CHECK (
+        competencia BETWEEN 200001 AND 209912
+        AND (competencia % 100) BETWEEN 1 AND 12
+    )
+);
+
+CREATE INDEX ix_landing_tenant_comp ON landing.raw_extractions (tenant_id, competencia);
+CREATE INDEX ix_landing_job          ON landing.raw_extractions (job_id);
+CREATE INDEX ix_landing_pending      ON landing.raw_extractions (ingested_ts)
+    WHERE ingested_ts IS NULL;
+```
+
+Semântica: `extracao_ts` marca geração pelo edge agent; `ingested_ts`
+NULL indica pendente de consumo pelo `data_processor`. Zero UPDATE/DELETE
+em produção — `ingested_ts` é o único campo mutável (flag ciclo de
+vida).
+
+---
+
+## 3. Layer `gold` — Dimensões
+
+Schema `gold`. Surrogate keys `INT4 GENERATED ALWAYS AS IDENTITY`.
+
+### 3.1 `gold.dim_profissional`
+
+`cpf_hash` = SHA256 truncado em 11 chars. Fontes merged via JSONB
+(nunca sobrescrever).
+
+```sql
+CREATE TABLE gold.dim_profissional (
+    sk_profissional     INT4         GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    cpf_hash            CHAR(11)     NOT NULL UNIQUE,
+    nome                TEXT         NOT NULL,
+    cns                 CHAR(15),
+    sk_cbo_principal    INT4,
+    fontes              JSONB        NOT NULL DEFAULT '{}'::JSONB,
+    criado_em           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    atualizado_em       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_profissional_cbo
+        FOREIGN KEY (sk_cbo_principal) REFERENCES gold.dim_cbo (sk_cbo)
+);
+
+CREATE INDEX ix_profissional_cbo ON gold.dim_profissional (sk_cbo_principal);
+```
+
+### 3.2 `gold.dim_estabelecimento`
+
+`cnes CHAR(7)` inclui DV. `tp_unid` é código de tipo de unidade SIGTAP.
+
+```sql
+CREATE TABLE gold.dim_estabelecimento (
+    sk_estabelecimento  INT4         GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    cnes                CHAR(7)      NOT NULL UNIQUE,
+    nome                TEXT         NOT NULL,
+    cnpj_mantenedora    CHAR(14),
+    tp_unid             SMALLINT     NOT NULL,
+    sk_municipio        INT4         NOT NULL,
+    fontes              JSONB        NOT NULL DEFAULT '{}'::JSONB,
+    criado_em           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    atualizado_em       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_estab_municipio
+        FOREIGN KEY (sk_municipio) REFERENCES gold.dim_municipio (sk_municipio)
+);
+
+CREATE INDEX ix_estab_municipio ON gold.dim_estabelecimento (sk_municipio);
+CREATE INDEX ix_estab_tp_unid   ON gold.dim_estabelecimento (tp_unid);
+```
+
+### 3.3 `gold.dim_procedimento_sus`
+
+SIGTAP canônico, 10 dígitos com DV. Vigência por competência para
+rastrear procedimentos descontinuados.
+
+```sql
+CREATE TABLE gold.dim_procedimento_sus (
+    sk_procedimento            INT4      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    cod_sigtap                 CHAR(10)  NOT NULL UNIQUE,
+    descricao                  TEXT      NOT NULL,
+    complexidade               SMALLINT,
+    financiamento              CHAR(3),
+    modalidade                 CHAR(3),
+    competencia_vigencia_ini   INT4,
+    competencia_vigencia_fim   INT4,
+    CONSTRAINT chk_complexidade  CHECK (complexidade IN (1, 2, 3)),
+    CONSTRAINT chk_financiamento CHECK (financiamento IN ('MAC', 'FAE', 'PAB', 'VISA')),
+    CONSTRAINT chk_modalidade    CHECK (modalidade IN ('AMB', 'HOSP', 'APAC'))
+);
+
+CREATE INDEX ix_procedimento_vigencia
+    ON gold.dim_procedimento_sus (competencia_vigencia_ini, competencia_vigencia_fim);
+CREATE INDEX ix_procedimento_financ ON gold.dim_procedimento_sus (financiamento);
+```
+
+Domínios: `complexidade` 1=baixa/2=média/3=alta. `financiamento` MAC
+(Média/Alta Complexidade) / FAE (Fundo Ações Estratégicas) / PAB (Piso
+Atenção Básica) / VISA (Vigilância Sanitária). `modalidade` AMB /
+HOSP / APAC.
+
+### 3.4 `gold.dim_cbo`
+
+```sql
+CREATE TABLE gold.dim_cbo (
+    sk_cbo       INT4      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    cod_cbo      CHAR(6)   NOT NULL UNIQUE,
+    descricao    TEXT      NOT NULL
+);
+```
+
+### 3.5 `gold.dim_cid10`
+
+```sql
+CREATE TABLE gold.dim_cid10 (
+    sk_cid       INT4      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    cod_cid      CHAR(4)   NOT NULL UNIQUE,
+    descricao    TEXT      NOT NULL,
+    capitulo     SMALLINT  NOT NULL,
+    CONSTRAINT chk_capitulo CHECK (capitulo BETWEEN 1 AND 22)
+);
+
+CREATE INDEX ix_cid_capitulo ON gold.dim_cid10 (capitulo);
+```
+
+### 3.6 `gold.dim_municipio`
+
+`teto_pab_cents` descoberto no SIA `CADMUN.DBF` (`TETOPAB`) — mantido em
+Gold para JOIN em análises de cobertura sem descer ao DBF raw.
+
+```sql
+CREATE TABLE gold.dim_municipio (
+    sk_municipio          INT4      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    ibge6                 CHAR(6)   NOT NULL UNIQUE,
+    ibge7                 CHAR(7)   NOT NULL UNIQUE,
+    nome                  TEXT      NOT NULL,
+    uf                    CHAR(2)   NOT NULL,
+    populacao_estimada    INT4,
+    teto_pab_cents        BIGINT
+);
+
+CREATE INDEX ix_municipio_uf ON gold.dim_municipio (uf);
+```
+
+### 3.7 `gold.dim_competencia`
+
+Pré-populada 2020-01 → 2040-12 em migration inicial. `sk_competencia`
+sequencial (202001→1, 202002→2, ...) usado como range boundary em
+partitioning de fatos. Nunca renumerar sk existente.
+
+```sql
+CREATE TABLE gold.dim_competencia (
+    sk_competencia      INT4      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    competencia         INT4      NOT NULL UNIQUE,
+    ano                 SMALLINT  NOT NULL,
+    mes                 SMALLINT  NOT NULL,
+    qtd_dias_uteis      SMALLINT,
+    inicio_coleta       DATE,
+    fim_coleta          DATE,
+    CONSTRAINT chk_mes_valido CHECK (mes BETWEEN 1 AND 12)
+);
+
+CREATE INDEX ix_competencia_ano_mes ON gold.dim_competencia (ano, mes);
+```
+
+---
+
+## 4. Layer `gold` — Fatos
+
+Todos particionados via `PARTITION BY RANGE (sk_competencia)` nativo
+Postgres. PK composta inclui `sk_competencia`.
+
+### 4.1 `gold.fato_vinculo_cnes`
+
+Origem: CNES `LFCES021` (TB_CARGA_HORARIA_SUS) + join `LFCES060` para
+equipe ESF/NASF.
+
+```sql
+CREATE TABLE gold.fato_vinculo_cnes (
+    sk_vinculo           BIGINT        GENERATED ALWAYS AS IDENTITY,
+    sk_profissional      INT4          NOT NULL,
+    sk_estabelecimento   INT4          NOT NULL,
+    sk_cbo               INT4          NOT NULL,
+    sk_competencia       INT4          NOT NULL,
+    carga_horaria_sem    SMALLINT,
+    ind_vinc             CHAR(6),
+    sk_equipe            INT4,
+    job_id               UUID          NOT NULL,
+    fonte_sistema        TEXT          NOT NULL,
+    extracao_ts          TIMESTAMPTZ   NOT NULL,
+    PRIMARY KEY (sk_competencia, sk_vinculo),
+    CONSTRAINT fk_vinculo_prof  FOREIGN KEY (sk_profissional)    REFERENCES gold.dim_profissional (sk_profissional),
+    CONSTRAINT fk_vinculo_estab FOREIGN KEY (sk_estabelecimento) REFERENCES gold.dim_estabelecimento (sk_estabelecimento),
+    CONSTRAINT fk_vinculo_cbo   FOREIGN KEY (sk_cbo)             REFERENCES gold.dim_cbo (sk_cbo),
+    CONSTRAINT fk_vinculo_comp  FOREIGN KEY (sk_competencia)     REFERENCES gold.dim_competencia (sk_competencia),
+    CONSTRAINT chk_fonte_cnes   CHECK (fonte_sistema IN ('CNES_LOCAL', 'CNES_NACIONAL'))
+) PARTITION BY RANGE (sk_competencia);
+
+CREATE INDEX ix_vinculo_estab_comp ON gold.fato_vinculo_cnes (sk_estabelecimento, sk_competencia);
+CREATE INDEX ix_vinculo_prof_comp  ON gold.fato_vinculo_cnes (sk_profissional, sk_competencia);
+```
+
+### 4.2 `gold.fato_producao_ambulatorial`
+
+Produção unificada SIA (APA, BPI) + BPA (BPA-C, BPA-I). Cross-source
+dedup em `fontes_reportadas JSONB` (regras em §9).
+
+```sql
+CREATE TABLE gold.fato_producao_ambulatorial (
+    sk_producao            BIGINT        GENERATED ALWAYS AS IDENTITY,
+    sk_profissional        INT4          NOT NULL,
+    sk_estabelecimento     INT4          NOT NULL,
+    sk_procedimento        INT4          NOT NULL,
+    sk_competencia         INT4          NOT NULL,
+    sk_cid_principal       INT4,
+    qtd                    INT4          NOT NULL,
+    valor_aprov_cents      BIGINT        NOT NULL DEFAULT 0,
+    dt_atendimento         DATE,
+    job_id                 UUID          NOT NULL,
+    fonte_sistema          TEXT          NOT NULL,
+    extracao_ts            TIMESTAMPTZ   NOT NULL,
+    fontes_reportadas      JSONB,
+    PRIMARY KEY (sk_competencia, sk_producao),
+    CONSTRAINT fk_prod_prof      FOREIGN KEY (sk_profissional)    REFERENCES gold.dim_profissional (sk_profissional),
+    CONSTRAINT fk_prod_estab     FOREIGN KEY (sk_estabelecimento) REFERENCES gold.dim_estabelecimento (sk_estabelecimento),
+    CONSTRAINT fk_prod_proc      FOREIGN KEY (sk_procedimento)    REFERENCES gold.dim_procedimento_sus (sk_procedimento),
+    CONSTRAINT fk_prod_comp      FOREIGN KEY (sk_competencia)     REFERENCES gold.dim_competencia (sk_competencia),
+    CONSTRAINT fk_prod_cid       FOREIGN KEY (sk_cid_principal)   REFERENCES gold.dim_cid10 (sk_cid),
+    CONSTRAINT chk_fonte_amb     CHECK (fonte_sistema IN ('SIA_APA', 'SIA_BPI', 'BPA_C', 'BPA_I')),
+    CONSTRAINT chk_qtd_positivo  CHECK (qtd > 0),
+    CONSTRAINT chk_valor_nao_neg CHECK (valor_aprov_cents >= 0)
+) PARTITION BY RANGE (sk_competencia);
+
+CREATE INDEX ix_prod_estab_comp ON gold.fato_producao_ambulatorial (sk_estabelecimento, sk_competencia);
+CREATE INDEX ix_prod_prof_comp  ON gold.fato_producao_ambulatorial (sk_profissional, sk_competencia);
+CREATE INDEX ix_prod_proc_comp  ON gold.fato_producao_ambulatorial (sk_procedimento, sk_competencia);
+CREATE INDEX ix_prod_dedup      ON gold.fato_producao_ambulatorial (
+    sk_estabelecimento, sk_profissional, sk_procedimento, sk_competencia, dt_atendimento
+);
+```
+
+### 4.3 `gold.fato_internacao`
+
+Somente AIHs fechadas (`TB_HAIH`). `TB_AIH` em movimento não alimenta
+Gold para evitar dupla contagem.
+
+```sql
+CREATE TABLE gold.fato_internacao (
+    sk_aih                      BIGINT        GENERATED ALWAYS AS IDENTITY,
+    num_aih                     CHAR(13)      NOT NULL,
+    sk_profissional_solicit     INT4,
+    sk_estabelecimento          INT4          NOT NULL,
+    sk_competencia              INT4          NOT NULL,
+    sk_cid_principal            INT4,
+    dt_internacao               DATE          NOT NULL,
+    dt_saida                    DATE,
+    valor_total_cents           BIGINT,
+    job_id                      UUID          NOT NULL,
+    fonte_sistema               TEXT          NOT NULL DEFAULT 'SIHD',
+    extracao_ts                 TIMESTAMPTZ   NOT NULL,
+    PRIMARY KEY (sk_competencia, sk_aih),
+    CONSTRAINT fk_aih_prof     FOREIGN KEY (sk_profissional_solicit) REFERENCES gold.dim_profissional (sk_profissional),
+    CONSTRAINT fk_aih_estab    FOREIGN KEY (sk_estabelecimento)      REFERENCES gold.dim_estabelecimento (sk_estabelecimento),
+    CONSTRAINT fk_aih_comp     FOREIGN KEY (sk_competencia)          REFERENCES gold.dim_competencia (sk_competencia),
+    CONSTRAINT fk_aih_cid      FOREIGN KEY (sk_cid_principal)        REFERENCES gold.dim_cid10 (sk_cid),
+    CONSTRAINT chk_fonte_sihd  CHECK (fonte_sistema = 'SIHD'),
+    CONSTRAINT chk_datas_aih   CHECK (dt_saida IS NULL OR dt_saida >= dt_internacao)
+) PARTITION BY RANGE (sk_competencia);
+
+CREATE INDEX ix_aih_numero     ON gold.fato_internacao (num_aih);
+CREATE INDEX ix_aih_estab_comp ON gold.fato_internacao (sk_estabelecimento, sk_competencia);
+CREATE INDEX ix_aih_cid        ON gold.fato_internacao (sk_cid_principal);
+```
+
+### 4.4 `gold.fato_procedimento_aih`
+
+Procedimentos executados em cada AIH (`TB_HPA`). `sk_aih` é FK lógico
+cross-partition, validado pelo transformer (não enforced como constraint).
+
+```sql
+CREATE TABLE gold.fato_procedimento_aih (
+    sk_proc_aih              BIGINT        GENERATED ALWAYS AS IDENTITY,
+    sk_aih                   BIGINT        NOT NULL,
+    sk_procedimento          INT4          NOT NULL,
+    sk_profissional_exec     INT4,
+    sk_competencia           INT4          NOT NULL,
+    qtd                      INT4          NOT NULL DEFAULT 1,
+    valor_cents              BIGINT,
+    job_id                   UUID          NOT NULL,
+    extracao_ts              TIMESTAMPTZ   NOT NULL,
+    PRIMARY KEY (sk_competencia, sk_proc_aih),
+    CONSTRAINT fk_pa_proc     FOREIGN KEY (sk_procedimento)      REFERENCES gold.dim_procedimento_sus (sk_procedimento),
+    CONSTRAINT fk_pa_prof     FOREIGN KEY (sk_profissional_exec) REFERENCES gold.dim_profissional (sk_profissional),
+    CONSTRAINT fk_pa_comp     FOREIGN KEY (sk_competencia)       REFERENCES gold.dim_competencia (sk_competencia),
+    CONSTRAINT chk_qtd_aih    CHECK (qtd > 0),
+    CONSTRAINT chk_valor_aih  CHECK (valor_cents IS NULL OR valor_cents >= 0)
+) PARTITION BY RANGE (sk_competencia);
+
+CREATE INDEX ix_pa_aih       ON gold.fato_procedimento_aih (sk_aih);
+CREATE INDEX ix_pa_proc_comp ON gold.fato_procedimento_aih (sk_procedimento, sk_competencia);
+```
+
+### 4.5 Partition template (anual)
+
+Script roda em job anual (novembro do ano anterior). Ex: ano 2026
+assume `sk_competencia` 202601=73 e 202701=85.
+
+```sql
+CREATE TABLE gold.fato_vinculo_cnes_2026
+    PARTITION OF gold.fato_vinculo_cnes
+    FOR VALUES FROM (73) TO (85);
+
+CREATE TABLE gold.fato_producao_ambulatorial_2026
+    PARTITION OF gold.fato_producao_ambulatorial
+    FOR VALUES FROM (73) TO (85);
+
+CREATE TABLE gold.fato_internacao_2026
+    PARTITION OF gold.fato_internacao
+    FOR VALUES FROM (73) TO (85);
+
+CREATE TABLE gold.fato_procedimento_aih_2026
+    PARTITION OF gold.fato_procedimento_aih
+    FOR VALUES FROM (73) TO (85);
+```
+
+Partições >3 anos podem ser detached + movidas para tier secundário
+via `pg_cron` + `pg_dump`.
+
+---
+
+## 5. Materialized View `gold.view_auditoria_producao`
+
+`FULL OUTER JOIN` entre 3 fatos principais por tupla
+`(sk_profissional, sk_estabelecimento, sk_competencia)`. Refresh semanal
+`CONCURRENTLY` (requer índice UNIQUE — aplicado).
+
+```sql
+CREATE MATERIALIZED VIEW gold.view_auditoria_producao AS
+SELECT
+    COALESCE(fv.sk_profissional, fpa.sk_profissional, fi.sk_profissional_solicit)  AS sk_profissional,
+    COALESCE(fv.sk_estabelecimento, fpa.sk_estabelecimento, fi.sk_estabelecimento) AS sk_estabelecimento,
+    COALESCE(fv.sk_competencia, fpa.sk_competencia, fi.sk_competencia)             AS sk_competencia,
+    COUNT(DISTINCT fv.sk_vinculo)                                                  AS qtd_vinculos,
+    COUNT(DISTINCT fpa.sk_producao)                                                AS qtd_producao_amb,
+    COUNT(DISTINCT fi.sk_aih)                                                      AS qtd_aih,
+    COALESCE(SUM(fpa.valor_aprov_cents), 0)                                        AS valor_producao_cents,
+    COALESCE(SUM(fi.valor_total_cents), 0)                                         AS valor_aih_cents
+FROM gold.fato_vinculo_cnes fv
+FULL OUTER JOIN gold.fato_producao_ambulatorial fpa
+    USING (sk_profissional, sk_estabelecimento, sk_competencia)
+FULL OUTER JOIN gold.fato_internacao fi
+    ON  fi.sk_profissional_solicit = COALESCE(fv.sk_profissional, fpa.sk_profissional)
+    AND fi.sk_estabelecimento      = COALESCE(fv.sk_estabelecimento, fpa.sk_estabelecimento)
+    AND fi.sk_competencia          = COALESCE(fv.sk_competencia, fpa.sk_competencia)
+GROUP BY 1, 2, 3;
+
+CREATE UNIQUE INDEX ix_vap_key
+    ON gold.view_auditoria_producao (sk_profissional, sk_estabelecimento, sk_competencia);
+CREATE INDEX ix_vap_comp ON gold.view_auditoria_producao (sk_competencia);
+```
+
+Refresh:
+
+```sql
+REFRESH MATERIALIZED VIEW CONCURRENTLY gold.view_auditoria_producao;
+```
+
+Scheduling: weekly cron via `central_api` admin endpoint, domingo 03:00
+UTC após fim de semana sem writes pesados.
+
+---
+
+## 6. Byte Budget
+
+Comparação Gold atual vs proposto (storage lógico, overhead Postgres +
+TOAST excluídos).
+
+| Tabela | Bytes/row atual | Bytes/row proposto | Economia / 1M rows |
+|---|---|---|---|
+| `fato_vinculo_cnes` | ~250 (3×UUID + VARCHAR + TIMESTAMPTZ + JSONB) | ~80 (4×INT4 + SMALLINT + CHAR(6) + INT4 + UUID + TEXT + TIMESTAMPTZ) | ~170 MB |
+| `fato_producao_ambulatorial` | N/A (novo) | ~85 | baseline |
+| `fato_internacao` | N/A (novo) | ~90 | baseline |
+| `fato_procedimento_aih` | N/A (novo) | ~60 | baseline |
+| `dim_profissional` | ~200 | ~100 | ~100 MB / 10k rows |
+| `dim_estabelecimento` | ~200 | ~120 | ~80 MB / 1k rows |
+| `dim_procedimento_sus` | N/A (novo) | ~80 | baseline |
+| `dim_cbo` | N/A (novo) | ~50 | baseline |
+| `dim_cid10` | N/A (novo) | ~60 | baseline |
+| `dim_municipio` | ~170 | ~60 | ~110 MB / 5.7k rows |
+| `dim_competencia` | N/A (novo) | ~22 | baseline |
+
+**Extrapolação produção:** 10 competências × 100 municípios ×
+1M rows/competência ≈ **1 bilhão de linhas em fatos**.
+
+- Gold atual (≈250 B/row): **~1.3 TB**.
+- Gold v2 (≈80 B/row avg ponderado): **~400 GB**.
+- Economia ≈ **65%**.
+
+Ganhos secundários: índices `INT4` ~4× menores que `UUID`; JOINs mais
+rápidos (cache-friendly); partition pruning por `sk_competencia`
+elimina I/O em queries filtradas por ano/mês.
+
+---
+
+## 7. Query motriz (auditoria)
+
+Valida se o schema sustenta o caso de uso primário: identificar
+profissionais × estabelecimento × competência com alto volume
+financeiro (produção + internação).
+
+```sql
+SELECT
+    sk_profissional,
+    sk_estabelecimento,
+    sk_competencia,
+    qtd_vinculos,
+    qtd_producao_amb,
+    qtd_aih,
+    valor_producao_cents + valor_aih_cents AS total_cents
+FROM gold.view_auditoria_producao
+WHERE sk_competencia BETWEEN :ini AND :fim
+ORDER BY total_cents DESC
+LIMIT 100;
+```
+
+**Dry-run conceitual:**
+
+- Sem MV: 3×`fato_*` range scan + 3 GROUP BY — custo O(n log n).
+- Com MV refresh semanal: custo O(linhas filtradas por
+  `sk_competencia`), tipicamente ≤10k/ano em município pequeno —
+  latência <100ms. Paginação por keyset `(total_cents DESC,
+  sk_profissional ASC)`.
+
+---
+
+## 8. Cross-source dedup SIA + BPA
+
+Chave canônica:
+
+```
+(sk_estabelecimento, sk_profissional, sk_procedimento, sk_competencia, dt_atendimento)
+```
+
+Regras:
+
+1. Match entre SIA e BPA para mesma tupla → **1 linha** em
+   `fato_producao_ambulatorial`.
+2. `fonte_sistema` recebe fonte primária por precedência:
+   - **SIA > BPA** (SIA é submissão oficial, BPA é captação local).
+   - SIA_APA > SIA_BPI (APAC cobre alta complexidade).
+   - BPA_I > BPA_C (individualizado é granular).
+3. `fontes_reportadas JSONB` lista todas as fontes + valores divergentes:
+
+```json
+{
+  "SIA_APA":  {"qtd": 3, "valor_aprov_cents": 15000},
+  "SIA_BPI":  {"qtd": 3, "valor_aprov_cents": 15000},
+  "BPA_I":    {"qtd": 4, "valor_aprov_cents": 20000}
+}
+```
+
+4. Divergências (qtd ou valor diferentes) são auditáveis — preservadas
+   em `fontes_reportadas` sem tentativa de reconciliar.
+
+Ingestão ordenada: SIA primeiro, depois BPA. Row mapper BPA faz UPSERT
+condicional — se chave dedup existe, UPDATE `fontes_reportadas` com
+merge JSON; senão INSERT.
+
+---
+
+## 9. Naming conventions
+
+- **Idioma:** PT-BR em tabelas/colunas/docstrings de domínio. SQL
+  keywords em inglês maiúsculo.
+- **Prefixos:** `landing.raw_*` (imutável) / `gold.dim_*` / `gold.fato_*`
+  / `gold.view_*`.
+- **Surrogate keys:** `sk_` prefix, `INT4` em dimensões, `BIGINT` em
+  fatos. Nome descritivo completo (`sk_profissional`, não `sk_prof`).
+- **Hashes/códigos naturais:** colunas explícitas (`cpf_hash`,
+  `cod_sigtap`, `cod_cid`, `cnes`, `ibge6`) para debug e reconciliação.
+- **Valores monetários:** **sempre** `BIGINT` em centavos com sufixo
+  `_cents`. Nunca `NUMERIC(N,2)`.
+- **Datas:** `DATE` quando só a data importa; `TIMESTAMPTZ` UTC para
+  eventos (`extracao_ts`, `criado_em`, `atualizado_em`).
+- **Boolean-like:** `SMALLINT`/`CHAR(N)` + CHECK ao invés de `BOOLEAN`
+  quando domínio pode evoluir >2 valores.
+- **Partitioning:** sempre por `sk_competencia` range anual.
+- **Índices:** `ix_<tabela-curta>_<colunas>`. UNIQUE: `uniq_...`.
+- **FKs:** `fk_<tabela-curta>_<ref>`. Check: `chk_<descricao>`.
+
+---
+
+## 10. Integrações novas — SIA + BPA (pós-approval)
+
+### 10.1 `dump_agent_go` (edge)
+
+Novas intents em `apps/dump_agent_go/internal/intent/`:
+
+- `sia_apa` — lê `E:/siasus/S_APA.DBF` via biblioteca Go `dbase`
+  (DBF reader, encoding cp1252). `fonte_sistema=SIA_APA`.
+- `sia_bpi` — lê `S_BPI.DBF`. `fonte_sistema=SIA_BPI`.
+- `bpa_c` — lê `BPAMAG.GDB` via `fbdriver` Go (Firebird 1.5.5); fallback
+  operacional: TXT de remessa (layout 50B linhas).
+  `fonte_sistema=BPA_C`.
+- `bpa_i` — idem, 352B linhas. `fonte_sistema=BPA_I`.
+
+Cada intent produz 1 Parquet por competência, registrado em
+`landing.raw_extractions`.
+
+### 10.2 `data_processor` (worker)
+
+Novos row mappers em `apps/data_processor/app/mappers/`:
+
+- `sia_apa_mapper.py` — APA_* → `fato_producao_ambulatorial` subtipo
+  SIA_APA + FK resolution (CPF hash / CNES / cod_sigtap / CID).
+- `sia_bpi_mapper.py` — BPI_* → subtipo SIA_BPI.
+- `bpa_c_mapper.py` — BPA-C agregado sem paciente. Chave natural
+  `(estab, competência, cbo, idade, procedimento)`.
+- `bpa_i_mapper.py` — BPA-I granular com CNS profissional + paciente
+  (paciente out-of-scope nesta spec).
+
+### 10.3 `central_api`
+
+Sem mudança estrutural — rotas presigned URL minting genéricas já
+suportam qualquer `fonte_sistema`. Adicionar validação no Pydantic
+schema para aceitar novos valores (`SIA_APA`, `SIA_BPI`, `BPA_C`,
+`BPA_I`).
+
+### 10.4 Campos obrigatórios extraídos
+
+Do Layout_Exportacao_BPA (ver `docs/data-dictionary-bpa.md`):
+
+- `cbc-mvm` → `competencia`
+- `cbc-cgccpf` → `cnpj_mantenedora` (quando PJ)
+- `prd-cnes` → resolve `sk_estabelecimento`
+- `prd-cbo` → resolve `sk_cbo`
+- `prd-pa` → resolve `sk_procedimento` (SIGTAP 10 dígitos)
+- `prd-cmp` → `sk_competencia`
+- `prd-qt` → `qtd`
+- `Prd_dtaten` (BPA-I) → `dt_atendimento`
+- `Prd_cnsmed` (BPA-I) → resolve `sk_profissional` via CNS quando CPF
+  ausente
+
+Do SIA DBFs (ver `docs/data-dictionary-sia.md`):
+
+- `APA_CNES` / `BPI_CNES` → `sk_estabelecimento`
+- `APA_CMP` / `BPI_CMP` → `sk_competencia`
+- `APA_PROC` / `BPI_PROC` → `sk_procedimento`
+- `APA_CNS_MEDEXE` / `BPI_CNSMED` → `sk_profissional`
+- `APA_CID` → `sk_cid_principal`
+- `APA_VAPROV` / `BPI_VAPROV` × 100 → `valor_aprov_cents`
+- `APA_DTINI` / `BPI_DTATEN` → `dt_atendimento`
+
+---
+
+## 11. Exit criteria
+
+Matching spec §12:
+
+- [ ] `docs/data-dictionary-gold-v2.md` completo (este arquivo),
+      review pelo autor
+- [ ] `docs/data-dictionary-sia.md` completo com 105 DBFs + schema por
+      DBF prioritária (Task 5 — feito)
+- [ ] `docs/data-dictionary-bpa.md` completo com layout TXT
+      introspectado + fluxo operacional (Task 7 — feito)
+- [ ] `docs/data-dictionary-cnes.md`, `data-dictionary-sihd-hospital.md`,
+      `data-dictionary-firebird-bigquery.md` atualizados com §Gold v2 Mapping
+- [ ] `docs/migration-plan-gold-v2.md` com revs Alembic 010-015 +
+      rollback
+- [ ] Byte budget tabelado para cada tabela (§6)
+- [ ] Query motriz `view_auditoria_producao` documentada + dry-run
+      comentado (§7)
+- [ ] Zero código / migration executada — spec é paper only
+- [ ] User review approved
+
+---
+
+**Fim da proposta Gold v2.** Próximo passo pós-approval: spec
+`migration-plan-gold-v2.md` com Alembic revs 010-015 detalhadas e
+plano de dual-write/shadow validation ≥2 competências antes de
+descartar schema legado.

--- a/docs/data-dictionary-sia.md
+++ b/docs/data-dictionary-sia.md
@@ -3018,3 +3018,62 @@ Observações da introspecção real:
 | PA_PROCCEO | C(1) | 1 | 0 |
 | PA_6MESES | C(1) | 1 | 0 |
 | PA_EXIGAUT | C(1) | 1 | 0 |
+
+## Referências PDF Datasus
+
+### MANUAL_OPERACIONAL_SIA.pdf
+
+Source: `E:/siasus/MANUAL_OPERACIONAL_SIA.pdf` (43 páginas, ed. CGSI/DRAC/SAS/MS).
+
+Principais achados relevantes para Gold v2:
+
+- **Arquitetura do SIA (§2.1-2.2):** SIA é o sistema de processamento central
+  operado pelo gestor local (SES/SMS). Recebe dados de três aplicativos de
+  captação: **BPA-Mag** (atenção básica + média complexidade),
+  **APAC-Mag** (procedimentos de alta complexidade que exigem autorização
+  prévia) e **RAAS** (atenção psicossocial / atenção domiciliar). Entradas
+  adicionais: CNES (DE-PARA), SIGTAP (tabela de procedimentos), FPO-Mag
+  (programação físico-orçamentária).
+- **SIGTAP como tabela mestre (§9):** instituída pela Portaria GM/MS nº 321/2007,
+  unifica procedimentos ambulatoriais e hospitalares em uma única base. Atributos
+  de cada procedimento: tipo de financiamento (PAB/VISA, **MAC**, **FAEC**),
+  instrumento de registro (BPA-C, BPA-I, APAC, RAAS), valor, CBO exigido, CID,
+  serviço/classificação, habilitações, incrementos financeiros, complexidade.
+- **Financiamento (§2.2 - FPO-Mag):** três tipos configurados na programação:
+  - **PAB/VISA** — Piso de Atenção Básica (não mais permitido na FPO a partir
+    de Julho/2014);
+  - **MAC** — Média e Alta Complexidade;
+  - **FAEC** — Fundo de Ações Estratégicas e Compensação.
+- **Subtipos ambulatoriais (§2.4 / §6):** três fluxos distintos de registro,
+  todos convergindo para o SIA:
+  - **BPA-C** (Consolidado) — registro agregado por CNES/Competência/CBO/Idade;
+    chave: `(CNES, Mês/Ano, Folha, Seq)`; sem dados do paciente.
+  - **BPA-I** (Individualizado) — registro por atendimento com CNS do paciente,
+    CID, sexo, raça/cor, etnia, nacionalidade, endereço; chave:
+    `(CNES, CNS_prof, Mês/Ano, Folha, Seq)`.
+  - **APAC** — registro autorizado por laudo; número de autorização de 13
+    dígitos (UF + AA + tipo + sequencial + DV). Tipos: `2` ambulatorial comum,
+    `4` CNRAC, `5` cirurgia eletiva MC.
+- **Fluxo de remessa (§7-8):** até Jun/2016, arquivos eram consistidos via
+  aplicativo externo **VERSIA** que gerava `.DTS` para transmissão. A partir de
+  Jul/2016, o SIA gera `.DTS` nativamente em `<SIA>/DTS/<AAAAMM>/`. Essa mudança
+  temporal explica variações de schema nos arquivos `.dbc` históricos
+  disponibilizados pelo DATASUS.
+- **Chave operacional mínima:** toda produção ambulatorial carrega `CNES +
+  Competência (AAAAMM) + Tipo de Registro`. Para deduplicação cross-sistema
+  recomendamos `(sk_estabelecimento, sk_competencia, fonte_sistema,
+  folha, seq)` em BPA e `(sk_estabelecimento, sk_competencia, num_apac)` em APAC.
+
+### Integração com Gold v2
+
+- SIGTAP procedimentos → `dim_procedimento_sus` (fonte de valor bruto, tipo
+  de financiamento, complexidade, CBO exigido, CID compatível, instrumento
+  de registro).
+- CBO profissionais → `dim_cbo` (tabela SUS importada via KIT SIA).
+- Subtipos ambulatoriais (APAC/BPA-I/BPA-C/RAAS) →
+  `fato_producao_ambulatorial.fonte_sistema` com domínio
+  `{SIA_APAC, SIA_BPA_I, SIA_BPA_C, SIA_RAAS}`.
+- Financiamento MAC/FAEC/PAB → `fato_producao_ambulatorial.tipo_financiamento`
+  (coluna categórica ou FK para `dim_financiamento`).
+- Número de autorização APAC (13 dígitos com DV) → coluna natural
+  `num_apac` em `fato_producao_ambulatorial` para rastreio de auditoria.

--- a/docs/data-dictionary-sia.md
+++ b/docs/data-dictionary-sia.md
@@ -1,0 +1,3020 @@
+# Dicionario de Dados - SIA (SIASUS DBFs)
+
+> Introspeccao automatica via `scripts/introspect_sia_dbf.py`.
+> Source: `E:\siasus`
+> DBFs: 105
+
+## DBFs prioritárias
+
+Baseado em tamanho + papel inferido (via Manual_Operacional_SIA + nome):
+
+| DBF | Propósito | Mapeia para Gold v2 |
+|---|---|---|
+| `S_APA.DBF` | Autorização Procedimentos de Alta Complexidade (APAC) | `fato_producao_ambulatorial` (subtipo `SIA_APA`) |
+| `S_BPI.DBF` | BPA Individualizado (procedimentos por paciente) | `fato_producao_ambulatorial` (subtipo `SIA_BPI`) |
+| `S_BPIHST.DBF` | BPA-I histórico | `fato_producao_ambulatorial` histórico |
+| `S_CDN.DBF` | Cadastro domínio de códigos | `dim_procedimento_sus` sync |
+| `CADMUN.DBF` | Cadastro municípios | `dim_municipio` reconciliação |
+| `consiste.dbf` | Regras de consistência | **Ignorar** (lógica de negócio) |
+
+Observações da introspecção real:
+- `S_APA.DBF` (1381 records, 62 fields): prefixos `APA_*` confirmam APAC individualizada (paciente, procedimento, dt_inicio/fim, CID).
+- `S_BPI.DBF` (910 records, 59 fields) e `S_BPIHST.DBF` (1792 records, 59 fields): schema idêntico com prefixo `BPI_*` (CNS paciente, CNS profissional, CBO, procedimento, folha/seq). Confirma BPA-Individualizado; `HST` é histórico de competências anteriores.
+- `S_CDN.DBF` (5570 records, 4 fields): schema genérico `CDN_TB/IT/DSCR/CHKSM` — tabela de domínio normalizada (dicionário de códigos). Útil para `dim_procedimento_sus` e demais dimensões que dependem de lookups SIA.
+- `CADMUN.DBF` (5715 records, 8 fields): `CODUF/CODMUNIC/NOME/CONDIC/TETOPAB/CALCPAB` — cadastro municípios com tetos PAB. Complementa `dim_municipio` com metadados financeiros se necessário.
+- `consiste.dbf` (469 records, 15 fields, prefixo misto `UID/CMP/TIPO/APAC/FOLHA/SEQ`): inconsistências de lote — lógica de auditoria interna do SIA, **ignorar** na Gold.
+
+## Summary
+
+| Arquivo | Records | Size (bytes) |
+|---|---|---|
+| S_CEP.DBF | 1576563 | 23,648,543 |
+| S_FXAPAC.DBF | 1315705 | 52,628,330 |
+| S_PACBO.DBF | 1160735 | 32,500,743 |
+| S_PACID.DBF | 488085 | 13,178,490 |
+| S_PAHA.DBF | 65443 | 2,028,960 |
+| S_PADET.DBF | 60864 | 1,521,763 |
+| S_PROCED.DBF | 32721 | 5,563,181 |
+| S_PASRV.DBF | 24493 | 685,999 |
+| S_PAPA.DBF | 24181 | 894,924 |
+| S_VPA.DBF | 20387 | 1,977,926 |
+| S_PAREGR.DBF | 19833 | 515,821 |
+| S_PA.DBF | 19133 | 3,158,067 |
+| S_PAP.DBF | 18097 | 3,602,667 |
+| S_CID.DBF | 15611 | 1,280,521 |
+| S_UPSPRF.DBF | 12870 | 1,944,044 |
+| S_TPCRD.DBF | 5919 | 1,078,093 |
+| CADMUN.DBF | 5715 | 457,490 |
+| S_DEPARA.DBF | 5576 | 184,170 |
+| S_CDN.DBF | 5570 | 317,652 |
+| S_FXRAAS.DBF | 4639 | 185,690 |
+| S_PRD.DBF | 3391 | 1,175,017 |
+| S_PRDHST.DBF | 2596 | 70,254 |
+| S_COMPFEDERAL.DBF | 2570 | 2,218,936 |
+| S_BPIHST.DBF | 1792 | 770,691 |
+| S_IPU.DBF | 1670 | 334,675 |
+| S_APA.DBF | 1381 | 1,076,589 |
+| S_EMU.DBF | 1197 | 49,367 |
+| S_SRV.DBF | 1152 | 31,330 |
+| S_BPI.DBF | 910 | 392,313 |
+| S_PAIN.DBF | 858 | 31,083 |
+| S_EQUIPE.DBF | 592 | 78,034 |
+| S_UPSGES.DBF | 541 | 9,359 |
+| consiste.dbf | 469 | 133,242 |
+| S_CNSQTD.DBF | 452 | 64,310 |
+| S_TUEMA.DBF | 99 | 15,245 |
+| S_RUB.DBF | 42 | 2,104 |
+| S_CFA.DBF | 38 | 1,568 |
+| S_FFI.DBF | 30 | 1,604 |
+| S_UPS.DBF | 27 | 10,838 |
+| s_reprd.dbf | 27 | 2,537 |
+| S_PRFIRR.DBF | 22 | 1,096 |
+| S_RELAT.DBF | 22 | 73,600 |
+| S_ENCERR.DBF | 18 | 4,333 |
+| S_CGCEX.DBF | 8 | 274 |
+| S_UPSHA.DBF | 8 | 474 |
+| tot_cons.dbf | 8 | 947 |
+| CONFIMP.DBF | 5 | 5,830 |
+| S_TDIR.DBF | 5 | 414 |
+| S_UPSRC.DBF | 4 | 258 |
+| S_CTR.DBF | 1 | 314 |
+| S_MNT.DBF | 1 | 1,006 |
+| S_SS.DBF | 1 | 770 |
+| s_cor.dbf | 1 | 886 |
+| ADESAO.DBF | 0 | 163 |
+| APCNES_TERC.DBF | 0 | 323 |
+| S_CD.DBF | 0 | 162 |
+| S_CDX.DBF | 0 | 162 |
+| S_CIDM.DBF | 0 | 98 |
+| S_CRD.DBF | 0 | 643 |
+| S_DPG.DBF | 0 | 419 |
+| S_FORNEC.DBF | 0 | 386 |
+| S_MN.DBF | 0 | 130 |
+| S_OCORR.DBF | 0 | 515 |
+| S_RAPA.DBF | 0 | 1,155 |
+| S_RAS.DBF | 0 | 1,603 |
+| S_TRMOTC.DBF | 0 | 321 |
+| S_UPSAUT.DBF | 0 | 162 |
+| advertencia_sexo.dbf | 0 | 483 |
+| cadgesmn.dbf | 0 | 195 |
+| cpx.dbf | 0 | 962 |
+| crit_lmc.dbf | 0 | 547 |
+| crit_trastuzumabe.dbf | 0 | 419 |
+| erro.dbf | 0 | 386 |
+| faixa.dbf | 0 | 162 |
+| pa.dbf | 0 | 962 |
+| psico.dbf | 0 | 1,025 |
+| s_ad.dbf | 0 | 1,251 |
+| s_adpa.dbf | 0 | 707 |
+| s_apal.dbf | 0 | 4,259 |
+| s_cnesia.dbf | 0 | 130 |
+| s_corpo.dbf | 0 | 1,505 |
+| s_eqesf.dbf | 0 | 257 |
+| s_fcd.dbf | 0 | 2,050 |
+| s_fco.dbf | 0 | 2,434 |
+| s_imperr.dbf | 0 | 195 |
+| s_ipul.dbf | 0 | 449 |
+| s_iput.dbf | 0 | 227 |
+| s_prdl.dbf | 0 | 1,251 |
+| s_prdlc.dbf | 0 | 355 |
+| s_prdli.dbf | 0 | 1,283 |
+| s_prdlt.dbf | 0 | 195 |
+| s_prdrep.dbf | 0 | 1,635 |
+| s_proc.dbf | 0 | 449 |
+| s_rapal.dbf | 0 | 675 |
+| s_sce.dbf | 0 | 162 |
+| s_trab.dbf | 0 | 1,443 |
+| s_upsval.dbf | 0 | 67 |
+| s_varia.dbf | 0 | 161 |
+| s_vpal.dbf | 0 | 385 |
+| temu.dbf | 0 | 193 |
+| tsrv.dbf | 0 | 161 |
+| ttvpa.dbf | 0 | 385 |
+| vepe.dbf | 0 | 257 |
+| versaomn.dbf | 0 | 257 |
+| vig.dbf | 0 | 993 |
+
+## Detalhes por DBF
+
+### `S_CEP.DBF`
+
+- 1576563 records
+- Size: 23,648,543 bytes
+- Encoding: cp1252
+- Fields: 2
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CEP | C(8) | 8 | 0 |
+| MUNICIPIO | C(6) | 6 | 0 |
+
+### `S_FXAPAC.DBF`
+
+- 1315705 records
+- Size: 52,628,330 bytes
+- Encoding: cp1252
+- Fields: 3
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| FX_INI | C(12) | 12 | 0 |
+| FX_FIM | C(12) | 12 | 0 |
+| FX_SKSUM | C(15) | 15 | 0 |
+
+### `S_PACBO.DBF`
+
+- 1160735 records
+- Size: 32,500,743 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PACBO_CMP | C(6) | 6 | 0 |
+| PACBO_PA | C(9) | 9 | 0 |
+| PACBO_CBO | C(6) | 6 | 0 |
+| PACBOCHKSM | C(6) | 6 | 0 |
+
+### `S_PACID.DBF`
+
+- 488085 records
+- Size: 13,178,490 bytes
+- Encoding: cp1252
+- Fields: 5
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PACID_CMP | C(6) | 6 | 0 |
+| PACID_PA | C(9) | 9 | 0 |
+| PACID_CID | C(4) | 4 | 0 |
+| PACID_PRIN | C(1) | 1 | 0 |
+| PACIDCHKSM | C(6) | 6 | 0 |
+
+### `S_PAHA.DBF`
+
+- 65443 records
+- Size: 2,028,960 bytes
+- Encoding: cp1252
+- Fields: 6
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PAHA_CMP | C(6) | 6 | 0 |
+| PAHA_PA | C(9) | 9 | 0 |
+| PAHA_GRP | C(4) | 4 | 0 |
+| PAHA_HA | C(4) | 4 | 0 |
+| N | C(1) | 1 | 0 |
+| PAHA_CHKSM | C(6) | 6 | 0 |
+
+### `S_PADET.DBF`
+
+- 60864 records
+- Size: 1,521,763 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| DET_CMP | C(6) | 6 | 0 |
+| DET_PA | C(9) | 9 | 0 |
+| DET_COD | C(3) | 3 | 0 |
+| DET_CHKSM | C(6) | 6 | 0 |
+
+### `S_PROCED.DBF`
+
+- 32721 records
+- Size: 5,563,181 bytes
+- Encoding: cp1252
+- Fields: 18
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PA_CMP | C(6) | 6 | 0 |
+| PA_ID | C(9) | 9 | 0 |
+| PA_DV | C(1) | 1 | 0 |
+| PA_DC | C(60) | 60 | 0 |
+| PA_RUB | C(4) | 4 | 0 |
+| PA_CPX | C(4) | 4 | 0 |
+| PA_CTF | C(4) | 4 | 0 |
+| PA_IDADEMX | N(3) | 3 | 0 |
+| PA_IDADEMN | N(3) | 3 | 0 |
+| PA_SEXO | C(1) | 1 | 0 |
+| PA_QTDMAX | N(6) | 6 | 0 |
+| PA_ELETIVA | C(1) | 1 | 0 |
+| PA_SH | N(12,2) | 12 | 2 |
+| PA_SP | N(12,2) | 12 | 2 |
+| PA_SA | N(12,2) | 12 | 2 |
+| PA_TPREG | C(10) | 10 | 0 |
+| PA_SKSUM | C(15) | 15 | 0 |
+| PA_CHKSM | C(6) | 6 | 0 |
+
+### `S_PASRV.DBF`
+
+- 24493 records
+- Size: 685,999 bytes
+- Encoding: cp1252
+- Fields: 5
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PASRV_CMP | C(6) | 6 | 0 |
+| PASRV_PA | C(9) | 9 | 0 |
+| PASRV_SRV | C(3) | 3 | 0 |
+| PASRV_CSF | C(3) | 3 | 0 |
+| PASRVCHKSM | C(6) | 6 | 0 |
+
+### `S_PAPA.DBF`
+
+- 24181 records
+- Size: 894,924 bytes
+- Encoding: cp1252
+- Fields: 6
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PAPA_CMP | C(6) | 6 | 0 |
+| PAPA_TRAT | C(2) | 2 | 0 |
+| PAPA_PRINC | C(9) | 9 | 0 |
+| PAPA_SECUN | C(9) | 9 | 0 |
+| PAPA_QTMAX | C(4) | 4 | 0 |
+| PAPA_CHKSM | C(6) | 6 | 0 |
+
+### `S_VPA.DBF`
+
+- 20387 records
+- Size: 1,977,926 bytes
+- Encoding: cp1252
+- Fields: 11
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| VPA_PA | C(9) | 9 | 0 |
+| VPA_CMP | C(6) | 6 | 0 |
+| VPA_SP | N(15,2) | 15 | 2 |
+| VPA_SA | N(15,2) | 15 | 2 |
+| VPA_SH | N(15,2) | 15 | 2 |
+| VPA_TOTAL | N(15,2) | 15 | 2 |
+| VPA_MUN | C(6) | 6 | 0 |
+| VPA_TIPO | C(1) | 1 | 0 |
+| VPA_CTF | C(2) | 2 | 0 |
+| VPA_RUB | C(6) | 6 | 0 |
+| VPA_MVM | C(6) | 6 | 0 |
+
+### `S_PAREGR.DBF`
+
+- 19833 records
+- Size: 515,821 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| REG_CMP | C(6) | 6 | 0 |
+| REG_PA | C(9) | 9 | 0 |
+| REG_REGRA | C(4) | 4 | 0 |
+| REG_CHKSM | C(6) | 6 | 0 |
+
+### `S_PA.DBF`
+
+- 19133 records
+- Size: 3,158,067 bytes
+- Encoding: cp1252
+- Fields: 34
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PA_CMP | C(6) | 6 | 0 |
+| PA_ID | C(9) | 9 | 0 |
+| PA_DV | C(1) | 1 | 0 |
+| PA_PAB | C(1) | 1 | 0 |
+| PA_TOTAL | N(12,2) | 12 | 2 |
+| PA_FAEC | C(1) | 1 | 0 |
+| PA_DC | C(60) | 60 | 0 |
+| PA_RUB | C(4) | 4 | 0 |
+| PA_TPCC | C(1) | 1 | 0 |
+| PA_AUX | C(20) | 20 | 0 |
+| PA_CPX | C(4) | 4 | 0 |
+| PA_CTF | C(4) | 4 | 0 |
+| PA_DOC | C(1) | 1 | 0 |
+| PA_IDADEMX | N(3) | 3 | 0 |
+| PA_IDADEMN | N(3) | 3 | 0 |
+| PA_SEXO | C(1) | 1 | 0 |
+| PA_QTDMAX | N(6) | 6 | 0 |
+| PA_LAUDO | C(2) | 2 | 0 |
+| PA_PRINC | C(1) | 1 | 0 |
+| PA_SECUN | C(1) | 1 | 0 |
+| PA_IDEBPA | C(1) | 1 | 0 |
+| PA_CNSPCN | C(1) | 1 | 0 |
+| PA_CNRAC | C(1) | 1 | 0 |
+| PA_CCMANAL | C(2) | 2 | 0 |
+| PA_ELETIVA | C(1) | 1 | 0 |
+| PA_APACONT | C(1) | 1 | 0 |
+| PA_EXIGCBO | C(1) | 1 | 0 |
+| PA_PROCCEO | C(1) | 1 | 0 |
+| PA_6MESES | C(1) | 1 | 0 |
+| PA_EXIGAUT | C(1) | 1 | 0 |
+| PA_PERMAN | N(4) | 4 | 0 |
+| PA_EXIGCAS | C(1) | 1 | 0 |
+| PA_SECOBRI | C(1) | 1 | 0 |
+| PA_CHKSM | C(6) | 6 | 0 |
+
+### `S_PAP.DBF`
+
+- 18097 records
+- Size: 3,602,667 bytes
+- Encoding: cp1252
+- Fields: 31
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PAP_UID | C(7) | 7 | 0 |
+| PAP_CMP | C(6) | 6 | 0 |
+| PAP_NUM | C(13) | 13 | 0 |
+| PAP_PA | C(10) | 10 | 0 |
+| PAP_SEQ | C(2) | 2 | 0 |
+| PAP_CBO | C(6) | 6 | 0 |
+| PAP_IDADE | N(3) | 3 | 0 |
+| PAP_QT_P | N(6) | 6 | 0 |
+| PAP_QT_A | N(6) | 6 | 0 |
+| PAP_MVM | C(6) | 6 | 0 |
+| PAP_ORG | C(3) | 3 | 0 |
+| PAP_FLPA | C(1) | 1 | 0 |
+| PAP_FLEMA | C(1) | 1 | 0 |
+| PAP_FLCBO | C(1) | 1 | 0 |
+| PAP_FLQT | C(1) | 1 | 0 |
+| PAP_FLER | C(1) | 1 | 0 |
+| PAP_CNPJ | C(14) | 14 | 0 |
+| PAP_NFISC | C(6) | 6 | 0 |
+| PAP_CIDPRI | C(6) | 6 | 0 |
+| PAP_CIDSEC | C(6) | 6 | 0 |
+| PAP_EQUIPE | C(12) | 12 | 0 |
+| PAP_VL_FED | N(15,2) | 15 | 2 |
+| PAP_VL_LOC | N(15,2) | 15 | 2 |
+| PAP_VL_INC | N(15,2) | 15 | 2 |
+| PAP_INCOUT | C(4) | 4 | 0 |
+| PAP_INCURG | C(4) | 4 | 0 |
+| PAP_RUB | C(6) | 6 | 0 |
+| PAP_TPFIN | C(1) | 1 | 0 |
+| PAP_CPX | C(1) | 1 | 0 |
+| PAP_RC | C(4) | 4 | 0 |
+| PAP_UNTERC | C(7) | 7 | 0 |
+
+### `S_CID.DBF`
+
+- 15611 records
+- Size: 1,280,521 bytes
+- Encoding: cp1252
+- Fields: 12
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CD_COD | C(4) | 4 | 0 |
+| OPC | C(1) | 1 | 0 |
+| CAT | C(1) | 1 | 0 |
+| SUBCAT | C(1) | 1 | 0 |
+| CD_DESCR | C(50) | 50 | 0 |
+| RESTRSEXO | C(1) | 1 | 0 |
+| CAMPOS_RAD | C(3) | 3 | 0 |
+| ESTADIO | C(1) | 1 | 0 |
+| REPETE_RAD | C(1) | 1 | 0 |
+| CMP_INI | C(6) | 6 | 0 |
+| CMP_FIM | C(6) | 6 | 0 |
+| CID_CHKSM | C(6) | 6 | 0 |
+
+### `S_UPSPRF.DBF`
+
+- 12870 records
+- Size: 1,944,044 bytes
+- Encoding: cp1252
+- Fields: 20
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PRF_CMP | C(6) | 6 | 0 |
+| PRF_CNES | C(7) | 7 | 0 |
+| PRF_MUN | C(6) | 6 | 0 |
+| PRF_AREA | C(4) | 4 | 0 |
+| PRF_SEQ | C(8) | 8 | 0 |
+| PRF_CNS | C(15) | 15 | 0 |
+| PRF_DTINI | C(8) | 8 | 0 |
+| PRF_DTFIM | C(8) | 8 | 0 |
+| PRF_CBO | C(6) | 6 | 0 |
+| PRF_IDVINC | C(6) | 6 | 0 |
+| PRF_TPNSUS | C(1) | 1 | 0 |
+| PRF_EQPMIN | C(1) | 1 | 0 |
+| PRF_MICROA | C(2) | 2 | 0 |
+| PRF_QT_HR | N(5) | 5 | 0 |
+| PRF_SRVTER | C(3) | 3 | 0 |
+| PRF_TERCEI | C(7) | 7 | 0 |
+| PRF_NOME | C(40) | 40 | 0 |
+| PRF_LOCNAC | C(1) | 1 | 0 |
+| PRF_CHKSM | C(6) | 6 | 0 |
+| PRF_INE | C(10) | 10 | 0 |
+
+### `S_TPCRD.DBF`
+
+- 5919 records
+- Size: 1,078,093 bytes
+- Encoding: cp1252
+- Fields: 25
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| TPCRDIFJ | C(1) | 1 | 0 |
+| TPCRD_RAD | C(8) | 8 | 0 |
+| TPCRDLIAL | C(6) | 6 | 0 |
+| TPCRD_BCO | C(3) | 3 | 0 |
+| TPCRD_AB | C(6) | 6 | 0 |
+| TPCRD_CC | C(14) | 14 | 0 |
+| TPCRD_IR | C(1) | 1 | 0 |
+| TPCRD_ID | C(7) | 7 | 0 |
+| TPCRD_CMP | C(6) | 6 | 0 |
+| TPCRD_FLH | C(13) | 13 | 0 |
+| TPCRD_SEQ | C(2) | 2 | 0 |
+| TPCRD_PA | C(9) | 9 | 0 |
+| TPCRD_ORG | C(3) | 3 | 0 |
+| TPCRD_CR | C(1) | 1 | 0 |
+| TPCRD_VL | N(13,2) | 13 | 2 |
+| TPCRD_INCC | C(1) | 1 | 0 |
+| TPCRD_CNPJ | C(14) | 14 | 0 |
+| TPCRD_NFIS | C(6) | 6 | 0 |
+| TPCRD_RUB | C(6) | 6 | 0 |
+| TPCRD_CNS | C(15) | 15 | 0 |
+| TPCRD_CBO | C(6) | 6 | 0 |
+| TPCRD_CPX | C(1) | 1 | 0 |
+| TPCRD_VFED | N(13,2) | 13 | 2 |
+| TPCRD_VLOC | N(13,2) | 13 | 2 |
+| TPCRD_VINC | N(13,2) | 13 | 2 |
+
+### `CADMUN.DBF`
+
+- 5715 records
+- Size: 457,490 bytes
+- Encoding: cp1252
+- Fields: 8
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CODUF | C(2) | 2 | 0 |
+| CODMUNIC | C(4) | 4 | 0 |
+| NOME | C(40) | 40 | 0 |
+| CONDIC | C(2) | 2 | 0 |
+| TETOPAB | N(12,2) | 12 | 2 |
+| CALCPAB | N(12,2) | 12 | 2 |
+| DTHABIL | C(6) | 6 | 0 |
+| CIB_SAS | C(1) | 1 | 0 |
+
+### `S_DEPARA.DBF`
+
+- 5576 records
+- Size: 184,170 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| ORIGEM | C(10) | 10 | 0 |
+| DESTINO | C(10) | 10 | 0 |
+| CMP_INI | C(6) | 6 | 0 |
+| CMP_FIM | C(6) | 6 | 0 |
+
+### `S_CDN.DBF`
+
+- 5570 records
+- Size: 317,652 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CDN_TB | C(2) | 2 | 0 |
+| CDN_IT | C(8) | 8 | 0 |
+| CDN_DSCR | C(40) | 40 | 0 |
+| CDN_CHKSM | C(6) | 6 | 0 |
+
+### `S_FXRAAS.DBF`
+
+- 4639 records
+- Size: 185,690 bytes
+- Encoding: cp1252
+- Fields: 3
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| FX_INI | C(12) | 12 | 0 |
+| FX_FIM | C(12) | 12 | 0 |
+| FX_SKSUM | C(15) | 15 | 0 |
+
+### `S_PRD.DBF`
+
+- 3391 records
+- Size: 1,175,017 bytes
+- Encoding: cp1252
+- Fields: 53
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PRD_UID | C(7) | 7 | 0 |
+| PRD_CMP | C(6) | 6 | 0 |
+| PRD_FLH | C(3) | 3 | 0 |
+| PRD_SEQ | C(2) | 2 | 0 |
+| PRD_PA | C(10) | 10 | 0 |
+| PRD_CBO | C(6) | 6 | 0 |
+| PRD_IDADE | N(3) | 3 | 0 |
+| PRD_QT_P | N(6) | 6 | 0 |
+| PRD_QT_A | N(6) | 6 | 0 |
+| PRD_VL_P | N(15,2) | 15 | 2 |
+| PRD_VL_A | N(15,2) | 15 | 2 |
+| PRD_MVM | C(6) | 6 | 0 |
+| PRD_ORG | C(3) | 3 | 0 |
+| PRD_FLPA | C(1) | 1 | 0 |
+| PRD_FLCBO | C(1) | 1 | 0 |
+| PRD_FLCA | C(1) | 1 | 0 |
+| PRD_FLIDA | C(1) | 1 | 0 |
+| PRD_FLQT | C(1) | 1 | 0 |
+| PRD_FLER | C(1) | 1 | 0 |
+| PRD_APANUM | C(13) | 13 | 0 |
+| PRD_CNSMED | C(15) | 15 | 0 |
+| PRD_RMS | C(4) | 4 | 0 |
+| PRD_CNPJ | C(14) | 14 | 0 |
+| PRD_NFIS | C(6) | 6 | 0 |
+| PRD_RESID | C(6) | 6 | 0 |
+| PRD_RUB | C(6) | 6 | 0 |
+| PRD_TPFIN | C(1) | 1 | 0 |
+| PRD_CPX | C(1) | 1 | 0 |
+| PRD_QTDATR | N(6) | 6 | 0 |
+| PRD_QTDATU | N(6) | 6 | 0 |
+| PRD_RC | C(4) | 4 | 0 |
+| PRD_CIDPRI | C(6) | 6 | 0 |
+| PRD_CIDSEC | C(6) | 6 | 0 |
+| PRD_CIDCAS | C(6) | 6 | 0 |
+| PRD_INCOUT | C(4) | 4 | 0 |
+| PRD_INCURG | C(4) | 4 | 0 |
+| PRD_INSRG | C(3) | 3 | 0 |
+| PRD_CPFPCT | C(11) | 11 | 0 |
+| PRD_CNSPCN | C(15) | 15 | 0 |
+| PRD_DTINI | C(8) | 8 | 0 |
+| PRD_DTREA | C(8) | 8 | 0 |
+| PRD_SRV | C(3) | 3 | 0 |
+| PRD_CSF | C(3) | 3 | 0 |
+| PRD_EQUIP | C(12) | 12 | 0 |
+| PRD_VL_FED | N(10,2) | 10 | 2 |
+| PRD_VL_LOC | N(10,2) | 10 | 2 |
+| PRD_VL_INC | N(10,2) | 10 | 2 |
+| PRD_RUBFED | C(6) | 6 | 0 |
+| PRD_LREX | C(1) | 1 | 0 |
+| PRD_INE | C(10) | 10 | 0 |
+| PRD_UNTERC | C(7) | 7 | 0 |
+| PRD_CHKSM | C(6) | 6 | 0 |
+| PRD_TEMP | C(20) | 20 | 0 |
+
+### `S_PRDHST.DBF`
+
+- 2596 records
+- Size: 70,254 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PRD_CMP | C(6) | 6 | 0 |
+| PRD_UID | C(7) | 7 | 0 |
+| PRD_PA | C(10) | 10 | 0 |
+| PRD_INSRG | C(3) | 3 | 0 |
+
+### `S_COMPFEDERAL.DBF`
+
+- 2570 records
+- Size: 2,218,936 bytes
+- Encoding: cp1252
+- Fields: 31
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CODPA | C(10) | 10 | 0 |
+| DTINI | C(6) | 6 | 0 |
+| DTFIM | C(6) | 6 | 0 |
+| CAMPO_FED | C(30) | 30 | 0 |
+| CAMPO_AC | C(30) | 30 | 0 |
+| CAMPO_AL | C(30) | 30 | 0 |
+| CAMPO_AP | C(30) | 30 | 0 |
+| CAMPO_AM | C(30) | 30 | 0 |
+| CAMPO_BA | C(30) | 30 | 0 |
+| CAMPO_CE | C(30) | 30 | 0 |
+| CAMPO_DF | C(30) | 30 | 0 |
+| CAMPO_ES | C(30) | 30 | 0 |
+| CAMPO_GO | C(30) | 30 | 0 |
+| CAMPO_MA | C(30) | 30 | 0 |
+| CAMPO_MT | C(30) | 30 | 0 |
+| CAMPO_MS | C(30) | 30 | 0 |
+| CAMPO_MG | C(30) | 30 | 0 |
+| CAMPO_PA | C(30) | 30 | 0 |
+| CAMPO_PB | C(30) | 30 | 0 |
+| CAMPO_PR | C(30) | 30 | 0 |
+| CAMPO_PE | C(30) | 30 | 0 |
+| CAMPO_PI | C(30) | 30 | 0 |
+| CAMPO_RJ | C(30) | 30 | 0 |
+| CAMPO_RN | C(30) | 30 | 0 |
+| CAMPO_RS | C(30) | 30 | 0 |
+| CAMPO_RO | C(30) | 30 | 0 |
+| CAMPO_RR | C(30) | 30 | 0 |
+| CAMPO_SC | C(30) | 30 | 0 |
+| CAMPO_SP | C(30) | 30 | 0 |
+| CAMPO_SE | C(30) | 30 | 0 |
+| CAMPO_TO | C(30) | 30 | 0 |
+
+### `S_BPIHST.DBF`
+
+- 1792 records
+- Size: 770,691 bytes
+- Encoding: cp1252
+- Fields: 59
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| BPI_UID | C(7) | 7 | 0 |
+| BPI_CMP | C(6) | 6 | 0 |
+| BPI_CNSMED | C(15) | 15 | 0 |
+| BPI_CBO | C(6) | 6 | 0 |
+| BPI_FLH | C(3) | 3 | 0 |
+| BPI_SEQ | C(2) | 2 | 0 |
+| BPI_PA | C(10) | 10 | 0 |
+| BPI_CPFPCT | C(11) | 11 | 0 |
+| BPI_CNSPAC | C(15) | 15 | 0 |
+| BPI_NMPAC | C(30) | 30 | 0 |
+| BPI_DTNASC | C(8) | 8 | 0 |
+| BPI_SEXO | C(1) | 1 | 0 |
+| BPI_IBGE | C(6) | 6 | 0 |
+| BPI_DTATEN | C(8) | 8 | 0 |
+| BPI_CID | C(4) | 4 | 0 |
+| BPI_CATEN | C(2) | 2 | 0 |
+| BPI_NAUT | C(13) | 13 | 0 |
+| BPI_QT_P | N(6) | 6 | 0 |
+| BPI_QT_A | N(6) | 6 | 0 |
+| BPI_IDADE | N(3) | 3 | 0 |
+| BPI_MVM | C(6) | 6 | 0 |
+| BPI_ORG | C(3) | 3 | 0 |
+| BPI_TPFIN | C(1) | 1 | 0 |
+| BPI_RMS | C(4) | 4 | 0 |
+| BPI_FLPA | C(1) | 1 | 0 |
+| BPI_FLCID | C(1) | 1 | 0 |
+| BPI_FLCBO | C(1) | 1 | 0 |
+| BPI_FLCA | C(1) | 1 | 0 |
+| BPI_FLIDA | C(1) | 1 | 0 |
+| BPI_FLQT | C(1) | 1 | 0 |
+| BPI_FLER | C(1) | 1 | 0 |
+| BPI_RACA | C(2) | 2 | 0 |
+| BPI_ETNIA | C(4) | 4 | 0 |
+| BPI_NACIO | C(3) | 3 | 0 |
+| BPI_SRV | C(3) | 3 | 0 |
+| BPI_CSF | C(3) | 3 | 0 |
+| BPI_EQUIPE | C(12) | 12 | 0 |
+| BPI_CNPJ | C(14) | 14 | 0 |
+| BPI_CEPPCN | C(8) | 8 | 0 |
+| BPI_CDLOGR | C(3) | 3 | 0 |
+| BPI_LOGPCN | C(30) | 30 | 0 |
+| BPI_CPLPCN | C(10) | 10 | 0 |
+| BPI_NUMPCN | C(5) | 5 | 0 |
+| BPI_BAIRRO | C(30) | 30 | 0 |
+| BPI_DDD | C(2) | 2 | 0 |
+| BPI_TEL | C(9) | 9 | 0 |
+| BPI_EMAIL | C(40) | 40 | 0 |
+| BPI_VL_FED | N(10,2) | 10 | 2 |
+| BPI_VL_LOC | N(10,2) | 10 | 2 |
+| BPI_VL_INC | N(10,2) | 10 | 2 |
+| BPI_INCOUT | C(4) | 4 | 0 |
+| BPI_INCURG | C(4) | 4 | 0 |
+| BPI_RUB | C(6) | 6 | 0 |
+| BPI_CPX | C(1) | 1 | 0 |
+| BPI_RC | C(4) | 4 | 0 |
+| BPI_CHKSM | C(6) | 6 | 0 |
+| BPI_INE | C(10) | 10 | 0 |
+| BPI_STRUA | C(1) | 1 | 0 |
+| BPI_ADVSEX | C(1) | 1 | 0 |
+
+### `S_IPU.DBF`
+
+- 1670 records
+- Size: 334,675 bytes
+- Encoding: cp1252
+- Fields: 20
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| IPU_UID | C(7) | 7 | 0 |
+| IPU_CMP | C(6) | 6 | 0 |
+| IPU_PA | C(9) | 9 | 0 |
+| IPU_TPFIN | C(1) | 1 | 0 |
+| IPU_NAPU | C(1) | 1 | 0 |
+| IPU_QT_O | N(8) | 8 | 0 |
+| IPU_VU_O | N(15,2) | 15 | 2 |
+| IPU_VL_O | N(15,2) | 15 | 2 |
+| IPU_QT_P | N(8) | 8 | 0 |
+| IPU_VL_P | N(15,2) | 15 | 2 |
+| IPU_QT_A | N(8) | 8 | 0 |
+| IPU_VL_A | N(15,2) | 15 | 2 |
+| IPU_VLAEST | N(15,2) | 15 | 2 |
+| IPU_VLPEST | N(15,2) | 15 | 2 |
+| IPU_VLOE | N(15,2) | 15 | 2 |
+| IPU_VL_J | N(12,2) | 12 | 2 |
+| IPU_MVM | C(6) | 6 | 0 |
+| IPU_AUX | C(21) | 21 | 0 |
+| IPU_FPOMAG | C(1) | 1 | 0 |
+| IPU_CHKSM | C(6) | 6 | 0 |
+
+### `S_APA.DBF`
+
+- 1381 records
+- Size: 1,076,589 bytes
+- Encoding: cp1252
+- Fields: 62
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| APA_UID | C(7) | 7 | 0 |
+| APA_NUM | C(13) | 13 | 0 |
+| APA_EMISSA | C(8) | 8 | 0 |
+| APA_DTINIC | C(8) | 8 | 0 |
+| APA_DTFIM | C(8) | 8 | 0 |
+| APA_TPATEN | C(2) | 2 | 0 |
+| APA_TPAPAC | C(1) | 1 | 0 |
+| APA_NMPCN | C(30) | 30 | 0 |
+| APA_UFPCN | C(3) | 3 | 0 |
+| APA_MAEPCN | C(30) | 30 | 0 |
+| APA_LOGPCN | C(30) | 30 | 0 |
+| APA_NUMPCN | C(5) | 5 | 0 |
+| APA_CPLPCN | C(10) | 10 | 0 |
+| APA_CEPPCN | C(8) | 8 | 0 |
+| APA_MUNPCN | C(7) | 7 | 0 |
+| APA_DTNASC | C(8) | 8 | 0 |
+| APA_SEXPCN | C(1) | 1 | 0 |
+| APA_VARIA | C(141) | 141 | 0 |
+| APA_CPFRES | C(11) | 11 | 0 |
+| APA_NMRES | C(30) | 30 | 0 |
+| APA_MOTCOB | C(2) | 2 | 0 |
+| APA_DTOBAL | C(8) | 8 | 0 |
+| APA_CPFDIR | C(11) | 11 | 0 |
+| APA_NMDIR | C(30) | 30 | 0 |
+| APA_CMP | C(6) | 6 | 0 |
+| APA_MVM | C(6) | 6 | 0 |
+| APA_RMS | C(4) | 4 | 0 |
+| APA_DTGER | C(8) | 8 | 0 |
+| APA_FLER | C(10) | 10 | 0 |
+| APA_INERPP | C(1) | 1 | 0 |
+| APA_PRIPAL | C(9) | 9 | 0 |
+| APA_CPFPCT | C(11) | 11 | 0 |
+| APA_CNSPCT | C(15) | 15 | 0 |
+| APA_CNSRES | C(15) | 15 | 0 |
+| APA_CNSDIR | C(15) | 15 | 0 |
+| APA_CIDCA | C(4) | 4 | 0 |
+| APA_NPRONT | C(10) | 10 | 0 |
+| APA_CODSOL | C(7) | 7 | 0 |
+| APA_DTSOL | C(8) | 8 | 0 |
+| APA_DTAUT | C(8) | 8 | 0 |
+| APA_CODEMI | C(10) | 10 | 0 |
+| APA_CATEND | C(2) | 2 | 0 |
+| APA_APACAN | C(14) | 14 | 0 |
+| APA_RACA | C(2) | 2 | 0 |
+| APA_NOMERE | C(30) | 30 | 0 |
+| APA_ETNIA | C(4) | 4 | 0 |
+| APA_ADVLMC | C(1) | 1 | 0 |
+| APA_ADVTZM | C(1) | 1 | 0 |
+| APA_SRV | C(3) | 3 | 0 |
+| APA_CSF | C(3) | 3 | 0 |
+| APA_CDLOGR | C(3) | 3 | 0 |
+| APA_BAIRRO | C(30) | 30 | 0 |
+| APA_DDD | C(2) | 2 | 0 |
+| APA_TEL | C(9) | 9 | 0 |
+| APA_EMAIL | C(40) | 40 | 0 |
+| APA_CNSEXE | C(15) | 15 | 0 |
+| APA_INE | C(10) | 10 | 0 |
+| APA_ADVSEX | C(1) | 1 | 0 |
+| APA_EXPMAE | C(1) | 1 | 0 |
+| APA_STRUA | C(1) | 1 | 0 |
+| APA_FNTORC | C(2) | 2 | 0 |
+| APA_EMEPAR | C(1) | 1 | 0 |
+
+### `S_EMU.DBF`
+
+- 1197 records
+- Size: 49,367 bytes
+- Encoding: cp1252
+- Fields: 8
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| EMU_UID | C(7) | 7 | 0 |
+| EMU_CMP | C(6) | 6 | 0 |
+| EMU_EMA | C(6) | 6 | 0 |
+| EMU_QT_PR | N(3) | 3 | 0 |
+| EMU_QT_HR | N(5) | 5 | 0 |
+| EMU_LOCNAC | C(1) | 1 | 0 |
+| EMU_MVM | C(6) | 6 | 0 |
+| EMU_CHKSM | C(6) | 6 | 0 |
+
+### `S_SRV.DBF`
+
+- 1152 records
+- Size: 31,330 bytes
+- Encoding: cp1252
+- Fields: 6
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| SRV_UID | C(7) | 7 | 0 |
+| SRV_CMP | C(6) | 6 | 0 |
+| SRV_SR | C(3) | 3 | 0 |
+| SRV_CSF | C(3) | 3 | 0 |
+| SRV_LOCNAC | C(1) | 1 | 0 |
+| SRV_CHKSM | C(6) | 6 | 0 |
+
+### `S_BPI.DBF`
+
+- 910 records
+- Size: 392,313 bytes
+- Encoding: cp1252
+- Fields: 59
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| BPI_UID | C(7) | 7 | 0 |
+| BPI_CMP | C(6) | 6 | 0 |
+| BPI_CNSMED | C(15) | 15 | 0 |
+| BPI_CBO | C(6) | 6 | 0 |
+| BPI_FLH | C(3) | 3 | 0 |
+| BPI_SEQ | C(2) | 2 | 0 |
+| BPI_PA | C(10) | 10 | 0 |
+| BPI_CPFPCT | C(11) | 11 | 0 |
+| BPI_CNSPAC | C(15) | 15 | 0 |
+| BPI_NMPAC | C(30) | 30 | 0 |
+| BPI_DTNASC | C(8) | 8 | 0 |
+| BPI_SEXO | C(1) | 1 | 0 |
+| BPI_IBGE | C(6) | 6 | 0 |
+| BPI_DTATEN | C(8) | 8 | 0 |
+| BPI_CID | C(4) | 4 | 0 |
+| BPI_CATEN | C(2) | 2 | 0 |
+| BPI_NAUT | C(13) | 13 | 0 |
+| BPI_QT_P | N(6) | 6 | 0 |
+| BPI_QT_A | N(6) | 6 | 0 |
+| BPI_IDADE | N(3) | 3 | 0 |
+| BPI_MVM | C(6) | 6 | 0 |
+| BPI_ORG | C(3) | 3 | 0 |
+| BPI_TPFIN | C(1) | 1 | 0 |
+| BPI_RMS | C(4) | 4 | 0 |
+| BPI_FLPA | C(1) | 1 | 0 |
+| BPI_FLCID | C(1) | 1 | 0 |
+| BPI_FLCBO | C(1) | 1 | 0 |
+| BPI_FLCA | C(1) | 1 | 0 |
+| BPI_FLIDA | C(1) | 1 | 0 |
+| BPI_FLQT | C(1) | 1 | 0 |
+| BPI_FLER | C(1) | 1 | 0 |
+| BPI_RACA | C(2) | 2 | 0 |
+| BPI_ETNIA | C(4) | 4 | 0 |
+| BPI_NACIO | C(3) | 3 | 0 |
+| BPI_SRV | C(3) | 3 | 0 |
+| BPI_CSF | C(3) | 3 | 0 |
+| BPI_EQUIPE | C(12) | 12 | 0 |
+| BPI_CNPJ | C(14) | 14 | 0 |
+| BPI_CEPPCN | C(8) | 8 | 0 |
+| BPI_CDLOGR | C(3) | 3 | 0 |
+| BPI_LOGPCN | C(30) | 30 | 0 |
+| BPI_CPLPCN | C(10) | 10 | 0 |
+| BPI_NUMPCN | C(5) | 5 | 0 |
+| BPI_BAIRRO | C(30) | 30 | 0 |
+| BPI_DDD | C(2) | 2 | 0 |
+| BPI_TEL | C(9) | 9 | 0 |
+| BPI_EMAIL | C(40) | 40 | 0 |
+| BPI_VL_FED | N(10,2) | 10 | 2 |
+| BPI_VL_LOC | N(10,2) | 10 | 2 |
+| BPI_VL_INC | N(10,2) | 10 | 2 |
+| BPI_INCOUT | C(4) | 4 | 0 |
+| BPI_INCURG | C(4) | 4 | 0 |
+| BPI_RUB | C(6) | 6 | 0 |
+| BPI_CPX | C(1) | 1 | 0 |
+| BPI_RC | C(4) | 4 | 0 |
+| BPI_CHKSM | C(6) | 6 | 0 |
+| BPI_INE | C(10) | 10 | 0 |
+| BPI_STRUA | C(1) | 1 | 0 |
+| BPI_ADVSEX | C(1) | 1 | 0 |
+
+### `S_PAIN.DBF`
+
+- 858 records
+- Size: 31,083 bytes
+- Encoding: cp1252
+- Fields: 5
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PAIN_CMP | C(6) | 6 | 0 |
+| PAIN_PA | C(9) | 9 | 0 |
+| PAIN_HA | C(4) | 4 | 0 |
+| PAIN_IN | N(10,2) | 10 | 2 |
+| PAIN_CHKSM | C(6) | 6 | 0 |
+
+### `S_EQUIPE.DBF`
+
+- 592 records
+- Size: 78,034 bytes
+- Encoding: cp1252
+- Fields: 14
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| EQP_CMP | C(6) | 6 | 0 |
+| EQP_CNES | C(7) | 7 | 0 |
+| EQP_AREA | C(4) | 4 | 0 |
+| EQP_SEQ | C(8) | 8 | 0 |
+| EQP_MUN | C(6) | 6 | 0 |
+| EQP_TP | C(2) | 2 | 0 |
+| EQP_NOME | C(60) | 60 | 0 |
+| EQP_DTINI | C(8) | 8 | 0 |
+| EQP_DTFIM | C(8) | 8 | 0 |
+| EQP_MOTFIM | C(2) | 2 | 0 |
+| EQP_TPFIM | C(2) | 2 | 0 |
+| EQP_LOCNAC | C(1) | 1 | 0 |
+| EQP_CHKSM | C(6) | 6 | 0 |
+| EQP_INE | C(10) | 10 | 0 |
+
+### `S_UPSGES.DBF`
+
+- 541 records
+- Size: 9,359 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| GES_CMP | C(6) | 6 | 0 |
+| GES_UID | C(7) | 7 | 0 |
+| GES_CPX | C(2) | 2 | 0 |
+| GES_IN | C(1) | 1 | 0 |
+
+### `consiste.dbf`
+
+- 469 records
+- Size: 133,242 bytes
+- Encoding: cp1252
+- Fields: 15
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| UID | C(7) | 7 | 0 |
+| CMP | C(6) | 6 | 0 |
+| TIPO | C(1) | 1 | 0 |
+| APAC | C(13) | 13 | 0 |
+| FOLHA | C(3) | 3 | 0 |
+| SEQ | C(2) | 2 | 0 |
+| PROCEDIM | C(10) | 10 | 0 |
+| CBO | C(6) | 6 | 0 |
+| CNSMED | C(15) | 15 | 0 |
+| CNSPCT | C(15) | 15 | 0 |
+| DTINIC | C(8) | 8 | 0 |
+| COD_ERRO | C(4) | 4 | 0 |
+| DESCR_ERRO | C(80) | 80 | 0 |
+| ERRO_67 | C(100) | 100 | 0 |
+| EQUIPE | C(12) | 12 | 0 |
+
+### `S_CNSQTD.DBF`
+
+- 452 records
+- Size: 64,310 bytes
+- Encoding: cp1252
+- Fields: 17
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CNSPCT | C(15) | 15 | 0 |
+| CMP | C(6) | 6 | 0 |
+| PROCEDIM | C(10) | 10 | 0 |
+| QTD | N(8) | 8 | 0 |
+| SUBTOT | N(15) | 15 | 0 |
+| UID | C(7) | 7 | 0 |
+| TIPO | C(1) | 1 | 0 |
+| APAC | C(13) | 13 | 0 |
+| FOLHA | C(3) | 3 | 0 |
+| SEQ | C(2) | 2 | 0 |
+| CBO | C(6) | 6 | 0 |
+| CNSMED | C(15) | 15 | 0 |
+| MVM | C(6) | 6 | 0 |
+| ORG | C(3) | 3 | 0 |
+| PRINCIPAL | C(9) | 9 | 0 |
+| ERRO | C(1) | 1 | 0 |
+| X | C(20) | 20 | 0 |
+
+### `S_TUEMA.DBF`
+
+- 99 records
+- Size: 15,245 bytes
+- Encoding: cp1252
+- Fields: 2
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| TUEMA_TUP | C(2) | 2 | 0 |
+| TUEMA_EMA | C(150) | 150 | 0 |
+
+### `S_RUB.DBF`
+
+- 42 records
+- Size: 2,104 bytes
+- Encoding: cp1252
+- Fields: 3
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| RUB_ID | C(4) | 4 | 0 |
+| RUB_DC | C(40) | 40 | 0 |
+| RUB_TOTAL | C(2) | 2 | 0 |
+
+### `S_CFA.DBF`
+
+- 38 records
+- Size: 1,568 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CFAINICIAL | C(12) | 12 | 0 |
+| CFAFINAL | C(12) | 12 | 0 |
+| CFAAMINI | C(6) | 6 | 0 |
+| CFAAMFIN | C(6) | 6 | 0 |
+
+### `S_FFI.DBF`
+
+- 30 records
+- Size: 1,604 bytes
+- Encoding: cp1252
+- Fields: 5
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| FFI_IN_PF | C(1) | 1 | 0 |
+| FFI_CGCCPF | C(14) | 14 | 0 |
+| FFI_MVM | C(6) | 6 | 0 |
+| FFI_VL | N(13,2) | 13 | 2 |
+| FFI_IR | N(12,2) | 12 | 2 |
+
+### `S_UPS.DBF`
+
+- 27 records
+- Size: 10,838 bytes
+- Encoding: cp1252
+- Fields: 44
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| UPS_ID | C(7) | 7 | 0 |
+| UPS_UF | C(2) | 2 | 0 |
+| UPS_RZSC | C(35) | 35 | 0 |
+| UPS_NMFN | C(35) | 35 | 0 |
+| UPS_IN_ATV | C(1) | 1 | 0 |
+| UPS_IN_FJ | C(1) | 1 | 0 |
+| UPS_CGCCPF | C(14) | 14 | 0 |
+| UPS_IR | C(1) | 1 | 0 |
+| UPS_LOGR | C(30) | 30 | 0 |
+| UPS_NUM | C(10) | 10 | 0 |
+| UPS_COMPL | C(15) | 15 | 0 |
+| UPS_BAIRRO | C(15) | 15 | 0 |
+| UPS_DDD | C(5) | 5 | 0 |
+| UPS_TELE | C(7) | 7 | 0 |
+| UPS_CEP | C(8) | 8 | 0 |
+| UPS_MN | C(6) | 6 | 0 |
+| UPS_DS | C(3) | 3 | 0 |
+| UPS_RS | C(3) | 3 | 0 |
+| UPS_AB | C(6) | 6 | 0 |
+| UPS_NU_CC | C(14) | 14 | 0 |
+| UPS_IN_MN | C(1) | 1 | 0 |
+| UPS_NU_CT | C(8) | 8 | 0 |
+| UPS_DT_IN | D(8) | 8 | 0 |
+| UPS_DT_CT | D(8) | 8 | 0 |
+| UPS_DT_PR | D(8) | 8 | 0 |
+| UPS_TUP | C(2) | 2 | 0 |
+| UPS_TP | C(2) | 2 | 0 |
+| UPS_QT_CM | N(3) | 3 | 0 |
+| UPS_QT_EO | N(3) | 3 | 0 |
+| UPS_QT_SG | N(2) | 2 | 0 |
+| UPS_QT_SPC | N(2) | 2 | 0 |
+| UPS_QT_SCA | N(2) | 2 | 0 |
+| UPS_TA | C(2) | 2 | 0 |
+| UPS_FC | C(2) | 2 | 0 |
+| UPS_CNES | C(7) | 7 | 0 |
+| UPS_IDANT | C(7) | 7 | 0 |
+| UPS_NH | C(2) | 2 | 0 |
+| UPSATUCNES | C(1) | 1 | 0 |
+| UPS_BANCO | C(3) | 3 | 0 |
+| UPS_MNT | C(14) | 14 | 0 |
+| UPS_NATJUR | C(4) | 4 | 0 |
+| UNIDADE_ID | C(31) | 31 | 0 |
+| UPS_LOCNAC | C(1) | 1 | 0 |
+| UPS_CHKSM | C(6) | 6 | 0 |
+
+### `s_reprd.dbf`
+
+- 27 records
+- Size: 2,537 bytes
+- Encoding: cp1252
+- Fields: 9
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| RE_CUNID | C(7) | 7 | 0 |
+| RE_CNOME | C(35) | 35 | 0 |
+| RE_CCOMP | C(6) | 6 | 0 |
+| RE_NQTFL | N(4) | 4 | 0 |
+| RE_NQTBPI | N(4) | 4 | 0 |
+| RE_NQAPA | N(7) | 7 | 0 |
+| RE_NQAD | N(5) | 5 | 0 |
+| RE_NQPSI | N(5) | 5 | 0 |
+| RE_MENSAGE | C(8) | 8 | 0 |
+
+### `S_PRFIRR.DBF`
+
+- 22 records
+- Size: 1,096 bytes
+- Encoding: cp1252
+- Fields: 5
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PRF_MVM | C(6) | 6 | 0 |
+| PRF_CNES | C(7) | 7 | 0 |
+| PRF_CPF | C(11) | 11 | 0 |
+| PRF_CNS | C(15) | 15 | 0 |
+| PRF_FLG | C(1) | 1 | 0 |
+
+### `S_RELAT.DBF`
+
+- 22 records
+- Size: 73,600 bytes
+- Encoding: cp1252
+- Fields: 24
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CODIGO | C(8) | 8 | 0 |
+| DESCR | C(40) | 40 | 0 |
+| CABEC | C(200) | 200 | 0 |
+| HEADER | C(200) | 200 | 0 |
+| IND_ORDEM | C(100) | 100 | 0 |
+| QUEBRA1 | C(100) | 100 | 0 |
+| HEAD_1 | C(200) | 200 | 0 |
+| FOOT_1 | C(200) | 200 | 0 |
+| QUEBRA2 | C(100) | 100 | 0 |
+| HEAD_2 | C(200) | 200 | 0 |
+| FOOT_2 | C(250) | 250 | 0 |
+| QUEBRA3 | C(100) | 100 | 0 |
+| HEAD_3 | C(200) | 200 | 0 |
+| FOOT_3 | C(200) | 200 | 0 |
+| DETALHE | C(250) | 250 | 0 |
+| DETALHE_CO | C(200) | 200 | 0 |
+| SOMA1 | C(100) | 100 | 0 |
+| SOMA2 | C(100) | 100 | 0 |
+| SOMA3 | C(100) | 100 | 0 |
+| SOMA4 | C(100) | 100 | 0 |
+| SOMA5 | C(100) | 100 | 0 |
+| FILTRO | C(30) | 30 | 0 |
+| TOT_GER | C(200) | 200 | 0 |
+| I_TEMP_PRD | C(30) | 30 | 0 |
+
+### `S_ENCERR.DBF`
+
+- 18 records
+- Size: 4,333 bytes
+- Encoding: cp1252
+- Fields: 28
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| ENC_MVM | C(6) | 6 | 0 |
+| ENC_BDSIA | C(7) | 7 | 0 |
+| ENC_SIASUS | C(5) | 5 | 0 |
+| ENC_TDTINI | C(8) | 8 | 0 |
+| ENC_THRINI | C(6) | 6 | 0 |
+| ENC_TDTFIM | C(8) | 8 | 0 |
+| ENC_THRFIM | C(6) | 6 | 0 |
+| ENC_CDTINI | C(8) | 8 | 0 |
+| ENC_CHRINI | C(6) | 6 | 0 |
+| ENC_CDTFIM | C(8) | 8 | 0 |
+| ENC_CHRFIM | C(6) | 6 | 0 |
+| ENC_BDTINI | C(8) | 8 | 0 |
+| ENC_BHRINI | C(6) | 6 | 0 |
+| ENC_BDTFIM | C(8) | 8 | 0 |
+| ENC_BHRFIM | C(6) | 6 | 0 |
+| ENC_VDTINI | C(8) | 8 | 0 |
+| ENC_VHRINI | C(6) | 6 | 0 |
+| ENC_VDTFIM | C(8) | 8 | 0 |
+| ENC_VHRFIM | C(6) | 6 | 0 |
+| ENC_RDTINI | C(8) | 8 | 0 |
+| ENC_RHRINI | C(6) | 6 | 0 |
+| ENC_RDTFIM | C(8) | 8 | 0 |
+| ENC_RHRFIM | C(6) | 6 | 0 |
+| ENC_TTOTH | C(6) | 6 | 0 |
+| ENC_CTOTH | C(6) | 6 | 0 |
+| ENC_BTOTH | C(6) | 6 | 0 |
+| ENC_VTOTH | C(6) | 6 | 0 |
+| ENC_RTOTH | C(6) | 6 | 0 |
+
+### `S_CGCEX.DBF`
+
+- 8 records
+- Size: 274 bytes
+- Encoding: cp1252
+- Fields: 3
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CGC_NUM | C(14) | 14 | 0 |
+| CGC_UF | C(2) | 2 | 0 |
+| CGC_FINANC | C(1) | 1 | 0 |
+
+### `S_UPSHA.DBF`
+
+- 8 records
+- Size: 474 bytes
+- Encoding: cp1252
+- Fields: 6
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| UPSHA_UPS | C(7) | 7 | 0 |
+| UPSHA_HA | C(4) | 4 | 0 |
+| UPSHA_INI | C(6) | 6 | 0 |
+| UPSHA_FIM | C(6) | 6 | 0 |
+| UHA_LOCNAC | C(1) | 1 | 0 |
+| UHA_CHKSM | C(6) | 6 | 0 |
+
+### `tot_cons.dbf`
+
+- 8 records
+- Size: 947 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| GRUPO | C(3) | 3 | 0 |
+| COD_ERRO | C(4) | 4 | 0 |
+| DESCR_ERRO | C(80) | 80 | 0 |
+| QTD_TOTAL | N(10) | 10 | 0 |
+
+### `CONFIMP.DBF`
+
+- 5 records
+- Size: 5,830 bytes
+- Encoding: cp1252
+- Fields: 15
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| NOME_IMP | C(20) | 20 | 0 |
+| SEQ_INIT | C(80) | 80 | 0 |
+| SEQ_RESET | C(80) | 80 | 0 |
+| TAM_1 | C(80) | 80 | 0 |
+| TAM_2 | C(80) | 80 | 0 |
+| TAM_3 | C(80) | 80 | 0 |
+| TAM_4 | C(80) | 80 | 0 |
+| TAM_5 | C(80) | 80 | 0 |
+| NEGRITO | C(80) | 80 | 0 |
+| DNEGRITO | C(80) | 80 | 0 |
+| CARTA | C(80) | 80 | 0 |
+| DCARTA | C(80) | 80 | 0 |
+| EXPANDIDO | C(80) | 80 | 0 |
+| DEXPANDIDO | C(80) | 80 | 0 |
+| MAXLIN | N(2) | 2 | 0 |
+
+### `S_TDIR.DBF`
+
+- 5 records
+- Size: 414 bytes
+- Encoding: cp1252
+- Fields: 5
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| TDIR_FJ | C(1) | 1 | 0 |
+| TDIR_DE | N(12,2) | 12 | 2 |
+| TDIR_ATE | N(12,2) | 12 | 2 |
+| TDIR_TX | N(6,2) | 6 | 2 |
+| TDIR_PARC | N(12,2) | 12 | 2 |
+
+### `S_UPSRC.DBF`
+
+- 4 records
+- Size: 258 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| UPSRC_UPS | C(7) | 7 | 0 |
+| UPSRC_RC | C(4) | 4 | 0 |
+| UPSRC_INI | C(6) | 6 | 0 |
+| UPSRC_FIM | C(6) | 6 | 0 |
+
+### `S_CTR.DBF`
+
+- 1 records
+- Size: 314 bytes
+- Encoding: cp1252
+- Fields: 8
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CTR_MVM | C(6) | 6 | 0 |
+| CTR_CAD | C(1) | 1 | 0 |
+| CTR_FPO | C(1) | 1 | 0 |
+| CTR_BDP | C(1) | 1 | 0 |
+| CTR_PRD | C(1) | 1 | 0 |
+| CTR_CRD | C(1) | 1 | 0 |
+| CTR_CONS | C(1) | 1 | 0 |
+| CTR_VERSAO | C(10) | 10 | 0 |
+
+### `S_MNT.DBF`
+
+- 1 records
+- Size: 1,006 bytes
+- Encoding: cp1252
+- Fields: 24
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| MNT_ID | C(8) | 8 | 0 |
+| MNT_CGCFI | C(4) | 4 | 0 |
+| MNT_CGCDV | C(2) | 2 | 0 |
+| MNT_IR | C(1) | 1 | 0 |
+| MNT_LOGR | C(30) | 30 | 0 |
+| MNT_NUM | C(5) | 5 | 0 |
+| MNT_COMPL | C(10) | 10 | 0 |
+| MNT_BAIRRO | C(15) | 15 | 0 |
+| MNT_CEP | C(8) | 8 | 0 |
+| MNT_DDD | C(5) | 5 | 0 |
+| MNT_TELE | C(8) | 8 | 0 |
+| MNT_DT_PR | D(8) | 8 | 0 |
+| MNT_DT_IN | D(8) | 8 | 0 |
+| MNT_DT_CT | D(8) | 8 | 0 |
+| MNT_DT_UA | D(8) | 8 | 0 |
+| MNT_RZSC | C(35) | 35 | 0 |
+| MNT_AB | C(6) | 6 | 0 |
+| MNT_NU_CC | C(14) | 14 | 0 |
+| MNT_MN | C(6) | 6 | 0 |
+| MNT_RS | C(3) | 3 | 0 |
+| MNT_TPCC | C(1) | 1 | 0 |
+| MNT_BANCO | C(3) | 3 | 0 |
+| MNT_LOCNAC | C(1) | 1 | 0 |
+| MNT_CHKSM | C(6) | 6 | 0 |
+
+### `S_SS.DBF`
+
+- 1 records
+- Size: 770 bytes
+- Encoding: cp1252
+- Fields: 17
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| SS_UFIBGE | C(2) | 2 | 0 |
+| SS_UFSIGL | C(2) | 2 | 0 |
+| SS_UFNOME | C(30) | 30 | 0 |
+| SS_NM | C(40) | 40 | 0 |
+| SS_SIGL | C(10) | 10 | 0 |
+| SS_CGC | C(14) | 14 | 0 |
+| SS_IN | C(1) | 1 | 0 |
+| SS_ABDV | C(5) | 5 | 0 |
+| SS_CCDV | C(10) | 10 | 0 |
+| SS_CONDIC | C(2) | 2 | 0 |
+| SS_GESTAO | C(6) | 6 | 0 |
+| SS_CONVBB | C(6) | 6 | 0 |
+| SS_DPCNES | C(10) | 10 | 0 |
+| SS_TXTCNE | C(10) | 10 | 0 |
+| SS_CRD | C(14) | 14 | 0 |
+| SS_DEPARA | C(14) | 14 | 0 |
+| SS_CFCES0 | C(14) | 14 | 0 |
+
+### `s_cor.dbf`
+
+- 1 records
+- Size: 886 bytes
+- Encoding: cp1252
+- Fields: 14
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| QUE_LINHA | N(2) | 2 | 0 |
+| PAD_NOME | C(40) | 40 | 0 |
+| CABEC | C(30) | 30 | 0 |
+| MENSAGEM | C(30) | 30 | 0 |
+| CAMPOGET | C(30) | 30 | 0 |
+| CAMPOSAY | C(30) | 30 | 0 |
+| MENU | C(30) | 30 | 0 |
+| PMENU | C(30) | 30 | 0 |
+| PISCA | C(30) | 30 | 0 |
+| ASTER | C(30) | 30 | 0 |
+| SOMBRA | C(30) | 30 | 0 |
+| OUTRO1 | C(30) | 30 | 0 |
+| OUTRO2 | C(30) | 30 | 0 |
+| OUTRO3 | C(30) | 30 | 0 |
+
+### `ADESAO.DBF`
+
+- 0 records
+- Size: 163 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| FINANC | C(4) | 4 | 0 |
+| GESTOR | C(6) | 6 | 0 |
+| CMP_INI | C(6) | 6 | 0 |
+| CMP_FIM | C(6) | 6 | 0 |
+
+### `APCNES_TERC.DBF`
+
+- 0 records
+- Size: 323 bytes
+- Encoding: cp1252
+- Fields: 9
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| UID | C(7) | 7 | 0 |
+| CMP | C(6) | 6 | 0 |
+| APAC | C(13) | 13 | 0 |
+| PROC_PRIC | C(10) | 10 | 0 |
+| SEQ | C(2) | 2 | 0 |
+| PROC_SEC | C(10) | 10 | 0 |
+| UID_TERC | C(7) | 7 | 0 |
+| QTD | N(6) | 6 | 0 |
+| MVM | C(6) | 6 | 0 |
+
+### `S_CD.DBF`
+
+- 0 records
+- Size: 162 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CD_TB | C(2) | 2 | 0 |
+| CD_IT | C(8) | 8 | 0 |
+| CD_DSCR | C(40) | 40 | 0 |
+| CD_MEMO | M(10) | 10 | 0 |
+
+### `S_CDX.DBF`
+
+- 0 records
+- Size: 162 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CDX_TB1 | C(2) | 2 | 0 |
+| CDX_TB2 | C(2) | 2 | 0 |
+| CDX_IT1 | C(9) | 9 | 0 |
+| CDX_IT2 | C(9) | 9 | 0 |
+
+### `S_CIDM.DBF`
+
+- 0 records
+- Size: 98 bytes
+- Encoding: cp1252
+- Fields: 2
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CDN_COD | C(6) | 6 | 0 |
+| CDN_DESCR | C(68) | 68 | 0 |
+
+### `S_CRD.DBF`
+
+- 0 records
+- Size: 643 bytes
+- Encoding: cp1252
+- Fields: 19
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CRD_IN_PF | C(1) | 1 | 0 |
+| CRD_CGCCPF | C(14) | 14 | 0 |
+| CRD_MVM | C(6) | 6 | 0 |
+| CRD_BCO | C(3) | 3 | 0 |
+| CRD_AB | C(6) | 6 | 0 |
+| CRD_CC | C(14) | 14 | 0 |
+| CRD_MN | C(6) | 6 | 0 |
+| CRD_VL | N(13,2) | 13 | 2 |
+| CRDPAB | N(13,2) | 13 | 2 |
+| CRDMEDIA | N(13,2) | 13 | 2 |
+| CRDESTRAT | N(13,2) | 13 | 2 |
+| CRDALTA | N(13,2) | 13 | 2 |
+| CRDBDP | N(13,2) | 13 | 2 |
+| CRDBDP_OUT | N(13,2) | 13 | 2 |
+| CRD_IR | N(13,2) | 13 | 2 |
+| CRD_DESCIR | C(1) | 1 | 0 |
+| CRD_VL_FED | N(13,2) | 13 | 2 |
+| CRD_VL_LOC | N(13,2) | 13 | 2 |
+| CRD_VL_INC | N(13,2) | 13 | 2 |
+
+### `S_DPG.DBF`
+
+- 0 records
+- Size: 419 bytes
+- Encoding: cp1252
+- Fields: 12
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| DPG_CMP | C(6) | 6 | 0 |
+| DPG_FLH | C(3) | 3 | 0 |
+| DPG_SEQ | C(2) | 2 | 0 |
+| DPG_UID | C(7) | 7 | 0 |
+| DPG_PA | C(10) | 10 | 0 |
+| DPG_QT | N(6) | 6 | 0 |
+| DPG_VL | N(13,2) | 13 | 2 |
+| DPG_VL_EF | N(13,2) | 13 | 2 |
+| DPG_RC | C(4) | 4 | 0 |
+| DPG_MVM | C(6) | 6 | 0 |
+| DPG_CL | C(1) | 1 | 0 |
+| DPG_CHKSM | C(6) | 6 | 0 |
+
+### `S_FORNEC.DBF`
+
+- 0 records
+- Size: 386 bytes
+- Encoding: cp1252
+- Fields: 11
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| FOR_CNPJ | C(14) | 14 | 0 |
+| FOR_RZSOC | C(80) | 80 | 0 |
+| FOR_FANTA | C(80) | 80 | 0 |
+| FOR_BANCO | C(3) | 3 | 0 |
+| FOR_AG | C(6) | 6 | 0 |
+| FOR_CC | C(14) | 14 | 0 |
+| FOR_END | C(60) | 60 | 0 |
+| FOR_BAIRRO | C(20) | 20 | 0 |
+| FOR_CEP | C(20) | 20 | 0 |
+| FOR_IBGE | C(6) | 6 | 0 |
+| FOR_TMP | C(1) | 1 | 0 |
+
+### `S_MN.DBF`
+
+- 0 records
+- Size: 130 bytes
+- Encoding: cp1252
+- Fields: 3
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| MN_IBGE | C(6) | 6 | 0 |
+| MN_NOME | C(40) | 40 | 0 |
+| MN_UF | C(2) | 2 | 0 |
+
+### `S_OCORR.DBF`
+
+- 0 records
+- Size: 515 bytes
+- Encoding: cp1252
+- Fields: 15
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| ORR_CMP | C(6) | 6 | 0 |
+| ORR_INSRG | C(3) | 3 | 0 |
+| ORR_UID | C(7) | 7 | 0 |
+| ORR_FLH | C(3) | 3 | 0 |
+| ORR_SEQ | C(2) | 2 | 0 |
+| ORR_APANUM | C(13) | 13 | 0 |
+| ORR_CNSMED | C(15) | 15 | 0 |
+| ORR_CBO | C(6) | 6 | 0 |
+| ORR_CNSPCN | C(15) | 15 | 0 |
+| ORR_DTINI | C(8) | 8 | 0 |
+| ORR_PA | C(10) | 10 | 0 |
+| ORR_TIP | C(3) | 3 | 0 |
+| ORR_COD | C(6) | 6 | 0 |
+| ORR_DSCR | C(100) | 100 | 0 |
+| ORR_MVM | C(6) | 6 | 0 |
+
+### `S_RAPA.DBF`
+
+- 0 records
+- Size: 1,155 bytes
+- Encoding: cp1252
+- Fields: 35
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| RAPA_INSRG | C(3) | 3 | 0 |
+| RAPA_UID | C(7) | 7 | 0 |
+| RAPA_CMP | C(6) | 6 | 0 |
+| RAPA_CPFPC | C(11) | 11 | 0 |
+| RAPA_CNSPC | C(15) | 15 | 0 |
+| RAPA_DTINI | C(8) | 8 | 0 |
+| RAPA_PA | C(10) | 10 | 0 |
+| RAPA_CBO | C(6) | 6 | 0 |
+| RAPA_CNSEX | C(15) | 15 | 0 |
+| RAPA_DTREA | C(8) | 8 | 0 |
+| RAPA_SRV | C(3) | 3 | 0 |
+| RAPA_CSF | C(3) | 3 | 0 |
+| RAPA_EQUIP | C(12) | 12 | 0 |
+| RAPA_QT_P | N(6) | 6 | 0 |
+| RAPA_QT_A | N(6) | 6 | 0 |
+| RAPA_ORG | C(3) | 3 | 0 |
+| RAPA_CID | C(4) | 4 | 0 |
+| RAPA_LREX | C(1) | 1 | 0 |
+| RAPA_CHKSU | C(4) | 4 | 0 |
+| RAPA_MVM | C(6) | 6 | 0 |
+| RAPA_FLPA | C(1) | 1 | 0 |
+| RAPA_FLEMA | C(1) | 1 | 0 |
+| RAPA_FLCBO | C(1) | 1 | 0 |
+| RAPA_FLQT | C(1) | 1 | 0 |
+| RAPA_FLER | C(1) | 1 | 0 |
+| RAPAVL_FED | N(10,2) | 10 | 2 |
+| RAPAVL_LOC | N(10,2) | 10 | 2 |
+| RAPAVL_INC | N(10,2) | 10 | 2 |
+| RAPAINCOUT | C(4) | 4 | 0 |
+| RAPAINCURG | C(4) | 4 | 0 |
+| RAPA_RUB | C(6) | 6 | 0 |
+| RAPA_TPFIN | C(1) | 1 | 0 |
+| RAPA_CPX | C(1) | 1 | 0 |
+| RAPA_RC | C(4) | 4 | 0 |
+| RAPA_INE | C(10) | 10 | 0 |
+
+### `S_RAS.DBF`
+
+- 0 records
+- Size: 1,603 bytes
+- Encoding: cp1252
+- Fields: 49
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| RA_INSRG | C(3) | 3 | 0 |
+| RA_UID | C(7) | 7 | 0 |
+| RA_CMP | C(6) | 6 | 0 |
+| RA_CPFPCT | C(11) | 11 | 0 |
+| RA_CNSPCT | C(15) | 15 | 0 |
+| RA_DTINIC | C(8) | 8 | 0 |
+| RA_DTFIM | C(8) | 8 | 0 |
+| RA_NMPCN | C(30) | 30 | 0 |
+| RA_NPRONT | C(10) | 10 | 0 |
+| RA_NACPCN | C(3) | 3 | 0 |
+| RA_MAEPCN | C(30) | 30 | 0 |
+| RA_NOMERE | C(30) | 30 | 0 |
+| RA_LOGPCN | C(30) | 30 | 0 |
+| RA_NUMPCN | C(5) | 5 | 0 |
+| RA_CPLPCN | C(10) | 10 | 0 |
+| RA_CEPPCN | C(8) | 8 | 0 |
+| RA_MUNPCN | C(7) | 7 | 0 |
+| RA_DTNASC | C(8) | 8 | 0 |
+| RA_SEXPCN | C(1) | 1 | 0 |
+| RA_RACA | C(2) | 2 | 0 |
+| RA_ETNIA | C(4) | 4 | 0 |
+| RA_TELEF | C(11) | 11 | 0 |
+| RA_CELULAR | C(11) | 11 | 0 |
+| RA_MOTCOB | C(2) | 2 | 0 |
+| RA_DTOBAL | C(8) | 8 | 0 |
+| RA_CATEND | C(2) | 2 | 0 |
+| RA_CIDPRI | C(4) | 4 | 0 |
+| RA_CIDCA | C(4) | 4 | 0 |
+| RA_CIDSEC1 | C(4) | 4 | 0 |
+| RA_CIDSEC2 | C(4) | 4 | 0 |
+| RA_CIDSEC3 | C(4) | 4 | 0 |
+| RA_PCNORI | C(2) | 2 | 0 |
+| RA_CODESF | C(1) | 1 | 0 |
+| RA_CNESESF | C(7) | 7 | 0 |
+| RA_DESTPCT | C(2) | 2 | 0 |
+| RA_ORG | C(3) | 3 | 0 |
+| RA_STRUA | C(1) | 1 | 0 |
+| RA_USUDRGA | C(1) | 1 | 0 |
+| RA_TPDRGA | C(3) | 3 | 0 |
+| RA_NAUTO | C(13) | 13 | 0 |
+| RA_CHKSU | C(4) | 4 | 0 |
+| RA_RMS | C(4) | 4 | 0 |
+| RA_DTGER | C(8) | 8 | 0 |
+| RA_FLER | C(10) | 10 | 0 |
+| RA_INERPP | C(1) | 1 | 0 |
+| RA_MVM | C(6) | 6 | 0 |
+| RA_CDLOGR | C(3) | 3 | 0 |
+| RA_BAIRRO | C(30) | 30 | 0 |
+| RA_EMAIL | C(40) | 40 | 0 |
+
+### `S_TRMOTC.DBF`
+
+- 0 records
+- Size: 321 bytes
+- Encoding: cp1252
+- Fields: 9
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| TRMOTC_A00 | C(6) | 6 | 0 |
+| TRMOTC_A01 | C(6) | 6 | 0 |
+| TRMOTC_A02 | C(13) | 13 | 0 |
+| TRMOTC_A03 | C(8) | 8 | 0 |
+| TRMOTC_A04 | C(30) | 30 | 0 |
+| TRMOTC_A05 | C(30) | 30 | 0 |
+| TRMOTC_A06 | C(30) | 30 | 0 |
+| TRMOTC_A07 | C(30) | 30 | 0 |
+| TRMOTC_A08 | C(5) | 5 | 0 |
+
+### `S_UPSAUT.DBF`
+
+- 0 records
+- Size: 162 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| UPSAUT_UPS | C(6) | 6 | 0 |
+| UPSAUT_HA | C(4) | 4 | 0 |
+| UPSAUT_INI | C(6) | 6 | 0 |
+| UPSAUT_FIM | C(6) | 6 | 0 |
+
+### `advertencia_sexo.dbf`
+
+- 0 records
+- Size: 483 bytes
+- Encoding: cp1252
+- Fields: 14
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| TIPO | C(4) | 4 | 0 |
+| UID | C(7) | 7 | 0 |
+| CMP | C(6) | 6 | 0 |
+| CNS | C(15) | 15 | 0 |
+| APAC | C(13) | 13 | 0 |
+| PROCEDIM | C(9) | 9 | 0 |
+| DIGITO | C(1) | 1 | 0 |
+| SEXO | C(1) | 1 | 0 |
+| MVM | C(6) | 6 | 0 |
+| CNSMED | C(15) | 15 | 0 |
+| CBO | C(6) | 6 | 0 |
+| FOLHA | C(3) | 3 | 0 |
+| SEQ | C(2) | 2 | 0 |
+| ERRO | C(1) | 1 | 0 |
+
+### `cadgesmn.dbf`
+
+- 0 records
+- Size: 195 bytes
+- Encoding: cp1252
+- Fields: 5
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CODUF | C(2) | 2 | 0 |
+| CODMUNIC | C(4) | 4 | 0 |
+| NOME | C(40) | 40 | 0 |
+| CONDIC | C(2) | 2 | 0 |
+| CIB_SAS | C(1) | 1 | 0 |
+
+### `cpx.dbf`
+
+- 0 records
+- Size: 962 bytes
+- Encoding: cp1252
+- Fields: 29
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PA_CMP | C(6) | 6 | 0 |
+| PA_ID | C(9) | 9 | 0 |
+| PA_DV | C(1) | 1 | 0 |
+| PA_PAB | C(1) | 1 | 0 |
+| PA_TOTAL | N(12,2) | 12 | 2 |
+| PA_FAEC | C(1) | 1 | 0 |
+| PA_DC | C(60) | 60 | 0 |
+| PA_RUB | C(4) | 4 | 0 |
+| PA_TPCC | C(1) | 1 | 0 |
+| PA_AUX | C(20) | 20 | 0 |
+| PA_CPX | C(4) | 4 | 0 |
+| PA_CTF | C(4) | 4 | 0 |
+| PA_DOC | C(1) | 1 | 0 |
+| PA_IDADEMX | N(3) | 3 | 0 |
+| PA_IDADEMN | N(3) | 3 | 0 |
+| PA_SEXO | C(1) | 1 | 0 |
+| PA_QTDMAX | N(6) | 6 | 0 |
+| PA_LAUDO | C(2) | 2 | 0 |
+| PA_PRINC | C(1) | 1 | 0 |
+| PA_SECUN | C(1) | 1 | 0 |
+| PA_IDEBPA | C(1) | 1 | 0 |
+| PA_CNSPCN | C(1) | 1 | 0 |
+| PA_CNRAC | C(1) | 1 | 0 |
+| PA_CCMANAL | C(2) | 2 | 0 |
+| PA_ELETIVA | C(1) | 1 | 0 |
+| PA_APACONT | C(1) | 1 | 0 |
+| PA_EXIGCBO | C(1) | 1 | 0 |
+| PA_PROCCEO | C(1) | 1 | 0 |
+| PA_6MESES | C(1) | 1 | 0 |
+
+### `crit_lmc.dbf`
+
+- 0 records
+- Size: 547 bytes
+- Encoding: cp1252
+- Fields: 16
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| UID | C(7) | 7 | 0 |
+| CMP | C(6) | 6 | 0 |
+| APAC | C(13) | 13 | 0 |
+| PROCEDIM | C(9) | 9 | 0 |
+| DIGITO | C(1) | 1 | 0 |
+| QTD | N(6) | 6 | 0 |
+| MVM | C(6) | 6 | 0 |
+| FASE | C(1) | 1 | 0 |
+| LINHA | C(1) | 1 | 0 |
+| SUB_TOT | N(6) | 6 | 0 |
+| PERC | C(6) | 6 | 0 |
+| TOTAL | N(12) | 12 | 0 |
+| STOT_2L | N(6) | 6 | 0 |
+| PERC_2L | C(6) | 6 | 0 |
+| ERROF | C(1) | 1 | 0 |
+| ERROL | C(1) | 1 | 0 |
+
+### `crit_trastuzumabe.dbf`
+
+- 0 records
+- Size: 419 bytes
+- Encoding: cp1252
+- Fields: 12
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| UID | C(7) | 7 | 0 |
+| CMP | C(6) | 6 | 0 |
+| APAC | C(13) | 13 | 0 |
+| CRITICO | C(1) | 1 | 0 |
+| PROCEDIM | C(9) | 9 | 0 |
+| DIGITO | C(1) | 1 | 0 |
+| QTD | N(6) | 6 | 0 |
+| MVM | C(6) | 6 | 0 |
+| SUB_TOT | N(6) | 6 | 0 |
+| PERC | C(6) | 6 | 0 |
+| TOTAL | N(12) | 12 | 0 |
+| ERRO | C(1) | 1 | 0 |
+
+### `erro.dbf`
+
+- 0 records
+- Size: 386 bytes
+- Encoding: cp1252
+- Fields: 11
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| VPA_PA | C(9) | 9 | 0 |
+| VPA_CMP | C(6) | 6 | 0 |
+| VPA_TOTAL | N(13,2) | 13 | 2 |
+| VPA_SP | N(13,2) | 13 | 2 |
+| VPA_SA | N(13,2) | 13 | 2 |
+| VPA_SH | N(13,2) | 13 | 2 |
+| VPA_MUN | C(6) | 6 | 0 |
+| VPA_TIPO | C(1) | 1 | 0 |
+| VPA_CTF | C(2) | 2 | 0 |
+| VPA_RUB | C(6) | 6 | 0 |
+| VPA_MVM | C(6) | 6 | 0 |
+
+### `faixa.dbf`
+
+- 0 records
+- Size: 162 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CFAINICIAL | C(12) | 12 | 0 |
+| CFAFINAL | C(12) | 12 | 0 |
+| CFAAMINI | C(6) | 6 | 0 |
+| CFAAMFIN | C(6) | 6 | 0 |
+
+### `pa.dbf`
+
+- 0 records
+- Size: 962 bytes
+- Encoding: cp1252
+- Fields: 29
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PA_CMP | C(6) | 6 | 0 |
+| PA_ID | C(9) | 9 | 0 |
+| PA_DV | C(1) | 1 | 0 |
+| PA_PAB | C(1) | 1 | 0 |
+| PA_TOTAL | N(12,2) | 12 | 2 |
+| PA_FAEC | C(1) | 1 | 0 |
+| PA_DC | C(60) | 60 | 0 |
+| PA_RUB | C(4) | 4 | 0 |
+| PA_TPCC | C(1) | 1 | 0 |
+| PA_AUX | C(20) | 20 | 0 |
+| PA_CPX | C(4) | 4 | 0 |
+| PA_CTF | C(4) | 4 | 0 |
+| PA_DOC | C(1) | 1 | 0 |
+| PA_IDADEMX | N(3) | 3 | 0 |
+| PA_IDADEMN | N(3) | 3 | 0 |
+| PA_SEXO | C(1) | 1 | 0 |
+| PA_QTDMAX | N(6) | 6 | 0 |
+| PA_LAUDO | C(2) | 2 | 0 |
+| PA_PRINC | C(1) | 1 | 0 |
+| PA_SECUN | C(1) | 1 | 0 |
+| PA_IDEBPA | C(1) | 1 | 0 |
+| PA_CNSPCN | C(1) | 1 | 0 |
+| PA_CNRAC | C(1) | 1 | 0 |
+| PA_CCMANAL | C(2) | 2 | 0 |
+| PA_ELETIVA | C(1) | 1 | 0 |
+| PA_APACONT | C(1) | 1 | 0 |
+| PA_EXIGCBO | C(1) | 1 | 0 |
+| PA_PROCCEO | C(1) | 1 | 0 |
+| PA_6MESES | C(1) | 1 | 0 |
+
+### `psico.dbf`
+
+- 0 records
+- Size: 1,025 bytes
+- Encoding: cp1252
+- Fields: 31
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PA_CMP | C(6) | 6 | 0 |
+| PA_ID | C(9) | 9 | 0 |
+| PA_DV | C(1) | 1 | 0 |
+| PA_PAB | C(1) | 1 | 0 |
+| PA_TOTAL | N(12,2) | 12 | 2 |
+| PA_FAEC | C(1) | 1 | 0 |
+| PA_DC | C(60) | 60 | 0 |
+| PA_RUB | C(4) | 4 | 0 |
+| PA_TPCC | C(1) | 1 | 0 |
+| PA_AUX | C(20) | 20 | 0 |
+| PA_CPX | C(4) | 4 | 0 |
+| PA_CTF | C(4) | 4 | 0 |
+| PA_DOC | C(1) | 1 | 0 |
+| PA_IDADEMX | N(3) | 3 | 0 |
+| PA_IDADEMN | N(3) | 3 | 0 |
+| PA_SEXO | C(1) | 1 | 0 |
+| PA_QTDMAX | N(6) | 6 | 0 |
+| PA_LAUDO | C(2) | 2 | 0 |
+| PA_PRINC | C(1) | 1 | 0 |
+| PA_SECUN | C(1) | 1 | 0 |
+| PA_IDEBPA | C(1) | 1 | 0 |
+| PA_CNSPCN | C(1) | 1 | 0 |
+| PA_CNRAC | C(1) | 1 | 0 |
+| PA_CCMANAL | C(2) | 2 | 0 |
+| PA_ELETIVA | C(1) | 1 | 0 |
+| PA_APACONT | C(1) | 1 | 0 |
+| PA_EXIGCBO | C(1) | 1 | 0 |
+| PA_PROCCEO | C(1) | 1 | 0 |
+| PA_6MESES | C(1) | 1 | 0 |
+| PA_EXIGAUT | C(1) | 1 | 0 |
+| PA_PERMAN | N(4) | 4 | 0 |
+
+### `s_ad.dbf`
+
+- 0 records
+- Size: 1,251 bytes
+- Encoding: cp1252
+- Fields: 38
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| AD_UID | C(7) | 7 | 0 |
+| AD_CMP | C(6) | 6 | 0 |
+| AD_NUM | C(15) | 15 | 0 |
+| AD_CNSPCT | C(15) | 15 | 0 |
+| AD_DTINIC | C(8) | 8 | 0 |
+| AD_DTFIM | C(8) | 8 | 0 |
+| AD_NMPCN | C(30) | 30 | 0 |
+| AD_NPRONT | C(10) | 10 | 0 |
+| AD_NACPCN | C(3) | 3 | 0 |
+| AD_MAEPCN | C(30) | 30 | 0 |
+| AD_NOMERE | C(30) | 30 | 0 |
+| AD_LOGPCN | C(30) | 30 | 0 |
+| AD_NUMPCN | C(5) | 5 | 0 |
+| AD_CPLPCN | C(10) | 10 | 0 |
+| AD_CEPPCN | C(8) | 8 | 0 |
+| AD_MUNPCN | C(7) | 7 | 0 |
+| AD_DTNASC | C(8) | 8 | 0 |
+| AD_SEXPCN | C(1) | 1 | 0 |
+| AD_RACA | C(2) | 2 | 0 |
+| AD_ETNIA | C(4) | 4 | 0 |
+| AD_TELEF | C(11) | 11 | 0 |
+| AD_CELULAR | C(11) | 11 | 0 |
+| AD_MOTCOB | C(2) | 2 | 0 |
+| AD_DTOBAL | C(8) | 8 | 0 |
+| AD_CATEND | C(2) | 2 | 0 |
+| AD_CIDPRI | C(4) | 4 | 0 |
+| AD_CIDCA | C(4) | 4 | 0 |
+| AD_CIDSEC1 | C(4) | 4 | 0 |
+| AD_CIDSEC2 | C(4) | 4 | 0 |
+| AD_CIDSEC3 | C(4) | 4 | 0 |
+| AD_PCNORI | C(1) | 1 | 0 |
+| AD_CODESF | C(1) | 1 | 0 |
+| AD_CNESESF | C(7) | 7 | 0 |
+| AD_RMS | C(4) | 4 | 0 |
+| AD_FLER | C(10) | 10 | 0 |
+| AD_INERPP | C(1) | 1 | 0 |
+| AD_ORG | C(3) | 3 | 0 |
+| AD_MVM | C(6) | 6 | 0 |
+
+### `s_adpa.dbf`
+
+- 0 records
+- Size: 707 bytes
+- Encoding: cp1252
+- Fields: 21
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| ADPA_UID | C(7) | 7 | 0 |
+| ADPA_CMP | C(6) | 6 | 0 |
+| ADPA_CNSPC | C(15) | 15 | 0 |
+| ADPA_NUM | C(15) | 15 | 0 |
+| ADPA_DTINI | C(8) | 8 | 0 |
+| ADPA_PA | C(10) | 10 | 0 |
+| ADPA_CBO | C(6) | 6 | 0 |
+| ADPA_CNSEX | C(15) | 15 | 0 |
+| ADPA_DTREA | C(8) | 8 | 0 |
+| ADPA_SRV | C(3) | 3 | 0 |
+| ADPA_CSF | C(3) | 3 | 0 |
+| ADPA_EQUIP | C(12) | 12 | 0 |
+| ADPA_QT_P | N(6) | 6 | 0 |
+| ADPA_QT_A | N(6) | 6 | 0 |
+| ADPA_MVM | C(6) | 6 | 0 |
+| ADPA_ORG | C(3) | 3 | 0 |
+| ADPA_FLPA | C(1) | 1 | 0 |
+| ADPA_FLEMA | C(1) | 1 | 0 |
+| ADPA_FLCBO | C(1) | 1 | 0 |
+| ADPA_FLQT | C(1) | 1 | 0 |
+| ADPA_FLER | C(1) | 1 | 0 |
+
+### `s_apal.dbf`
+
+- 0 records
+- Size: 4,259 bytes
+- Encoding: cp1252
+- Fields: 132
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| APA_UF | C(2) | 2 | 0 |
+| APA_UID | C(7) | 7 | 0 |
+| APA_NUM | C(13) | 13 | 0 |
+| APA_EMISSA | C(8) | 8 | 0 |
+| APA_DTINIC | C(8) | 8 | 0 |
+| APA_DTFIM | C(8) | 8 | 0 |
+| APA_TPATEN | C(2) | 2 | 0 |
+| APA_TPAPAC | C(1) | 1 | 0 |
+| APA_NMPCN | C(30) | 30 | 0 |
+| APA_FILLER | C(2) | 2 | 0 |
+| APA_MAEPCN | C(30) | 30 | 0 |
+| APA_LOGPCN | C(30) | 30 | 0 |
+| APA_NUMPCN | C(5) | 5 | 0 |
+| APA_CPLPCN | C(10) | 10 | 0 |
+| APA_CEPPCN | C(8) | 8 | 0 |
+| APA_MUNPCN | C(7) | 7 | 0 |
+| APA_DTNASC | C(8) | 8 | 0 |
+| APA_SEXPCN | C(1) | 1 | 0 |
+| APA_VARIA | C(141) | 141 | 0 |
+| APA_CPFRES | C(11) | 11 | 0 |
+| APA_NMRES | C(30) | 30 | 0 |
+| PAP_PA1 | C(10) | 10 | 0 |
+| PAP_AT_P1 | C(6) | 6 | 0 |
+| PAP_QT_P1 | C(7) | 7 | 0 |
+| PAP_PA2 | C(10) | 10 | 0 |
+| PAP_AT_P2 | C(6) | 6 | 0 |
+| PAP_QT_P2 | C(7) | 7 | 0 |
+| PAP_PA3 | C(10) | 10 | 0 |
+| PAP_AT_P3 | C(6) | 6 | 0 |
+| PAP_QT_P3 | C(7) | 7 | 0 |
+| PAP_PA4 | C(10) | 10 | 0 |
+| PAP_AT_P4 | C(6) | 6 | 0 |
+| PAP_QT_P4 | C(7) | 7 | 0 |
+| PAP_PA5 | C(10) | 10 | 0 |
+| PAP_AT_P5 | C(6) | 6 | 0 |
+| PAP_QT_P5 | C(7) | 7 | 0 |
+| PAP_PA6 | C(10) | 10 | 0 |
+| PAP_AT_P6 | C(6) | 6 | 0 |
+| PAP_QT_P6 | C(7) | 7 | 0 |
+| PAP_PA7 | C(10) | 10 | 0 |
+| PAP_AT_P7 | C(6) | 6 | 0 |
+| PAP_QT_P7 | C(7) | 7 | 0 |
+| PAP_PA8 | C(10) | 10 | 0 |
+| PAP_AT_P8 | C(6) | 6 | 0 |
+| PAP_QT_P8 | C(7) | 7 | 0 |
+| PAP_PA9 | C(10) | 10 | 0 |
+| PAP_AT_P9 | C(6) | 6 | 0 |
+| PAP_QT_P9 | C(7) | 7 | 0 |
+| PAP_PA10 | C(10) | 10 | 0 |
+| PAP_AT_P10 | C(6) | 6 | 0 |
+| PAP_QT_P10 | C(7) | 7 | 0 |
+| APA_MOTCOB | C(2) | 2 | 0 |
+| APA_DTOBAL | C(8) | 8 | 0 |
+| APA_CPFDIR | C(11) | 11 | 0 |
+| APA_NMDIR | C(30) | 30 | 0 |
+| APA_CONT | C(1) | 1 | 0 |
+| PAP_CGC1 | C(14) | 14 | 0 |
+| PAP_NF1 | C(6) | 6 | 0 |
+| PAP_CGC2 | C(14) | 14 | 0 |
+| PAP_NF2 | C(6) | 6 | 0 |
+| PAP_CGC3 | C(14) | 14 | 0 |
+| PAP_NF3 | C(6) | 6 | 0 |
+| PAP_CGC4 | C(14) | 14 | 0 |
+| PAP_NF4 | C(6) | 6 | 0 |
+| PAP_CGC5 | C(14) | 14 | 0 |
+| PAP_NF5 | C(6) | 6 | 0 |
+| PAP_CGC6 | C(14) | 14 | 0 |
+| PAP_NF6 | C(6) | 6 | 0 |
+| PAP_CGC7 | C(14) | 14 | 0 |
+| PAP_NF7 | C(6) | 6 | 0 |
+| PAP_CGC8 | C(14) | 14 | 0 |
+| PAP_NF8 | C(6) | 6 | 0 |
+| PAP_CGC9 | C(14) | 14 | 0 |
+| PAP_NF9 | C(6) | 6 | 0 |
+| PAP_CGC10 | C(14) | 14 | 0 |
+| PAP_NF10 | C(6) | 6 | 0 |
+| APA_CNSPCT | C(15) | 15 | 0 |
+| APA_CNSRES | C(15) | 15 | 0 |
+| APA_CNSDIR | C(15) | 15 | 0 |
+| CIDPR1 | C(4) | 4 | 0 |
+| CIDSE1 | C(4) | 4 | 0 |
+| CIDPR2 | C(4) | 4 | 0 |
+| CIDSE2 | C(4) | 4 | 0 |
+| CIDPR3 | C(4) | 4 | 0 |
+| CIDSE3 | C(4) | 4 | 0 |
+| CIDPR4 | C(4) | 4 | 0 |
+| CIDSE4 | C(4) | 4 | 0 |
+| CIDPR5 | C(4) | 4 | 0 |
+| CIDSE5 | C(4) | 4 | 0 |
+| CIDPR6 | C(4) | 4 | 0 |
+| CIDSE6 | C(4) | 4 | 0 |
+| CIDPR7 | C(4) | 4 | 0 |
+| CIDSE7 | C(4) | 4 | 0 |
+| CIDPR8 | C(4) | 4 | 0 |
+| CIDSE8 | C(4) | 4 | 0 |
+| CIDPR9 | C(4) | 4 | 0 |
+| CIDSE9 | C(4) | 4 | 0 |
+| CIDPR10 | C(4) | 4 | 0 |
+| CIDSE10 | C(4) | 4 | 0 |
+| AP_CIDCA | C(4) | 4 | 0 |
+| AP_NPRONT | C(10) | 10 | 0 |
+| AP_CODSOL | C(7) | 7 | 0 |
+| AP_DTSOLIC | C(8) | 8 | 0 |
+| AP_DTAUTOR | C(8) | 8 | 0 |
+| AP_CODEMIS | C(10) | 10 | 0 |
+| AP_CATEND | C(2) | 2 | 0 |
+| AP_APACANT | C(13) | 13 | 0 |
+| APA_RACA | C(2) | 2 | 0 |
+| APA_NOMERE | C(30) | 30 | 0 |
+| APA_UFPCN | C(3) | 3 | 0 |
+| APA_ETNIA | C(4) | 4 | 0 |
+| AP_SRV | C(3) | 3 | 0 |
+| AP_CSF | C(3) | 3 | 0 |
+| AP_EQUIPE1 | C(12) | 12 | 0 |
+| AP_EQUIPE2 | C(12) | 12 | 0 |
+| AP_EQUIPE3 | C(12) | 12 | 0 |
+| AP_EQUIPE4 | C(12) | 12 | 0 |
+| AP_EQUIPE5 | C(12) | 12 | 0 |
+| AP_EQUIPE6 | C(12) | 12 | 0 |
+| AP_EQUIPE7 | C(12) | 12 | 0 |
+| AP_EQUIPE8 | C(12) | 12 | 0 |
+| AP_EQUIPE9 | C(12) | 12 | 0 |
+| AP_EQUIPE0 | C(12) | 12 | 0 |
+| AP_CDLOGR | C(3) | 3 | 0 |
+| AP_BAIRRO | C(30) | 30 | 0 |
+| AP_DDD | C(2) | 2 | 0 |
+| AP_TEL | C(9) | 9 | 0 |
+| AP_EMAIL | C(40) | 40 | 0 |
+| AP_CNSEXE | C(15) | 15 | 0 |
+| AP_INE | C(10) | 10 | 0 |
+| APAL_SOMA | N(15) | 15 | 0 |
+| APAL_X | C(25) | 25 | 0 |
+
+### `s_cnesia.dbf`
+
+- 0 records
+- Size: 130 bytes
+- Encoding: cp1252
+- Fields: 3
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| COD_CNES | C(7) | 7 | 0 |
+| COD_SIA | C(7) | 7 | 0 |
+| GESTAO | C(6) | 6 | 0 |
+
+### `s_corpo.dbf`
+
+- 0 records
+- Size: 1,505 bytes
+- Encoding: cp1252
+- Fields: 46
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| IDENTIF | C(2) | 2 | 0 |
+| AP_CMP | C(6) | 6 | 0 |
+| AP_NUMAPAC | C(13) | 13 | 0 |
+| AP_CODUF | C(2) | 2 | 0 |
+| AP_CODUNI | C(7) | 7 | 0 |
+| AP_DTEMI | C(8) | 8 | 0 |
+| AP_DTINVAL | C(8) | 8 | 0 |
+| AP_DTFIVAL | C(8) | 8 | 0 |
+| AP_TIPATE | C(2) | 2 | 0 |
+| AP_TIPAPAC | C(1) | 1 | 0 |
+| AP_NOMEPAC | C(30) | 30 | 0 |
+| AP_NOMEMAE | C(30) | 30 | 0 |
+| AP_ENDPAC | C(30) | 30 | 0 |
+| AP_ENDNUM | C(5) | 5 | 0 |
+| AP_ENDCOMP | C(10) | 10 | 0 |
+| AP_ENDCEP | C(8) | 8 | 0 |
+| AP_CODMUN | C(7) | 7 | 0 |
+| AP_DTNASC | C(8) | 8 | 0 |
+| AP_SEXO | C(1) | 1 | 0 |
+| AP_NOMESOL | C(30) | 30 | 0 |
+| AP_CDPROC0 | C(10) | 10 | 0 |
+| AP_CODCOB | C(2) | 2 | 0 |
+| AP_DTOCORR | C(8) | 8 | 0 |
+| AP_NOMEDIR | C(30) | 30 | 0 |
+| AP_CNS | C(15) | 15 | 0 |
+| AP_CNSRES | C(15) | 15 | 0 |
+| AP_CNSDIR | C(15) | 15 | 0 |
+| AP_CIDCA | C(4) | 4 | 0 |
+| AP_NPRONT | C(10) | 10 | 0 |
+| AP_CODSOL | C(7) | 7 | 0 |
+| AP_DTSOLIC | C(8) | 8 | 0 |
+| AP_DTAUTOR | C(8) | 8 | 0 |
+| AP_CODEMIS | C(10) | 10 | 0 |
+| AP_CATEND | C(2) | 2 | 0 |
+| AP_APACANT | C(13) | 13 | 0 |
+| AP_RACA | C(2) | 2 | 0 |
+| AP_NOMERES | C(30) | 30 | 0 |
+| AP_UFNASC | C(3) | 3 | 0 |
+| AP_ETNIA | C(4) | 4 | 0 |
+| AP_CDLOGR | C(3) | 3 | 0 |
+| AP_BAIRRO | C(30) | 30 | 0 |
+| AP_DDD | C(2) | 2 | 0 |
+| AP_TEL | C(9) | 9 | 0 |
+| AP_EMAIL | C(40) | 40 | 0 |
+| AP_CNSEXE | C(15) | 15 | 0 |
+| AP_INE | C(10) | 10 | 0 |
+
+### `s_eqesf.dbf`
+
+- 0 records
+- Size: 257 bytes
+- Encoding: cp1252
+- Fields: 7
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| ESF_CMP | C(6) | 6 | 0 |
+| ESF_IBGE | C(6) | 6 | 0 |
+| ESF_CNES | C(7) | 7 | 0 |
+| ESF_SEQ | C(8) | 8 | 0 |
+| ESF_AREA | C(4) | 4 | 0 |
+| ESF_NOME | C(60) | 60 | 0 |
+| ESF_TIPO | C(2) | 2 | 0 |
+
+### `s_fcd.dbf`
+
+- 0 records
+- Size: 2,050 bytes
+- Encoding: cp1252
+- Fields: 63
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| FCD_ID | C(7) | 7 | 0 |
+| FCD_SLHAG | N(2) | 2 | 0 |
+| FCD_SLHAG_ | N(2) | 2 | 0 |
+| FCD_SLDPI | N(2) | 2 | 0 |
+| FCD_SLDPAC | N(2) | 2 | 0 |
+| FCD_MQPROP | N(2) | 2 | 0 |
+| FCD_MQOUTR | N(2) | 2 | 0 |
+| FCD_MQDPI | N(2) | 2 | 0 |
+| FCD_INDTR1 | C(1) | 1 | 0 |
+| FCD_INDTR2 | C(1) | 1 | 0 |
+| FCD_INDTR3 | C(1) | 1 | 0 |
+| FCD_INDTR4 | C(1) | 1 | 0 |
+| FCD_INDTR5 | C(1) | 1 | 0 |
+| FCD_INDTR6 | C(1) | 1 | 0 |
+| FCD_HTPMN | C(7) | 7 | 0 |
+| FCD_HTPCGC | C(14) | 14 | 0 |
+| FCD_HTPRZ | C(35) | 35 | 0 |
+| FCD_LHCMN | C(7) | 7 | 0 |
+| FCD_LHCCGC | C(14) | 14 | 0 |
+| FCD_LHCRZ | C(35) | 35 | 0 |
+| FCD_HGMN1 | C(7) | 7 | 0 |
+| FCD_HGCGC1 | C(14) | 14 | 0 |
+| FCD_HGRZ1 | C(35) | 35 | 0 |
+| FCD_HGMN2 | C(7) | 7 | 0 |
+| FCD_HGCGC2 | C(14) | 14 | 0 |
+| FCD_HGRZ2 | C(35) | 35 | 0 |
+| FCD_PLMN1 | C(7) | 7 | 0 |
+| FCD_PLCGC1 | C(14) | 14 | 0 |
+| FCD_PLRZ1 | C(35) | 35 | 0 |
+| FCD_PLMN2 | C(7) | 7 | 0 |
+| FCD_PLCGC2 | C(14) | 14 | 0 |
+| FCD_PLRZ2 | C(35) | 35 | 0 |
+| FCD_MEDMN | C(7) | 7 | 0 |
+| FCD_MEDCGC | C(14) | 14 | 0 |
+| FCD_MEDRZ | C(35) | 35 | 0 |
+| FCD_MTAMN | C(7) | 7 | 0 |
+| FCD_MTACGC | C(14) | 14 | 0 |
+| FCD_MTARZ | C(35) | 35 | 0 |
+| FCD_LAAMN | C(7) | 7 | 0 |
+| FCD_LAACGC | C(14) | 14 | 0 |
+| FCD_LAARZ | C(35) | 35 | 0 |
+| FCD_RDMN1 | C(7) | 7 | 0 |
+| FCD_RDCGC1 | C(14) | 14 | 0 |
+| FCD_RDRZ1 | C(35) | 35 | 0 |
+| FCD_RDMN2 | C(7) | 7 | 0 |
+| FCD_RDCGC2 | C(14) | 14 | 0 |
+| FCD_RDRZ2 | C(35) | 35 | 0 |
+| FCD_USMN1 | C(7) | 7 | 0 |
+| FCD_USCGC1 | C(14) | 14 | 0 |
+| FCD_USRZ1 | C(35) | 35 | 0 |
+| FCD_USMN2 | C(7) | 7 | 0 |
+| FCD_USCGC2 | C(14) | 14 | 0 |
+| FCD_USRZ2 | C(35) | 35 | 0 |
+| FCD_APMN1 | C(7) | 7 | 0 |
+| FCD_APCGC1 | C(14) | 14 | 0 |
+| FCD_APRZ1 | C(35) | 35 | 0 |
+| FCD_APMN2 | C(7) | 7 | 0 |
+| FCD_APCGC2 | C(14) | 14 | 0 |
+| FCD_APRZ2 | C(35) | 35 | 0 |
+| FCD_NFRNM | C(35) | 35 | 0 |
+| FCD_NFRCPF | C(11) | 11 | 0 |
+| FCD_DIRNM | C(35) | 35 | 0 |
+| FCD_DIRCPF | C(11) | 11 | 0 |
+
+### `s_fco.dbf`
+
+- 0 records
+- Size: 2,434 bytes
+- Encoding: cp1252
+- Fields: 75
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| FCO_ID | C(7) | 7 | 0 |
+| FCO_SLRSIM | N(2) | 2 | 0 |
+| FCO_SLRPLA | N(2) | 2 | 0 |
+| FCO_SLRARF | N(2) | 2 | 0 |
+| FCO_SLRCOM | N(2) | 2 | 0 |
+| FCO_SLRMOL | N(2) | 2 | 0 |
+| FCO_SLRBLP | N(2) | 2 | 0 |
+| FCO_SLQARM | N(2) | 2 | 0 |
+| FCO_SLQPRE | N(2) | 2 | 0 |
+| FCO_SLQCDU | N(2) | 2 | 0 |
+| FCO_SLQLDU | N(2) | 2 | 0 |
+| FCO_SLQCFL | N(2) | 2 | 0 |
+| FCO_RSIMUL | N(2) | 2 | 0 |
+| FCO_RAL6MV | N(2) | 2 | 0 |
+| FCO_RALM6S | N(2) | 2 | 0 |
+| FCO_RALM6C | N(2) | 2 | 0 |
+| FCO_RO50K | N(2) | 2 | 0 |
+| FCO_RO150K | N(2) | 2 | 0 |
+| FCO_RO500K | N(2) | 2 | 0 |
+| FCO_RUNCOB | N(2) | 2 | 0 |
+| FCO_RBRAQB | N(2) | 2 | 0 |
+| FCO_RBRAQM | N(2) | 2 | 0 |
+| FCO_RBRAQA | N(2) | 2 | 0 |
+| FCO_RMONAR | N(2) | 2 | 0 |
+| FCO_RMONIN | N(2) | 2 | 0 |
+| FCO_RSICPL | N(2) | 2 | 0 |
+| FCO_RDOSCL | N(2) | 2 | 0 |
+| FCO_RFONSE | N(2) | 2 | 0 |
+| FCO_RADMN | C(7) | 7 | 0 |
+| FCO_RADCGC | C(14) | 14 | 0 |
+| FCO_RADRZ | C(35) | 35 | 0 |
+| FCO_LHCMN | C(7) | 7 | 0 |
+| FCO_LHCCGC | C(14) | 14 | 0 |
+| FCO_LHCRZ | C(35) | 35 | 0 |
+| FCO_TACMN | C(7) | 7 | 0 |
+| FCO_TACCGC | C(14) | 14 | 0 |
+| FCO_TACRZ | C(35) | 35 | 0 |
+| FCO_RMMN | C(7) | 7 | 0 |
+| FCO_RMCGC | C(14) | 14 | 0 |
+| FCO_RMRZ | C(35) | 35 | 0 |
+| FCO_APCMN | C(7) | 7 | 0 |
+| FCO_APCCGC | C(14) | 14 | 0 |
+| FCO_APCRZ | C(35) | 35 | 0 |
+| FCO_PCMN | C(7) | 7 | 0 |
+| FCO_PCCGC | C(14) | 14 | 0 |
+| FCO_PCRZ | C(35) | 35 | 0 |
+| FCO_USMN | C(7) | 7 | 0 |
+| FCO_USCGC | C(14) | 14 | 0 |
+| FCO_USRZ | C(35) | 35 | 0 |
+| FCO_MNMN | C(7) | 7 | 0 |
+| FCO_MNCGC | C(14) | 14 | 0 |
+| FCO_MNRZ | C(35) | 35 | 0 |
+| FCO_PRMN | C(7) | 7 | 0 |
+| FCO_PRCGC | C(14) | 14 | 0 |
+| FCO_PRRZ | C(35) | 35 | 0 |
+| FCO_MEMN | C(7) | 7 | 0 |
+| FCO_MECGC | C(14) | 14 | 0 |
+| FCO_MERZ | C(35) | 35 | 0 |
+| FCO_QTMN | C(7) | 7 | 0 |
+| FCO_QTCGC | C(14) | 14 | 0 |
+| FCO_QTRZ | C(35) | 35 | 0 |
+| FCO_QTMN1 | C(7) | 7 | 0 |
+| FCO_QTCGC1 | C(14) | 14 | 0 |
+| FCO_QTRZ1 | C(35) | 35 | 0 |
+| FCO_QTMN2 | C(7) | 7 | 0 |
+| FCO_QTCGC2 | C(14) | 14 | 0 |
+| FCO_QTRZ2 | C(35) | 35 | 0 |
+| FCO_MRACPF | C(11) | 11 | 0 |
+| FCO_MRANM | C(35) | 35 | 0 |
+| FCO_MROCPF | C(11) | 11 | 0 |
+| FCO_MRONM | C(35) | 35 | 0 |
+| FCO_MOCCPF | C(11) | 11 | 0 |
+| FCO_MOCNM | C(35) | 35 | 0 |
+| FCO_MRRCPF | C(11) | 11 | 0 |
+| FCO_MRRNM | C(35) | 35 | 0 |
+
+### `s_imperr.dbf`
+
+- 0 records
+- Size: 195 bytes
+- Encoding: cp1252
+- Fields: 5
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| ID_ERRO | C(6) | 6 | 0 |
+| AP_CMP | C(6) | 6 | 0 |
+| APA_UF | C(2) | 2 | 0 |
+| AP_NUMAPAC | C(13) | 13 | 0 |
+| AP_CDPROC | C(10) | 10 | 0 |
+
+### `s_ipul.dbf`
+
+- 0 records
+- Size: 449 bytes
+- Encoding: cp1252
+- Fields: 13
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| IPUL_UPS | C(7) | 7 | 0 |
+| IPUL_CMP | C(6) | 6 | 0 |
+| IPUL_TPFIN | C(1) | 1 | 0 |
+| IPUL_PA | C(9) | 9 | 0 |
+| IPUL_QT_O | N(8) | 8 | 0 |
+| IPUL_NAPU | C(1) | 1 | 0 |
+| IPUL_VU_O | N(12,2) | 12 | 2 |
+| IPUL_VL_O | N(12,2) | 12 | 2 |
+| IPUL_ARQ | C(12) | 12 | 0 |
+| IPUL_VERS | C(5) | 5 | 0 |
+| IPUL_CHK1 | C(4) | 4 | 0 |
+| IPUL_CHK2 | C(4) | 4 | 0 |
+| IPUL_LINE | N(6) | 6 | 0 |
+
+### `s_iput.dbf`
+
+- 0 records
+- Size: 227 bytes
+- Encoding: cp1252
+- Fields: 6
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| IPUL_UPS | C(7) | 7 | 0 |
+| IPUL_CMP | C(6) | 6 | 0 |
+| IPUL_PA | C(9) | 9 | 0 |
+| IPUL_QT_O | N(8) | 8 | 0 |
+| IPUL_NAPU | C(1) | 1 | 0 |
+| IPUL_ARQ | C(12) | 12 | 0 |
+
+### `s_prdl.dbf`
+
+- 0 records
+- Size: 1,251 bytes
+- Encoding: cp1252
+- Fields: 38
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PRDL_UPS | C(7) | 7 | 0 |
+| PRDL_CMP | C(6) | 6 | 0 |
+| PRDL_CNSME | C(15) | 15 | 0 |
+| PRDL_CBO | C(6) | 6 | 0 |
+| PRDL_DTATE | C(8) | 8 | 0 |
+| PRDL_FLH | C(3) | 3 | 0 |
+| PRDL_SEQ | C(2) | 2 | 0 |
+| PRDL_PA | C(10) | 10 | 0 |
+| PRDL_CNSPA | C(15) | 15 | 0 |
+| PRDL_SEXO | C(1) | 1 | 0 |
+| PRDL_IBGE | C(6) | 6 | 0 |
+| PRDL_CID | C(4) | 4 | 0 |
+| PRDL_IDADE | N(3) | 3 | 0 |
+| PRDL_QT_P | N(6) | 6 | 0 |
+| PRDL_CATEN | C(2) | 2 | 0 |
+| PRDL_NAUT | C(13) | 13 | 0 |
+| PRDL_ORG | C(3) | 3 | 0 |
+| PRDL_NMPAC | C(30) | 30 | 0 |
+| PRDL_DTNAS | C(8) | 8 | 0 |
+| PRDL_TIPO | C(1) | 1 | 0 |
+| PRDL_RACA | C(2) | 2 | 0 |
+| PRDL_ETNIA | C(4) | 4 | 0 |
+| PRDL_NACIO | C(3) | 3 | 0 |
+| PRDL_SRV | C(3) | 3 | 0 |
+| PRDL_CSF | C(3) | 3 | 0 |
+| PRDL_EQUIP | C(12) | 12 | 0 |
+| PRDL_CNPJ | C(14) | 14 | 0 |
+| BPI_CEPPCN | C(8) | 8 | 0 |
+| BPI_CDLOGR | C(3) | 3 | 0 |
+| BPI_LOGPCN | C(30) | 30 | 0 |
+| BPI_CPLPCN | C(10) | 10 | 0 |
+| BPI_NUMPCN | C(5) | 5 | 0 |
+| BPI_BAIRRO | C(30) | 30 | 0 |
+| BPI_DDD | C(2) | 2 | 0 |
+| BPI_TEL | C(9) | 9 | 0 |
+| BPI_EMAIL | C(40) | 40 | 0 |
+| BPI_INE | C(40) | 40 | 0 |
+| CBO_ANT | C(6) | 6 | 0 |
+
+### `s_prdlc.dbf`
+
+- 0 records
+- Size: 355 bytes
+- Encoding: cp1252
+- Fields: 10
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| IDENTIF | C(2) | 2 | 0 |
+| PRDL_UPS | C(7) | 7 | 0 |
+| PRDL_CMP | C(6) | 6 | 0 |
+| PRDL_CBO | C(6) | 6 | 0 |
+| PRDL_FLH | C(3) | 3 | 0 |
+| PRDL_SEQ | C(2) | 2 | 0 |
+| PRDL_PA | C(10) | 10 | 0 |
+| PRDL_IDADE | N(3) | 3 | 0 |
+| PRDL_QT_P | N(6) | 6 | 0 |
+| PRDL_ORG | C(3) | 3 | 0 |
+
+### `s_prdli.dbf`
+
+- 0 records
+- Size: 1,283 bytes
+- Encoding: cp1252
+- Fields: 39
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| IDENTIF | C(2) | 2 | 0 |
+| PRDL_UPS | C(7) | 7 | 0 |
+| PRDL_CMP | C(6) | 6 | 0 |
+| PRDL_CNSME | C(15) | 15 | 0 |
+| PRDL_CBO | C(6) | 6 | 0 |
+| PRDL_DTATE | C(8) | 8 | 0 |
+| PRDL_FLH | C(3) | 3 | 0 |
+| PRDL_SEQ | C(2) | 2 | 0 |
+| PRDL_PA | C(10) | 10 | 0 |
+| PRDL_CNSPA | C(15) | 15 | 0 |
+| PRDL_SEXO | C(1) | 1 | 0 |
+| PRDL_IBGE | C(6) | 6 | 0 |
+| PRDL_CID | C(4) | 4 | 0 |
+| PRDL_IDADE | N(3) | 3 | 0 |
+| PRDL_QT_P | N(6) | 6 | 0 |
+| PRDL_CATEN | C(2) | 2 | 0 |
+| PRDL_NAUT | C(13) | 13 | 0 |
+| PRDL_ORG | C(3) | 3 | 0 |
+| PRDL_NMPAC | C(30) | 30 | 0 |
+| PRDL_DTNAS | C(8) | 8 | 0 |
+| PRDL_RACA | C(2) | 2 | 0 |
+| PRDL_ETNIA | C(4) | 4 | 0 |
+| PRDL_NACIO | C(3) | 3 | 0 |
+| PRDL_SRV | C(3) | 3 | 0 |
+| PRDL_CSF | C(3) | 3 | 0 |
+| PRDL_EQUIP | C(12) | 12 | 0 |
+| PRDL_CNPJ | C(14) | 14 | 0 |
+| BPI_CEPPCN | C(8) | 8 | 0 |
+| BPI_CDLOGR | C(3) | 3 | 0 |
+| BPI_LOGPCN | C(30) | 30 | 0 |
+| BPI_CPLPCN | C(10) | 10 | 0 |
+| BPI_NUMPCN | C(5) | 5 | 0 |
+| BPI_BAIRRO | C(30) | 30 | 0 |
+| BPI_DDD | C(2) | 2 | 0 |
+| BPI_TEL | C(9) | 9 | 0 |
+| BPI_EMAIL | C(40) | 40 | 0 |
+| BPI_INE | C(10) | 10 | 0 |
+| T1 | N(15) | 15 | 0 |
+| T2 | N(2) | 2 | 0 |
+
+### `s_prdlt.dbf`
+
+- 0 records
+- Size: 195 bytes
+- Encoding: cp1252
+- Fields: 5
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| ID | N(1) | 1 | 0 |
+| PRDL_PA | N(10) | 10 | 0 |
+| PRDL_QT_P | N(6) | 6 | 0 |
+| T1 | N(2) | 2 | 0 |
+| S1 | N(17) | 17 | 0 |
+
+### `s_prdrep.dbf`
+
+- 0 records
+- Size: 1,635 bytes
+- Encoding: cp1252
+- Fields: 50
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PRD_UID | C(7) | 7 | 0 |
+| PRD_CMP | C(6) | 6 | 0 |
+| PRD_FLH | C(3) | 3 | 0 |
+| PRD_SEQ | C(2) | 2 | 0 |
+| PRD_PA | C(10) | 10 | 0 |
+| PRD_CBO | C(6) | 6 | 0 |
+| PRD_IDADE | N(3) | 3 | 0 |
+| PRD_QT_P | N(6) | 6 | 0 |
+| PRD_QT_A | N(6) | 6 | 0 |
+| PRD_VL_P | N(15,2) | 15 | 2 |
+| PRD_VL_A | N(15,2) | 15 | 2 |
+| PRD_MVM | C(6) | 6 | 0 |
+| PRD_ORG | C(3) | 3 | 0 |
+| PRD_FLPA | C(1) | 1 | 0 |
+| PRD_FLCBO | C(1) | 1 | 0 |
+| PRD_FLCA | C(1) | 1 | 0 |
+| PRD_FLIDA | C(1) | 1 | 0 |
+| PRD_FLQT | C(1) | 1 | 0 |
+| PRD_FLER | C(1) | 1 | 0 |
+| PRD_APANUM | C(13) | 13 | 0 |
+| PRD_CNSMED | C(15) | 15 | 0 |
+| PRD_RMS | C(4) | 4 | 0 |
+| PRD_CNPJ | C(14) | 14 | 0 |
+| PRD_NFIS | C(6) | 6 | 0 |
+| PRD_RESID | C(6) | 6 | 0 |
+| PRD_RUB | C(6) | 6 | 0 |
+| PRD_TPFIN | C(1) | 1 | 0 |
+| PRD_CPX | C(1) | 1 | 0 |
+| PRD_QTDATR | N(6) | 6 | 0 |
+| PRD_QTDATU | N(6) | 6 | 0 |
+| PRD_RC | C(4) | 4 | 0 |
+| PRD_CIDPRI | C(6) | 6 | 0 |
+| PRD_CIDSEC | C(6) | 6 | 0 |
+| PRD_CIDCAS | C(6) | 6 | 0 |
+| PRD_INCOUT | C(4) | 4 | 0 |
+| PRD_INCURG | C(4) | 4 | 0 |
+| PRD_INSRG | C(3) | 3 | 0 |
+| PRD_CNSPCN | C(15) | 15 | 0 |
+| PRD_DTINI | C(8) | 8 | 0 |
+| PRD_DTREA | C(8) | 8 | 0 |
+| PRD_SRV | C(3) | 3 | 0 |
+| PRD_CSF | C(3) | 3 | 0 |
+| PRD_EQUIP | C(12) | 12 | 0 |
+| PRD_VL_FED | N(10,2) | 10 | 2 |
+| PRD_VL_LOC | N(10,2) | 10 | 2 |
+| PRD_VL_INC | N(10,2) | 10 | 2 |
+| PRD_RUBFED | C(6) | 6 | 0 |
+| PRD_LREX | C(1) | 1 | 0 |
+| PRD_TEMP | C(20) | 20 | 0 |
+| PRD_MVMORI | C(6) | 6 | 0 |
+
+### `s_proc.dbf`
+
+- 0 records
+- Size: 449 bytes
+- Encoding: cp1252
+- Fields: 13
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| IDENTIF | C(2) | 2 | 0 |
+| AP_CMP | C(6) | 6 | 0 |
+| AP_NUMAPAC | C(13) | 13 | 0 |
+| AP_CDPROC | C(10) | 10 | 0 |
+| AP_CDATIV | C(6) | 6 | 0 |
+| AP_QTPROC | C(7) | 7 | 0 |
+| AP_CNPJ | C(14) | 14 | 0 |
+| AP_NFISC | C(6) | 6 | 0 |
+| AP_CIDPRI | C(4) | 4 | 0 |
+| AP_CIDSEC | C(4) | 4 | 0 |
+| AP_SRV | C(3) | 3 | 0 |
+| AP_CSF | C(3) | 3 | 0 |
+| AP_EQUIPE | C(12) | 12 | 0 |
+
+### `s_rapal.dbf`
+
+- 0 records
+- Size: 675 bytes
+- Encoding: cp1252
+- Fields: 20
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| COD_LIN | C(2) | 2 | 0 |
+| RAPA_UF | C(2) | 2 | 0 |
+| RAPA_CMP | C(6) | 6 | 0 |
+| RAPA_UID | C(7) | 7 | 0 |
+| RAPA_CNSPC | C(15) | 15 | 0 |
+| RAPA_DTINI | C(8) | 8 | 0 |
+| RAPA_PA | C(10) | 10 | 0 |
+| RAPA_CBO | C(6) | 6 | 0 |
+| RAPA_CNSEX | C(15) | 15 | 0 |
+| RAPA_DTREA | C(8) | 8 | 0 |
+| RAPA_SRV | C(3) | 3 | 0 |
+| RAPA_CSF | C(3) | 3 | 0 |
+| RAPA_EQUIP | C(12) | 12 | 0 |
+| RAPA_QT_P | N(6) | 6 | 0 |
+| RAPA_ORG | C(3) | 3 | 0 |
+| RAPA_CID | C(4) | 4 | 0 |
+| RAPA_CHKSU | C(4) | 4 | 0 |
+| RAPA_MVM | C(6) | 6 | 0 |
+| X | C(30) | 30 | 0 |
+| RAPA_INSRG | C(3) | 3 | 0 |
+
+### `s_sce.dbf`
+
+- 0 records
+- Size: 162 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| SCE_SRV | C(3) | 3 | 0 |
+| SCE_CSF | C(3) | 3 | 0 |
+| SCE_EMAS | C(200) | 200 | 0 |
+| SCE_TEMP | C(3) | 3 | 0 |
+
+### `s_trab.dbf`
+
+- 0 records
+- Size: 1,443 bytes
+- Encoding: cp1252
+- Fields: 44
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| TRAB_INSRG | C(3) | 3 | 0 |
+| TRAB_UID | C(7) | 7 | 0 |
+| TRAB_CMP | C(6) | 6 | 0 |
+| TRAB_CNSPC | C(15) | 15 | 0 |
+| TRAB_DTINI | C(8) | 8 | 0 |
+| TRAB_DTFIM | C(8) | 8 | 0 |
+| TRAB_NMPCN | C(30) | 30 | 0 |
+| TRAB_NPRON | C(10) | 10 | 0 |
+| TRAB_NACPC | C(3) | 3 | 0 |
+| TRAB_MAEPC | C(30) | 30 | 0 |
+| TRAB_NOMER | C(30) | 30 | 0 |
+| TRAB_LOGPC | C(30) | 30 | 0 |
+| TRAB_NUMPC | C(5) | 5 | 0 |
+| TRAB_CPLPC | C(10) | 10 | 0 |
+| TRAB_CEPPC | C(8) | 8 | 0 |
+| TRAB_MUNPC | C(7) | 7 | 0 |
+| TRAB_DTNAS | C(8) | 8 | 0 |
+| TRAB_SEXPC | C(1) | 1 | 0 |
+| TRAB_RACA | C(2) | 2 | 0 |
+| TRAB_ETNIA | C(4) | 4 | 0 |
+| TRAB_TELEF | C(11) | 11 | 0 |
+| TRAB_CELUL | C(11) | 11 | 0 |
+| TRAB_CDLOG | C(3) | 3 | 0 |
+| TRAB_BAIRR | C(30) | 30 | 0 |
+| TRAB_EMAIL | C(40) | 40 | 0 |
+| TRAB_MOTCO | C(2) | 2 | 0 |
+| TRAB_DTOBA | C(8) | 8 | 0 |
+| TRAB_CATEN | C(2) | 2 | 0 |
+| TRAB_CIDPR | C(4) | 4 | 0 |
+| TRAB_CIDCA | C(4) | 4 | 0 |
+| TRAB_CIDS1 | C(4) | 4 | 0 |
+| TRAB_CIDS2 | C(4) | 4 | 0 |
+| TRAB_CIDS3 | C(4) | 4 | 0 |
+| TRAB_PCNOR | C(1) | 1 | 0 |
+| TRAB_CODES | C(1) | 1 | 0 |
+| TRAB_CNESE | C(7) | 7 | 0 |
+| TRAB_DESTP | C(2) | 2 | 0 |
+| TRAB_ORG | C(3) | 3 | 0 |
+| TRAB_CHKSU | C(4) | 4 | 0 |
+| TRAB_RMS | C(4) | 4 | 0 |
+| TRAB_DTGER | C(8) | 8 | 0 |
+| TRAB_FLER | C(10) | 10 | 0 |
+| TRAB_INERP | C(1) | 1 | 0 |
+| TRAB_MVM | C(6) | 6 | 0 |
+
+### `s_upsval.dbf`
+
+- 0 records
+- Size: 67 bytes
+- Encoding: cp1252
+- Fields: 1
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CO_CNES | C(7) | 7 | 0 |
+
+### `s_varia.dbf`
+
+- 0 records
+- Size: 161 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| IDENTIF | C(2) | 2 | 0 |
+| AP_CMP | C(6) | 6 | 0 |
+| AP_NUMAPAC | C(13) | 13 | 0 |
+| AP_VARIA | C(140) | 140 | 0 |
+
+### `s_vpal.dbf`
+
+- 0 records
+- Size: 385 bytes
+- Encoding: cp1252
+- Fields: 11
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| VPAL_CMP | C(6) | 6 | 0 |
+| VPAL_PA | C(9) | 9 | 0 |
+| VPAL_ID | C(1) | 1 | 0 |
+| VPA_MUN | C(6) | 6 | 0 |
+| VPA_ZERO | C(1) | 1 | 0 |
+| VPA_TIPO | C(1) | 1 | 0 |
+| VPAL_SA | N(8) | 8 | 0 |
+| VPAL_SH | N(8) | 8 | 0 |
+| VPAL_SP | N(8) | 8 | 0 |
+| VPA_CTF | C(2) | 2 | 0 |
+| VPA_RUB | C(6) | 6 | 0 |
+
+### `temu.dbf`
+
+- 0 records
+- Size: 193 bytes
+- Encoding: cp1252
+- Fields: 5
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| EMU_UID | C(7) | 7 | 0 |
+| EMU_CMP | C(6) | 6 | 0 |
+| EMU_EMA | C(6) | 6 | 0 |
+| EMU_QT_PR | N(3) | 3 | 0 |
+| EMU_QT_HR | N(5) | 5 | 0 |
+
+### `tsrv.dbf`
+
+- 0 records
+- Size: 161 bytes
+- Encoding: cp1252
+- Fields: 4
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| SRV_UID | C(7) | 7 | 0 |
+| SRV_CMP | C(6) | 6 | 0 |
+| SRV_SR | C(3) | 3 | 0 |
+| SRV_CSF | C(3) | 3 | 0 |
+
+### `ttvpa.dbf`
+
+- 0 records
+- Size: 385 bytes
+- Encoding: cp1252
+- Fields: 11
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| VPA_PA | C(9) | 9 | 0 |
+| VPA_CMP | C(6) | 6 | 0 |
+| VPA_TOTAL | N(13,2) | 13 | 2 |
+| VPA_SP | N(13,2) | 13 | 2 |
+| VPA_SA | N(13,2) | 13 | 2 |
+| VPA_SH | N(13,2) | 13 | 2 |
+| VPA_MUN | C(6) | 6 | 0 |
+| VPA_TIPO | C(1) | 1 | 0 |
+| VPA_CTF | C(2) | 2 | 0 |
+| VPA_RUB | C(6) | 6 | 0 |
+| VPA_MVM | C(6) | 6 | 0 |
+
+### `vepe.dbf`
+
+- 0 records
+- Size: 257 bytes
+- Encoding: cp1252
+- Fields: 7
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| ORDEM | C(6) | 6 | 0 |
+| REGRAC | C(4) | 4 | 0 |
+| TP_FINANC | C(2) | 2 | 0 |
+| CD_RUB | C(4) | 4 | 0 |
+| CPX | C(1) | 1 | 0 |
+| TTOTAL | N(15,2) | 15 | 2 |
+| DESCRICAO | C(40) | 40 | 0 |
+
+### `versaomn.dbf`
+
+- 0 records
+- Size: 257 bytes
+- Encoding: cp1252
+- Fields: 7
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| CMP | C(6) | 6 | 0 |
+| FILL1 | C(1) | 1 | 0 |
+| DEPARA | C(5) | 5 | 0 |
+| FILL2 | C(1) | 1 | 0 |
+| BDSIA | C(7) | 7 | 0 |
+| FILL3 | C(1) | 1 | 0 |
+| SIA | C(5) | 5 | 0 |
+
+### `vig.dbf`
+
+- 0 records
+- Size: 993 bytes
+- Encoding: cp1252
+- Fields: 30
+
+| Field | Type | Length | Decimal |
+|---|---|---|---|
+| PA_CMP | C(6) | 6 | 0 |
+| PA_ID | C(9) | 9 | 0 |
+| PA_DV | C(1) | 1 | 0 |
+| PA_PAB | C(1) | 1 | 0 |
+| PA_TOTAL | N(12,2) | 12 | 2 |
+| PA_FAEC | C(1) | 1 | 0 |
+| PA_DC | C(60) | 60 | 0 |
+| PA_RUB | C(4) | 4 | 0 |
+| PA_TPCC | C(1) | 1 | 0 |
+| PA_AUX | C(20) | 20 | 0 |
+| PA_CPX | C(4) | 4 | 0 |
+| PA_CTF | C(4) | 4 | 0 |
+| PA_DOC | C(1) | 1 | 0 |
+| PA_IDADEMX | N(3) | 3 | 0 |
+| PA_IDADEMN | N(3) | 3 | 0 |
+| PA_SEXO | C(1) | 1 | 0 |
+| PA_QTDMAX | N(6) | 6 | 0 |
+| PA_LAUDO | C(2) | 2 | 0 |
+| PA_PRINC | C(1) | 1 | 0 |
+| PA_SECUN | C(1) | 1 | 0 |
+| PA_IDEBPA | C(1) | 1 | 0 |
+| PA_CNSPCN | C(1) | 1 | 0 |
+| PA_CNRAC | C(1) | 1 | 0 |
+| PA_CCMANAL | C(2) | 2 | 0 |
+| PA_ELETIVA | C(1) | 1 | 0 |
+| PA_APACONT | C(1) | 1 | 0 |
+| PA_EXIGCBO | C(1) | 1 | 0 |
+| PA_PROCCEO | C(1) | 1 | 0 |
+| PA_6MESES | C(1) | 1 | 0 |
+| PA_EXIGAUT | C(1) | 1 | 0 |

--- a/docs/data-dictionary-sihd-hospital.md
+++ b/docs/data-dictionary-sihd-hospital.md
@@ -309,3 +309,19 @@ FROM TB_HAIH
 WHERE AH_CMPT = :competencia
   AND AH_SITUACAO = '1'
 ```
+
+---
+
+## §Gold v2 Mapping
+
+| Origem SIHD | → | Gold v2 | Observação |
+|---|---|---|---|
+| `TB_HAIH` (AIH processadas) | → | `fato_internacao` | AH_OE_GESTOR+AH_SEQ → num_aih CHAR(13); valores em centavos |
+| `TB_HPA` (procedimentos AIH histórico) | → | `fato_procedimento_aih` | referência sk_aih via num_aih lookup |
+| `TU_PROCEDIMENTO` | → | `dim_procedimento_sus` | sync periódico SIGTAP |
+| `TU_CID` | → | `dim_cid10` | sync |
+| `TB_MUN` | → | reconciliação com `dim_municipio` | COD_MUN → ibge6 |
+| `TB_AIH` + `TB_PA` (em processamento) | → | **NÃO mapear para gold** | só histórico (post-close); evita fatos mutáveis |
+
+Ingestão: `dump_agent_go` já tem `sihd_producao` intent. Mapper `data_processor` 
+a criar (fora de escopo Spec B).

--- a/docs/migration-plan-gold-v2.md
+++ b/docs/migration-plan-gold-v2.md
@@ -1,0 +1,156 @@
+# Migration Plan — Gold Schema v2
+
+- **Data:** 2026-04-21
+- **Status:** Design — não executar sem aprovação
+- **Spec:** `docs/superpowers/specs/2026-04-21-gold-schema-refactor-sia-bpa-design.md`
+- **Target DB:** Postgres (central) — schemas `gold` + `landing`
+
+## Convenções
+
+- Alembic script_location: `packages/cnes_infra/src/cnes_infra/alembic/versions/`
+- Revision numerada sequencial (próxima = `010`, já que 009 é agent_version de Plan C)
+- Cada rev é atômica; rollback via `alembic downgrade`
+
+## Revisões propostas
+
+### `010_gold_dim_compartilhadas_novas`
+
+**Conteúdo:**
+- CREATE TABLE gold.dim_profissional_new (sk_profissional INT4 identity, cpf_hash CHAR(11), ...)
+- CREATE TABLE gold.dim_estabelecimento_new (...)
+- CREATE TABLE gold.dim_procedimento_sus (sk_procedimento INT4 identity, cod_sigtap CHAR(10), ...)
+- CREATE TABLE gold.dim_cbo (sk_cbo INT4 identity, cod_cbo CHAR(6), ...)
+- CREATE TABLE gold.dim_cid10 (...)
+- CREATE TABLE gold.dim_municipio (...)
+- CREATE TABLE gold.dim_competencia (...)
+
+**Rollback:** DROP TABLE gold.dim_*_new + gold.dim_procedimento_sus + gold.dim_cbo.
+
+**Risco:** nenhum — coexiste com gold antigo.
+
+---
+
+### `011_gold_popular_dims_iniciais`
+
+**Conteúdo:**
+```sql
+INSERT INTO gold.dim_profissional_new (cpf_hash, nome, cns, fontes, criado_em)
+SELECT cpf, nome, cns, fontes, criado_em FROM gold.dim_profissional;
+
+INSERT INTO gold.dim_estabelecimento_new (cnes, nome, cnpj_mantenedora, tp_unid, sk_municipio, fontes)
+SELECT cnes, nome, cnpj_mant, tp_unid_id, sk_municipio, fontes
+FROM gold.dim_estabelecimento
+JOIN gold.dim_municipio_lookup ON ...
+```
+
+Backfill dim_municipio + dim_cbo via sincronização inicial contra fontes domínio
+(NFCES005 + CADMUN SIA + TB_MUN SIHD reconciliados).
+
+**Rollback:** TRUNCATE gold.dim_*_new.
+
+---
+
+### `012_gold_fatos_novos_particionados`
+
+**Conteúdo:**
+- CREATE TABLE gold.fato_vinculo_cnes (sk_vinculo BIGINT identity, sk_profissional INT4, ...) PARTITION BY RANGE (sk_competencia)
+- Criar partições iniciais para competências 202401-202612 (24 ranges)
+- CREATE TABLE gold.fato_producao_ambulatorial (...) PARTITION BY RANGE
+- CREATE TABLE gold.fato_internacao (...) PARTITION BY RANGE
+- CREATE TABLE gold.fato_procedimento_aih (...) PARTITION BY RANGE
+
+**Rollback:** DROP TABLE gold.fato_* CASCADE.
+
+---
+
+### `013_gold_migrar_fato_vinculo`
+
+**Conteúdo:**
+- INSERT INTO gold.fato_vinculo_cnes SELECT ... FROM gold.fato_vinculo (antigo) com sk_* resolvidos via JOIN nas novas dims
+- data_processor atualiza para dual-write (escrever tanto em fato_vinculo antigo quanto fato_vinculo_cnes novo)
+- Validar paridade: `SELECT count(*) FROM fato_vinculo` vs `SELECT count(*) FROM fato_vinculo_cnes` → igual ±0.1%
+
+**Rollback:** TRUNCATE gold.fato_vinculo_cnes + revert data_processor dual-write code.
+
+**Risco:** médio — dual-write complica código. Manter por 2 competências máximo.
+
+---
+
+### `014_gold_view_auditoria`
+
+**Conteúdo:**
+```sql
+CREATE MATERIALIZED VIEW gold.view_auditoria_producao AS
+SELECT ... FROM gold.fato_vinculo_cnes fv
+FULL OUTER JOIN gold.fato_producao_ambulatorial fpa USING (sk_profissional, sk_estabelecimento, sk_competencia)
+FULL OUTER JOIN gold.fato_internacao fi ON ...
+GROUP BY ROLLUP (1, 2, 3);
+
+CREATE UNIQUE INDEX ix_vap_key
+    ON gold.view_auditoria_producao (sk_profissional, sk_estabelecimento, sk_competencia);
+```
+
+Cron semanal no central_api para REFRESH CONCURRENTLY.
+
+**Rollback:** DROP MATERIALIZED VIEW gold.view_auditoria_producao.
+
+---
+
+### `015_gold_drop_tabelas_antigas` (DESTRUTIVA)
+
+**Pre-flight obrigatório:**
+- [ ] Executar `SELECT count(*)` nas _old vs nas novas — paridade ≥ 99.9%
+- [ ] `pg_dump --schema=gold` executado + armazenado em bucket retention 30d
+- [ ] data_processor stable há ≥ 2 competências sem anomalia
+- [ ] Shadow E2E gold ≥ 7 consecutivas verdes (paridade dados)
+
+**Conteúdo:**
+```sql
+DROP TABLE gold.fato_vinculo;
+DROP TABLE gold.dim_profissional;
+DROP TABLE gold.dim_estabelecimento;
+ALTER TABLE gold.dim_profissional_new RENAME TO dim_profissional;
+ALTER TABLE gold.dim_estabelecimento_new RENAME TO dim_estabelecimento;
+```
+
+**Rollback:** restaurar via pg_dump (~30min para DB de 100GB). Not reversible via alembic downgrade.
+
+**Risco:** alto — destrutivo. Só após todo pipeline confirmar paridade.
+
+---
+
+## Timeline recomendada pós-approval
+
+| Semana | Rev | Ação | Responsável |
+|---|---|---|---|
+| 1 | 010, 011 | Aplicar em staging + dev local | Backend eng |
+| 2 | 012 | Criar fatos particionados + popular competências teste | Backend eng |
+| 3 | 013 | Dual-write data_processor + primeira competência dual | Data eng |
+| 4 | — | Validar paridade 1ª competência | Data eng |
+| 5 | — | Segunda competência dual + validação | Data eng |
+| 6 | 014 | MatView + cron refresh | Backend eng |
+| 7 | 015 | Drop destrutivo + pg_dump pre-flight | DBA |
+| 8 | — | Consumer Gold v2 ativo em queries de auditoria | Audit team |
+
+## Risk matrix
+
+| Rev | Destrutivo | Rollback | Downtime estimado |
+|---|---|---|---|
+| 010 | não | alembic downgrade | 0 |
+| 011 | não (idempotent) | TRUNCATE | <5min |
+| 012 | não | DROP CASCADE | 0 |
+| 013 | não | TRUNCATE + revert code | <10min |
+| 014 | não | DROP MATVIEW | 0 |
+| 015 | sim | pg_dump restore (~30min) | 10-30min |
+
+## Integração SIA + BPA (pós-015)
+
+Após gold v2 estabilizado, adicionar:
+- Adapter Go: `dump_agent_go` novos intents `sia_apa`, `sia_bpi`, `bpa_c`, `bpa_i`
+- Mappers data_processor: `sia_bpi_row_mapper.py`, `bpa_producao_row_mapper.py`
+- Fontes: `fato_producao_ambulatorial.fonte_sistema` IN (SIA_APA, SIA_BPI, BPA_C, BPA_I)
+- Dedup cross-source: chave (sk_estab, sk_prof, sk_procedimento, sk_competencia, dt_atendimento)
+
+---
+
+**Fim migration plan.** Execução real em Spec C futura.

--- a/scripts/introspect_bpa_gdb.py
+++ b/scripts/introspect_bpa_gdb.py
@@ -1,0 +1,148 @@
+"""Introspeccao BPAMAG.GDB via fdb (Firebird 1.5/2.5 compat).
+
+Le RDB$RELATIONS + RDB$RELATION_FIELDS + RDB$FIELDS para extrair schema
+de tabelas nao-sistema. Emite markdown em docs/data-dictionary-bpa.md.
+
+Uso:
+    python scripts/introspect_bpa_gdb.py \\
+        --gdb E:/BPA/BPAMAG.GDB \\
+        --dll E:/BPA/fbclient.dll \\
+        --output docs/data-dictionary-bpa.md
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ColumnInfo:
+    name: str
+    type_name: str
+    nullable: bool
+    length: int | None
+
+
+@dataclass
+class TableInfo:
+    name: str
+    columns: list[ColumnInfo]
+    row_count_estimate: int
+
+
+_FB_TYPE_MAP = {
+    7: "SMALLINT", 8: "INTEGER", 10: "FLOAT", 12: "DATE", 13: "TIME",
+    14: "CHAR", 16: "BIGINT", 27: "DOUBLE PRECISION", 35: "TIMESTAMP",
+    37: "VARCHAR", 261: "BLOB",
+}
+
+
+def _connect(gdb: Path, dll: Path):
+    import fdb
+    fdb.load_api(str(dll))
+    return fdb.connect(
+        dsn=str(gdb), user="SYSDBA", password="masterkey",
+        charset="WIN1252",
+    )
+
+
+def list_tables(conn) -> list[str]:
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT TRIM(RDB$RELATION_NAME)
+        FROM RDB$RELATIONS
+        WHERE RDB$SYSTEM_FLAG = 0
+        ORDER BY RDB$RELATION_NAME
+    """)
+    return [r[0] for r in cur.fetchall()]
+
+
+def describe_table(conn, table_name: str) -> TableInfo:
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT
+            TRIM(RF.RDB$FIELD_NAME),
+            F.RDB$FIELD_TYPE,
+            F.RDB$FIELD_LENGTH,
+            RF.RDB$NULL_FLAG
+        FROM RDB$RELATION_FIELDS RF
+        JOIN RDB$FIELDS F ON F.RDB$FIELD_NAME = RF.RDB$FIELD_SOURCE
+        WHERE RF.RDB$RELATION_NAME = ?
+        ORDER BY RF.RDB$FIELD_POSITION
+    """, (table_name,))
+    columns = []
+    for name, ftype, length, null_flag in cur.fetchall():
+        columns.append(ColumnInfo(
+            name=name,
+            type_name=_FB_TYPE_MAP.get(ftype, f"UNKNOWN({ftype})"),
+            nullable=(null_flag != 1),
+            length=length if length and length > 0 else None,
+        ))
+
+    try:
+        cur.execute(f'SELECT COUNT(*) FROM "{table_name}"')
+        (count,) = cur.fetchone()
+    except Exception:
+        count = -1
+    return TableInfo(name=table_name, columns=columns, row_count_estimate=count)
+
+
+def format_table_markdown(t: TableInfo) -> str:
+    lines = [
+        f"### `{t.name}`",
+        "",
+        f"- Rows (estimate): {t.row_count_estimate} rows",
+        f"- Columns: {len(t.columns)}",
+        "",
+        "| Coluna | Tipo | Nullable |",
+        "|---|---|---|",
+    ]
+    for c in t.columns:
+        type_str = f"{c.type_name}({c.length})" if c.length else c.type_name
+        null_str = "nullable" if c.nullable else "NOT NULL"
+        lines.append(f"| {c.name} | {type_str} | {null_str} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gdb", type=Path, required=True)
+    parser.add_argument("--dll", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    conn = _connect(args.gdb, args.dll)
+    try:
+        tables = list_tables(conn)
+        logger.info("bpa_tables_found count=%d", len(tables))
+
+        out_lines = [
+            "# Dicionario de Dados - BPA-Mag (BPAMAG.GDB)",
+            "",
+            "> Introspeccao automatica via `scripts/introspect_bpa_gdb.py`.",
+            f"> Source: `{args.gdb}` | Firebird 1.5/2.5 | Charset: WIN1252",
+            f"> Tabelas nao-sistema: {len(tables)}",
+            "",
+            "## Tabelas",
+            "",
+        ]
+        for t_name in tables:
+            info = describe_table(conn, t_name)
+            out_lines.append(format_table_markdown(info))
+
+        args.output.write_text("\n".join(out_lines), encoding="utf-8")
+        logger.info("bpa_dict_written path=%s tables=%d", args.output, len(tables))
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/introspect_bpa_gdb_test.py
+++ b/scripts/introspect_bpa_gdb_test.py
@@ -1,0 +1,21 @@
+"""Teste do introspect_bpa_gdb - parse + format."""
+from scripts.introspect_bpa_gdb import ColumnInfo, TableInfo, format_table_markdown
+
+
+def test_format_table_markdown_emite_seccao() -> None:
+    t = TableInfo(
+        name="TB_PRODUCAO",
+        columns=[
+            ColumnInfo(name="ID", type_name="INTEGER", nullable=False, length=None),
+            ColumnInfo(name="COD_CNES", type_name="CHAR", nullable=False, length=7),
+            ColumnInfo(name="VL_APROV", type_name="NUMERIC", nullable=True, length=None),
+        ],
+        row_count_estimate=12345,
+    )
+    md = format_table_markdown(t)
+    assert "### `TB_PRODUCAO`" in md
+    assert "12345 rows" in md
+    assert "| ID | INTEGER |" in md
+    assert "| COD_CNES | CHAR(7) |" in md
+    assert "| VL_APROV | NUMERIC |" in md
+    assert "nullable" in md.lower()

--- a/scripts/introspect_sia_dbf.py
+++ b/scripts/introspect_sia_dbf.py
@@ -70,7 +70,7 @@ def main() -> int:
     args = parser.parse_args()
 
     dbfs = sorted(
-        list(args.dir.glob("*.DBF")) + list(args.dir.glob("*.dbf")),
+        {p.resolve() for p in list(args.dir.glob("*.DBF")) + list(args.dir.glob("*.dbf"))},
         key=lambda p: p.name,
     )
     logger.info("sia_dbfs_found count=%d", len(dbfs))

--- a/scripts/introspect_sia_dbf.py
+++ b/scripts/introspect_sia_dbf.py
@@ -1,0 +1,117 @@
+"""Introspeccao de DBF files em E:/siasus/ via dbfread.
+
+Le cada .DBF, extrai field_names + types + record_count, emite markdown em
+docs/data-dictionary-sia.md.
+
+Uso:
+    python scripts/introspect_sia_dbf.py \\
+        --dir E:/siasus/ \\
+        --output docs/data-dictionary-sia.md
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DBFInfo:
+    path: Path
+    encoding: str
+    record_count: int
+    fields: list[tuple[str, str, int, int]]  # (name, type, length, decimal)
+
+
+def read_dbf(dbf_path: Path) -> DBFInfo:
+    from dbfread import DBF
+    d = DBF(str(dbf_path), encoding="cp1252", ignore_missing_memofile=True)
+    fields = [
+        (f.name, f.type, f.length, f.decimal_count or 0)
+        for f in d.fields
+    ]
+    return DBFInfo(
+        path=dbf_path,
+        encoding="cp1252",
+        record_count=len(d),
+        fields=fields,
+    )
+
+
+def format_dbf_markdown(info: DBFInfo) -> str:
+    size_bytes = info.path.stat().st_size if info.path.exists() else 0
+    lines = [
+        f"### `{info.path.name}`",
+        "",
+        f"- {info.record_count} records",
+        f"- Size: {size_bytes:,} bytes",
+        f"- Encoding: {info.encoding}",
+        f"- Fields: {len(info.fields)}",
+        "",
+        "| Field | Type | Length | Decimal |",
+        "|---|---|---|---|",
+    ]
+    for name, ftype, length, decimal in info.fields:
+        type_str = f"{ftype}({length})" if decimal == 0 else f"{ftype}({length},{decimal})"
+        lines.append(f"| {name} | {type_str} | {length} | {decimal} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    dbfs = sorted(
+        list(args.dir.glob("*.DBF")) + list(args.dir.glob("*.dbf")),
+        key=lambda p: p.name,
+    )
+    logger.info("sia_dbfs_found count=%d", len(dbfs))
+
+    out_lines = [
+        "# Dicionario de Dados - SIA (SIASUS DBFs)",
+        "",
+        "> Introspeccao automatica via `scripts/introspect_sia_dbf.py`.",
+        f"> Source: `{args.dir}`",
+        f"> DBFs: {len(dbfs)}",
+        "",
+        "## Summary",
+        "",
+        "| Arquivo | Records | Size (bytes) |",
+        "|---|---|---|",
+    ]
+
+    infos = []
+    for dbf in dbfs:
+        try:
+            info = read_dbf(dbf)
+            infos.append(info)
+        except Exception as e:
+            logger.warning("dbf_skip path=%s err=%s", dbf, e)
+            continue
+
+    infos.sort(key=lambda i: -i.record_count)
+    out_lines.extend(
+        f"| {info.path.name} | {info.record_count} | {info.path.stat().st_size:,} |"
+        for info in infos
+    )
+
+    out_lines.append("")
+    out_lines.append("## Detalhes por DBF")
+    out_lines.append("")
+    out_lines.extend(format_dbf_markdown(info) for info in infos)
+
+    args.output.write_text("\n".join(out_lines), encoding="utf-8")
+    logger.info("sia_dict_written path=%s dbfs=%d", args.output, len(infos))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/introspect_sia_dbf_test.py
+++ b/scripts/introspect_sia_dbf_test.py
@@ -1,0 +1,23 @@
+"""Teste do introspect_sia_dbf."""
+from pathlib import Path
+
+from scripts.introspect_sia_dbf import DBFInfo, format_dbf_markdown
+
+
+def test_format_dbf_markdown_lista_colunas() -> None:
+    info = DBFInfo(
+        path=Path("S_APA.DBF"),
+        encoding="cp1252",
+        record_count=100,
+        fields=[
+            ("CNES", "C", 7, 0),
+            ("CBO", "C", 6, 0),
+            ("QT", "N", 11, 0),
+            ("VL", "N", 10, 2),
+        ],
+    )
+    md = format_dbf_markdown(info)
+    assert "### `S_APA.DBF`" in md
+    assert "100 records" in md
+    assert "| CNES | C(7) |" in md
+    assert "| VL | N(10,2) |" in md

--- a/scripts/parse_datasus_pdfs.py
+++ b/scripts/parse_datasus_pdfs.py
@@ -1,0 +1,71 @@
+"""Extrai schemas/tabelas de PDFs Datasus (MANUAL_OPERACIONAL_SIA.pdf etc.).
+
+Uso:
+    python scripts/parse_datasus_pdfs.py \\
+        --pdf E:/siasus/MANUAL_OPERACIONAL_SIA.pdf \\
+        --output docs/_tmp_sia_pdf_extract.md
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def extract_schema_tables(text: str) -> list[list[str]]:
+    """Heuristica simples: agrupa linhas que comecam com codigo numerico."""
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    table: list[str] = []
+    tables: list[list[str]] = []
+    for ln in lines:
+        if re.match(r"^\d{6,12}\s", ln):
+            table.append(ln)
+        else:
+            if len(table) >= 2:
+                tables.append(table)
+            table = []
+    if len(table) >= 2:
+        tables.append(table)
+    return tables
+
+
+def main() -> int:
+    import pdfplumber
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pdf", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    with pdfplumber.open(str(args.pdf)) as pdf:
+        parts = [
+            f"# Extract from `{args.pdf.name}`",
+            "",
+            f"> Pages: {len(pdf.pages)}",
+            "",
+        ]
+        for i, page in enumerate(pdf.pages, 1):
+            text = page.extract_text() or ""
+            tables = extract_schema_tables(text)
+            if tables:
+                parts.append(f"## Page {i}")
+                parts.append("")
+                for t in tables:
+                    parts.append("```")
+                    parts.extend(t[:30])
+                    if len(t) > 30:
+                        parts.append(f"... ({len(t) - 30} more rows)")
+                    parts.append("```")
+                    parts.append("")
+
+        args.output.write_text("\n".join(parts), encoding="utf-8")
+        logger.info("pdf_extract_written path=%s pages=%d", args.output, len(pdf.pages))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/parse_datasus_pdfs_test.py
+++ b/scripts/parse_datasus_pdfs_test.py
@@ -1,0 +1,14 @@
+"""Teste do parse_datasus_pdfs."""
+from scripts.parse_datasus_pdfs import extract_schema_tables
+
+
+def test_extract_schema_tables_retorna_linhas_tabela() -> None:
+    fake_page_text = """
+Tabela de Procedimentos
+Codigo  Descricao
+0101010010  Consulta medica em atencao basica
+0301060010  Cirurgia de catarata
+"""
+    tables = extract_schema_tables(fake_page_text)
+    assert len(tables) >= 1
+    assert any("0101010010" in row for row in tables[0])


### PR DESCRIPTION
## Summary

Docs-only PR — Spec B entrega análise e proposta de Gold schema v2 híbrido + introspecção real SIA/BPA.

### Scripts introspecção (reutilizáveis)
- `scripts/introspect_bpa_gdb.py` + test — fdb + RDB$ tables lookup
- `scripts/introspect_sia_dbf.py` + test — dbfread cp1252, dedup case-insensitive
- `scripts/parse_datasus_pdfs.py` + test — pdfplumber heuristic table extraction

### Dicionários novos
- `docs/data-dictionary-sia.md` (3020 linhas) — 105 DBFs introspectados, top-5 por record count (S_CEP, S_FXAPAC, S_PACBO, S_PACID, S_PAHA), DBFs prioritárias identificadas (S_APA APAC, S_BPI BPA-I, CADMUN com teto_pab)
- `docs/data-dictionary-bpa.md` (217 linhas, preliminar) — BPA layout completo capturado via PDF (cabeçalho 132B + BPA-C 50B + BPA-I 352B + ~39 campos documentados), introspecção GDB deferida por fbclient.dll ausente
- `docs/data-dictionary-gold-v2.md` (645 linhas) — 1 landing + 7 dims + 4 fatos particionados + 1 matview + byte budget (-65%) + query motriz + dedup SIA+BPA + naming conventions
- `docs/migration-plan-gold-v2.md` (156 linhas) — Alembic revs 010-015 conceituais + rollback matrix + timeline 8 semanas

### Atualizações
- `docs/data-dictionary-cnes.md` — §Gold v2 Mapping (LFCES/NFCES → dim/fato)
- `docs/data-dictionary-sihd-hospital.md` — §Gold v2 Mapping (TB_HAIH → fato_internacao)
- `docs/data-dictionary-firebird-bigquery.md` — §Gold v2 Mapping (redirect para cnes dict canonical)

## Commits (11)

1. f02162a introspect_bpa_gdb via fdb
2. b0ebf73 introspect_sia_dbf via dbfread
3. 81ebf62 dicionário SIA DBFs introspectado (105 arquivos)
4. 1b89000 parse_datasus_pdfs via pdfplumber
5. 1b211fd seção PDF Datasus em SIA + preliminar BPA
6. 2891d6b data-dictionary-gold-v2 proposta híbrida
7. 8d112fc §Gold v2 Mapping em CNES dict
8. 8603962 §Gold v2 Mapping em SIHD dict
9. d9299bc §Gold v2 Mapping em firebird-bigquery dict
10. 8a0d7f6 migration plan Alembic 010-015
11. (2 test files + 1 script test = included in 1,2,4 acima)

## Descobertas-chave

**SIA (via DBF + PDF):**
- 105 DBFs encontrados (não 63 — subagent dedup case-insensitive). Maiores: S_CEP 1.5M, S_FXAPAC 1.3M, S_PACBO 1.1M records
- SIGTAP é tabela mestre (Portaria 321/2007) — unifica código, CBO, CID, valor, financiamento (MAC/FAE/PAB/VISA)
- APAC número = 13 dígitos (UF+AA+tipo+sequencial+DV)
- **CADMUN contém tetos PAB** (campo `TETOPAB`) — novo atributo adicionado a `dim_municipio.teto_pab_cents`

**BPA (via PDF):**
- Layout completo capturado: cabeçalho 132 bytes, BPA-C 50 bytes (11 campos), BPA-I 352 bytes (~39 campos)
- Paciente identificado por CPF OU CNS (exclusive or)
- Algoritmo check-sum: \`((soma(pa+qt) mod 1111) + 1111)\`
- Firebird 1.5.5 embarca GDB; introspecção via fdb viável após fbclient.dll extraído de Firebird155.exe

## Scope boundaries

- Zero código/migration executada — pure docs
- Implementação real (SIA/BPA extractors Go, mappers data_processor, migrations Alembic) vira Spec C futura
- BPAMAG.GDB introspection marcada TODO (requer fbclient.dll)

## Next step

User review Gold v2 schema + migration plan. Implementation virá em Spec C após review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)