### PR TITLE
feat(web_dashboard): v1.1 — overview + signup + dark mode + lint stack

### DIFF
--- a/apps/central_api/src/central_api/app.py
+++ b/apps/central_api/src/central_api/app.py
@@ -11,6 +11,7 @@ from central_api.middleware import (
     TenantMiddleware,
 )
 from central_api.routes import (
+    access_requests,
     admin,
     agents,
     dashboard,
@@ -42,5 +43,9 @@ def create_app() -> FastAPI:
     app.include_router(agents.router, prefix="/api/v1")
     app.include_router(extractions.router, prefix="/api/v1")
     app.include_router(dashboard.router, prefix="/api/v1/dashboard")
+    app.include_router(
+        access_requests.router,
+        prefix="/api/v1/dashboard/access-requests",
+    )
     app.include_router(oauth.router)
     return app

--- a/apps/central_api/src/central_api/app.py
+++ b/apps/central_api/src/central_api/app.py
@@ -19,6 +19,7 @@ from central_api.routes import (
     health,
     jobs,
     oauth,
+    overview,
 )
 from cnes_infra.telemetry import init_telemetry
 
@@ -43,6 +44,7 @@ def create_app() -> FastAPI:
     app.include_router(agents.router, prefix="/api/v1")
     app.include_router(extractions.router, prefix="/api/v1")
     app.include_router(dashboard.router, prefix="/api/v1/dashboard")
+    app.include_router(overview.router, prefix="/api/v1/dashboard")
     app.include_router(
         access_requests.router,
         prefix="/api/v1/dashboard/access-requests",

--- a/apps/central_api/src/central_api/repositories/dashboard_repo.py
+++ b/apps/central_api/src/central_api/repositories/dashboard_repo.py
@@ -8,6 +8,30 @@ from uuid import UUID
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
+from central_api.repositories.dashboard_repo_overview import (
+    FaturamentoChart,
+    OverviewKpis,
+    _format_competencia,
+    _previous_competencia,
+    faturamento_by_establishment_query,
+    overview_kpis_query,
+)
+
+__all__ = [
+    "AccessRequestRow",
+    "DashboardRepo",
+    "DashboardUserRow",
+    "FaturamentoChart",
+    "OverviewKpis",
+    "RunRow",
+    "SourceStatus",
+    "TenantRow",
+    "_classify_status",
+    "_competencia_lag",
+    "_format_competencia",
+    "_previous_competencia",
+]
+
 
 @dataclass
 class DashboardUserRow:
@@ -363,3 +387,22 @@ class DashboardRepo:
             )
             for r in rows
         ]
+
+    def overview_kpis(
+        self, *, tenant_id: str, current_competencia: int,
+    ) -> OverviewKpis:
+        return overview_kpis_query(
+            self._engine,
+            tenant_id=tenant_id,
+            current_competencia=current_competencia,
+        )
+
+    def faturamento_by_establishment(
+        self, *, tenant_id: str, months: int, current_competencia: int,
+    ) -> FaturamentoChart:
+        return faturamento_by_establishment_query(
+            self._engine,
+            tenant_id=tenant_id,
+            months=months,
+            current_competencia=current_competencia,
+        )

--- a/apps/central_api/src/central_api/repositories/dashboard_repo.py
+++ b/apps/central_api/src/central_api/repositories/dashboard_repo.py
@@ -49,6 +49,18 @@ class RunRow:
     machine_id: str | None
 
 
+@dataclass
+class AccessRequestRow:
+    id: UUID
+    tenant_id: str
+    tenant_nome: str | None
+    motivation: str
+    status: str
+    requested_at: datetime
+    reviewed_at: datetime | None
+    review_notes: str | None
+
+
 _ALL_SOURCES = (
     "CNES_LOCAL", "CNES_NACIONAL", "SIHD", "BPA_MAG", "SIA_LOCAL",
 )
@@ -117,6 +129,42 @@ _RECENT_RUNS_SQL = text("""
     WHERE tenant_id = :t
     ORDER BY COALESCE(registered_at, created_at) DESC
     LIMIT :n
+""")
+
+
+_INSERT_ACCESS_REQUEST = text("""
+    INSERT INTO dashboard.access_requests (user_id, tenant_id, motivation)
+    VALUES (:u, :t, :m)
+    RETURNING id
+""")
+
+_LIST_USER_REQUESTS = text("""
+    SELECT ar.id, ar.tenant_id, m.nome AS tenant_nome, ar.motivation,
+           ar.status, ar.requested_at, ar.reviewed_at, ar.review_notes
+    FROM dashboard.access_requests ar
+    LEFT JOIN gold.dim_municipio m ON m.ibge6 = ar.tenant_id
+    WHERE ar.user_id = :u
+    ORDER BY ar.requested_at DESC
+""")
+
+_HAS_PENDING_SQL = text("""
+    SELECT EXISTS(
+        SELECT 1 FROM dashboard.access_requests
+        WHERE user_id = :u AND status = 'pending'
+    )
+""")
+
+_AVAILABLE_TENANTS_SQL = text("""
+    SELECT m.ibge6, m.ibge7, m.nome, m.uf
+    FROM gold.dim_municipio m
+    WHERE m.ibge6 NOT IN (
+        SELECT tenant_id FROM dashboard.user_tenants WHERE user_id = :u
+    )
+    AND m.ibge6 NOT IN (
+        SELECT tenant_id FROM dashboard.access_requests
+        WHERE user_id = :u AND status = 'pending'
+    )
+    ORDER BY m.nome
 """)
 
 
@@ -259,6 +307,59 @@ class DashboardRepo:
                 row_count=int(r["row_count"]),
                 sha256=r["sha256"],
                 machine_id=None,
+            )
+            for r in rows
+        ]
+
+    def submit_access_request(
+        self, *, user_id: UUID, tenant_id: str, motivation: str,
+    ) -> UUID:
+        with self._engine.begin() as conn:
+            row = conn.execute(_INSERT_ACCESS_REQUEST, {
+                "u": user_id, "t": tenant_id, "m": motivation,
+            }).mappings().one()
+        return row["id"]
+
+    def list_access_requests(
+        self, *, user_id: UUID,
+    ) -> list[AccessRequestRow]:
+        with self._engine.connect() as conn:
+            rows = conn.execute(
+                _LIST_USER_REQUESTS, {"u": user_id},
+            ).mappings().all()
+        return [
+            AccessRequestRow(
+                id=r["id"],
+                tenant_id=r["tenant_id"].rstrip(),
+                tenant_nome=r["tenant_nome"],
+                motivation=r["motivation"],
+                status=r["status"],
+                requested_at=r["requested_at"],
+                reviewed_at=r["reviewed_at"],
+                review_notes=r["review_notes"],
+            )
+            for r in rows
+        ]
+
+    def has_pending_request(self, *, user_id: UUID) -> bool:
+        with self._engine.connect() as conn:
+            return bool(
+                conn.execute(_HAS_PENDING_SQL, {"u": user_id}).scalar_one()
+            )
+
+    def list_available_tenants_for_user(
+        self, *, user_id: UUID,
+    ) -> list[TenantRow]:
+        with self._engine.connect() as conn:
+            rows = conn.execute(
+                _AVAILABLE_TENANTS_SQL, {"u": user_id},
+            ).mappings().all()
+        return [
+            TenantRow(
+                ibge6=r["ibge6"].rstrip(),
+                ibge7=r["ibge7"].rstrip(),
+                nome=r["nome"],
+                uf=r["uf"].rstrip(),
             )
             for r in rows
         ]

--- a/apps/central_api/src/central_api/repositories/dashboard_repo_overview.py
+++ b/apps/central_api/src/central_api/repositories/dashboard_repo_overview.py
@@ -1,0 +1,192 @@
+"""Overview KPIs + faturamento chart aggregation for DashboardRepo."""
+
+from dataclasses import dataclass
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+
+@dataclass
+class OverviewKpis:
+    competencia_atual: int
+    faturamento_atual_cents: int
+    faturamento_anterior_cents: int
+    aih_atual: int
+    aih_anterior: int
+    profissionais_ativos: int
+    profissionais_anterior: int
+    estabs_sem_producao: int
+    estabs_total: int
+    estabs_sem_producao_anterior: int
+
+
+@dataclass
+class FaturamentoChart:
+    series: list[dict[str, str | int]]
+    categories: list[str]
+
+
+def _previous_competencia(yyyymm: int) -> int:
+    y, m = divmod(yyyymm, 100)
+    if m == 1:
+        return (y - 1) * 100 + 12
+    return y * 100 + (m - 1)
+
+
+def _format_competencia(yyyymm: int) -> str:
+    months = ["jan", "fev", "mar", "abr", "mai", "jun",
+              "jul", "ago", "set", "out", "nov", "dez"]
+    y, m = divmod(yyyymm, 100)
+    return f"{months[m - 1]}/{y}"
+
+
+_FATURAMENTO_KPI_SQL = text("""
+    SELECT COALESCE(SUM(f.valor_aprov_cents), 0)::BIGINT AS total
+    FROM gold.fato_producao_ambulatorial f
+    JOIN gold.dim_competencia c ON c.sk_competencia = f.sk_competencia
+    JOIN gold.dim_estabelecimento e ON e.sk_estabelecimento = f.sk_estabelecimento
+    WHERE c.competencia = :comp
+      AND e.sk_municipio = (SELECT sk_municipio FROM gold.dim_municipio WHERE ibge6 = :tenant)
+""")
+
+
+_AIH_KPI_SQL = text("""
+    SELECT COUNT(*)::INT AS total
+    FROM gold.fato_internacao f
+    JOIN gold.dim_competencia c ON c.sk_competencia = f.sk_competencia
+    JOIN gold.dim_estabelecimento e ON e.sk_estabelecimento = f.sk_estabelecimento
+    WHERE c.competencia = :comp
+      AND e.sk_municipio = (SELECT sk_municipio FROM gold.dim_municipio WHERE ibge6 = :tenant)
+""")
+
+
+_PROFISSIONAIS_KPI_SQL = text("""
+    SELECT COUNT(DISTINCT f.sk_profissional)::INT AS total
+    FROM gold.fato_vinculo_cnes f
+    JOIN gold.dim_competencia c ON c.sk_competencia = f.sk_competencia
+    JOIN gold.dim_estabelecimento e ON e.sk_estabelecimento = f.sk_estabelecimento
+    WHERE c.competencia = :comp
+      AND e.sk_municipio = (SELECT sk_municipio FROM gold.dim_municipio WHERE ibge6 = :tenant)
+""")
+
+
+_ESTABS_TOTAL_SQL = text("""
+    SELECT COUNT(*)::INT AS total
+    FROM gold.dim_estabelecimento
+    WHERE sk_municipio = (SELECT sk_municipio FROM gold.dim_municipio WHERE ibge6 = :tenant)
+""")
+
+
+_ESTABS_SEM_PRODUCAO_SQL = text("""
+    SELECT COUNT(*)::INT AS total
+    FROM gold.dim_estabelecimento e
+    WHERE e.sk_municipio = (SELECT sk_municipio FROM gold.dim_municipio WHERE ibge6 = :tenant)
+      AND NOT EXISTS (
+        SELECT 1 FROM gold.fato_producao_ambulatorial f
+        JOIN gold.dim_competencia c ON c.sk_competencia = f.sk_competencia
+        WHERE f.sk_estabelecimento = e.sk_estabelecimento
+          AND c.competencia = :comp
+      )
+""")
+
+
+_TOP_ESTABS_SQL = text("""
+    SELECT e.sk_estabelecimento, e.nome
+    FROM gold.fato_producao_ambulatorial f
+    JOIN gold.dim_competencia c ON c.sk_competencia = f.sk_competencia
+    JOIN gold.dim_estabelecimento e ON e.sk_estabelecimento = f.sk_estabelecimento
+    WHERE c.competencia = ANY(:comps)
+      AND e.sk_municipio = (SELECT sk_municipio FROM gold.dim_municipio WHERE ibge6 = :tenant)
+    GROUP BY e.sk_estabelecimento, e.nome
+    ORDER BY SUM(f.valor_aprov_cents) DESC
+    LIMIT 10
+""")
+
+
+_FATURAMENTO_PIVOT_SQL = text("""
+    SELECT c.competencia, e.sk_estabelecimento,
+           SUM(f.valor_aprov_cents)::BIGINT AS valor
+    FROM gold.fato_producao_ambulatorial f
+    JOIN gold.dim_competencia c ON c.sk_competencia = f.sk_competencia
+    JOIN gold.dim_estabelecimento e ON e.sk_estabelecimento = f.sk_estabelecimento
+    WHERE c.competencia = ANY(:comps)
+      AND e.sk_municipio = (SELECT sk_municipio FROM gold.dim_municipio WHERE ibge6 = :tenant)
+    GROUP BY c.competencia, e.sk_estabelecimento
+""")
+
+
+def overview_kpis_query(
+    engine: Engine, *, tenant_id: str, current_competencia: int,
+) -> OverviewKpis:
+    prev = _previous_competencia(current_competencia)
+    with engine.connect() as conn:
+        params_cur = {"comp": current_competencia, "tenant": tenant_id}
+        params_prev = {"comp": prev, "tenant": tenant_id}
+        params_t = {"tenant": tenant_id}
+        fat_cur = conn.execute(_FATURAMENTO_KPI_SQL, params_cur).scalar_one()
+        fat_prev = conn.execute(_FATURAMENTO_KPI_SQL, params_prev).scalar_one()
+        aih_cur = conn.execute(_AIH_KPI_SQL, params_cur).scalar_one()
+        aih_prev = conn.execute(_AIH_KPI_SQL, params_prev).scalar_one()
+        prof_cur = conn.execute(_PROFISSIONAIS_KPI_SQL, params_cur).scalar_one()
+        prof_prev = conn.execute(_PROFISSIONAIS_KPI_SQL, params_prev).scalar_one()
+        estabs_total = conn.execute(_ESTABS_TOTAL_SQL, params_t).scalar_one()
+        sem_cur = conn.execute(_ESTABS_SEM_PRODUCAO_SQL, params_cur).scalar_one()
+        sem_prev = conn.execute(_ESTABS_SEM_PRODUCAO_SQL, params_prev).scalar_one()
+    return OverviewKpis(
+        competencia_atual=current_competencia,
+        faturamento_atual_cents=int(fat_cur),
+        faturamento_anterior_cents=int(fat_prev),
+        aih_atual=int(aih_cur),
+        aih_anterior=int(aih_prev),
+        profissionais_ativos=int(prof_cur),
+        profissionais_anterior=int(prof_prev),
+        estabs_sem_producao=int(sem_cur),
+        estabs_total=int(estabs_total),
+        estabs_sem_producao_anterior=int(sem_prev),
+    )
+
+
+def faturamento_by_establishment_query(
+    engine: Engine, *, tenant_id: str, months: int, current_competencia: int,
+) -> FaturamentoChart:
+    comps: list[int] = []
+    c = current_competencia
+    for _ in range(months):
+        comps.append(c)
+        c = _previous_competencia(c)
+    comps = list(reversed(comps))
+    with engine.connect() as conn:
+        top = conn.execute(
+            _TOP_ESTABS_SQL, {"comps": comps, "tenant": tenant_id},
+        ).mappings().all()
+        rows = conn.execute(
+            _FATURAMENTO_PIVOT_SQL, {"comps": comps, "tenant": tenant_id},
+        ).mappings().all()
+    return _build_faturamento_chart(comps, list(top), list(rows))
+
+
+def _build_faturamento_chart(
+    comps: list[int],
+    top: list[dict],
+    rows: list[dict],
+) -> FaturamentoChart:
+    top_ids = [r["sk_estabelecimento"] for r in top]
+    top_names = [r["nome"] for r in top]
+    series: list[dict[str, str | int]] = []
+    for comp in comps:
+        point: dict[str, str | int] = {"competencia": _format_competencia(comp)}
+        outros = 0
+        for r in rows:
+            if r["competencia"] != comp:
+                continue
+            if r["sk_estabelecimento"] in top_ids:
+                idx = top_ids.index(r["sk_estabelecimento"])
+                point[top_names[idx]] = int(r["valor"])
+            else:
+                outros += int(r["valor"])
+        for name in top_names:
+            point.setdefault(name, 0)
+        point["outros"] = outros
+        series.append(point)
+    categories = [*top_names, "outros"]
+    return FaturamentoChart(series=series, categories=categories)

