### PR TITLE
fix(rollout): NULL NO_SOCIAL scan error em shadow E2E

### DIFF
--- a/apps/dump_agent_go/internal/extractor/cnes.go
+++ b/apps/dump_agent_go/internal/extractor/cnes.go
@@ -16,7 +16,7 @@ type ExtractionParams struct {
 const sqlProfissionais = `
 	SELECT
 		prof.CPF_PROF, prof.COD_CNS, prof.NOME_PROF,
-		prof.NO_SOCIAL, prof.SEXO, prof.DATA_NASC,
+		COALESCE(prof.NO_SOCIAL, '') AS NO_SOCIAL, prof.SEXO, prof.DATA_NASC,
 		vinc.COD_CBO, vinc.IND_VINC, vinc.TP_SUS_NAO_SUS,
 		(COALESCE(vinc.CG_HORAAMB, 0)
 		 + COALESCE(vinc.CGHORAOUTR, 0)

--- a/scripts/shadow_baseline_py.py
+++ b/scripts/shadow_baseline_py.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 _SQL_PROFISSIONAIS = """
 SELECT
     prof.CPF_PROF, prof.COD_CNS, prof.NOME_PROF,
-    prof.NO_SOCIAL, prof.SEXO, prof.DATA_NASC,
+    COALESCE(prof.NO_SOCIAL, '') AS NO_SOCIAL, prof.SEXO, prof.DATA_NASC,
     vinc.COD_CBO, vinc.IND_VINC, vinc.TP_SUS_NAO_SUS,
     COALESCE(vinc.CG_HORAAMB, 0) AS CG_HORAAMB,
     COALESCE(vinc.CGHORAOUTR, 0) AS CGHORAOUTR,


### PR DESCRIPTION
## Bug

Shadow-e2e failed: \`scan_profissionais: sql: Scan error on column index 3, name "NO_SOCIAL": converting NULL to string is unsupported\`.

Seed tem NO_SOCIAL NULL (campo opcional LFCES018). Go database/sql não converte NULL → string (target é plain string + parquet tag espera string).

## Fix

COALESCE(prof.NO_SOCIAL, '') em ambos SQLs:
- apps/dump_agent_go/internal/extractor/cnes.go
- scripts/shadow_baseline_py.py

Paridade shadow preservada.