### PR TITLE
fix(ci): shadow-e2e missing fdb dep

### DIFF
--- a/.github/workflows/shadow-e2e.yml
+++ b/.github/workflows/shadow-e2e.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e packages/cnes_domain packages/cnes_infra
-          pip install pytest polars faker dbfread
+          pip install pytest polars faker dbfread fdb
 
       - name: Start shadow containers
         run: |


### PR DESCRIPTION
`scripts/shadow_baseline_py.py` imports `fdb` but pip install step in shadow-e2e.yml only installs polars/faker/dbfread. Add fdb.