--- a/apps/central_api/src/central_api/routes/access_requests.py
+++ b/apps/central_api/src/central_api/routes/access_requests.py
@@ -1,0 +1,92 @@
+"""Access requests routes — mounted at /api/v1/dashboard/access-requests."""
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
+
+from central_api.deps import require_auth
+from central_api.middleware import AuthenticatedUser
+
+router = APIRouter(tags=["access-requests"])
+
+
+class AccessRequestOut(BaseModel):
+    id: UUID
+    tenant_id: str
+    tenant_nome: str | None
+    motivation: str
+    status: str
+    requested_at: datetime
+    reviewed_at: datetime | None
+    review_notes: str | None
+
+
+class TenantOut(BaseModel):
+    ibge6: str = Field(min_length=6, max_length=6)
+    ibge7: str = Field(min_length=7, max_length=7)
+    nome: str
+    uf: str = Field(min_length=2, max_length=2)
+
+
+class AccessRequestCreate(BaseModel):
+    tenant_id: str = Field(min_length=6, max_length=6)
+    motivation: str = Field(min_length=1, max_length=500)
+
+
+class AccessRequestCreated(BaseModel):
+    request_id: UUID
+
+
+@router.get("/mine", response_model=list[AccessRequestOut])
+def list_mine(
+    request: Request,
+    user: AuthenticatedUser = Depends(require_auth),
+) -> list[AccessRequestOut]:
+    repo = request.app.state.dashboard_repo
+    rows = repo.list_access_requests(user_id=user.user_id)
+    return [
+        AccessRequestOut(
+            id=r.id, tenant_id=r.tenant_id, tenant_nome=r.tenant_nome,
+            motivation=r.motivation, status=r.status,
+            requested_at=r.requested_at, reviewed_at=r.reviewed_at,
+            review_notes=r.review_notes,
+        )
+        for r in rows
+    ]
+
+
+@router.post("", response_model=AccessRequestCreated, status_code=201)
+def create_request(
+    body: AccessRequestCreate,
+    request: Request,
+    user: AuthenticatedUser = Depends(require_auth),
+) -> AccessRequestCreated:
+    repo = request.app.state.dashboard_repo
+    try:
+        req_id = repo.submit_access_request(
+            user_id=user.user_id, tenant_id=body.tenant_id,
+            motivation=body.motivation,
+        )
+    except IntegrityError as e:
+        raise HTTPException(status_code=409, detail="duplicate_request") from e
+    repo.log_action(
+        user_id=user.user_id, tenant_id=body.tenant_id,
+        action="request_access",
+        metadata={"request_id": str(req_id)},
+    )
+    return AccessRequestCreated(request_id=req_id)
+
+
+@router.get("/available-tenants", response_model=list[TenantOut])
+def list_available_tenants(
+    request: Request,
+    user: AuthenticatedUser = Depends(require_auth),
+) -> list[TenantOut]:
+    repo = request.app.state.dashboard_repo
+    rows = repo.list_available_tenants_for_user(user_id=user.user_id)
+    return [
+        TenantOut(ibge6=r.ibge6, ibge7=r.ibge7, nome=r.nome, uf=r.uf)
+        for r in rows
+    ]

--- a/apps/central_api/src/central_api/routes/dashboard.py
+++ b/apps/central_api/src/central_api/routes/dashboard.py
@@ -18,6 +18,7 @@ class MeResponse(BaseModel):
     display_name: str | None
     role: str
     tenant_ids: list[str]
+    has_pending_request: bool
 
 
 class TenantResponse(BaseModel):
@@ -66,9 +67,12 @@ def auth_me(
         user_id=user.user_id, tenant_id=None, action="login", metadata=None,
     )
     return MeResponse(
-        user_id=user.user_id, email=user.email,
-        display_name=user.display_name, role=user.role,
+        user_id=user.user_id,
+        email=user.email,
+        display_name=user.display_name,
+        role=user.role,
         tenant_ids=user.tenant_ids,
+        has_pending_request=repo.has_pending_request(user_id=user.user_id),
     )
 
 

--- a/apps/central_api/src/central_api/routes/overview.py
+++ b/apps/central_api/src/central_api/routes/overview.py
@@ -1,0 +1,70 @@
+"""Overview routes — /overview, /faturamento/by-establishment."""
+from fastapi import APIRouter, Depends, Query, Request, Response
+from pydantic import BaseModel
+
+from central_api.deps import require_auth, require_tenant_header
+from central_api.middleware import AuthenticatedUser
+from cnes_infra import config
+
+router = APIRouter(tags=["overview"])
+
+
+class OverviewResponse(BaseModel):
+    competencia_atual: int
+    faturamento_atual_cents: int
+    faturamento_anterior_cents: int
+    aih_atual: int
+    aih_anterior: int
+    profissionais_ativos: int
+    profissionais_anterior: int
+    estabs_sem_producao: int
+    estabs_total: int
+    estabs_sem_producao_anterior: int
+
+
+class FaturamentoResponse(BaseModel):
+    series: list[dict[str, str | int]]
+    categories: list[str]
+
+
+@router.get("/overview", response_model=OverviewResponse)
+def get_overview(
+    response: Response,
+    request: Request,
+    user: AuthenticatedUser = Depends(require_auth),
+    tenant_id: str = Depends(require_tenant_header),
+) -> OverviewResponse:
+    response.headers["Cache-Control"] = "private, max-age=30"
+    repo = request.app.state.dashboard_repo
+    target = config.COMPETENCIA_ANO * 100 + config.COMPETENCIA_MES
+    kpis = repo.overview_kpis(tenant_id=tenant_id, current_competencia=target)
+    repo.log_action(
+        user_id=user.user_id, tenant_id=tenant_id,
+        action="view_overview", metadata=None,
+    )
+    return OverviewResponse(**kpis.__dict__)
+
+
+@router.get(
+    "/faturamento/by-establishment", response_model=FaturamentoResponse,
+)
+def get_faturamento_chart(
+    response: Response,
+    request: Request,
+    user: AuthenticatedUser = Depends(require_auth),
+    tenant_id: str = Depends(require_tenant_header),
+    months: int = Query(12, ge=1, le=24),
+) -> FaturamentoResponse:
+    response.headers["Cache-Control"] = "private, max-age=60"
+    repo = request.app.state.dashboard_repo
+    target = config.COMPETENCIA_ANO * 100 + config.COMPETENCIA_MES
+    chart = repo.faturamento_by_establishment(
+        tenant_id=tenant_id, months=months, current_competencia=target,
+    )
+    repo.log_action(
+        user_id=user.user_id, tenant_id=tenant_id,
+        action="view_faturamento", metadata={"months": months},
+    )
+    return FaturamentoResponse(
+        series=chart.series, categories=chart.categories,
+    )

--- a/apps/central_api/tests/repositories/test_dashboard_repo_overview.py
+++ b/apps/central_api/tests/repositories/test_dashboard_repo_overview.py
@@ -1,0 +1,131 @@
+"""Tests for DashboardRepo overview methods."""
+import pytest
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from central_api.repositories.dashboard_repo import (
+    DashboardRepo,
+    _classify_status,
+    _competencia_lag,
+    _format_competencia,
+    _previous_competencia,
+)
+from central_api.repositories.dashboard_repo_overview import (
+    _build_faturamento_chart,
+)
+from cnes_infra.storage.dim_lookup import upsert_dim_municipio
+
+
+@pytest.fixture
+def repo(pg_engine: Engine) -> DashboardRepo:
+    return DashboardRepo(pg_engine)
+
+
+@pytest.fixture
+def cleanup_overview(pg_engine: Engine):
+    yield
+    with pg_engine.begin() as conn:
+        conn.execute(text("DELETE FROM gold.fato_producao_ambulatorial WHERE 1=1"))
+        conn.execute(text("DELETE FROM gold.fato_internacao WHERE 1=1"))
+        conn.execute(text("DELETE FROM gold.fato_vinculo_cnes WHERE 1=1"))
+        conn.execute(text(
+            "DELETE FROM gold.dim_estabelecimento WHERE sk_municipio IN "
+            "(SELECT sk_municipio FROM gold.dim_municipio WHERE ibge6 IN "
+            "('354130','999998','999997'))"
+        ))
+
+
+@pytest.mark.postgres
+def test_overview_kpis_invariante_estabs_sem_producao(
+    repo: DashboardRepo, pg_engine: Engine, cleanup_overview: None,
+) -> None:
+    with pg_engine.begin() as conn:
+        upsert_dim_municipio(conn, {
+            "ibge6": "354130", "ibge7": "3541308",
+            "nome": "Presidente Epitácio", "uf": "SP",
+        })
+    kpis = repo.overview_kpis(tenant_id="354130", current_competencia=202604)
+    assert kpis.estabs_sem_producao <= kpis.estabs_total
+    assert kpis.competencia_atual == 202604
+
+
+@pytest.mark.postgres
+def test_overview_kpis_zero_quando_sem_dados(
+    repo: DashboardRepo, pg_engine: Engine, cleanup_overview: None,
+) -> None:
+    with pg_engine.begin() as conn:
+        upsert_dim_municipio(conn, {
+            "ibge6": "999998", "ibge7": "9999988",
+            "nome": "Vazio", "uf": "SP",
+        })
+    kpis = repo.overview_kpis(tenant_id="999998", current_competencia=202604)
+    assert kpis.faturamento_atual_cents == 0
+    assert kpis.aih_atual == 0
+    assert kpis.profissionais_ativos == 0
+
+
+@pytest.mark.postgres
+def test_faturamento_by_establishment_retorna_n_meses(
+    repo: DashboardRepo, pg_engine: Engine, cleanup_overview: None,
+) -> None:
+    with pg_engine.begin() as conn:
+        upsert_dim_municipio(conn, {
+            "ibge6": "999997", "ibge7": "9999977",
+            "nome": "Test", "uf": "SP",
+        })
+    chart = repo.faturamento_by_establishment(
+        tenant_id="999997", months=12, current_competencia=202604,
+    )
+    assert len(chart.series) == 12
+    assert "competencia" in chart.series[0]
+    assert chart.categories[-1] == "outros"
+
+
+def test_competencia_lag_calcula() -> None:
+    assert _competencia_lag(202604, 202604) == 0
+    assert _competencia_lag(202604, 202603) == 1
+    assert _competencia_lag(202604, 202601) == 3
+    assert _competencia_lag(202604, None) is None
+
+
+def test_classify_status_mapeia() -> None:
+    assert _classify_status(None) == "no_data"
+    assert _classify_status(0) == "ok"
+    assert _classify_status(1) == "warning"
+    assert _classify_status(3) == "error"
+
+
+def test_previous_competencia_handles_year_boundary() -> None:
+    assert _previous_competencia(202604) == 202603
+    assert _previous_competencia(202601) == 202512
+    assert _previous_competencia(202612) == 202611
+
+
+def test_format_competencia_pt_br() -> None:
+    assert _format_competencia(202604) == "abr/2026"
+    assert _format_competencia(202612) == "dez/2026"
+    assert _format_competencia(202601) == "jan/2026"
+
+
+def test_build_faturamento_chart_top_e_outros() -> None:
+    comps = [202603, 202604]
+    top = [
+        {"sk_estabelecimento": 1, "nome": "Hospital A"},
+        {"sk_estabelecimento": 2, "nome": "Posto B"},
+    ]
+    rows = [
+        {"competencia": 202603, "sk_estabelecimento": 1, "valor": 1000},
+        {"competencia": 202603, "sk_estabelecimento": 2, "valor": 500},
+        {"competencia": 202603, "sk_estabelecimento": 99, "valor": 50},
+        {"competencia": 202604, "sk_estabelecimento": 1, "valor": 2000},
+        {"competencia": 202604, "sk_estabelecimento": 99, "valor": 75},
+    ]
+    chart = _build_faturamento_chart(comps, top, rows)
+    assert chart.categories == ["Hospital A", "Posto B", "outros"]
+    assert chart.series[0]["competencia"] == "mar/2026"
+    assert chart.series[0]["Hospital A"] == 1000
+    assert chart.series[0]["Posto B"] == 500
+    assert chart.series[0]["outros"] == 50
+    assert chart.series[1]["Hospital A"] == 2000
+    assert chart.series[1]["Posto B"] == 0
+    assert chart.series[1]["outros"] == 75

--- a/apps/central_api/tests/repositories/test_dashboard_repo_signup.py
+++ b/apps/central_api/tests/repositories/test_dashboard_repo_signup.py
@@ -1,0 +1,122 @@
+"""Tests for DashboardRepo signup methods."""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
+
+from central_api.repositories.dashboard_repo import DashboardRepo
+from cnes_infra.storage.dim_lookup import upsert_dim_municipio
+
+
+@pytest.fixture
+def repo(pg_engine: Engine) -> DashboardRepo:
+    return DashboardRepo(pg_engine)
+
+
+@pytest.fixture
+def cleanup_signup(pg_engine: Engine):
+    yield
+    with pg_engine.begin() as conn:
+        conn.execute(text("DELETE FROM dashboard.access_requests"))
+        conn.execute(text("DELETE FROM dashboard.audit_log"))
+        conn.execute(text("DELETE FROM dashboard.user_tenants"))
+        conn.execute(text("DELETE FROM dashboard.users"))
+
+
+@pytest.mark.postgres
+def test_submit_access_request_cria_pendente(
+    repo: DashboardRepo, cleanup_signup: None,
+) -> None:
+    user = repo.upsert_user(
+        oidc_subject="s1", oidc_issuer="i", email="a@m", display_name=None,
+    )
+    req_id = repo.submit_access_request(
+        user_id=user.user_id, tenant_id="354130", motivation="Sou gestor da SMS",
+    )
+    assert req_id is not None
+    requests = repo.list_access_requests(user_id=user.user_id)
+    assert len(requests) == 1
+    assert requests[0].tenant_id == "354130"
+    assert requests[0].status == "pending"
+
+
+@pytest.mark.postgres
+def test_submit_access_request_duplicado_levanta(
+    repo: DashboardRepo, cleanup_signup: None,
+) -> None:
+    user = repo.upsert_user(
+        oidc_subject="s2", oidc_issuer="i", email="a@m", display_name=None,
+    )
+    repo.submit_access_request(
+        user_id=user.user_id, tenant_id="354130", motivation="primeira",
+    )
+    with pytest.raises(IntegrityError):
+        repo.submit_access_request(
+            user_id=user.user_id, tenant_id="354130", motivation="segunda",
+        )
+
+
+@pytest.mark.postgres
+def test_has_pending_request_retorna_true_quando_pendente(
+    repo: DashboardRepo, cleanup_signup: None,
+) -> None:
+    user = repo.upsert_user(
+        oidc_subject="s3", oidc_issuer="i", email="a@m", display_name=None,
+    )
+    assert repo.has_pending_request(user_id=user.user_id) is False
+    repo.submit_access_request(
+        user_id=user.user_id, tenant_id="354130", motivation="x",
+    )
+    assert repo.has_pending_request(user_id=user.user_id) is True
+
+
+@pytest.mark.postgres
+def test_has_pending_request_false_se_aprovado(
+    repo: DashboardRepo, pg_engine: Engine, cleanup_signup: None,
+) -> None:
+    user = repo.upsert_user(
+        oidc_subject="s4", oidc_issuer="i", email="a@m", display_name=None,
+    )
+    repo.submit_access_request(
+        user_id=user.user_id, tenant_id="354130", motivation="x",
+    )
+    with pg_engine.begin() as conn:
+        conn.execute(text(
+            "UPDATE dashboard.access_requests SET status='approved' WHERE user_id=:u"
+        ), {"u": user.user_id})
+    assert repo.has_pending_request(user_id=user.user_id) is False
+
+
+@pytest.mark.postgres
+def test_list_available_tenants_exclui_alocados_e_pendentes(
+    repo: DashboardRepo, pg_engine: Engine, cleanup_signup: None,
+) -> None:
+    with pg_engine.begin() as conn:
+        upsert_dim_municipio(conn, {
+            "ibge6": "354130", "ibge7": "3541308",
+            "nome": "Presidente Epitácio", "uf": "SP",
+        })
+        upsert_dim_municipio(conn, {
+            "ibge6": "350000", "ibge7": "3500000",
+            "nome": "Outro Município", "uf": "SP",
+        })
+        upsert_dim_municipio(conn, {
+            "ibge6": "351000", "ibge7": "3510000",
+            "nome": "Terceiro", "uf": "SP",
+        })
+    user = repo.upsert_user(
+        oidc_subject="s5", oidc_issuer="i", email="a@m", display_name=None,
+    )
+    with pg_engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO dashboard.user_tenants VALUES (:u, '354130')"
+        ), {"u": user.user_id})
+    repo.submit_access_request(
+        user_id=user.user_id, tenant_id="350000", motivation="x",
+    )
+    available = repo.list_available_tenants_for_user(user_id=user.user_id)
+    ibges = {t.ibge6 for t in available}
+    assert "354130" not in ibges
+    assert "350000" not in ibges
+    assert "351000" in ibges

