### PR TITLE
fix(rollout): column case paridade + streak strict

### DIFF
--- a/.github/workflows/shadow-e2e.yml
+++ b/.github/workflows/shadow-e2e.yml
@@ -112,7 +112,7 @@ jobs:
                 --body "Shadow E2E reported diff (run ${{ github.run_id }}). Artifact: shadow-diff-report-${{ github.run_number }}" \
                 --label "shadow-drift" 2>/dev/null || true
               echo "status=DIFF_FOUND" >> $GITHUB_STEP_SUMMARY
-              exit 0
+              exit 1
           fi
 
           # Este run passou. Conta quantos runs anteriores consecutivos foram success.

--- a/scripts/shadow_baseline_py.py
+++ b/scripts/shadow_baseline_py.py
@@ -63,7 +63,8 @@ def extract_to_parquet(
 ) -> int:
     cur = conn.cursor()
     cur.execute(sql, (param,))
-    cols = [d[0] for d in cur.description]
+    # Lowercase para paridade com Go (parquet tags são lowercase)
+    cols = [d[0].lower() for d in cur.description]
     rows = cur.fetchall()
     df = pl.DataFrame(
         rows,


### PR DESCRIPTION
## Bugs

1. **Case mismatch (shadow_diff reportou mas step mascarou):** Python FB retorna UPPERCASE cols; Go parquet tags são lowercase. shadow_diff output:
   \`\`\`
   identical=False diff=-1 summary=column mismatch
   a=[CARGA_HORARIA_TOTAL, CGHORAHOSP, ...]
   b=[carga_horaria_total, cghorahosp, ...]
   \`\`\`

2. **Streak step exit 0 on DIFF_FOUND:** runs com diff reais retornavam success no workflow, counter incrementava incorretamente.

## Fix

- \`scripts/shadow_baseline_py.py\`: lowercase cols via \`d[0].lower()\` após cur.description
- \`shadow-e2e.yml\`: exit 1 no branch DIFF_FOUND do streak step (após criar issue)

## Streak impacta

Streak reset para 0 após este merge (runs anteriores marcadas success mas eram falsos positivos). Próximo 3 runs verdes genuínos → cleanup trigger.

## Resposta sobre PAT (user pergunta)

Stateless counter (#32) usa GITHUB_TOKEN default + actions:write perm. PAT (GH_TOKEN secret do repo) NÃO é necessária. Workflow atual funciona sem PAT.

Se quiser usar PAT mesmo assim: adicionar \`GH_TOKEN: \${{ secrets.GH_TOKEN }}\` (substituir github.token) — útil se quiser dispatching cross-workflow em branches protegidas. Não requerido para 3-green trigger.