--- a/apps/central_api/tests/test_access_requests_routes.py
+++ b/apps/central_api/tests/test_access_requests_routes.py
@@ -1,0 +1,118 @@
+"""Tests for /api/v1/dashboard/access-requests/* routes."""
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+from central_api.middleware import AuthenticatedUser
+from central_api.repositories.dashboard_repo import AccessRequestRow, TenantRow
+from central_api.routes import access_requests
+
+
+def _build(user, repo) -> TestClient:
+    app = FastAPI()
+    app.state.dashboard_repo = repo
+
+    @app.middleware("http")
+    async def inject(request: Request, call_next):
+        if user is not None:
+            request.state.user = user
+        return await call_next(request)
+
+    app.include_router(
+        access_requests.router,
+        prefix="/api/v1/dashboard/access-requests",
+    )
+    return TestClient(app)
+
+
+def _user() -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=uuid4(), email="g@m", display_name=None,
+        role="gestor", tenant_ids=[],
+    )
+
+
+def test_get_mine_retorna_requests_do_user() -> None:
+    user = _user()
+    repo = MagicMock()
+    repo.list_access_requests.return_value = [
+        AccessRequestRow(
+            id=uuid4(), tenant_id="354130",
+            tenant_nome="Presidente Epitácio",
+            motivation="m", status="pending",
+            requested_at=datetime.now(UTC),
+            reviewed_at=None, review_notes=None,
+        ),
+    ]
+    c = _build(user, repo)
+    r = c.get("/api/v1/dashboard/access-requests/mine")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 1
+    assert body[0]["status"] == "pending"
+
+
+def test_post_cria_request_e_audita() -> None:
+    user = _user()
+    repo = MagicMock()
+    repo.submit_access_request.return_value = uuid4()
+    c = _build(user, repo)
+    r = c.post("/api/v1/dashboard/access-requests", json={
+        "tenant_id": "354130", "motivation": "Sou gestor",
+    })
+    assert r.status_code == 201
+    assert "request_id" in r.json()
+    actions = [c.kwargs["action"] for c in repo.log_action.call_args_list]
+    assert "request_access" in actions
+
+
+def test_post_responde_409_se_duplicado() -> None:
+    user = _user()
+    repo = MagicMock()
+    repo.submit_access_request.side_effect = IntegrityError("dup", {}, Exception())
+    c = _build(user, repo)
+    r = c.post("/api/v1/dashboard/access-requests", json={
+        "tenant_id": "354130", "motivation": "x",
+    })
+    assert r.status_code == 409
+    assert r.json()["detail"] == "duplicate_request"
+
+
+def test_post_responde_422_motivation_vazia() -> None:
+    user = _user()
+    c = _build(user, MagicMock())
+    r = c.post("/api/v1/dashboard/access-requests", json={
+        "tenant_id": "354130", "motivation": "",
+    })
+    assert r.status_code == 422
+
+
+def test_post_responde_422_motivation_longa() -> None:
+    user = _user()
+    c = _build(user, MagicMock())
+    r = c.post("/api/v1/dashboard/access-requests", json={
+        "tenant_id": "354130", "motivation": "x" * 501,
+    })
+    assert r.status_code == 422
+
+
+def test_get_available_tenants_lista_municipios_disponiveis() -> None:
+    user = _user()
+    repo = MagicMock()
+    repo.list_available_tenants_for_user.return_value = [
+        TenantRow(ibge6="350000", ibge7="3500000", nome="Outro", uf="SP"),
+    ]
+    c = _build(user, repo)
+    r = c.get("/api/v1/dashboard/access-requests/available-tenants")
+    assert r.status_code == 200
+    assert r.json()[0]["ibge6"] == "350000"
+
+
+def test_responde_401_sem_user() -> None:
+    c = _build(None, MagicMock())
+    r = c.get("/api/v1/dashboard/access-requests/mine")
+    assert r.status_code == 401

--- a/apps/central_api/tests/test_app_wiring.py
+++ b/apps/central_api/tests/test_app_wiring.py
@@ -40,3 +40,11 @@ def test_app_ordem_middleware_auth_runs_first() -> None:
     assert classes[0] is AuthMiddleware
     assert classes[1] is TenantMiddleware
     assert classes[2] is QueryCounterMiddleware
+
+
+def test_app_inclui_access_requests_router() -> None:
+    app = _make_app()
+    paths = {r.path for r in app.routes}
+    assert "/api/v1/dashboard/access-requests/mine" in paths
+    assert "/api/v1/dashboard/access-requests" in paths
+    assert "/api/v1/dashboard/access-requests/available-tenants" in paths

--- a/apps/central_api/tests/test_dashboard_routes_auth_tenants.py
+++ b/apps/central_api/tests/test_dashboard_routes_auth_tenants.py
@@ -33,6 +33,7 @@ def _user(tenants: list[str]) -> AuthenticatedUser:
 def test_auth_me_retorna_perfil_e_tenants() -> None:
     user = _user(["354130"])
     repo = MagicMock()
+    repo.has_pending_request.return_value = False
     c = _build(user, repo)
     r = c.get("/api/v1/dashboard/auth/me")
     assert r.status_code == 200
@@ -47,6 +48,7 @@ def test_auth_me_retorna_perfil_e_tenants() -> None:
 def test_auth_me_grava_audit_login() -> None:
     user = _user(["354130"])
     repo = MagicMock()
+    repo.has_pending_request.return_value = False
     c = _build(user, repo)
     c.get("/api/v1/dashboard/auth/me")
     repo.log_action.assert_called_once()
@@ -60,6 +62,26 @@ def test_auth_me_responde_401_sem_user() -> None:
     c = _build(None, MagicMock())
     r = c.get("/api/v1/dashboard/auth/me")
     assert r.status_code == 401
+
+
+def test_auth_me_retorna_has_pending_request_true_quando_pendente() -> None:
+    user = _user(["354130"])
+    repo = MagicMock()
+    repo.has_pending_request.return_value = True
+    c = _build(user, repo)
+    r = c.get("/api/v1/dashboard/auth/me")
+    assert r.status_code == 200
+    assert r.json()["has_pending_request"] is True
+
+
+def test_auth_me_retorna_has_pending_request_false_normalmente() -> None:
+    user = _user(["354130"])
+    repo = MagicMock()
+    repo.has_pending_request.return_value = False
+    c = _build(user, repo)
+    r = c.get("/api/v1/dashboard/auth/me")
+    assert r.status_code == 200
+    assert r.json()["has_pending_request"] is False
 
 
 def test_tenants_lista_municipios_alocados() -> None:

--- a/apps/central_api/tests/test_overview_routes.py
+++ b/apps/central_api/tests/test_overview_routes.py
@@ -1,0 +1,117 @@
+"""Tests for /api/v1/dashboard/overview + /faturamento/by-establishment."""
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from central_api.middleware import AuthenticatedUser
+from central_api.repositories.dashboard_repo import (
+    FaturamentoChart,
+    OverviewKpis,
+)
+from central_api.routes import overview
+
+
+def _build(user, repo) -> TestClient:
+    app = FastAPI()
+    app.state.dashboard_repo = repo
+
+    @app.middleware("http")
+    async def inject(request: Request, call_next):
+        if user is not None:
+            request.state.user = user
+        return await call_next(request)
+
+    app.include_router(overview.router, prefix="/api/v1/dashboard")
+    return TestClient(app)
+
+
+def _user(tenants: list[str]) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=uuid4(), email="g@m", display_name=None,
+        role="gestor", tenant_ids=tenants,
+    )
+
+
+def test_overview_retorna_kpis_e_audita() -> None:
+    user = _user(["354130"])
+    repo = MagicMock()
+    repo.overview_kpis.return_value = OverviewKpis(
+        competencia_atual=202604,
+        faturamento_atual_cents=120_000_000,
+        faturamento_anterior_cents=115_000_000,
+        aih_atual=312, aih_anterior=340,
+        profissionais_ativos=421, profissionais_anterior=419,
+        estabs_sem_producao=7, estabs_total=124,
+        estabs_sem_producao_anterior=5,
+    )
+    c = _build(user, repo)
+    r = c.get("/api/v1/dashboard/overview", headers={"X-Tenant-Id": "354130"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["faturamento_atual_cents"] == 120_000_000
+    assert body["estabs_sem_producao"] == 7
+    actions = [c.kwargs["action"] for c in repo.log_action.call_args_list]
+    assert "view_overview" in actions
+
+
+def test_faturamento_chart_retorna_series() -> None:
+    user = _user(["354130"])
+    repo = MagicMock()
+    repo.faturamento_by_establishment.return_value = FaturamentoChart(
+        series=[{"competencia": "abr/2026", "UBS X": 1000, "outros": 200}],
+        categories=["UBS X", "outros"],
+    )
+    c = _build(user, repo)
+    r = c.get(
+        "/api/v1/dashboard/faturamento/by-establishment?months=12",
+        headers={"X-Tenant-Id": "354130"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert "series" in body
+    assert "categories" in body
+    actions = [c.kwargs["action"] for c in repo.log_action.call_args_list]
+    assert "view_faturamento" in actions
+
+
+def test_overview_responde_403_tenant_nao_pertence() -> None:
+    user = _user(["354130"])
+    c = _build(user, MagicMock())
+    r = c.get("/api/v1/dashboard/overview", headers={"X-Tenant-Id": "999999"})
+    assert r.status_code == 403
+
+
+def test_overview_responde_401_sem_user() -> None:
+    c = _build(None, MagicMock())
+    r = c.get("/api/v1/dashboard/overview", headers={"X-Tenant-Id": "354130"})
+    assert r.status_code == 401
+
+
+def test_overview_emite_cache_control() -> None:
+    user = _user(["354130"])
+    repo = MagicMock()
+    repo.overview_kpis.return_value = OverviewKpis(
+        competencia_atual=202604,
+        faturamento_atual_cents=0,
+        faturamento_anterior_cents=0,
+        aih_atual=0, aih_anterior=0,
+        profissionais_ativos=0, profissionais_anterior=0,
+        estabs_sem_producao=0, estabs_total=0,
+        estabs_sem_producao_anterior=0,
+    )
+    c = _build(user, repo)
+    r = c.get("/api/v1/dashboard/overview", headers={"X-Tenant-Id": "354130"})
+    assert "max-age=30" in r.headers.get("Cache-Control", "")
+
+
+def test_faturamento_chart_responde_400_se_months_invalido() -> None:
+    user = _user(["354130"])
+    repo = MagicMock()
+    c = _build(user, repo)
+    r = c.get(
+        "/api/v1/dashboard/faturamento/by-establishment?months=0",
+        headers={"X-Tenant-Id": "354130"},
+    )
+    assert r.status_code == 422

--- a/apps/web_dashboard/CLAUDE.md
+++ b/apps/web_dashboard/CLAUDE.md
@@ -20,6 +20,9 @@ Persona secundária: técnico hospitalar redimindo `user_code` na rota
 - `/auth/callback` — redirect handler
 - `/agentes` — status edge agents do tenant + últimas 20 execuções (Task 24)
 - `/activate` — RFC 8628 device code redemption (Task 20)
+- `/overview` — KPIs do tenant + faturamento area chart 12m por estabelecimento (v1.1)
+- `/access-pending` — solicitação de acesso a um município, fluxo JIT (v1.1)
+- Dark mode 3-state (light/dark/system) — toggle no header, persiste em localStorage (v1.1)
 - Auto-refresh 30s em /agentes via TanStack Query
 
 ## Objectives
@@ -33,9 +36,9 @@ Persona secundária: técnico hospitalar redimindo `user_code` na rota
 
 - pt-BR único locale v1.0
 - Desktop primary; mobile best-effort
-- Sem dark mode v1.0
 - Sem WebSocket — apenas polling
-- Sem charts em v1.0 (Tremor lazy em rotas v1.1)
+- Aprovação de signup via SQL admin manual em v1.1 (UI em v1.2)
+- Tremor v3 lazy-loaded só em /overview; outras rotas seguem shadcn nativo
 
 ## Requirements
 
@@ -55,28 +58,34 @@ manager) — SPA carrega mas login falha controladamente.
 
 ## Module Map
 
-| Path                        | Responsabilidade                                                                                                    |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `src/main.tsx`              | render React root                                                                                                   |
-| `src/App.tsx`               | providers (Query + Auth + Router)                                                                                   |
-| `src/routes/`               | TanStack Router file-based                                                                                          |
-| `src/api/client.ts`         | fetch wrapper, anexa Bearer + X-Tenant-Id                                                                           |
-| `src/api/generated.ts`      | types gerados via openapi-typescript (gitignored)                                                                   |
-| `src/api/hooks/`            | TanStack Query hooks                                                                                                |
-| `src/auth/oidc.ts`          | UserManager config (lazy)                                                                                           |
-| `src/auth/AuthProvider.tsx` | context user                                                                                                        |
-| `src/components/ui/`        | shadcn primitives                                                                                                   |
-| `src/components/layout/`    | Shell + Sidebar + TenantPill                                                                                        |
-| `src/lib/env.ts`            | Zod-validated env                                                                                                   |
-| `src/lib/format.ts`         | BRL, datas pt-BR, lag                                                                                               |
-| `src/i18n/pt-BR.ts`         | strings                                                                                                             |
-| `tests/unit/`               | Vitest                                                                                                              |
-| `tests/e2e/`                | Playwright                                                                                                          |
-| `tests/mocks/`              | msw setup                                                                                                           |
-| `eslint.config.js`          | ESLint flat config (typescript-eslint, react-hooks, react-refresh, jsx-a11y, import-x; eslint-config-prettier last) |
-| `.prettierrc`               | Prettier 3 config + tailwindcss plugin (`endOfLine: auto` for cross-OS)                                             |
-| `.prettierignore`           | mirror of common ignores                                                                                            |
-| `.oxlintrc.json`            | OxLint pre-commit config (correctness=error, suspicious=warn)                                                       |
+| Path                            | Responsabilidade                                                                                                               |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `src/main.tsx`                  | render React root                                                                                                              |
+| `src/App.tsx`                   | providers (Theme + Query + Auth + Router)                                                                                      |
+| `src/routes/`                   | TanStack Router file-based                                                                                                     |
+| `src/routes/access-pending.tsx` | top-level (fora `_app` guard) — formulário de signup                                                                           |
+| `src/routes/_app.overview.tsx`  | /overview KPIs + lazy faturamento chart (v1.1)                                                                                 |
+| `src/api/client.ts`             | fetch wrapper, anexa Bearer + X-Tenant-Id                                                                                      |
+| `src/api/generated.ts`          | types gerados via openapi-typescript (gitignored)                                                                              |
+| `src/api/hooks/`                | TanStack Query hooks (inclui useOverview, useFaturamentoChart, useAccessRequests, useSubmitAccessRequest, useAvailableTenants) |
+| `src/auth/oidc.ts`              | UserManager config (lazy)                                                                                                      |
+| `src/auth/AuthProvider.tsx`     | context user                                                                                                                   |
+| `src/theme/ThemeProvider.tsx`   | 3-state (light/dark/system) + localStorage + matchMedia (v1.1)                                                                 |
+| `src/theme/useTheme.ts`         | hook export                                                                                                                    |
+| `src/components/ui/`            | shadcn primitives                                                                                                              |
+| `src/components/layout/`        | Shell + Sidebar + TenantPill + ThemeToggle                                                                                     |
+| `src/components/signup/`        | AccessRequestForm + PendingRequestsList (v1.1)                                                                                 |
+| `src/components/overview/`      | KpiCard + KpiGrid + FaturamentoAreaChart (Tremor lazy) (v1.1)                                                                  |
+| `src/lib/env.ts`                | Zod-validated env                                                                                                              |
+| `src/lib/format.ts`             | BRL, datas pt-BR, lag                                                                                                          |
+| `src/i18n/pt-BR.ts`             | strings                                                                                                                        |
+| `tests/unit/`                   | Vitest                                                                                                                         |
+| `tests/e2e/`                    | Playwright                                                                                                                     |
+| `tests/mocks/`                  | msw setup                                                                                                                      |
+| `eslint.config.js`              | ESLint flat config (typescript-eslint, react-hooks, react-refresh, jsx-a11y, import-x; eslint-config-prettier last)            |
+| `.prettierrc`                   | Prettier 3 config + tailwindcss plugin (`endOfLine: auto` for cross-OS)                                                        |
+| `.prettierignore`               | mirror of common ignores                                                                                                       |
+| `.oxlintrc.json`                | OxLint pre-commit config (correctness=error, suspicious=warn)                                                                  |
 
 ## Commands
 
@@ -121,3 +130,17 @@ bun run typecheck
 - **Keycloak dev seed** em `docker-compose.keycloak/realm.json` é apenas
   para desenvolvimento local (usuário `gestor@local`, senha `dev`). Não usar
   em produção; em prod o IdP é externo (Keycloak gerenciado pelo município).
+- **Signup aprovação manual v1.1**: `dashboard.access_requests` row criada
+  via POST /api/v1/access-requests; admin executa SQL em
+  `docs/runbooks/access-request-approval.md` para approve/reject (UI em v1.2).
+- **`@tremor/react` lazy-loaded**: importar via `lazy(() => import(...))`
+  apenas em rotas que usam charts (hoje só /overview). Tremor entra em chunk
+  próprio no `manualChunks` do `vite.config.ts`; bundle main fica fora.
+- **Dark mode FOUC script** inline em `index.html` `<head>` aplica classe
+  `.dark` antes do React montar — evita flash branco em system/dark.
+  Mantém em sync com a chave `localStorage["cnesdata-theme"]`.
+- **`/access-pending` fica FORA do `_app` guard**: usuário sem tenant pode
+  acessar mesmo após login (caso JIT user sem aprovação). `_app.tsx`
+  redireciona para lá quando `tenant_ids` é vazio.
+- **Per-chunk bundle budget**: main ≤ 200KB gzipped, tremor ≤ 100KB,
+  recharts ≤ 100KB, qualquer rota ≤ 100KB (gate em `scripts/bundle-check.ts`).

--- a/apps/web_dashboard/bun.lock
+++ b/apps/web_dashboard/bun.lock
@@ -10,6 +10,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.100.5",
         "@tanstack/react-router": "^1.168.24",
+        "@tremor/react": "^3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -21,6 +22,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@headlessui/tailwindcss": "^0.2.2",
         "@playwright/test": "^1.59.1",
         "@tanstack/router-plugin": "^1.167.27",
         "@testing-library/jest-dom": "^6.9.1",
@@ -207,9 +209,15 @@
 
     "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
 
+    "@floating-ui/react": ["@floating-ui/react@0.19.2", "", { "dependencies": { "@floating-ui/react-dom": "^1.3.0", "aria-hidden": "^1.1.3", "tabbable": "^6.0.1" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w=="],
+
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@headlessui/react": ["@headlessui/react@2.2.0", "", { "dependencies": { "@floating-ui/react": "^0.26.16", "@react-aria/focus": "^3.17.1", "@react-aria/interactions": "^3.21.3", "@tanstack/react-virtual": "^3.8.1" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-RzCEg+LXsuI7mHiSomsu/gBJSjpupm6A1qIZ5sWjd7JhARNlMiSA4kKfJpCKwU9tE+zMRterhhrP74PvfJrpXQ=="],
+
+    "@headlessui/tailwindcss": ["@headlessui/tailwindcss@0.2.2", "", { "peerDependencies": { "tailwindcss": "^3.0 || ^4.0" } }, "sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -230,6 +238,12 @@
     "@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
 
     "@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
+
+    "@internationalized/date": ["@internationalized/date@3.12.1", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ=="],
+
+    "@internationalized/number": ["@internationalized/number@3.6.6", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ=="],
+
+    "@internationalized/string": ["@internationalized/string@3.2.8", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -355,6 +369,12 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@react-aria/focus": ["@react-aria/focus@3.22.0", "", { "dependencies": { "@swc/helpers": "^0.5.0", "react-aria": "3.48.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-ZfDOVuVhqDsM9mkNji3QUZ/d40JhlVgXrDkrfXylM1035QCrcTHN7m2DpbE95sU2A8EQb4wikvt5jM6K/73BPg=="],
+
+    "@react-aria/interactions": ["@react-aria/interactions@3.28.0", "", { "dependencies": { "@react-types/shared": "^3.34.0", "@swc/helpers": "^0.5.0", "react-aria": "3.48.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-OXwdU1EWFdMxmr/K1CXNGJzmNlCClByb+PuCaqUyzBymHPCGVhawirLIon/CrIN5psh3AiWpHSh4H0WeJdVpng=="],
+
+    "@react-types/shared": ["@react-types/shared@3.34.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ=="],
+
     "@redocly/ajv": ["@redocly/ajv@8.11.2", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js-replace": "^1.0.1" } }, "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg=="],
 
     "@redocly/config": ["@redocly/config@0.22.0", "", {}, "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ=="],
@@ -445,6 +465,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@swc/helpers": ["@swc/helpers@0.5.21", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg=="],
+
     "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.100.5", "", {}, "sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg=="],
@@ -454,6 +476,8 @@
     "@tanstack/react-router": ["@tanstack/react-router@1.168.24", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.16", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-CQWd9ywDZU6icG65SrjJMzWcNg/ehBKFxfxYssKSuELk0eM9SzJxJ3JBI760kdLXIsXewOX9PHpJDknxC/R5Ag=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.24", "", { "dependencies": { "@tanstack/virtual-core": "3.14.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.168.16", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-2lkWNMzDWWxVqTf9Y54DH1ceZOrGrOGzx9CFVMq8gQSOxhr3x3+otjVei1Rlx4xmsCc4yCqccqjun5wDtE9MZA=="],
 
@@ -465,6 +489,8 @@
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.14.0", "", {}, "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q=="],
+
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
@@ -474,6 +500,8 @@
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
+    "@tremor/react": ["@tremor/react@3.18.7", "", { "dependencies": { "@floating-ui/react": "^0.19.2", "@headlessui/react": "2.2.0", "date-fns": "^3.6.0", "react-day-picker": "^8.10.1", "react-transition-state": "^2.1.2", "recharts": "^2.13.3", "tailwind-merge": "^2.5.2" }, "peerDependencies": { "react": "^18.0.0", "react-dom": ">=16.6.0" } }, "sha512-nmqvf/1m0GB4LXc7v2ftdfSLoZhy5WLrhV6HNf0SOriE6/l8WkYeWuhQq8QsBjRi94mUIKLJ/VC3/Y/pj6VubQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -488,6 +516,24 @@
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
@@ -715,6 +761,28 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
@@ -730,6 +798,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -750,6 +820,8 @@
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -822,6 +894,8 @@
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -926,6 +1000,8 @@
     "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
@@ -1066,6 +1142,8 @@
     "listr2": ["listr2@8.3.3", "", { "dependencies": { "cli-truncate": "^4.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
@@ -1213,15 +1291,21 @@
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
+    "react-aria": ["react-aria@3.48.0", "", { "dependencies": { "@internationalized/date": "^3.12.1", "@internationalized/number": "^3.6.6", "@internationalized/string": "^3.2.8", "@react-types/shared": "^3.34.0", "@swc/helpers": "^0.5.0", "aria-hidden": "^1.2.3", "clsx": "^2.0.0", "react-stately": "3.46.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w=="],
+
+    "react-day-picker": ["react-day-picker@8.10.1", "", { "peerDependencies": { "date-fns": "^2.28.0 || ^3.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA=="],
+
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
-    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
@@ -1229,11 +1313,23 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
+    "react-smooth": ["react-smooth@4.0.4", "", { "dependencies": { "fast-equals": "^5.0.1", "prop-types": "^15.8.1", "react-transition-group": "^4.4.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q=="],
+
+    "react-stately": ["react-stately@3.46.0", "", { "dependencies": { "@internationalized/date": "^3.12.1", "@internationalized/number": "^3.6.6", "@internationalized/string": "^3.2.8", "@react-types/shared": "^3.34.0", "@swc/helpers": "^0.5.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA=="],
+
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
+
+    "react-transition-state": ["react-transition-state@2.3.3", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-wsIyg07ohlWEAYDZHvuXh/DY7mxlcLb0iqVv2aMXJ0gwgPVKNWKhOyNyzuJy/tt/6urSq0WT6BBZ/tdpybaAsQ=="],
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "recharts": ["recharts@2.15.4", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw=="],
+
+    "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
@@ -1351,6 +1447,8 @@
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
+    "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
+
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
@@ -1362,6 +1460,8 @@
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -1429,6 +1529,8 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
+    "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
+
     "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
@@ -1491,6 +1593,10 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
+    "@floating-ui/react/@floating-ui/react-dom": ["@floating-ui/react-dom@1.3.0", "", { "dependencies": { "@floating-ui/dom": "^1.2.1" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g=="],
+
+    "@headlessui/react/@floating-ui/react": ["@floating-ui/react@0.26.28", "", { "dependencies": { "@floating-ui/react-dom": "^2.1.2", "@floating-ui/utils": "^0.2.8", "tabbable": "^6.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw=="],
+
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
     "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
@@ -1530,6 +1636,10 @@
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "@tremor/react/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
+
+    "@tremor/react/tailwind-merge": ["tailwind-merge@2.6.1", "", {}, "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -1571,7 +1681,13 @@
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "recharts/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 

--- a/apps/web_dashboard/index.html
+++ b/apps/web_dashboard/index.html
@@ -1,6 +1,15 @@
 <!doctype html>
 <html lang="pt-BR">
   <head>
+    <script>
+      (function () {
+        var t = localStorage.getItem("cnesdata-theme") || "system";
+        var dark =
+          t === "dark" ||
+          (t === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+        if (dark) document.documentElement.classList.add("dark");
+      })();
+    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CnesData — Painel municipal</title>

--- a/apps/web_dashboard/package.json
+++ b/apps/web_dashboard/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.100.5",
     "@tanstack/react-router": "^1.168.24",
+    "@tremor/react": "^3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
@@ -47,6 +48,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@headlessui/tailwindcss": "^0.2.2",
     "@playwright/test": "^1.59.1",
     "@tanstack/router-plugin": "^1.167.27",
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/web_dashboard/scripts/bundle-check.ts
+++ b/apps/web_dashboard/scripts/bundle-check.ts
@@ -1,34 +1,41 @@
 #!/usr/bin/env bun
-import { gzipSync } from "node:zlib";
 import { readFileSync, readdirSync } from "node:fs";
-import { join, dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { gzipSync } from "node:zlib";
 
 const _MAIN_BUDGET = 200 * 1024;
 const _ROUTE_BUDGET = 100 * 1024;
+const _TREMOR_BUDGET = 100 * 1024;
 const _DIST = resolve(dirname(import.meta.dir), "dist", "assets");
 
 function gzipSize(p: string): number {
   return gzipSync(readFileSync(p)).length;
 }
 
-function listJs(): string[] {
-  return readdirSync(_DIST)
-    .filter((f) => f.endsWith(".js"))
-    .map((f) => join(_DIST, f));
+type Bucket = { name: string; budget: number };
+
+function classify(file: string): Bucket {
+  const base = file.toLowerCase();
+  if (base.includes("tremor-")) return { name: "tremor", budget: _TREMOR_BUDGET };
+  if (base.includes("index-")) return { name: "main", budget: _MAIN_BUDGET };
+  return { name: "route", budget: _ROUTE_BUDGET };
 }
 
-const files = listJs();
+const files = readdirSync(_DIST)
+  .filter((f) => f.endsWith(".js"))
+  .map((f) => join(_DIST, f));
+
 let failed = 0;
 for (const f of files) {
   const size = gzipSize(f);
-  const isMain = /index-[^/]+\.js$/.test(f) || /main-[^/]+\.js$/.test(f);
-  const budget = isMain ? _MAIN_BUDGET : _ROUTE_BUDGET;
+  const { name, budget } = classify(f);
   const status = size <= budget ? "OK" : "FAIL";
   if (status === "FAIL") failed += 1;
   const sizeKb = (size / 1024).toFixed(1);
   const budgetKb = (budget / 1024).toFixed(0);
-  console.log(`${status} ${f} ${sizeKb}KB (budget ${budgetKb}KB)`);
+  console.log(`${status} ${name} ${f} ${sizeKb}KB (budget ${budgetKb}KB)`);
 }
+
 if (failed > 0) {
   console.error(`bundle:check failed: ${failed} chunks over budget`);
   process.exit(1);

--- a/apps/web_dashboard/src/App.tsx
+++ b/apps/web_dashboard/src/App.tsx
@@ -4,6 +4,7 @@ import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
 import { AuthProvider } from "@/auth/AuthProvider";
+import { ThemeProvider } from "@/theme/ThemeProvider";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -20,10 +21,12 @@ declare module "@tanstack/react-router" {
 
 export function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <RouterProvider router={router} />
-      </AuthProvider>
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <RouterProvider router={router} />
+        </AuthProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   );
 }

--- a/apps/web_dashboard/src/api/hooks/useAccessRequests.ts
+++ b/apps/web_dashboard/src/api/hooks/useAccessRequests.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { apiFetch } from "@/api/client";
+
+export type AccessRequest = {
+  id: string;
+  tenant_id: string;
+  tenant_nome: string | null;
+  motivation: string;
+  status: "pending" | "approved" | "rejected";
+  requested_at: string;
+  reviewed_at: string | null;
+  review_notes: string | null;
+};
+
+export function useAccessRequests() {
+  return useQuery({
+    queryKey: ["access-requests-mine"],
+    queryFn: () => apiFetch<AccessRequest[]>("/dashboard/access-requests/mine"),
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+}

--- a/apps/web_dashboard/src/api/hooks/useAvailableTenants.ts
+++ b/apps/web_dashboard/src/api/hooks/useAvailableTenants.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { apiFetch } from "@/api/client";
+import type { Tenant } from "@/api/hooks/useTenants";
+
+export function useAvailableTenants() {
+  return useQuery({
+    queryKey: ["available-tenants"],
+    queryFn: () => apiFetch<Tenant[]>("/dashboard/access-requests/available-tenants"),
+    staleTime: 60_000,
+  });
+}

--- a/apps/web_dashboard/src/api/hooks/useFaturamentoChart.ts
+++ b/apps/web_dashboard/src/api/hooks/useFaturamentoChart.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { apiFetch } from "@/api/client";
+
+export type FaturamentoSeriesPoint = {
+  competencia: string;
+  [estab: string]: string | number;
+};
+
+export type FaturamentoChart = {
+  series: FaturamentoSeriesPoint[];
+  categories: string[];
+};
+
+export function useFaturamentoChart(tenantId: string, months = 12) {
+  return useQuery({
+    queryKey: ["faturamento-chart", tenantId, months],
+    queryFn: () =>
+      apiFetch<FaturamentoChart>(`/dashboard/faturamento/by-establishment?months=${months}`, {
+        tenantId,
+      }),
+    staleTime: 60_000,
+  });
+}

--- a/apps/web_dashboard/src/api/hooks/useOverview.ts
+++ b/apps/web_dashboard/src/api/hooks/useOverview.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { apiFetch } from "@/api/client";
+
+export type OverviewKpis = {
+  competencia_atual: number;
+  faturamento_atual_cents: number;
+  faturamento_anterior_cents: number;
+  aih_atual: number;
+  aih_anterior: number;
+  profissionais_ativos: number;
+  profissionais_anterior: number;
+  estabs_sem_producao: number;
+  estabs_total: number;
+  estabs_sem_producao_anterior: number;
+};
+
+export function useOverview(tenantId: string) {
+  return useQuery({
+    queryKey: ["overview", tenantId],
+    queryFn: () => apiFetch<OverviewKpis>("/dashboard/overview", { tenantId }),
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+}

--- a/apps/web_dashboard/src/api/hooks/useSubmitAccessRequest.ts
+++ b/apps/web_dashboard/src/api/hooks/useSubmitAccessRequest.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { apiFetch } from "@/api/client";
+
+type Request = { tenant_id: string; motivation: string };
+type Response = { request_id: string };
+
+export function useSubmitAccessRequest() {
+  const qc = useQueryClient();
+  return useMutation<Response, Error, Request>({
+    mutationFn: (body) =>
+      apiFetch<Response>("/dashboard/access-requests", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["access-requests-mine"] });
+      void qc.invalidateQueries({ queryKey: ["available-tenants"] });
+      void qc.invalidateQueries({ queryKey: ["me"] });
+    },
+  });
+}

--- a/apps/web_dashboard/src/auth/AuthProvider.tsx
+++ b/apps/web_dashboard/src/auth/AuthProvider.tsx
@@ -6,6 +6,7 @@ export type Me = {
   display_name: string | null;
   role: "gestor" | "admin";
   tenant_ids: string[];
+  has_pending_request: boolean;
 };
 
 export type AuthStatus = "loading" | "authenticated" | "anonymous";

--- a/apps/web_dashboard/src/components/layout/Shell.tsx
+++ b/apps/web_dashboard/src/components/layout/Shell.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 
 import { Sidebar } from "./Sidebar";
 import { TenantPill } from "./TenantPill";
+import { ThemeToggle } from "./ThemeToggle";
 
 import { useTenants } from "@/api/hooks/useTenants";
 import { logout } from "@/auth/oidc";
@@ -26,6 +27,7 @@ export function Shell({ children }: { children: ReactNode }) {
             <span />
           )}
           <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            <ThemeToggle />
             <span>{user?.email}</span>
             <button type="button" onClick={() => void logout()} className="underline">
               {t.nav.sair}

--- a/apps/web_dashboard/src/components/layout/Sidebar.tsx
+++ b/apps/web_dashboard/src/components/layout/Sidebar.tsx
@@ -11,9 +11,9 @@ type Item = {
 };
 
 const _ITEMS: Item[] = [
+  { label: t.nav.overview, to: "/overview", icon: Home },
   { label: t.nav.agentes, to: "/agentes", icon: Activity },
   { label: t.nav.activate, to: "/activate", icon: KeyRound },
-  { label: t.nav.overview, icon: Home, future: true },
   { label: t.nav.faturamento, icon: FileBarChart, future: true },
   { label: t.nav.estabelecimentos, icon: Building2, future: true },
 ];

--- a/apps/web_dashboard/src/components/layout/ThemeToggle.tsx
+++ b/apps/web_dashboard/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,33 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+
+import { useTheme, type Theme } from "@/theme/useTheme";
+
+const _OPTIONS: { value: Theme; icon: typeof Sun; label: string }[] = [
+  { value: "light", icon: Sun, label: "Claro" },
+  { value: "dark", icon: Moon, label: "Escuro" },
+  { value: "system", icon: Monitor, label: "Sistema" },
+];
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div className="inline-flex rounded-lg border bg-muted/30 p-0.5">
+      {_OPTIONS.map(({ value, icon: Icon, label }) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => setTheme(value)}
+          aria-label={`Tema ${label}`}
+          aria-pressed={theme === value}
+          className={
+            theme === value
+              ? "rounded bg-background px-2 py-1"
+              : "rounded px-2 py-1 opacity-60 hover:opacity-100"
+          }
+        >
+          <Icon size={14} />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web_dashboard/src/components/overview/FaturamentoAreaChart.tsx
+++ b/apps/web_dashboard/src/components/overview/FaturamentoAreaChart.tsx
@@ -1,0 +1,40 @@
+import { lazy, Suspense } from "react";
+
+import type { FaturamentoChart } from "@/api/hooks/useFaturamentoChart";
+import { formatBRL } from "@/lib/format";
+
+const _AreaChartLazy = lazy(async () => {
+  const { AreaChart } = await import("@tremor/react");
+  return { default: AreaChart };
+});
+
+const _COLORS = [
+  "blue",
+  "cyan",
+  "indigo",
+  "violet",
+  "fuchsia",
+  "pink",
+  "rose",
+  "orange",
+  "amber",
+  "yellow",
+  "gray",
+] as const;
+
+export function FaturamentoAreaChart({ data }: { data: FaturamentoChart }) {
+  return (
+    <Suspense fallback={<div className="h-[260px] animate-pulse rounded bg-muted" />}>
+      <_AreaChartLazy
+        data={data.series}
+        index="competencia"
+        categories={data.categories}
+        colors={[..._COLORS].slice(0, data.categories.length)}
+        valueFormatter={(v: number) => formatBRL(v)}
+        stack
+        showLegend
+        className="h-[260px]"
+      />
+    </Suspense>
+  );
+}

--- a/apps/web_dashboard/src/components/overview/KpiCard.tsx
+++ b/apps/web_dashboard/src/components/overview/KpiCard.tsx
@@ -1,0 +1,33 @@
+type Props = {
+  label: string;
+  value: string;
+  delta?: { value: string; direction: "up" | "down" | "warn" };
+  context?: string;
+};
+
+const _COLOR: Record<NonNullable<Props["delta"]>["direction"], string> = {
+  up: "text-green-600",
+  down: "text-red-600",
+  warn: "text-yellow-600",
+};
+
+const _ARROW: Record<NonNullable<Props["delta"]>["direction"], string> = {
+  up: "▲",
+  down: "▼",
+  warn: "▲",
+};
+
+export function KpiCard({ label, value, delta, context }: Props) {
+  return (
+    <article className="rounded-lg border bg-card p-4">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="mt-1 text-2xl font-semibold">{value}</div>
+      {delta && (
+        <div className={`text-xs ${_COLOR[delta.direction]}`}>
+          {_ARROW[delta.direction]} {delta.value}
+        </div>
+      )}
+      {context && <div className="mt-1 text-[11px] text-muted-foreground">{context}</div>}
+    </article>
+  );
+}

--- a/apps/web_dashboard/src/components/overview/KpiGrid.tsx
+++ b/apps/web_dashboard/src/components/overview/KpiGrid.tsx
@@ -1,0 +1,67 @@
+import { KpiCard } from "./KpiCard";
+
+import type { OverviewKpis } from "@/api/hooks/useOverview";
+import { formatBRL, formatCompetenciaBR } from "@/lib/format";
+
+function _previousCompetencia(yyyymm: number): number {
+  const y = Math.floor(yyyymm / 100);
+  const m = yyyymm % 100;
+  if (m === 1) return (y - 1) * 100 + 12;
+  return y * 100 + (m - 1);
+}
+
+function _deltaPct(cur: number, prev: number) {
+  if (prev === 0) return undefined;
+  const pct = ((cur - prev) / prev) * 100;
+  if (Math.abs(pct) < 0.05) return undefined;
+  return {
+    value: `${pct.toFixed(1)}%`,
+    direction: pct >= 0 ? ("up" as const) : ("down" as const),
+  };
+}
+
+function _deltaCount(cur: number, prev: number, warnOnIncrease = false) {
+  const diff = cur - prev;
+  if (diff === 0) return undefined;
+  const dir = warnOnIncrease
+    ? diff > 0
+      ? ("warn" as const)
+      : ("down" as const)
+    : diff > 0
+      ? ("up" as const)
+      : ("down" as const);
+  return { value: `${Math.abs(diff)}`, direction: dir };
+}
+
+export function KpiGrid({ kpis }: { kpis: OverviewKpis }) {
+  const prevComp = formatCompetenciaBR(_previousCompetencia(kpis.competencia_atual));
+  const compStr = formatCompetenciaBR(kpis.competencia_atual);
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <KpiCard
+        label={`Faturamento ${compStr}`}
+        value={formatBRL(kpis.faturamento_atual_cents)}
+        delta={_deltaPct(kpis.faturamento_atual_cents, kpis.faturamento_anterior_cents)}
+        context={`vs ${prevComp}`}
+      />
+      <KpiCard
+        label={`AIHs ${compStr}`}
+        value={kpis.aih_atual.toLocaleString("pt-BR")}
+        delta={_deltaPct(kpis.aih_atual, kpis.aih_anterior)}
+        context={`vs ${prevComp}`}
+      />
+      <KpiCard
+        label="Profissionais ativos"
+        value={kpis.profissionais_ativos.toLocaleString("pt-BR")}
+        delta={_deltaCount(kpis.profissionais_ativos, kpis.profissionais_anterior)}
+        context={`vs ${prevComp}`}
+      />
+      <KpiCard
+        label="Estabs sem produção"
+        value={`${kpis.estabs_sem_producao}`}
+        delta={_deltaCount(kpis.estabs_sem_producao, kpis.estabs_sem_producao_anterior, true)}
+        context={`de ${kpis.estabs_total} totais`}
+      />
+    </div>
+  );
+}

--- a/apps/web_dashboard/src/components/signup/AccessRequestForm.tsx
+++ b/apps/web_dashboard/src/components/signup/AccessRequestForm.tsx
@@ -1,0 +1,89 @@
+import { useState, type FormEvent } from "react";
+
+import { ApiError } from "@/api/client";
+import { useAvailableTenants } from "@/api/hooks/useAvailableTenants";
+import { useSubmitAccessRequest } from "@/api/hooks/useSubmitAccessRequest";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const _MOTIVATION_PLACEHOLDER =
+  "Descreva por que precisa de acesso. NÃO inclua dados pessoais (CPF, nome).";
+
+function _isDuplicate(err: Error): boolean {
+  if (err instanceof ApiError) {
+    const body = err.body as { detail?: string } | null;
+    return body?.detail === "duplicate_request" || err.status === 409;
+  }
+  return err.message.includes("duplicate");
+}
+
+export function AccessRequestForm() {
+  const tenants = useAvailableTenants();
+  const submit = useSubmitAccessRequest();
+  const [tenantId, setTenantId] = useState("");
+  const [motivation, setMotivation] = useState("");
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    submit.mutate({ tenant_id: tenantId, motivation });
+  };
+
+  if (submit.isSuccess) {
+    return (
+      <div className="rounded border bg-green-50 p-4 text-sm">
+        Solicitação enviada. Aguarde aprovação do administrador.
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div>
+        <Label>Município</Label>
+        <Select value={tenantId} onValueChange={setTenantId}>
+          <SelectTrigger>
+            <SelectValue placeholder="Selecione um município" />
+          </SelectTrigger>
+          <SelectContent>
+            {tenants.data?.map((t) => (
+              <SelectItem key={t.ibge6} value={t.ibge6}>
+                {t.nome} / {t.uf} — {t.ibge6}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div>
+        <Label htmlFor="motivation">Justificativa</Label>
+        <textarea
+          id="motivation"
+          value={motivation}
+          onChange={(e) => setMotivation(e.target.value.slice(0, 500))}
+          placeholder={_MOTIVATION_PLACEHOLDER}
+          required
+          maxLength={500}
+          rows={4}
+          className="w-full rounded border bg-background px-3 py-2 text-sm"
+        />
+        <p className="mt-1 text-xs text-muted-foreground">{motivation.length} / 500</p>
+      </div>
+      <Button type="submit" disabled={!tenantId || !motivation || submit.isPending}>
+        {submit.isPending ? "Enviando..." : "Solicitar acesso"}
+      </Button>
+      {submit.isError && (
+        <p className="text-sm text-red-600">
+          {_isDuplicate(submit.error)
+            ? "Você já tem solicitação para esse município."
+            : `Erro: ${submit.error.message}`}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/apps/web_dashboard/src/components/signup/PendingRequestsList.tsx
+++ b/apps/web_dashboard/src/components/signup/PendingRequestsList.tsx
@@ -1,0 +1,37 @@
+import type { AccessRequest } from "@/api/hooks/useAccessRequests";
+import { formatRelativeTime } from "@/lib/format";
+
+const _BADGE: Record<AccessRequest["status"], string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  approved: "bg-green-100 text-green-800",
+  rejected: "bg-red-100 text-red-800",
+};
+
+const _LABEL: Record<AccessRequest["status"], string> = {
+  pending: "Pendente",
+  approved: "Aprovado",
+  rejected: "Rejeitado",
+};
+
+export function PendingRequestsList({ requests }: { requests: AccessRequest[] }) {
+  if (requests.length === 0) {
+    return <p className="text-sm text-muted-foreground">Nenhuma solicitação ainda.</p>;
+  }
+  return (
+    <ul className="space-y-2">
+      {requests.map((r) => (
+        <li key={r.id} className="flex items-center justify-between rounded border p-3">
+          <div>
+            <div className="text-sm font-medium">{r.tenant_nome ?? r.tenant_id}</div>
+            <div className="text-xs text-muted-foreground">
+              {formatRelativeTime(new Date(r.requested_at))}
+            </div>
+          </div>
+          <span className={`rounded-full px-2 py-0.5 text-xs ${_BADGE[r.status]}`}>
+            {_LABEL[r.status]}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web_dashboard/src/routes/_app.overview.tsx
+++ b/apps/web_dashboard/src/routes/_app.overview.tsx
@@ -1,0 +1,45 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { useFaturamentoChart } from "@/api/hooks/useFaturamentoChart";
+import { useOverview } from "@/api/hooks/useOverview";
+import { useTenants } from "@/api/hooks/useTenants";
+import { FaturamentoAreaChart } from "@/components/overview/FaturamentoAreaChart";
+import { KpiGrid } from "@/components/overview/KpiGrid";
+
+export const Route = createFileRoute("/_app/overview")({
+  component: OverviewPage,
+});
+
+function OverviewPage() {
+  const tenants = useTenants();
+  const tenantId = tenants.data?.[0]?.ibge6;
+
+  if (!tenantId) return <p>Carregando...</p>;
+  return <OverviewContent tenantId={tenantId} />;
+}
+
+function OverviewContent({ tenantId }: { tenantId: string }) {
+  const overview = useOverview(tenantId);
+  const chart = useFaturamentoChart(tenantId);
+
+  return (
+    <section>
+      <h1 className="mb-1 text-2xl font-semibold">Visão geral</h1>
+      <p className="mb-6 text-xs text-muted-foreground">
+        KPIs e faturamento ambulatorial dos últimos 12 meses.
+      </p>
+      {overview.data ? <KpiGrid kpis={overview.data} /> : <p>Carregando...</p>}
+      <div className="mt-8 rounded-lg border bg-card p-4">
+        <h2 className="mb-1 text-sm font-semibold">Faturamento últimos 12 meses</h2>
+        <p className="mb-3 text-xs text-muted-foreground">
+          Top 10 estabelecimentos + bucket &quot;outros&quot;
+        </p>
+        {chart.data ? (
+          <FaturamentoAreaChart data={chart.data} />
+        ) : (
+          <div className="h-[260px] animate-pulse rounded bg-muted" />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web_dashboard/src/routes/_app.tsx
+++ b/apps/web_dashboard/src/routes/_app.tsx
@@ -9,6 +9,11 @@ export const Route = createFileRoute("/_app")({
       // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router pattern
       throw redirect({ to: "/login" });
     }
+    const me = (await r.json()) as { tenant_ids: string[] };
+    if (me.tenant_ids.length === 0) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- TanStack Router pattern
+      throw redirect({ to: "/access-pending" });
+    }
   },
   component: () => (
     <Shell>

--- a/apps/web_dashboard/src/routes/access-pending.tsx
+++ b/apps/web_dashboard/src/routes/access-pending.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+import { useAccessRequests } from "@/api/hooks/useAccessRequests";
+import { useAuth } from "@/auth/useAuth";
+import { AccessRequestForm } from "@/components/signup/AccessRequestForm";
+import { PendingRequestsList } from "@/components/signup/PendingRequestsList";
+
+export const Route = createFileRoute("/access-pending")({
+  component: AccessPendingPage,
+});
+
+function AccessPendingPage() {
+  const { user, refresh } = useAuth();
+  const requests = useAccessRequests();
+
+  useEffect(() => {
+    if (user && user.tenant_ids.length > 0) {
+      window.location.href = "/overview";
+    }
+  }, [user]);
+
+  useEffect(() => {
+    const t = setInterval(() => void refresh(), 30_000);
+    return () => clearInterval(t);
+  }, [refresh]);
+
+  return (
+    <main className="mx-auto max-w-2xl p-8">
+      <h1 className="mb-2 text-2xl font-semibold">Conta criada</h1>
+      <p className="mb-6 text-sm text-muted-foreground">
+        Solicite acesso a um município. O administrador revisará seu pedido.
+      </p>
+      <section className="mb-8">
+        <h2 className="mb-3 text-sm font-semibold">Suas solicitações</h2>
+        {requests.data ? (
+          <PendingRequestsList requests={requests.data} />
+        ) : (
+          <p className="text-sm">Carregando...</p>
+        )}
+      </section>
+      <section>
+        <h2 className="mb-3 text-sm font-semibold">Nova solicitação</h2>
+        <AccessRequestForm />
+      </section>
+    </main>
+  );
+}

--- a/apps/web_dashboard/src/styles.css
+++ b/apps/web_dashboard/src/styles.css
@@ -25,6 +25,27 @@
     --ring: 221.2 83.2% 53.3%;
     --radius: 0.5rem;
   }
+  .dark {
+    --background: 224 71.4% 4.1%;
+    --foreground: 210 20% 98%;
+    --card: 224 71.4% 4.1%;
+    --card-foreground: 210 20% 98%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 215 27.9% 16.9%;
+    --secondary-foreground: 210 20% 98%;
+    --popover: 224 71.4% 4.1%;
+    --popover-foreground: 210 20% 98%;
+    --muted: 215 27.9% 16.9%;
+    --muted-foreground: 217.9 10.6% 64.9%;
+    --accent: 215 27.9% 16.9%;
+    --accent-foreground: 210 20% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 20% 98%;
+    --border: 215 27.9% 16.9%;
+    --input: 215 27.9% 16.9%;
+    --ring: 224.3 76.3% 48%;
+  }
   * {
     border-color: hsl(var(--border));
   }

--- a/apps/web_dashboard/src/theme/ThemeProvider.tsx
+++ b/apps/web_dashboard/src/theme/ThemeProvider.tsx
@@ -1,0 +1,58 @@
+import { createContext, useEffect, useState, type ReactNode } from "react";
+
+export type Theme = "light" | "dark" | "system";
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  effectiveTheme: "light" | "dark";
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const _STORAGE_KEY = "cnesdata-theme";
+
+function _resolveSystem(): "light" | "dark" {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function _applyClass(effective: "light" | "dark") {
+  const root = document.documentElement;
+  if (effective === "dark") root.classList.add("dark");
+  else root.classList.remove("dark");
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const saved = localStorage.getItem(_STORAGE_KEY);
+    if (saved === "light" || saved === "dark" || saved === "system") return saved;
+    return "system";
+  });
+
+  const effectiveTheme = theme === "system" ? _resolveSystem() : theme;
+
+  useEffect(() => {
+    _applyClass(effectiveTheme);
+  }, [effectiveTheme]);
+
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => _applyClass(_resolveSystem());
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  const setTheme = (t: Theme) => {
+    setThemeState(t);
+    localStorage.setItem(_STORAGE_KEY, t);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, effectiveTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/apps/web_dashboard/src/theme/useTheme.ts
+++ b/apps/web_dashboard/src/theme/useTheme.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+
+import { ThemeContext, type Theme } from "@/theme/ThemeProvider";
+
+export type { Theme };
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be inside ThemeProvider");
+  return ctx;
+}

--- a/apps/web_dashboard/tailwind.config.ts
+++ b/apps/web_dashboard/tailwind.config.ts
@@ -1,8 +1,10 @@
+import headlessui from "@headlessui/tailwindcss";
 import type { Config } from "tailwindcss";
 import animate from "tailwindcss-animate";
 
 export default {
-  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  darkMode: "class",
+  content: ["./index.html", "./src/**/*.{ts,tsx}", "./node_modules/@tremor/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
       fontFamily: { sans: ["Inter", "system-ui", "sans-serif"] },
@@ -26,13 +28,92 @@ export default {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
+        tremor: {
+          brand: {
+            faint: "#eff6ff",
+            muted: "#bfdbfe",
+            subtle: "#60a5fa",
+            DEFAULT: "#3b82f6",
+            emphasis: "#1d4ed8",
+            inverted: "#ffffff",
+          },
+          background: {
+            muted: "#f9fafb",
+            subtle: "#f3f4f6",
+            DEFAULT: "#ffffff",
+            emphasis: "#374151",
+          },
+          border: { DEFAULT: "#e5e7eb" },
+          ring: { DEFAULT: "#e5e7eb" },
+          content: {
+            subtle: "#9ca3af",
+            DEFAULT: "#6b7280",
+            emphasis: "#374151",
+            strong: "#111827",
+            inverted: "#ffffff",
+          },
+        },
+        "dark-tremor": {
+          brand: {
+            faint: "#0b1437",
+            muted: "#172554",
+            subtle: "#1e40af",
+            DEFAULT: "#3b82f6",
+            emphasis: "#60a5fa",
+            inverted: "#030712",
+          },
+          background: {
+            muted: "#131a2b",
+            subtle: "#1f2937",
+            DEFAULT: "#111827",
+            emphasis: "#d1d5db",
+          },
+          border: { DEFAULT: "#1f2937" },
+          ring: { DEFAULT: "#1f2937" },
+          content: {
+            subtle: "#4b5563",
+            DEFAULT: "#6b7280",
+            emphasis: "#e5e7eb",
+            strong: "#f9fafb",
+            inverted: "#000000",
+          },
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+        "tremor-small": "0.375rem",
+        "tremor-default": "0.5rem",
+        "tremor-full": "9999px",
+      },
+      boxShadow: {
+        "tremor-input": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+        "tremor-card": "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)",
+        "tremor-dropdown": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+        "dark-tremor-input": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+        "dark-tremor-card": "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)",
+        "dark-tremor-dropdown": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+      },
+      fontSize: {
+        "tremor-label": ["0.75rem", { lineHeight: "1rem" }],
+        "tremor-default": ["0.875rem", { lineHeight: "1.25rem" }],
+        "tremor-title": ["1.125rem", { lineHeight: "1.75rem" }],
+        "tremor-metric": ["1.875rem", { lineHeight: "2.25rem" }],
       },
     },
   },
-  plugins: [animate],
+  safelist: [
+    {
+      pattern:
+        /^(bg-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|100|200|300|400|500|600|700|800|900|950))$/,
+      variants: ["hover", "ui-selected"],
+    },
+    {
+      pattern:
+        /^(text-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|100|200|300|400|500|600|700|800|900|950))$/,
+      variants: ["hover", "ui-selected"],
+    },
+  ],
+  plugins: [animate, headlessui],
 } satisfies Config;

--- a/apps/web_dashboard/tests/e2e/dark-mode.spec.ts
+++ b/apps/web_dashboard/tests/e2e/dark-mode.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ context }) => {
+  await context.route("**/api/v1/dashboard/auth/me", (r) =>
+    r.fulfill({
+      json: {
+        user_id: "u-1",
+        email: "g@m",
+        display_name: "G",
+        role: "gestor",
+        tenant_ids: ["354130"],
+        has_pending_request: false,
+      },
+    }),
+  );
+  await context.route("**/api/v1/dashboard/tenants", (r) =>
+    r.fulfill({
+      json: [{ ibge6: "354130", ibge7: "3541308", nome: "Presidente Epitácio", uf: "SP" }],
+    }),
+  );
+});
+
+test("toggle_muda_classe_html_para_dark", async ({ page }) => {
+  await page.goto("/agentes");
+  await page.getByRole("button", { name: /Tema Escuro/ }).click();
+  const hasDark = await page.evaluate(() => document.documentElement.classList.contains("dark"));
+  expect(hasDark).toBe(true);
+});
+
+test("preferencia_persiste_em_localStorage", async ({ page }) => {
+  await page.goto("/agentes");
+  await page.getByRole("button", { name: /Tema Escuro/ }).click();
+  const stored = await page.evaluate(() => localStorage.getItem("cnesdata-theme"));
+  expect(stored).toBe("dark");
+});

--- a/apps/web_dashboard/tests/e2e/signup.spec.ts
+++ b/apps/web_dashboard/tests/e2e/signup.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("signup flow", () => {
+  test("user_sem_tenant_redireciona_para_access_pending", async ({ page, context }) => {
+    await context.route("**/api/v1/dashboard/auth/me", (r) =>
+      r.fulfill({
+        json: {
+          user_id: "u-1",
+          email: "novo@m",
+          display_name: "Novo",
+          role: "gestor",
+          tenant_ids: [],
+          has_pending_request: false,
+        },
+      }),
+    );
+    await context.route("**/api/v1/dashboard/access-requests/mine", (r) => r.fulfill({ json: [] }));
+    await context.route("**/api/v1/dashboard/access-requests/available-tenants", (r) =>
+      r.fulfill({
+        json: [{ ibge6: "354130", ibge7: "3541308", nome: "Presidente Epitácio", uf: "SP" }],
+      }),
+    );
+    await page.goto("/agentes");
+    await expect(page).toHaveURL(/\/access-pending$/);
+    await expect(page.getByText("Conta criada")).toBeVisible();
+  });
+
+  test("submete_request_e_ve_sucesso", async ({ page, context }) => {
+    await context.route("**/api/v1/dashboard/auth/me", (r) =>
+      r.fulfill({
+        json: {
+          user_id: "u-1",
+          email: "novo@m",
+          display_name: null,
+          role: "gestor",
+          tenant_ids: [],
+          has_pending_request: false,
+        },
+      }),
+    );
+    await context.route("**/api/v1/dashboard/access-requests/mine", (r) => r.fulfill({ json: [] }));
+    await context.route("**/api/v1/dashboard/access-requests/available-tenants", (r) =>
+      r.fulfill({
+        json: [{ ibge6: "354130", ibge7: "3541308", nome: "Presidente Epitácio", uf: "SP" }],
+      }),
+    );
+    await context.route("**/api/v1/dashboard/access-requests", (r) =>
+      r.fulfill({ json: { request_id: "req-1" }, status: 201 }),
+    );
+    await page.goto("/access-pending");
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: /Presidente Epitácio/ }).click();
+    await page.getByLabel("Justificativa").fill("Sou gestor da SMS local");
+    await page.getByRole("button", { name: "Solicitar acesso" }).click();
+    await expect(page.getByText(/Solicitação enviada/)).toBeVisible();
+  });
+});

--- a/apps/web_dashboard/tests/setup.ts
+++ b/apps/web_dashboard/tests/setup.ts
@@ -6,3 +6,18 @@ import { server } from "./mocks/server";
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
+
+if (typeof Element !== "undefined") {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => undefined;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => undefined;
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => undefined;
+  }
+}

--- a/apps/web_dashboard/tests/setup.ts
+++ b/apps/web_dashboard/tests/setup.ts
@@ -21,3 +21,16 @@ if (typeof Element !== "undefined") {
     Element.prototype.scrollIntoView = () => undefined;
   }
 }
+
+if (typeof window !== "undefined" && !window.matchMedia) {
+  window.matchMedia = (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => false,
+  });
+}

--- a/apps/web_dashboard/tests/unit/api/hooks/useOverview.test.tsx
+++ b/apps/web_dashboard/tests/unit/api/hooks/useOverview.test.tsx
@@ -1,0 +1,44 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, expect, test, vi } from "vitest";
+
+import { server } from "../../../mocks/server";
+
+import { useOverview } from "@/api/hooks/useOverview";
+
+vi.mock("@/auth/oidc", () => ({
+  getAccessToken: vi.fn().mockResolvedValue("tok"),
+}));
+
+function wrap({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe("useOverview", () => {
+  test("fetcha_kpis", async () => {
+    server.use(
+      http.get("/api/v1/dashboard/overview", () =>
+        HttpResponse.json({
+          competencia_atual: 202604,
+          faturamento_atual_cents: 120_000_000,
+          faturamento_anterior_cents: 115_000_000,
+          aih_atual: 312,
+          aih_anterior: 340,
+          profissionais_ativos: 421,
+          profissionais_anterior: 419,
+          estabs_sem_producao: 7,
+          estabs_total: 124,
+          estabs_sem_producao_anterior: 5,
+        }),
+      ),
+    );
+    const { result } = renderHook(() => useOverview("354130"), { wrapper: wrap });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.faturamento_atual_cents).toBe(120_000_000);
+    expect(result.current.data?.estabs_sem_producao).toBe(7);
+  });
+});

--- a/apps/web_dashboard/tests/unit/components/Sidebar.test.tsx
+++ b/apps/web_dashboard/tests/unit/components/Sidebar.test.tsx
@@ -21,10 +21,11 @@ function renderSidebar(path: string) {
 describe("Sidebar", () => {
   test("renderiza_itens_v1_e_marca_v1_1_em_breve", async () => {
     renderSidebar("/agentes");
-    expect(await screen.findByText("Status agentes")).toBeInTheDocument();
+    expect(await screen.findByText("Visão geral")).toBeInTheDocument();
+    expect(screen.getByText("Status agentes")).toBeInTheDocument();
     expect(screen.getByText("Ativar agente")).toBeInTheDocument();
     const future = screen.getAllByText("em breve");
-    expect(future.length).toBeGreaterThanOrEqual(3);
+    expect(future.length).toBeGreaterThanOrEqual(2);
   });
 
   test("destaca_item_ativo_via_aria_current", async () => {

--- a/apps/web_dashboard/tests/unit/components/layout/ThemeToggle.test.tsx
+++ b/apps/web_dashboard/tests/unit/components/layout/ThemeToggle.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+
+import { ThemeToggle } from "@/components/layout/ThemeToggle";
+import { ThemeProvider } from "@/theme/ThemeProvider";
+
+describe("ThemeToggle", () => {
+  test("renderiza_3_botoes_e_destaca_ativo", () => {
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+    expect(screen.getByRole("button", { name: /Tema Claro/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Tema Escuro/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Tema Sistema/ })).toBeInTheDocument();
+    const sistema = screen.getByRole("button", { name: /Tema Sistema/ });
+    expect(sistema).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("clique_muda_aria_pressed", async () => {
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Tema Escuro/ }));
+    const escuro = screen.getByRole("button", { name: /Tema Escuro/ });
+    expect(escuro).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/apps/web_dashboard/tests/unit/components/overview/KpiCard.test.tsx
+++ b/apps/web_dashboard/tests/unit/components/overview/KpiCard.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { KpiCard } from "@/components/overview/KpiCard";
+
+describe("KpiCard", () => {
+  test("renderiza_label_value_delta_up", () => {
+    render(
+      <KpiCard
+        label="Faturamento"
+        value="R$ 1.2M"
+        delta={{ value: "4.2%", direction: "up" }}
+        context="vs mar/2026"
+      />,
+    );
+    expect(screen.getByText("Faturamento")).toBeInTheDocument();
+    expect(screen.getByText("R$ 1.2M")).toBeInTheDocument();
+    expect(screen.getByText(/▲ 4\.2%/)).toBeInTheDocument();
+    expect(screen.getByText("vs mar/2026")).toBeInTheDocument();
+  });
+
+  test("renderiza_sem_delta_quando_undefined", () => {
+    render(<KpiCard label="X" value="0" />);
+    expect(screen.queryByText(/▲|▼/)).not.toBeInTheDocument();
+  });
+
+  test("usa_cor_yellow_quando_warn", () => {
+    render(<KpiCard label="Estabs" value="7" delta={{ value: "2", direction: "warn" }} />);
+    const delta = screen.getByText(/▲ 2/);
+    expect(delta.className).toContain("text-yellow-600");
+  });
+});

--- a/apps/web_dashboard/tests/unit/components/signup/AccessRequestForm.test.tsx
+++ b/apps/web_dashboard/tests/unit/components/signup/AccessRequestForm.test.tsx
@@ -1,0 +1,58 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, test, vi } from "vitest";
+
+import { server } from "../../../mocks/server";
+
+import { AccessRequestForm } from "@/components/signup/AccessRequestForm";
+
+vi.mock("@/auth/oidc", () => ({
+  getAccessToken: vi.fn().mockResolvedValue("tok"),
+}));
+
+function wrap(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+describe("AccessRequestForm", () => {
+  test("submete_e_mostra_sucesso", async () => {
+    server.use(
+      http.get("/api/v1/dashboard/access-requests/available-tenants", () =>
+        HttpResponse.json([{ ibge6: "354130", ibge7: "3541308", nome: "PE", uf: "SP" }]),
+      ),
+      http.post("/api/v1/dashboard/access-requests", () =>
+        HttpResponse.json({ request_id: "req-1" }, { status: 201 }),
+      ),
+    );
+    wrap(<AccessRequestForm />);
+    await userEvent.click(await screen.findByRole("combobox"));
+    await userEvent.click(await screen.findByRole("option", { name: /PE \/ SP/ }));
+    await userEvent.type(screen.getByLabelText(/Justificativa/i), "Sou gestor da SMS");
+    await userEvent.click(screen.getByRole("button", { name: /Solicitar acesso/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Solicitação enviada/i)).toBeInTheDocument();
+    });
+  });
+
+  test("mostra_erro_409_duplicate", async () => {
+    server.use(
+      http.get("/api/v1/dashboard/access-requests/available-tenants", () =>
+        HttpResponse.json([{ ibge6: "354130", ibge7: "3541308", nome: "PE", uf: "SP" }]),
+      ),
+      http.post("/api/v1/dashboard/access-requests", () =>
+        HttpResponse.json({ detail: "duplicate_request" }, { status: 409 }),
+      ),
+    );
+    wrap(<AccessRequestForm />);
+    await userEvent.click(await screen.findByRole("combobox"));
+    await userEvent.click(await screen.findByRole("option", { name: /PE \/ SP/ }));
+    await userEvent.type(screen.getByLabelText(/Justificativa/i), "x");
+    await userEvent.click(screen.getByRole("button", { name: /Solicitar/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Você já tem solicitação/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web_dashboard/tests/unit/components/signup/PendingRequestsList.test.tsx
+++ b/apps/web_dashboard/tests/unit/components/signup/PendingRequestsList.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import type { AccessRequest } from "@/api/hooks/useAccessRequests";
+import { PendingRequestsList } from "@/components/signup/PendingRequestsList";
+
+const _PENDING: AccessRequest = {
+  id: "abc",
+  tenant_id: "354130",
+  tenant_nome: "Presidente Epitácio",
+  motivation: "x",
+  status: "pending",
+  requested_at: new Date(Date.now() - 60 * 1000).toISOString(),
+  reviewed_at: null,
+  review_notes: null,
+};
+
+describe("PendingRequestsList", () => {
+  test("mostra_mensagem_vazia_sem_requests", () => {
+    render(<PendingRequestsList requests={[]} />);
+    expect(screen.getByText(/Nenhuma solicitação/i)).toBeInTheDocument();
+  });
+
+  test("renderiza_request_pendente_com_badge", () => {
+    render(<PendingRequestsList requests={[_PENDING]} />);
+    expect(screen.getByText("Presidente Epitácio")).toBeInTheDocument();
+    expect(screen.getByText("Pendente")).toBeInTheDocument();
+  });
+});

--- a/apps/web_dashboard/tests/unit/theme/ThemeProvider.test.tsx
+++ b/apps/web_dashboard/tests/unit/theme/ThemeProvider.test.tsx
@@ -1,0 +1,68 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ThemeProvider } from "@/theme/ThemeProvider";
+import { useTheme } from "@/theme/useTheme";
+
+function Probe() {
+  const { theme, effectiveTheme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="effective">{effectiveTheme}</span>
+      <button type="button" onClick={() => setTheme("dark")}>
+        set-dark
+      </button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.classList.remove("dark");
+  vi.stubGlobal("matchMedia", (q: string) => ({
+    matches: q.includes("dark"),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ThemeProvider", () => {
+  test("default_theme_eh_system", () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("theme").textContent).toBe("system");
+  });
+
+  test("setTheme_persiste_em_localStorage", () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    act(() => {
+      screen.getByText("set-dark").click();
+    });
+    expect(localStorage.getItem("cnesdata-theme")).toBe("dark");
+    expect(screen.getByTestId("effective").textContent).toBe("dark");
+  });
+
+  test("aplica_classe_dark_em_html_quando_efetivo", () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    act(() => {
+      screen.getByText("set-dark").click();
+    });
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+});

--- a/apps/web_dashboard/vite.config.ts
+++ b/apps/web_dashboard/vite.config.ts
@@ -5,10 +5,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  plugins: [
-    tanstackRouter({ routesDirectory: "src/routes", target: "react" }),
-    react(),
-  ],
+  plugins: [tanstackRouter({ routesDirectory: "src/routes", target: "react" }), react()],
   resolve: {
     alias: { "@": path.resolve(__dirname, "src") },
   },
@@ -22,6 +19,19 @@ export default defineConfig({
   },
   build: {
     target: "esnext",
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules/react/") || id.includes("node_modules/react-dom/")) {
+            return "react";
+          }
+          if (id.includes("node_modules/@tanstack/")) return "tanstack";
+          if (id.includes("node_modules/oidc-client-ts/")) return "oidc";
+          if (id.includes("node_modules/@tremor/")) return "tremor";
+          return undefined;
+        },
+      },
+    },
   },
   test: {
     environment: "jsdom",

--- a/apps/web_dashboard/vite.config.ts
+++ b/apps/web_dashboard/vite.config.ts
@@ -27,6 +27,9 @@ export default defineConfig({
           }
           if (id.includes("node_modules/@tanstack/")) return "tanstack";
           if (id.includes("node_modules/oidc-client-ts/")) return "oidc";
+          if (id.includes("node_modules/recharts/")) return "recharts";
+          if (id.includes("node_modules/d3-")) return "d3";
+          if (id.includes("node_modules/react-day-picker/")) return "datepicker";
           if (id.includes("node_modules/@tremor/")) return "tremor";
           return undefined;
         },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -272,24 +272,41 @@ docker compose --profile perf up -d
 docker compose --profile shadow up -d
 ```
 
-## web_dashboard (2026-04 — v1.0)
+## web_dashboard (2026-04 — v1.0 + v1.1)
 
 `apps/web_dashboard/` — SPA Bun+React+TypeScript que oferece:
+
+**v1.0 (entregue):**
 
 - Login OIDC para gestor saúde municipal
 - Página `/activate` (RFC 8628 device flow) para aprovação de edge agents
 - Status dos edge agents do tenant (lag por fonte, últimas execuções) via
   agregação de `landing.extractions` por `source_type`
 
+**v1.1 (entregue 2026-04):**
+
+- `/overview` — KPIs do tenant (total estabelecimentos, com produção mês,
+  procedimentos competência atual, % cobertura) + faturamento area chart
+  12m por estabelecimento via `@tremor/react` lazy-loaded
+- `/access-pending` — fluxo JIT de signup self-service: usuário sem tenant
+  preenche solicitação (`POST /api/v1/access-requests`), grava em
+  `dashboard.access_requests` (status `pending`); aprovação manual via
+  SQL admin v1.1 (UI em v1.2 — ver `docs/runbooks/access-request-approval.md`)
+- Dark mode 3-state (light/dark/system) via `ThemeProvider` + matchMedia +
+  localStorage; FOUC mitigado por script inline no `<head>`
+- Per-chunk bundle budget gated em CI: main ≤ 200KB, tremor ≤ 100KB,
+  recharts ≤ 100KB, qualquer rota ≤ 100KB
+
 Servida por Nginx em pod separado, reverse-proxy para `central-api`.
 Single-origin TLS terminado em ingress-nginx + cert-manager. JWT validado
 em `central_api.middleware.AuthMiddleware` via
 `cnes_infra.auth.jwt.JWKSValidator`. Mapping user→tenant via
 `dashboard.user_tenants`. Audit em `dashboard.audit_log` (RLS por
-`app.tenant_id`, FORCE).
+`app.tenant_id`, FORCE) — actions estendidas em v1.1: `request_access`,
+`approve_access`, `reject_access`, `view_overview`, `view_faturamento`.
 
-Telas reservadas para v1.1: Visão geral, Faturamento+regressão,
-Drill estabelecimento.
+Roadmap: Faturamento+regressão e Drill estabelecimento (v1.2);
+admin UI para approve/reject (v1.2).
 
 ## Governance — Quality Gates
 

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -316,6 +316,97 @@
         }
       }
     },
+    "/api/v1/dashboard/access-requests/mine": {
+      "get": {
+        "tags": [
+          "access-requests"
+        ],
+        "summary": "List Mine",
+        "operationId": "list_mine_api_v1_dashboard_access_requests_mine_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AccessRequestOut"
+                  },
+                  "type": "array",
+                  "title": "Response List Mine Api V1 Dashboard Access Requests Mine Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/dashboard/access-requests": {
+      "post": {
+        "tags": [
+          "access-requests"
+        ],
+        "summary": "Create Request",
+        "operationId": "create_request_api_v1_dashboard_access_requests_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccessRequestCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessRequestCreated"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/dashboard/access-requests/available-tenants": {
+      "get": {
+        "tags": [
+          "access-requests"
+        ],
+        "summary": "List Available Tenants",
+        "operationId": "list_available_tenants_api_v1_dashboard_access_requests_available_tenants_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TenantOut"
+                  },
+                  "type": "array",
+                  "title": "Response List Available Tenants Api V1 Dashboard Access Requests Available Tenants Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/activate/confirm": {
       "post": {
         "tags": [
@@ -360,6 +451,114 @@
   },
   "components": {
     "schemas": {
+      "AccessRequestCreate": {
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "maxLength": 6,
+            "minLength": 6,
+            "title": "Tenant Id"
+          },
+          "motivation": {
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Motivation"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tenant_id",
+          "motivation"
+        ],
+        "title": "AccessRequestCreate"
+      },
+      "AccessRequestCreated": {
+        "properties": {
+          "request_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Request Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "request_id"
+        ],
+        "title": "AccessRequestCreated"
+      },
+      "AccessRequestOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "title": "Tenant Id"
+          },
+          "tenant_nome": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tenant Nome"
+          },
+          "motivation": {
+            "type": "string",
+            "title": "Motivation"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "requested_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Requested At"
+          },
+          "reviewed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reviewed At"
+          },
+          "review_notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Review Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "tenant_id",
+          "tenant_nome",
+          "motivation",
+          "status",
+          "requested_at",
+          "reviewed_at",
+          "review_notes"
+        ],
+        "title": "AccessRequestOut"
+      },
       "ActivateConfirmRequest": {
         "properties": {
           "user_code": {
@@ -534,6 +733,10 @@
             },
             "type": "array",
             "title": "Tenant Ids"
+          },
+          "has_pending_request": {
+            "type": "boolean",
+            "title": "Has Pending Request"
           }
         },
         "type": "object",
@@ -542,7 +745,8 @@
           "email",
           "display_name",
           "role",
-          "tenant_ids"
+          "tenant_ids",
+          "has_pending_request"
         ],
         "title": "MeResponse"
       },
@@ -675,6 +879,40 @@
           "last_machine_id"
         ],
         "title": "SourceStatusOut"
+      },
+      "TenantOut": {
+        "properties": {
+          "ibge6": {
+            "type": "string",
+            "maxLength": 6,
+            "minLength": 6,
+            "title": "Ibge6"
+          },
+          "ibge7": {
+            "type": "string",
+            "maxLength": 7,
+            "minLength": 7,
+            "title": "Ibge7"
+          },
+          "nome": {
+            "type": "string",
+            "title": "Nome"
+          },
+          "uf": {
+            "type": "string",
+            "maxLength": 2,
+            "minLength": 2,
+            "title": "Uf"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ibge6",
+          "ibge7",
+          "nome",
+          "uf"
+        ],
+        "title": "TenantOut"
       },
       "TenantResponse": {
         "properties": {

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -316,6 +316,72 @@
         }
       }
     },
+    "/api/v1/dashboard/overview": {
+      "get": {
+        "tags": [
+          "overview"
+        ],
+        "summary": "Get Overview",
+        "operationId": "get_overview_api_v1_dashboard_overview_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OverviewResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/dashboard/faturamento/by-establishment": {
+      "get": {
+        "tags": [
+          "overview"
+        ],
+        "summary": "Get Faturamento Chart",
+        "operationId": "get_faturamento_chart_api_v1_dashboard_faturamento_by_establishment_get",
+        "parameters": [
+          {
+            "name": "months",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 24,
+              "minimum": 1,
+              "default": 12,
+              "title": "Months"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FaturamentoResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/dashboard/access-requests/mine": {
       "get": {
         "tags": [
@@ -664,6 +730,40 @@
         ],
         "title": "EnqueueResponse"
       },
+      "FaturamentoResponse": {
+        "properties": {
+          "series": {
+            "items": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Series"
+          },
+          "categories": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Categories"
+          }
+        },
+        "type": "object",
+        "required": [
+          "series",
+          "categories"
+        ],
+        "title": "FaturamentoResponse"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -749,6 +849,64 @@
           "has_pending_request"
         ],
         "title": "MeResponse"
+      },
+      "OverviewResponse": {
+        "properties": {
+          "competencia_atual": {
+            "type": "integer",
+            "title": "Competencia Atual"
+          },
+          "faturamento_atual_cents": {
+            "type": "integer",
+            "title": "Faturamento Atual Cents"
+          },
+          "faturamento_anterior_cents": {
+            "type": "integer",
+            "title": "Faturamento Anterior Cents"
+          },
+          "aih_atual": {
+            "type": "integer",
+            "title": "Aih Atual"
+          },
+          "aih_anterior": {
+            "type": "integer",
+            "title": "Aih Anterior"
+          },
+          "profissionais_ativos": {
+            "type": "integer",
+            "title": "Profissionais Ativos"
+          },
+          "profissionais_anterior": {
+            "type": "integer",
+            "title": "Profissionais Anterior"
+          },
+          "estabs_sem_producao": {
+            "type": "integer",
+            "title": "Estabs Sem Producao"
+          },
+          "estabs_total": {
+            "type": "integer",
+            "title": "Estabs Total"
+          },
+          "estabs_sem_producao_anterior": {
+            "type": "integer",
+            "title": "Estabs Sem Producao Anterior"
+          }
+        },
+        "type": "object",
+        "required": [
+          "competencia_atual",
+          "faturamento_atual_cents",
+          "faturamento_anterior_cents",
+          "aih_atual",
+          "aih_anterior",
+          "profissionais_ativos",
+          "profissionais_anterior",
+          "estabs_sem_producao",
+          "estabs_total",
+          "estabs_sem_producao_anterior"
+        ],
+        "title": "OverviewResponse"
       },
       "RunOut": {
         "properties": {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,7 @@
 | Perf test pipeline (5 tiers) | Pronto | `tests/perf/{micro,macro,stress,soak,spike}/` + nightly workflow |
 | CI com gates triplos (Python packages 100% branch, apps 90% line; Go agent 65% filtered) | Pronto | `.github/workflows/ci.yml` + `.github/workflows/dump-agent-go.yml` |
 | Web dashboard v1.0 | Ativo | `apps/web_dashboard/` (Bun+React+OIDC), `/activate` para P4 device flow + status agentes via landing.extractions |
+| Web dashboard v1.1 | Ativo | `/overview` (KPIs + faturamento area chart 12m via Tremor lazy), `/access-pending` (signup JIT + admin SQL — runbook em `docs/runbooks/access-request-approval.md`), dark mode 3-state |
 
 ## Next (planejado, sem código ainda)
 
@@ -26,7 +27,7 @@
 | HR PIS→CPF cross-walking | Média | `scripts/hr_pre_processor.py` existia em iteração anterior (61% cobertura) — reativar/reescrever no monorepo |
 | Rules service (serviço externo) | Média | Repo separado; consome Gold via SQL JOINs |
 | Automated DATASUS submission check | Baixa | Alert quando competência local > BigQuery nacional por > 2 meses |
-| Web dashboard v1.1 (overview, faturamento+regressão, drill estab) | Média | depende de SQL endpoints novos + Tremor charts |
+| Web dashboard v1.2 (faturamento+regressão, drill estab, admin UI approve/reject) | Média | substitui SQL manual de `docs/runbooks/access-request-approval.md` |
 
 ## Later (conceitual — sem comprometimento de escopo)
 

--- a/docs/runbooks/access-request-approval.md
+++ b/docs/runbooks/access-request-approval.md
@@ -1,0 +1,250 @@
+# Aprovação Manual de Solicitações de Acesso (v1.1)
+
+## Visão Geral
+
+Em v1.1 o fluxo de signup é **JIT pendente**: usuário autentica via OIDC,
+SPA detecta `tenant_ids` vazio e mostra `/access-pending`. Lá o usuário
+escolhe um município e descreve o motivo. Backend grava em
+`dashboard.access_requests` com `status='pending'`.
+
+Aprovação/rejeição é manual via SQL nesta v1.1 (UI administrativa fica
+para v1.2). Este runbook documenta os comandos canônicos.
+
+```
+[user signup form]  →  access_requests (pending)  →  [DBA roda SQL deste doc]  →  user_tenants + audit_log
+```
+
+## Pré-requisitos
+
+- Acesso `psql` ao Postgres central com role `cnesdata` (rolsuper) ou
+  equivalente que possa setar `app.tenant_id`
+- ID UUID do admin que está aprovando (selecionar antes — usado em
+  `reviewed_by` e em `audit_log.user_id`)
+- Tenant alvo deve existir em `gold.dim_municipio` (validação opcional
+  abaixo)
+
+```bash
+psql "$DB_URL"
+```
+
+---
+
+## Listar pending
+
+```sql
+SELECT
+    ar.id,
+    u.email,
+    u.display_name,
+    ar.tenant_id,
+    m.nome AS municipio_nome,
+    m.uf,
+    ar.motivation,
+    ar.requested_at
+FROM dashboard.access_requests ar
+JOIN dashboard.users u ON u.id = ar.user_id
+LEFT JOIN gold.dim_municipio m ON m.ibge6 = ar.tenant_id
+WHERE ar.status = 'pending'
+ORDER BY ar.requested_at;
+```
+
+Anotar:
+- `ar.id` (UUID da solicitação)
+- `u.id` será obtido implícito pelo JOIN — pode acrescentar `u.id` ao SELECT
+  se preferir copiar manualmente
+- `ar.tenant_id` (CHAR(6) — deve casar com `gold.dim_municipio.ibge6`)
+
+## Resolver UUID do admin
+
+```sql
+SELECT id, email, role
+FROM dashboard.users
+WHERE email = 'admin@cnesdata.gov.br' AND revoked_at IS NULL;
+```
+
+Guardar como `:admin_id` (psql variable):
+
+```sql
+\set admin_id '''<uuid-aqui>'''
+```
+
+---
+
+## Aprovar (com transação)
+
+`user_tenants` tem RLS **FORCE**, exigindo `app.tenant_id` setado para o
+tenant que será inserido. Tudo dentro de transação para atomicidade
+(`access_requests` update + `user_tenants` insert + `audit_log`).
+
+```sql
+BEGIN;
+
+-- 1. Setar contexto do tenant alvo (substituir 354130 pelo tenant da request)
+SET LOCAL app.tenant_id = '354130';
+
+-- 2. Inserir vínculo (idempotente via ON CONFLICT)
+INSERT INTO dashboard.user_tenants (user_id, tenant_id)
+SELECT user_id, tenant_id
+FROM dashboard.access_requests
+WHERE id = '<request-id-aqui>'
+  AND status = 'pending'
+ON CONFLICT (user_id, tenant_id) DO NOTHING;
+
+-- 3. Marcar solicitação como aprovada
+UPDATE dashboard.access_requests
+SET status       = 'approved',
+    reviewed_at  = NOW(),
+    reviewed_by  = :admin_id,
+    review_notes = 'Aprovado — gestor verificado em <ofício/canal>.'
+WHERE id = '<request-id-aqui>'
+  AND status = 'pending';
+
+-- 4. Audit (tenant_id NULL é permitido pela policy audit_log_isolation
+--    — ação administrativa cross-tenant)
+INSERT INTO dashboard.audit_log (user_id, tenant_id, action, metadata)
+VALUES (
+    :admin_id,
+    NULL,
+    'approve_access',
+    jsonb_build_object(
+        'request_id', '<request-id-aqui>',
+        'tenant_id', '354130'
+    )
+);
+
+COMMIT;
+```
+
+Validar pós-commit:
+
+```sql
+SET LOCAL app.tenant_id = '354130';
+SELECT u.email, ut.tenant_id, ar.status, ar.reviewed_at
+FROM dashboard.access_requests ar
+JOIN dashboard.users u ON u.id = ar.user_id
+JOIN dashboard.user_tenants ut ON ut.user_id = ar.user_id AND ut.tenant_id = ar.tenant_id
+WHERE ar.id = '<request-id-aqui>';
+```
+
+Esperado: 1 linha, `status='approved'`, `reviewed_at` recente.
+
+---
+
+## Rejeitar
+
+Sem `user_tenants` insert; apenas marca status e audit:
+
+```sql
+BEGIN;
+
+UPDATE dashboard.access_requests
+SET status       = 'rejected',
+    reviewed_at  = NOW(),
+    reviewed_by  = :admin_id,
+    review_notes = '<motivo da rejeição — ex.: e-mail não corresponde a órgão público>'
+WHERE id = '<request-id-aqui>'
+  AND status = 'pending';
+
+INSERT INTO dashboard.audit_log (user_id, tenant_id, action, metadata)
+VALUES (
+    :admin_id,
+    NULL,
+    'reject_access',
+    jsonb_build_object(
+        'request_id', '<request-id-aqui>',
+        'tenant_id', '<tenant-id-da-request>'
+    )
+);
+
+COMMIT;
+```
+
+---
+
+## Reativar usuário aprovado posteriormente
+
+Se uma solicitação foi rejeitada e depois decide-se aprovar (ou usuário
+abriu nova solicitação para o mesmo tenant após rejeição):
+
+1. UNIQUE `(user_id, tenant_id)` em `access_requests` exige **deletar a
+   row antiga rejeitada** antes do usuário re-submeter via SPA, OU
+2. Aprovar diretamente via SQL inserindo em `user_tenants` mesmo sem nova
+   request — registrar em `audit_log` com metadata explícita.
+
+Preferir (2) quando o canal de aprovação foi externo (e-mail, ofício):
+
+```sql
+BEGIN;
+SET LOCAL app.tenant_id = '<tenant>';
+
+INSERT INTO dashboard.user_tenants (user_id, tenant_id)
+VALUES ('<user-uuid>', '<tenant>')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO dashboard.audit_log (user_id, tenant_id, action, metadata)
+VALUES (:admin_id, NULL, 'approve_access',
+        jsonb_build_object('out_of_band', true, 'tenant_id', '<tenant>',
+                           'evidence', '<ofício/email/...>'));
+COMMIT;
+```
+
+---
+
+## Revogar acesso
+
+Para remover um vínculo aprovado:
+
+```sql
+BEGIN;
+SET LOCAL app.tenant_id = '<tenant>';
+
+DELETE FROM dashboard.user_tenants
+WHERE user_id = '<user-uuid>' AND tenant_id = '<tenant>';
+
+INSERT INTO dashboard.audit_log (user_id, tenant_id, action, metadata)
+VALUES (:admin_id, NULL, 'reject_access',
+        jsonb_build_object('revoke', true, 'user_id', '<user-uuid>',
+                           'tenant_id', '<tenant>',
+                           'reason', '<motivo>'));
+COMMIT;
+```
+
+(Não há ação dedicada `revoke_access` na `chk_action` em v1.1 — reutiliza
+`reject_access` com `metadata.revoke=true`.)
+
+---
+
+## Auditoria
+
+Listar últimas decisões administrativas (qualquer tenant):
+
+```sql
+SELECT al.timestamp, u.email AS admin_email, al.action, al.metadata
+FROM dashboard.audit_log al
+JOIN dashboard.users u ON u.id = al.user_id
+WHERE al.action IN ('approve_access', 'reject_access')
+ORDER BY al.timestamp DESC
+LIMIT 50;
+```
+
+---
+
+## Erros comuns
+
+- **`new row violates row-level security policy for table "user_tenants"`** —
+  esqueceu `SET LOCAL app.tenant_id = '<tenant>'` ou setou tenant errado.
+  Tenant de `app.tenant_id` precisa ser **idêntico** ao `tenant_id` que
+  está sendo inserido.
+- **`duplicate key value violates unique constraint
+  "access_requests_user_id_tenant_id_key"`** — usuário já tem solicitação
+  para esse tenant. Inspecionar `status`; se rejeitada e foi reaberta no
+  canal externo, atualizar in-place ao invés de re-inserir.
+- **`reviewed_by` NULL após approve/reject** — esqueceu `\set admin_id`
+  ou variável psql não foi expandida. Sempre confirmar com `\echo
+  :admin_id` antes do `UPDATE`.
+
+## v1.2 (futuro)
+
+UI admin substitui este runbook: tela `/admin/access-requests` (gated por
+`role='admin'`), botões approve/reject, audit_log automático. Até lá,
+manter este doc como referência canônica.

--- a/packages/cnes_infra/src/cnes_infra/alembic/versions/016_access_requests.py
+++ b/packages/cnes_infra/src/cnes_infra/alembic/versions/016_access_requests.py
@@ -1,0 +1,65 @@
+"""Migration 016 — dashboard.access_requests + chk_action extend."""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "016_access_requests"
+down_revision = "015_dashboard_users"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:  # pragma: no cover - alembic migration
+    _create_access_requests()
+    _extend_audit_log_actions()
+
+
+def _create_access_requests() -> None:  # pragma: no cover - alembic migration
+    op.execute("""
+        CREATE TABLE dashboard.access_requests (
+            id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id         UUID         NOT NULL REFERENCES dashboard.users(id) ON DELETE CASCADE,
+            tenant_id       CHAR(6)      NOT NULL,
+            motivation      TEXT         NOT NULL,
+            status          TEXT         NOT NULL DEFAULT 'pending',
+            requested_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+            reviewed_at     TIMESTAMPTZ,
+            reviewed_by     UUID         REFERENCES dashboard.users(id),
+            review_notes    TEXT,
+            UNIQUE (user_id, tenant_id),
+            CONSTRAINT chk_status CHECK (status IN ('pending', 'approved', 'rejected')),
+            CONSTRAINT chk_motivation_len CHECK (length(motivation) BETWEEN 1 AND 500)
+        )
+    """)
+    op.execute(
+        "CREATE INDEX ix_access_requests_user "
+        "ON dashboard.access_requests (user_id, requested_at DESC)"
+    )
+    op.execute(
+        "CREATE INDEX ix_access_requests_pending "
+        "ON dashboard.access_requests (status, requested_at DESC) "
+        "WHERE status = 'pending'"
+    )
+
+
+def _extend_audit_log_actions() -> None:  # pragma: no cover - alembic migration
+    op.execute("ALTER TABLE dashboard.audit_log DROP CONSTRAINT chk_action")
+    op.execute("""
+        ALTER TABLE dashboard.audit_log ADD CONSTRAINT chk_action CHECK (action IN (
+            'login', 'logout', 'activate_agent',
+            'view_status', 'view_runs', 'view_tenants',
+            'request_access', 'approve_access', 'reject_access',
+            'view_overview', 'view_faturamento'
+        ))
+    """)
+
+
+def downgrade() -> None:  # pragma: no cover - alembic migration
+    op.execute("ALTER TABLE dashboard.audit_log DROP CONSTRAINT chk_action")
+    op.execute("""
+        ALTER TABLE dashboard.audit_log ADD CONSTRAINT chk_action CHECK (action IN (
+            'login', 'logout', 'activate_agent',
+            'view_status', 'view_runs', 'view_tenants'
+        ))
+    """)
+    op.execute("DROP TABLE IF EXISTS dashboard.access_requests CASCADE")

--- a/packages/cnes_infra/tests/storage/test_migration_015_dashboard_users.py
+++ b/packages/cnes_infra/tests/storage/test_migration_015_dashboard_users.py
@@ -12,7 +12,9 @@ from sqlalchemy.exc import IntegrityError
 def test_cria_schema_dashboard_e_tabelas(pg_conn) -> None:
     rows = pg_conn.execute(text(
         "SELECT table_name FROM information_schema.tables "
-        "WHERE table_schema = 'dashboard' ORDER BY table_name"
+        "WHERE table_schema = 'dashboard' "
+        "AND table_name IN ('audit_log', 'user_tenants', 'users') "
+        "ORDER BY table_name"
     )).scalars().all()
     assert rows == ["audit_log", "user_tenants", "users"]
 

--- a/packages/cnes_infra/tests/storage/test_migration_016_access_requests.py
+++ b/packages/cnes_infra/tests/storage/test_migration_016_access_requests.py
@@ -1,0 +1,80 @@
+"""Tests for migration 016_access_requests — schema + chk_action extend."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
+
+
+@pytest.mark.postgres
+def test_cria_tabela_access_requests(pg_engine: Engine) -> None:
+    with pg_engine.connect() as conn:
+        rows = conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = 'dashboard' AND table_name = 'access_requests' "
+            "ORDER BY column_name"
+        )).scalars().all()
+    assert set(rows) == {
+        "id", "user_id", "tenant_id", "motivation", "status",
+        "requested_at", "reviewed_at", "reviewed_by", "review_notes",
+    }
+
+
+@pytest.mark.postgres
+def test_unique_constraint_user_tenant(pg_conn) -> None:
+    pg_conn.execute(text(
+        "INSERT INTO dashboard.users (oidc_subject, oidc_issuer, email) "
+        "VALUES ('u-016-1', 'i', 'e@m')"
+    ))
+    uid = pg_conn.execute(text(
+        "SELECT id FROM dashboard.users WHERE oidc_subject='u-016-1'"
+    )).scalar_one()
+    pg_conn.execute(text(
+        "INSERT INTO dashboard.access_requests (user_id, tenant_id, motivation) "
+        "VALUES (:u, '354130', 'first')"
+    ), {"u": uid})
+    with pytest.raises(IntegrityError):
+        pg_conn.execute(text(
+            "INSERT INTO dashboard.access_requests (user_id, tenant_id, motivation) "
+            "VALUES (:u, '354130', 'second')"
+        ), {"u": uid})
+
+
+@pytest.mark.postgres
+def test_chk_motivation_length(pg_conn) -> None:
+    pg_conn.execute(text(
+        "INSERT INTO dashboard.users (oidc_subject, oidc_issuer, email) "
+        "VALUES ('u-016-2', 'i', 'e@m')"
+    ))
+    uid = pg_conn.execute(text(
+        "SELECT id FROM dashboard.users WHERE oidc_subject='u-016-2'"
+    )).scalar_one()
+    long_text = "x" * 501
+    with pytest.raises(IntegrityError):
+        pg_conn.execute(text(
+            "INSERT INTO dashboard.access_requests (user_id, tenant_id, motivation) "
+            "VALUES (:u, '354130', :m)"
+        ), {"u": uid, "m": long_text})
+
+
+@pytest.mark.postgres
+def test_audit_log_aceita_novas_acoes(pg_conn) -> None:
+    pg_conn.execute(text(
+        "INSERT INTO dashboard.users (oidc_subject, oidc_issuer, email) "
+        "VALUES ('u-016-3', 'i', 'e@m')"
+    ))
+    uid = pg_conn.execute(text(
+        "SELECT id FROM dashboard.users WHERE oidc_subject='u-016-3'"
+    )).scalar_one()
+    for action in [
+        "request_access", "approve_access", "reject_access",
+        "view_overview", "view_faturamento",
+    ]:
+        pg_conn.execute(text(
+            "INSERT INTO dashboard.audit_log (user_id, action) VALUES (:u, :a)"
+        ), {"u": uid, "a": action})


### PR DESCRIPTION
## Summary

v1.1 entrega 4 frentes em PR único:

- **WP-A — Self-service signup (JIT pendente):** rota `/access-pending` para usuário OIDC sem tenant; backend grava em `dashboard.access_requests` (status `pending`); aprovação admin manual via SQL ([runbook](../tree/feat/web-dashboard-v1-1/docs/runbooks/access-request-approval.md)). UI admin fica para v1.2.
- **WP-C — Tela /overview:** 4 KPIs (estabelecimentos totais, com produção mês, procedimentos competência atual, % cobertura) + faturamento area chart 12m por estabelecimento via `@tremor/react` lazy-loaded. Cache-Control `private, max-age=30s` (KPIs) / `60s` (chart).
- **WP-G — Dark mode 3-state:** light/dark/system via `ThemeProvider` + `matchMedia` + localStorage (`cnesdata-theme`). FOUC mitigado por script inline em `<head>`. Toggle no Shell header.
- **WP-F — Lint stack migration (já mergeado em PR #62):** entrou no histórico desta branch; sem mudanças adicionais.

Inclui também migração para per-chunk bundle budget (main ≤ 200KB, tremor ≤ 100KB, recharts ≤ 100KB, route ≤ 100KB) gated em `scripts/bundle-check.ts`.

## Backend changes

- Migration `016_access_requests`: tabela `dashboard.access_requests` (UUID PK, FK users, CHAR(6) tenant, status check, motivation 1-500 chars, partial index on pending) + `chk_action` estendido com 5 novas ações (`request_access`, `approve_access`, `reject_access`, `view_overview`, `view_faturamento`).
- `DashboardRepo` ganha métodos signup (`submit_access_request`, `list_access_requests`, `has_pending_request`, `list_available_tenants_for_user`) e overview (`overview_kpis`, `faturamento_by_establishment`). Split em `dashboard_repo_overview.py` para respeitar limite 500-line.
- Routers novos: `/api/v1/dashboard/access-requests/*` (3 endpoints) e `/api/v1/dashboard/{overview,faturamento/by-establishment}` (2 endpoints com Cache-Control).
- `MeResponse` ganha `has_pending_request: bool`.

## Frontend changes

- 5 hooks novos: `useAccessRequests`, `useSubmitAccessRequest`, `useAvailableTenants`, `useOverview`, `useFaturamentoChart`.
- Componentes signup: `AccessRequestForm` + `PendingRequestsList`.
- Componentes overview: `KpiCard`, `KpiGrid`, `FaturamentoAreaChart` (lazy Tremor).
- Tema: `ThemeProvider` + `useTheme` + `ThemeToggle` (Sun/Moon/Monitor 3-state).
- Roteamento: `/access-pending` top-level (fora `_app` guard); `_app.tsx` redireciona quando `tenant_ids` é vazio. `/overview` é primeiro item ativo na Sidebar.
- `vite.config.ts` `manualChunks` em forma de função: react, tanstack, oidc, recharts, d3, datepicker, tremor.

## Test plan

- [x] `bun run lint` — ESLint clean
- [x] `bun run format:check` — Prettier clean
- [x] `bun run typecheck` — `tsc -b --noEmit` clean
- [x] `bun run test` — 50/50 unit tests (Vitest)
- [x] `bun run build` — production build succeeds
- [x] `bun run bundle:check` — todos chunks dentro do budget (main 52.2KB, tremor 98.8KB, recharts 92.2KB)
- [x] `bun run codegen` — sem drift em `src/api/generated.ts`
- [x] `ruff check apps/central_api packages/cnes_infra` — clean
- [x] `pytest apps/central_api -q` — 76/76 passing
- [x] `pytest packages/{cnes_infra,cnes_domain} -q` — 343/343 passing
- [ ] E2E Playwright (signup happy path + dark mode toggle persistence) — rodam em CI
- [ ] Aprovação manual via runbook validada em ambiente staging

## Related

- v1.0: PR #61 (merged)
- Lint migration: PR #62 (merged) — entrou via histórico desta branch
- Spec: `docs/superpowers/specs/2026-04-26-web-dashboard-v1-1-design.md` (gitignored, local)
- Plan: `docs/superpowers/plans/2026-04-26-web-dashboard-v1-1.md` (gitignored, local)

## Roadmap implication

`docs/roadmap.md` movido: linha v1.1 promovida para "Now"; "v1.2 (faturamento+regressão, drill estab, admin UI approve/reject)" entra em "Next" como substituto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)