### PR TITLE
feat(central_api+cnes_infra/auth): /provision/cert/rotate via mTLS (Phase 2b/8)

### DIFF
--- a/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -3,3 +3,5 @@
 ## Recurring Violations
 
 - [recurring_violations.md](recurring_violations.md) — Patterns that appear repeatedly across reviews; pay extra attention to these.
+- [pattern_drift_contract_changes.md](pattern_drift_contract_changes.md) — Contract-only commits (cnes_contracts/landing.py, protocols.py) routinely leave central_api + cnes_infra tests red; always grep downstream consumers.
+- [pattern_drift_migration_downgrade.md](pattern_drift_migration_downgrade.md) — Drop+recreate migrations must reconstruct the EXACT prior CREATE TABLE in downgrade (col names, constraint names, allowed values, storage params), not a plausible approximation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,3 +196,137 @@ ver `apps/<app>/CLAUDE.md`.
   `apps/dump_agent_go/test/README.md` for filter regex + CI label vocab).
 
 > Para comandos RTK (Rust Token Killer), ver `~/.claude/CLAUDE.md` global.
+
+<!-- rtk-instructions v2 -->
+# RTK (Rust Token Killer) - Token-Optimized Commands
+
+## Golden Rule
+
+**Always prefix commands with `rtk`**. If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
+
+**Important**: Even in command chains with `&&`, use `rtk`:
+```bash
+# ❌ Wrong
+git add . && git commit -m "msg" && git push
+
+# ✅ Correct
+rtk git add . && rtk git commit -m "msg" && rtk git push
+```
+
+## RTK Commands by Workflow
+
+### Build & Compile (80-90% savings)
+```bash
+rtk cargo build         # Cargo build output
+rtk cargo check         # Cargo check output
+rtk cargo clippy        # Clippy warnings grouped by file (80%)
+rtk tsc                 # TypeScript errors grouped by file/code (83%)
+rtk lint                # ESLint/Biome violations grouped (84%)
+rtk prettier --check    # Files needing format only (70%)
+rtk next build          # Next.js build with route metrics (87%)
+```
+
+### Test (90-99% savings)
+```bash
+rtk cargo test          # Cargo test failures only (90%)
+rtk vitest run          # Vitest failures only (99.5%)
+rtk playwright test     # Playwright failures only (94%)
+rtk test <cmd>          # Generic test wrapper - failures only
+```
+
+### Git (59-80% savings)
+```bash
+rtk git status          # Compact status
+rtk git log             # Compact log (works with all git flags)
+rtk git diff            # Compact diff (80%)
+rtk git show            # Compact show (80%)
+rtk git add             # Ultra-compact confirmations (59%)
+rtk git commit          # Ultra-compact confirmations (59%)
+rtk git push            # Ultra-compact confirmations
+rtk git pull            # Ultra-compact confirmations
+rtk git branch          # Compact branch list
+rtk git fetch           # Compact fetch
+rtk git stash           # Compact stash
+rtk git worktree        # Compact worktree
+```
+
+Note: Git passthrough works for ALL subcommands, even those not explicitly listed.
+
+### GitHub (26-87% savings)
+```bash
+rtk gh pr view <num>    # Compact PR view (87%)
+rtk gh pr checks        # Compact PR checks (79%)
+rtk gh run list         # Compact workflow runs (82%)
+rtk gh issue list       # Compact issue list (80%)
+rtk gh api              # Compact API responses (26%)
+```
+
+### JavaScript/TypeScript Tooling (70-90% savings)
+```bash
+rtk pnpm list           # Compact dependency tree (70%)
+rtk pnpm outdated       # Compact outdated packages (80%)
+rtk pnpm install        # Compact install output (90%)
+rtk npm run <script>    # Compact npm script output
+rtk npx <cmd>           # Compact npx command output
+rtk prisma              # Prisma without ASCII art (88%)
+```
+
+### Files & Search (60-75% savings)
+```bash
+rtk ls <path>           # Tree format, compact (65%)
+rtk read <file>         # Code reading with filtering (60%)
+rtk grep <pattern>      # Search grouped by file (75%)
+rtk find <pattern>      # Find grouped by directory (70%)
+```
+
+### Analysis & Debug (70-90% savings)
+```bash
+rtk err <cmd>           # Filter errors only from any command
+rtk log <file>          # Deduplicated logs with counts
+rtk json <file>         # JSON structure without values
+rtk deps                # Dependency overview
+rtk env                 # Environment variables compact
+rtk summary <cmd>       # Smart summary of command output
+rtk diff                # Ultra-compact diffs
+```
+
+### Infrastructure (85% savings)
+```bash
+rtk docker ps           # Compact container list
+rtk docker images       # Compact image list
+rtk docker logs <c>     # Deduplicated logs
+rtk kubectl get         # Compact resource list
+rtk kubectl logs        # Deduplicated pod logs
+```
+
+### Network (65-70% savings)
+```bash
+rtk curl <url>          # Compact HTTP responses (70%)
+rtk wget <url>          # Compact download output (65%)
+```
+
+### Meta Commands
+```bash
+rtk gain                # View token savings statistics
+rtk gain --history      # View command history with savings
+rtk discover            # Analyze Claude Code sessions for missed RTK usage
+rtk proxy <cmd>         # Run command without filtering (for debugging)
+rtk init                # Add RTK instructions to CLAUDE.md
+rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
+```
+
+## Token Savings Overview
+
+| Category | Commands | Typical Savings |
+|----------|----------|-----------------|
+| Tests | vitest, playwright, cargo test | 90-99% |
+| Build | next, tsc, lint, prettier | 70-87% |
+| Git | status, log, diff, add, commit | 59-80% |
+| GitHub | gh pr, gh run, gh issue | 26-87% |
+| Package Managers | pnpm, npm, npx | 70-90% |
+| Files | ls, read, grep, find | 60-75% |
+| Infrastructure | docker, kubectl | 85% |
+| Network | curl, wget | 65-70% |
+
+Overall average: **60-90% token reduction** on common development operations.
+<!-- /rtk-instructions -->

--- a/apps/central_api/src/central_api/app.py
+++ b/apps/central_api/src/central_api/app.py
@@ -22,6 +22,7 @@ from central_api.routes import (
     oauth,
     overview,
     provision,
+    provision_rotate,
 )
 from cnes_infra.auth.errors import OAuthError
 from cnes_infra.telemetry import init_telemetry
@@ -65,4 +66,5 @@ def create_app() -> FastAPI:
     )
     app.include_router(oauth.router)
     app.include_router(provision.router)
+    app.include_router(provision_rotate.router)
     return app

--- a/apps/central_api/src/central_api/routes/provision_rotate.py
+++ b/apps/central_api/src/central_api/routes/provision_rotate.py
@@ -1,0 +1,68 @@
+"""Cert rotation route — POST /provision/cert/rotate (mTLS-gated)."""
+from __future__ import annotations
+
+from cryptography import x509
+from fastapi import APIRouter, Request
+
+from cnes_infra.auth import (
+    CertRotateRequest,
+    CertRotateResponse,
+    extract_peer_cert,
+    read_agent_id,
+    read_tenant_id,
+)
+from cnes_infra.auth.errors import OAuthError
+
+router = APIRouter(tags=["provision"])
+
+
+@router.post("/provision/cert/rotate", response_model=CertRotateResponse)
+async def provision_cert_rotate(
+    body: CertRotateRequest,
+    request: Request,
+) -> CertRotateResponse:
+    cert = extract_peer_cert(request)
+    agent_id = read_agent_id(cert)
+    tenant_id = read_tenant_id(cert)
+
+    audit = request.app.state.provisioned_certs
+    active = audit.find_active_by_agent_id(agent_id)
+    if active is None:
+        raise OAuthError("cert_revoked", status_code=401)
+    presented_serial = format(cert.serial_number, "x")
+    if presented_serial != active.ca_serial:
+        raise OAuthError("cert_revoked", status_code=401)
+
+    refresh_store = request.app.state.refresh_token_store
+    if not refresh_store.has_active_for_agent(agent_id):
+        raise OAuthError("agent_revoked", status_code=401)
+
+    ca = request.app.state.cert_authority
+    if ca is None:
+        raise OAuthError(
+            "server_error", description="ca_not_configured",
+            status_code=500,
+        )
+    ttl_days = request.app.state.cert_ttl_days
+    try:
+        leaf_pem = ca.issue_cert(
+            csr_pem=body.csr_pem.encode(),
+            agent_id=agent_id, tenant_id=tenant_id, ttl_days=ttl_days,
+        )
+    except ValueError as exc:
+        raise OAuthError("invalid_request", description=str(exc)) from exc
+
+    leaf = x509.load_pem_x509_certificate(leaf_pem)
+    subject_cn = leaf.subject.get_attributes_for_oid(
+        x509.NameOID.COMMON_NAME,
+    )[0].value
+    audit.record(
+        agent_id=agent_id, tenant_id=tenant_id, subject_cn=subject_cn,
+        ca_serial=format(leaf.serial_number, "x"),
+        expires_at=leaf.not_valid_after_utc,
+    )
+    return CertRotateResponse(
+        cert_pem=leaf_pem.decode(),
+        ca_chain_pem=ca.root_cert_pem.decode(),
+        expires_at=leaf.not_valid_after_utc,
+    )

--- a/apps/central_api/src/central_api/routes/provision_rotate.py
+++ b/apps/central_api/src/central_api/routes/provision_rotate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from cryptography import x509
 from fastapi import APIRouter, Request
 
+from cnes_domain.tenant import set_tenant_id
 from cnes_infra.auth import (
     CertRotateRequest,
     CertRotateResponse,
@@ -24,6 +25,7 @@ async def provision_cert_rotate(
     cert = extract_peer_cert(request)
     agent_id = read_agent_id(cert)
     tenant_id = read_tenant_id(cert)
+    set_tenant_id(tenant_id)
 
     audit = request.app.state.provisioned_certs
     active = audit.find_active_by_agent_id(agent_id)

--- a/apps/central_api/tests/routes/test_provision_rotate_e2e.py
+++ b/apps/central_api/tests/routes/test_provision_rotate_e2e.py
@@ -1,0 +1,67 @@
+"""End-to-end Phase 2b: full Phase 2 flow then rotate via mTLS."""
+import urllib.parse
+
+import pytest
+from cryptography import x509
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.postgres
+@pytest.mark.asyncio
+async def test_e2e_provision_seguido_de_rotate(
+    session_root_ca, monkeypatch, make_csr_pem, pg_engine,
+):
+    cert_path, key_path = session_root_ca
+    monkeypatch.setenv("AUTH_CA_CERT_PATH", str(cert_path))
+    monkeypatch.setenv("AUTH_CA_KEY_PATH", str(key_path))
+    monkeypatch.setenv("AUTH_DEVICE_VERIFICATION_URI", "https://example/activate")
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    monkeypatch.setenv("MINIO_ENDPOINT", "x:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "x")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "x")
+    monkeypatch.setenv("MINIO_BUCKET", "x")
+    from central_api.app import create_app
+    app = create_app()
+    with TestClient(app) as client:
+        auth = client.post(
+            "/oauth/device_authorization",
+            json={"client_id": "agent", "scope": "agent.provision"},
+        ).json()
+        await app.state.device_code_store.redeem_user_code(
+            auth["user_code"], tenant_id="354130",
+        )
+        tok = client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": auth["device_code"],
+                "client_id": "agent",
+            },
+        ).json()
+        first_cert = client.post(
+            "/provision/cert",
+            headers={"Authorization": f"Bearer {tok['access_token']}"},
+            json={
+                "csr_pem": make_csr_pem("agent-host-e2e").decode(),
+                "machine_fingerprint": "fp:e2e-rot-test",
+            },
+        ).json()
+
+        first_cert_pem = first_cert["cert_pem"]
+        rotate_resp = client.post(
+            "/provision/cert/rotate",
+            headers={
+                "X-SSL-Client-Verify": "SUCCESS",
+                "X-SSL-Client-Cert": urllib.parse.quote(first_cert_pem),
+            },
+            json={"csr_pem": make_csr_pem("agent-host-e2e-rot2").decode()},
+        )
+    assert rotate_resp.status_code == 200
+    body = rotate_resp.json()
+    new_cert = x509.load_pem_x509_certificate(body["cert_pem"].encode())
+    old_cert = x509.load_pem_x509_certificate(first_cert_pem.encode())
+    assert new_cert.serial_number != old_cert.serial_number
+    chain = x509.load_pem_x509_certificate(body["ca_chain_pem"].encode())
+    assert new_cert.issuer == chain.subject
+    delta = new_cert.not_valid_after_utc - new_cert.not_valid_before_utc
+    assert 89 <= delta.days <= 91

--- a/apps/central_api/tests/routes/test_provision_rotate_routes.py
+++ b/apps/central_api/tests/routes/test_provision_rotate_routes.py
@@ -1,0 +1,420 @@
+"""Tests for /provision/cert/rotate."""
+import datetime as dt
+import urllib.parse
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+_AGENT_OID = x509.ObjectIdentifier("1.3.6.1.4.1.99999.1.2")
+_TENANT_OID = x509.ObjectIdentifier("1.3.6.1.4.1.99999.1.1")
+
+_TEST_AGENT_IDS = (
+    "agent-rot-401a", "agent-rot-401b-orphan", "agent-rot-401c", "agent-rot-401d",
+    "agent-rot-400a", "agent-rot-200a", "agent-rot-200b", "agent-rot-200c",
+    "agent-rot-200d", "agent-rot-500a",
+)
+
+
+@pytest.fixture(autouse=True)
+def _limpar_rotate_tables(pg_engine):
+    """Clean up rows for these test agent_ids before each test."""
+    with pg_engine.begin() as conn:
+        conn.execute(
+            text(
+                "DELETE FROM auth_provisioned_certs WHERE agent_id = ANY(:ids)",
+            ),
+            {"ids": list(_TEST_AGENT_IDS)},
+        )
+        conn.execute(
+            text(
+                "DELETE FROM auth_refresh_tokens WHERE agent_id = ANY(:ids)",
+            ),
+            {"ids": list(_TEST_AGENT_IDS)},
+        )
+
+
+def _make_app(session_root_ca, monkeypatch):
+    cert_path, key_path = session_root_ca
+    monkeypatch.setenv("AUTH_CA_CERT_PATH", str(cert_path))
+    monkeypatch.setenv("AUTH_CA_KEY_PATH", str(key_path))
+    monkeypatch.setenv("AUTH_DEVICE_VERIFICATION_URI", "https://example/activate")
+    monkeypatch.setenv("DB_URL", "postgresql+psycopg://u:p@localhost/x")
+    monkeypatch.setenv("MINIO_ENDPOINT", "x:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "x")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "x")
+    monkeypatch.setenv("MINIO_BUCKET", "x")
+    from central_api.app import create_app
+    return create_app()
+
+
+def _sign_leaf(session_root_ca, *, agent_id="agent-rot-001",
+               tenant_id="354130", ca_serial_override=None,
+               include_oids=True):
+    """Sign a leaf cert directly with the test CA. Returns (PEM bytes, hex serial)."""
+    ca_cert_path, ca_key_path = session_root_ca
+    ca_cert = x509.load_pem_x509_certificate(ca_cert_path.read_bytes())
+    ca_key = serialization.load_pem_private_key(
+        ca_key_path.read_bytes(), password=None,
+    )
+    assert isinstance(ca_key, ec.EllipticCurvePrivateKey)
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "agent-machine-rot")])
+    serial = ca_serial_override or x509.random_serial_number()
+    now = dt.datetime.now(dt.UTC)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(leaf_key.public_key())
+        .serial_number(serial)
+        .not_valid_before(now - dt.timedelta(minutes=1))
+        .not_valid_after(now + dt.timedelta(days=90))
+    )
+    if include_oids:
+        builder = builder.add_extension(
+            x509.UnrecognizedExtension(_AGENT_OID, agent_id.encode()),
+            critical=False,
+        ).add_extension(
+            x509.UnrecognizedExtension(_TENANT_OID, tenant_id.encode()),
+            critical=False,
+        )
+    leaf = builder.sign(ca_key, hashes.SHA256())
+    return leaf.public_bytes(serialization.Encoding.PEM), format(serial, "x")
+
+
+def _mtls_headers(pem_bytes):
+    return {
+        "X-SSL-Client-Verify": "SUCCESS",
+        "X-SSL-Client-Cert": urllib.parse.quote(pem_bytes.decode()),
+    }
+
+
+def test_rotate_sem_headers_de_mtls_retorna_401(session_root_ca, monkeypatch, make_csr_pem):
+    app = _make_app(session_root_ca, monkeypatch)
+    with TestClient(app) as client:
+        r = client.post(
+            "/provision/cert/rotate",
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    assert r.status_code == 401
+    assert r.json() == {"error": "invalid_token"}
+
+
+def test_rotate_com_verify_failed_retorna_401(session_root_ca, monkeypatch, make_csr_pem):
+    app = _make_app(session_root_ca, monkeypatch)
+    pem_bytes, _ = _sign_leaf(session_root_ca)
+    headers = _mtls_headers(pem_bytes)
+    headers["X-SSL-Client-Verify"] = "FAILED:expired"
+    with TestClient(app) as client:
+        r = client.post(
+            "/provision/cert/rotate", headers=headers,
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    assert r.status_code == 401
+    assert r.json() == {"error": "invalid_token"}
+
+
+def test_rotate_com_cert_sem_agent_id_oid_retorna_401(
+    session_root_ca, monkeypatch, make_csr_pem,
+):
+    app = _make_app(session_root_ca, monkeypatch)
+    pem_bytes, _ = _sign_leaf(session_root_ca, include_oids=False)
+    with TestClient(app) as client:
+        r = client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    assert r.status_code == 401
+    assert r.json() == {"error": "invalid_token"}
+
+
+@pytest.mark.postgres
+def test_rotate_com_serial_diferente_do_audit_retorna_cert_revoked(
+    session_root_ca, monkeypatch, make_csr_pem, pg_engine,
+):
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    app = _make_app(session_root_ca, monkeypatch)
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    pem_bytes, _ = _sign_leaf(session_root_ca, agent_id="agent-rot-401a")
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    with TestClient(app) as client:
+        app.state.provisioned_certs.record(
+            agent_id="agent-rot-401a", tenant_id="354130",
+            subject_cn="cn", ca_serial="serial-different",
+            expires_at=expires,
+        )
+        app.state.refresh_token_store.create(
+            agent_id="agent-rot-401a", tenant_id="354130",
+            machine_fingerprint="fp:401a",
+        )
+        r = client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    assert r.status_code == 401
+    assert r.json() == {"error": "cert_revoked"}
+
+
+@pytest.mark.postgres
+def test_rotate_quando_agent_sem_audit_retorna_cert_revoked(
+    session_root_ca, monkeypatch, make_csr_pem, pg_engine,
+):
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    app = _make_app(session_root_ca, monkeypatch)
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    pem_bytes, _ = _sign_leaf(session_root_ca, agent_id="agent-rot-401b-orphan")
+    with TestClient(app) as client:
+        r = client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    assert r.status_code == 401
+    assert r.json() == {"error": "cert_revoked"}
+
+
+@pytest.mark.postgres
+def test_rotate_quando_agent_sem_refresh_token_retorna_agent_revoked(
+    session_root_ca, monkeypatch, make_csr_pem, pg_engine,
+):
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    app = _make_app(session_root_ca, monkeypatch)
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    pem_bytes, hex_serial = _sign_leaf(session_root_ca, agent_id="agent-rot-401c")
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    with TestClient(app) as client:
+        app.state.provisioned_certs.record(
+            agent_id="agent-rot-401c", tenant_id="354130",
+            subject_cn="cn", ca_serial=hex_serial, expires_at=expires,
+        )
+        r = client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    assert r.status_code == 401
+    assert r.json() == {"error": "agent_revoked"}
+
+
+@pytest.mark.postgres
+def test_rotate_quando_refresh_token_revogado_retorna_agent_revoked(
+    session_root_ca, monkeypatch, make_csr_pem, pg_engine,
+):
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    app = _make_app(session_root_ca, monkeypatch)
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    pem_bytes, hex_serial = _sign_leaf(session_root_ca, agent_id="agent-rot-401d")
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    with TestClient(app) as client:
+        app.state.provisioned_certs.record(
+            agent_id="agent-rot-401d", tenant_id="354130",
+            subject_cn="cn", ca_serial=hex_serial, expires_at=expires,
+        )
+        token = app.state.refresh_token_store.create(
+            agent_id="agent-rot-401d", tenant_id="354130",
+            machine_fingerprint="fp:401d",
+        )
+        app.state.refresh_token_store.revoke(token)
+        r = client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    assert r.status_code == 401
+    assert r.json() == {"error": "agent_revoked"}
+
+
+@pytest.mark.postgres
+def test_rotate_com_csr_invalido_retorna_invalid_request(
+    session_root_ca, monkeypatch, pg_engine,
+):
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    app = _make_app(session_root_ca, monkeypatch)
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    pem_bytes, hex_serial = _sign_leaf(session_root_ca, agent_id="agent-rot-400a")
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    with TestClient(app) as client:
+        app.state.provisioned_certs.record(
+            agent_id="agent-rot-400a", tenant_id="354130",
+            subject_cn="cn", ca_serial=hex_serial, expires_at=expires,
+        )
+        app.state.refresh_token_store.create(
+            agent_id="agent-rot-400a", tenant_id="354130",
+            machine_fingerprint="fp:400a",
+        )
+        r = client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": "not a real CSR with enough chars"},
+        )
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_request"
+
+
+@pytest.mark.postgres
+def test_rotate_com_chain_valida_emite_novo_cert_de_90_dias(
+    session_root_ca, monkeypatch, make_csr_pem, pg_engine,
+):
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    app = _make_app(session_root_ca, monkeypatch)
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    pem_bytes, hex_serial = _sign_leaf(session_root_ca, agent_id="agent-rot-200a")
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    with TestClient(app) as client:
+        app.state.provisioned_certs.record(
+            agent_id="agent-rot-200a", tenant_id="354130",
+            subject_cn="cn", ca_serial=hex_serial, expires_at=expires,
+        )
+        app.state.refresh_token_store.create(
+            agent_id="agent-rot-200a", tenant_id="354130",
+            machine_fingerprint="fp:200a",
+        )
+        r = client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert "BEGIN CERTIFICATE" in body["cert_pem"]
+    assert "BEGIN CERTIFICATE" in body["ca_chain_pem"]
+    parsed = dt.datetime.fromisoformat(body["expires_at"])
+    delta = parsed - dt.datetime.now(dt.UTC)
+    assert 89 <= delta.days <= 91
+
+
+@pytest.mark.postgres
+def test_rotate_grava_nova_linha_em_auth_provisioned_certs(
+    session_root_ca, monkeypatch, make_csr_pem, pg_engine,
+):
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    app = _make_app(session_root_ca, monkeypatch)
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    pem_bytes, hex_serial = _sign_leaf(session_root_ca, agent_id="agent-rot-200b")
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    with TestClient(app) as client:
+        app.state.provisioned_certs.record(
+            agent_id="agent-rot-200b", tenant_id="354130",
+            subject_cn="cn-old", ca_serial=hex_serial, expires_at=expires,
+        )
+        app.state.refresh_token_store.create(
+            agent_id="agent-rot-200b", tenant_id="354130",
+            machine_fingerprint="fp:200b",
+        )
+        client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    with pg_engine.connect() as conn:
+        count = conn.execute(
+            text(
+                "SELECT COUNT(*) FROM auth_provisioned_certs "
+                "WHERE agent_id = 'agent-rot-200b'",
+            ),
+        ).scalar()
+    assert count == 2  # Old (seeded) + new (rotation)
+
+
+@pytest.mark.postgres
+def test_rotate_nao_revoga_linha_anterior_overlap_periodo(
+    session_root_ca, monkeypatch, make_csr_pem, pg_engine,
+):
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    app = _make_app(session_root_ca, monkeypatch)
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    pem_bytes, hex_serial = _sign_leaf(session_root_ca, agent_id="agent-rot-200c")
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    with TestClient(app) as client:
+        app.state.provisioned_certs.record(
+            agent_id="agent-rot-200c", tenant_id="354130",
+            subject_cn="cn-old", ca_serial=hex_serial, expires_at=expires,
+        )
+        app.state.refresh_token_store.create(
+            agent_id="agent-rot-200c", tenant_id="354130",
+            machine_fingerprint="fp:200c",
+        )
+        client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    with pg_engine.connect() as conn:
+        old_revoked = conn.execute(
+            text(
+                "SELECT revoked_at FROM auth_provisioned_certs "
+                "WHERE agent_id = 'agent-rot-200c' AND ca_serial = :s",
+            ),
+            {"s": hex_serial},
+        ).scalar()
+    assert old_revoked is None
+
+
+@pytest.mark.postgres
+def test_rotate_preserva_refresh_token_existente(
+    session_root_ca, monkeypatch, make_csr_pem, pg_engine,
+):
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    app = _make_app(session_root_ca, monkeypatch)
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    pem_bytes, hex_serial = _sign_leaf(session_root_ca, agent_id="agent-rot-200d")
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    with TestClient(app) as client:
+        app.state.provisioned_certs.record(
+            agent_id="agent-rot-200d", tenant_id="354130",
+            subject_cn="cn", ca_serial=hex_serial, expires_at=expires,
+        )
+        app.state.refresh_token_store.create(
+            agent_id="agent-rot-200d", tenant_id="354130",
+            machine_fingerprint="fp:200d",
+        )
+        with pg_engine.connect() as conn:
+            before = conn.execute(
+                text(
+                    "SELECT COUNT(*) FROM auth_refresh_tokens "
+                    "WHERE agent_id = 'agent-rot-200d' AND revoked_at IS NULL",
+                ),
+            ).scalar()
+        client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+        with pg_engine.connect() as conn:
+            after = conn.execute(
+                text(
+                    "SELECT COUNT(*) FROM auth_refresh_tokens "
+                    "WHERE agent_id = 'agent-rot-200d' AND revoked_at IS NULL",
+                ),
+            ).scalar()
+    assert before == 1
+    assert after == 1
+
+
+@pytest.mark.postgres
+def test_rotate_com_ca_nao_configurada_retorna_500(
+    session_root_ca, monkeypatch, make_csr_pem, pg_engine,
+):
+    """When app.state.cert_authority is None, route returns 500 server_error.
+
+    Seeds full audit + refresh state to bypass earlier checks. Then nulls
+    cert_authority post-construction to exercise the CA-missing branch.
+    """
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    app = _make_app(session_root_ca, monkeypatch)
+    monkeypatch.setenv("DB_URL", pg_engine.url.render_as_string(hide_password=False))
+    pem_bytes, hex_serial = _sign_leaf(session_root_ca, agent_id="agent-rot-500a")
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    with TestClient(app) as client:
+        app.state.provisioned_certs.record(
+            agent_id="agent-rot-500a", tenant_id="354130",
+            subject_cn="cn", ca_serial=hex_serial, expires_at=expires,
+        )
+        app.state.refresh_token_store.create(
+            agent_id="agent-rot-500a", tenant_id="354130",
+            machine_fingerprint="fp:500a",
+        )
+        app.state.cert_authority = None
+        r = client.post(
+            "/provision/cert/rotate", headers=_mtls_headers(pem_bytes),
+            json={"csr_pem": make_csr_pem().decode()},
+        )
+    assert r.status_code == 500
+    assert r.json()["error"] == "server_error"

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -218,6 +218,44 @@
         "title": "CertProvisionResponse",
         "type": "object"
       },
+      "CertRotateRequest": {
+        "properties": {
+          "csr_pem": {
+            "title": "Csr Pem",
+            "type": "string"
+          }
+        },
+        "required": [
+          "csr_pem"
+        ],
+        "title": "CertRotateRequest",
+        "type": "object"
+      },
+      "CertRotateResponse": {
+        "description": "Response for /provision/cert/rotate. No refresh_token (persists).",
+        "properties": {
+          "ca_chain_pem": {
+            "title": "Ca Chain Pem",
+            "type": "string"
+          },
+          "cert_pem": {
+            "title": "Cert Pem",
+            "type": "string"
+          },
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cert_pem",
+          "ca_chain_pem",
+          "expires_at"
+        ],
+        "title": "CertRotateResponse",
+        "type": "object"
+      },
       "DeviceAuthorizationRequest": {
         "description": "Request body for POST /oauth/device_authorization (RFC 8628 §3.1).",
         "properties": {
@@ -1517,6 +1555,47 @@
           }
         },
         "summary": "Provision Cert",
+        "tags": [
+          "provision"
+        ]
+      }
+    },
+    "/provision/cert/rotate": {
+      "post": {
+        "operationId": "provision_cert_rotate_provision_cert_rotate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertRotateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertRotateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Provision Cert Rotate",
         "tags": [
           "provision"
         ]

--- a/packages/cnes_infra/src/cnes_infra/auth/__init__.py
+++ b/packages/cnes_infra/src/cnes_infra/auth/__init__.py
@@ -12,12 +12,17 @@ from cnes_infra.auth.models import (
     CertProvisionRequest,
     CertProvisionResponse,
     CertRotateRequest,
+    CertRotateResponse,
     DeviceAuthorizationRequest,
     DeviceAuthorizationResponse,
     TokenError,
     TokenResponse,
 )
-from cnes_infra.auth.provisioned_certs import ProvisionedCertsRepo
+from cnes_infra.auth.peer_cert import extract_peer_cert, read_agent_id, read_tenant_id
+from cnes_infra.auth.provisioned_certs import (
+    ProvisionedCertRow,
+    ProvisionedCertsRepo,
+)
 from cnes_infra.auth.refresh_tokens import RefreshTokenRow, RefreshTokenStore
 
 __all__ = [
@@ -27,6 +32,7 @@ __all__ = [
     "CertProvisionRequest",
     "CertProvisionResponse",
     "CertRotateRequest",
+    "CertRotateResponse",
     "DeviceAuthorization",
     "DeviceAuthorizationRequest",
     "DeviceAuthorizationResponse",
@@ -34,10 +40,14 @@ __all__ = [
     "DeviceCodeStore",
     "JWKSValidator",
     "OAuthError",
+    "ProvisionedCertRow",
     "ProvisionedCertsRepo",
     "RefreshTokenRow",
     "RefreshTokenStore",
     "TokenError",
     "TokenInvalid",
     "TokenResponse",
+    "extract_peer_cert",
+    "read_agent_id",
+    "read_tenant_id",
 ]

--- a/packages/cnes_infra/src/cnes_infra/auth/models.py
+++ b/packages/cnes_infra/src/cnes_infra/auth/models.py
@@ -53,6 +53,14 @@ class CertRotateRequest(BaseModel):
     csr_pem: str
 
 
+class CertRotateResponse(BaseModel):
+    """Response for /provision/cert/rotate. No refresh_token (persists)."""
+
+    cert_pem: str
+    ca_chain_pem: str
+    expires_at: datetime
+
+
 class DeviceAuthorizationRequest(BaseModel):
     """Request body for POST /oauth/device_authorization (RFC 8628 §3.1)."""
 

--- a/packages/cnes_infra/src/cnes_infra/auth/peer_cert.py
+++ b/packages/cnes_infra/src/cnes_infra/auth/peer_cert.py
@@ -1,0 +1,54 @@
+"""Extract peer cert from ingress-passed mTLS headers.
+
+Ingress (nginx, Traefik) terminates TLS, validates client cert chain
+against CA, forwards X-SSL-Client-Cert (URL-escaped PEM) +
+X-SSL-Client-Verify (SUCCESS|FAILED:<reason>|NONE).
+
+Server-side trust depends entirely on ingress config; this helper does
+NOT re-validate the chain. Wrong ingress config = security hole.
+"""
+from __future__ import annotations
+
+import urllib.parse
+from typing import TYPE_CHECKING
+
+from cryptography import x509
+
+from cnes_infra.auth.errors import OAuthError
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+_AGENT_ID_OID = x509.ObjectIdentifier("1.3.6.1.4.1.99999.1.2")
+_TENANT_OID = x509.ObjectIdentifier("1.3.6.1.4.1.99999.1.1")
+
+
+def extract_peer_cert(request: Request) -> x509.Certificate:
+    verify = request.headers.get("X-SSL-Client-Verify", "")
+    if verify != "SUCCESS":
+        raise OAuthError("invalid_token", status_code=401)
+    cert_header = request.headers.get("X-SSL-Client-Cert", "")
+    if not cert_header:
+        raise OAuthError("invalid_token", status_code=401)
+    pem = urllib.parse.unquote(cert_header)
+    try:
+        return x509.load_pem_x509_certificate(pem.encode())
+    except ValueError as exc:
+        raise OAuthError("invalid_token", status_code=401) from exc
+
+
+def _read_oid_value(
+    cert: x509.Certificate, oid: x509.ObjectIdentifier,
+) -> str:
+    for ext in cert.extensions:
+        if ext.oid == oid and isinstance(ext.value, x509.UnrecognizedExtension):
+            return ext.value.value.decode()
+    raise OAuthError("invalid_token", status_code=401)
+
+
+def read_agent_id(cert: x509.Certificate) -> str:
+    return _read_oid_value(cert, _AGENT_ID_OID)
+
+
+def read_tenant_id(cert: x509.Certificate) -> str:
+    return _read_oid_value(cert, _TENANT_OID)

--- a/packages/cnes_infra/src/cnes_infra/auth/peer_cert.py
+++ b/packages/cnes_infra/src/cnes_infra/auth/peer_cert.py
@@ -42,7 +42,12 @@ def _read_oid_value(
 ) -> str:
     for ext in cert.extensions:
         if ext.oid == oid and isinstance(ext.value, x509.UnrecognizedExtension):
-            return ext.value.value.decode()
+            try:
+                return ext.value.value.decode()
+            except UnicodeDecodeError as exc:
+                raise OAuthError(
+                    "invalid_token", status_code=401,
+                ) from exc
     raise OAuthError("invalid_token", status_code=401)
 
 

--- a/packages/cnes_infra/src/cnes_infra/auth/provisioned_certs.py
+++ b/packages/cnes_infra/src/cnes_infra/auth/provisioned_certs.py
@@ -1,19 +1,33 @@
-"""ProvisionedCertsRepo: append-only audit log of cert issuances.
+"""ProvisionedCertsRepo: append-only audit log + active-cert lookup.
 
 Writes one row per /provision/cert call. RLS-isolated by tenant_id.
-Append-only; no UNIQUE constraint at this layer.
+Append-only on write; SELECT helper for /provision/cert/rotate.
 """
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Engine, text
+from sqlalchemy import text
 
 if TYPE_CHECKING:
     import datetime as dt
 
+    from sqlalchemy import Engine
+
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ProvisionedCertRow:
+    agent_id: str
+    tenant_id: str
+    subject_cn: str
+    ca_serial: str
+    issued_at: dt.datetime
+    expires_at: dt.datetime
+    revoked_at: dt.datetime | None
 
 
 class ProvisionedCertsRepo:
@@ -46,4 +60,27 @@ class ProvisionedCertsRepo:
         logger.info(
             "provisioned_cert_recorded agent_id=%s tenant_id=%s ca_serial=%s",
             agent_id, tenant_id, ca_serial,
+        )
+
+    def find_active_by_agent_id(
+        self, agent_id: str,
+    ) -> ProvisionedCertRow | None:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT agent_id, tenant_id, subject_cn, ca_serial, "
+                    "issued_at, expires_at, revoked_at "
+                    "FROM auth_provisioned_certs "
+                    "WHERE agent_id = :a AND revoked_at IS NULL "
+                    "ORDER BY issued_at DESC LIMIT 1",
+                ),
+                {"a": agent_id},
+            ).one_or_none()
+        if row is None:
+            return None
+        return ProvisionedCertRow(
+            agent_id=row.agent_id, tenant_id=row.tenant_id,
+            subject_cn=row.subject_cn, ca_serial=row.ca_serial,
+            issued_at=row.issued_at, expires_at=row.expires_at,
+            revoked_at=row.revoked_at,
         )

--- a/packages/cnes_infra/src/cnes_infra/auth/provisioned_certs.py
+++ b/packages/cnes_infra/src/cnes_infra/auth/provisioned_certs.py
@@ -72,6 +72,7 @@ class ProvisionedCertsRepo:
                     "issued_at, expires_at, revoked_at "
                     "FROM auth_provisioned_certs "
                     "WHERE agent_id = :a AND revoked_at IS NULL "
+                    "AND expires_at > now() "
                     "ORDER BY issued_at DESC LIMIT 1",
                 ),
                 {"a": agent_id},

--- a/packages/cnes_infra/src/cnes_infra/auth/refresh_tokens.py
+++ b/packages/cnes_infra/src/cnes_infra/auth/refresh_tokens.py
@@ -110,3 +110,15 @@ class RefreshTokenStore:
                 {"h": token_hash},
             )
         logger.info("refresh_token_revoked")
+
+    def has_active_for_agent(self, agent_id: str) -> bool:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT 1 FROM auth_refresh_tokens "
+                    "WHERE agent_id = :a AND revoked_at IS NULL "
+                    "LIMIT 1",
+                ),
+                {"a": agent_id},
+            ).one_or_none()
+        return row is not None

--- a/packages/cnes_infra/tests/auth/test_models.py
+++ b/packages/cnes_infra/tests/auth/test_models.py
@@ -72,3 +72,16 @@ def test_token_response_aceita_refresh_token_none():
 def test_token_response_default_refresh_token_none():
     resp = TokenResponse(access_token="x", expires_in=300)  # noqa: S106
     assert resp.refresh_token is None
+
+
+def test_cert_rotate_response_serializa_pem_e_expires_at():
+    from cnes_infra.auth import CertRotateResponse
+    expires = datetime.now(UTC) + timedelta(days=90)
+    resp = CertRotateResponse(
+        cert_pem="-----BEGIN CERTIFICATE-----\nABC",
+        ca_chain_pem="-----BEGIN CERTIFICATE-----\nXYZ",
+        expires_at=expires,
+    )
+    assert "BEGIN CERTIFICATE" in resp.cert_pem
+    assert "BEGIN CERTIFICATE" in resp.ca_chain_pem
+    assert resp.expires_at == expires

--- a/packages/cnes_infra/tests/auth/test_peer_cert.py
+++ b/packages/cnes_infra/tests/auth/test_peer_cert.py
@@ -1,0 +1,131 @@
+"""peer_cert: mTLS header parsing + OID extraction."""
+import datetime as dt
+import urllib.parse
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from cnes_infra.auth.errors import OAuthError
+from cnes_infra.auth.peer_cert import (
+    extract_peer_cert,
+    read_agent_id,
+    read_tenant_id,
+)
+
+_AGENT_OID = x509.ObjectIdentifier("1.3.6.1.4.1.99999.1.2")
+_TENANT_OID = x509.ObjectIdentifier("1.3.6.1.4.1.99999.1.1")
+
+
+def _make_leaf_cert(*, agent_id: str | None = "agent-001",
+                    tenant_id: str | None = "354130") -> bytes:
+    """Build a leaf cert with optional custom OIDs."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "agent-test")])
+    now = dt.datetime.now(dt.UTC)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=1))
+        .not_valid_after(now + dt.timedelta(days=90))
+    )
+    if agent_id is not None:
+        builder = builder.add_extension(
+            x509.UnrecognizedExtension(_AGENT_OID, agent_id.encode()),
+            critical=False,
+        )
+    if tenant_id is not None:
+        builder = builder.add_extension(
+            x509.UnrecognizedExtension(_TENANT_OID, tenant_id.encode()),
+            critical=False,
+        )
+    cert = builder.sign(key, hashes.SHA256())
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+class _FakeRequest:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = headers
+
+
+def test_extract_peer_cert_rejeita_verify_ausente_retorna_401():
+    req = _FakeRequest({})
+    with pytest.raises(OAuthError) as exc:
+        extract_peer_cert(req)
+    assert exc.value.code == "invalid_token"
+    assert exc.value.status_code == 401
+
+
+def test_extract_peer_cert_rejeita_verify_failed_retorna_401():
+    req = _FakeRequest({"X-SSL-Client-Verify": "FAILED:expired"})
+    with pytest.raises(OAuthError) as exc:
+        extract_peer_cert(req)
+    assert exc.value.code == "invalid_token"
+
+
+def test_extract_peer_cert_rejeita_verify_none_retorna_401():
+    req = _FakeRequest({"X-SSL-Client-Verify": "NONE"})
+    with pytest.raises(OAuthError):
+        extract_peer_cert(req)
+
+
+def test_extract_peer_cert_rejeita_cert_header_ausente_retorna_401():
+    req = _FakeRequest({"X-SSL-Client-Verify": "SUCCESS"})
+    with pytest.raises(OAuthError):
+        extract_peer_cert(req)
+
+
+def test_extract_peer_cert_rejeita_pem_malformado_retorna_401():
+    req = _FakeRequest({
+        "X-SSL-Client-Verify": "SUCCESS",
+        "X-SSL-Client-Cert": "not%20a%20cert",
+    })
+    with pytest.raises(OAuthError):
+        extract_peer_cert(req)
+
+
+def test_extract_peer_cert_aceita_pem_url_escaped():
+    pem_bytes = _make_leaf_cert()
+    escaped = urllib.parse.quote(pem_bytes.decode())
+    req = _FakeRequest({
+        "X-SSL-Client-Verify": "SUCCESS",
+        "X-SSL-Client-Cert": escaped,
+    })
+    cert = extract_peer_cert(req)
+    assert isinstance(cert, x509.Certificate)
+
+
+def test_extract_peer_cert_aceita_pem_raw_idempotente():
+    pem_bytes = _make_leaf_cert()
+    req = _FakeRequest({
+        "X-SSL-Client-Verify": "SUCCESS",
+        "X-SSL-Client-Cert": pem_bytes.decode(),
+    })
+    cert = extract_peer_cert(req)
+    assert isinstance(cert, x509.Certificate)
+
+
+def test_read_agent_id_extrai_oid():
+    pem_bytes = _make_leaf_cert(agent_id="agent-xyz")
+    cert = x509.load_pem_x509_certificate(pem_bytes)
+    assert read_agent_id(cert) == "agent-xyz"
+
+
+def test_read_tenant_id_extrai_oid():
+    pem_bytes = _make_leaf_cert(tenant_id="354130")
+    cert = x509.load_pem_x509_certificate(pem_bytes)
+    assert read_tenant_id(cert) == "354130"
+
+
+def test_read_oid_levanta_401_quando_oid_ausente():
+    pem_bytes = _make_leaf_cert(agent_id=None)
+    cert = x509.load_pem_x509_certificate(pem_bytes)
+    with pytest.raises(OAuthError) as exc:
+        read_agent_id(cert)
+    assert exc.value.code == "invalid_token"
+    assert exc.value.status_code == 401

--- a/packages/cnes_infra/tests/auth/test_peer_cert.py
+++ b/packages/cnes_infra/tests/auth/test_peer_cert.py
@@ -129,3 +129,29 @@ def test_read_oid_levanta_401_quando_oid_ausente():
         read_agent_id(cert)
     assert exc.value.code == "invalid_token"
     assert exc.value.status_code == 401
+
+
+def test_read_oid_levanta_401_quando_oid_tem_bytes_invalidos_utf8():
+    """Critical regression: malformed UTF-8 in OID must NOT crash 500."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "agent-test")])
+    now = dt.datetime.now(dt.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject).issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=1))
+        .not_valid_after(now + dt.timedelta(days=90))
+        .add_extension(
+            x509.UnrecognizedExtension(_AGENT_OID, b"\xff\xfe\xfd"),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    pem = cert.public_bytes(serialization.Encoding.PEM)
+    parsed = x509.load_pem_x509_certificate(pem)
+    with pytest.raises(OAuthError) as exc:
+        read_agent_id(parsed)
+    assert exc.value.code == "invalid_token"
+    assert exc.value.status_code == 401

--- a/packages/cnes_infra/tests/auth/test_provisioned_certs.py
+++ b/packages/cnes_infra/tests/auth/test_provisioned_certs.py
@@ -6,7 +6,10 @@ from sqlalchemy import text
 
 from cnes_infra.auth.provisioned_certs import ProvisionedCertsRepo
 
-_AGENT_IDS = ("agent-101", "agent-102", "agent-103")
+_AGENT_IDS = (
+    "agent-101", "agent-102", "agent-103",
+    "agent-201-sem-linhas", "agent-202", "agent-203", "agent-204",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -79,3 +82,68 @@ def test_record_persiste_expires_at(pg_engine):
             {"a": "agent-103"},
         ).one()
     assert row.expires_at == expires
+
+
+@pytest.mark.postgres
+def test_find_active_retorna_none_quando_agent_sem_linhas(pg_engine):
+    repo = ProvisionedCertsRepo(pg_engine)
+    assert repo.find_active_by_agent_id("agent-201-sem-linhas") is None
+
+
+@pytest.mark.postgres
+def test_find_active_retorna_mais_recente_quando_multiplas_linhas(pg_engine):
+    repo = ProvisionedCertsRepo(pg_engine)
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    repo.record(
+        agent_id="agent-202", tenant_id="t1",
+        subject_cn="cn-old", ca_serial="serial-old", expires_at=expires,
+    )
+    repo.record(
+        agent_id="agent-202", tenant_id="t1",
+        subject_cn="cn-new", ca_serial="serial-new", expires_at=expires,
+    )
+    row = repo.find_active_by_agent_id("agent-202")
+    assert row is not None
+    assert row.ca_serial == "serial-new"
+
+
+@pytest.mark.postgres
+def test_find_active_ignora_linhas_revogadas(pg_engine):
+    repo = ProvisionedCertsRepo(pg_engine)
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    repo.record(
+        agent_id="agent-203", tenant_id="t1",
+        subject_cn="cn-rev", ca_serial="serial-rev", expires_at=expires,
+    )
+    with pg_engine.begin() as conn:
+        conn.execute(
+            text(
+                "UPDATE auth_provisioned_certs SET revoked_at = now() "
+                "WHERE agent_id = 'agent-203'",
+            ),
+        )
+    repo.record(
+        agent_id="agent-203", tenant_id="t1",
+        subject_cn="cn-active", ca_serial="serial-active", expires_at=expires,
+    )
+    row = repo.find_active_by_agent_id("agent-203")
+    assert row is not None
+    assert row.ca_serial == "serial-active"
+
+
+@pytest.mark.postgres
+def test_find_active_retorna_none_quando_todas_revogadas(pg_engine):
+    repo = ProvisionedCertsRepo(pg_engine)
+    expires = dt.datetime.now(dt.UTC) + dt.timedelta(days=90)
+    repo.record(
+        agent_id="agent-204", tenant_id="t1",
+        subject_cn="cn", ca_serial="serial-only", expires_at=expires,
+    )
+    with pg_engine.begin() as conn:
+        conn.execute(
+            text(
+                "UPDATE auth_provisioned_certs SET revoked_at = now() "
+                "WHERE agent_id = 'agent-204'",
+            ),
+        )
+    assert repo.find_active_by_agent_id("agent-204") is None

--- a/packages/cnes_infra/tests/auth/test_provisioned_certs.py
+++ b/packages/cnes_infra/tests/auth/test_provisioned_certs.py
@@ -9,6 +9,7 @@ from cnes_infra.auth.provisioned_certs import ProvisionedCertsRepo
 _AGENT_IDS = (
     "agent-101", "agent-102", "agent-103",
     "agent-201-sem-linhas", "agent-202", "agent-203", "agent-204",
+    "agent-205-expirado",
 )
 
 
@@ -147,3 +148,15 @@ def test_find_active_retorna_none_quando_todas_revogadas(pg_engine):
             ),
         )
     assert repo.find_active_by_agent_id("agent-204") is None
+
+
+@pytest.mark.postgres
+def test_find_active_ignora_linhas_expiradas(pg_engine):
+    """Critical regression: cert past expires_at MUST NOT be returned."""
+    repo = ProvisionedCertsRepo(pg_engine)
+    expired = dt.datetime.now(dt.UTC) - dt.timedelta(days=1)
+    repo.record(
+        agent_id="agent-205-expirado", tenant_id="t1",
+        subject_cn="cn-old", ca_serial="serial-expired", expires_at=expired,
+    )
+    assert repo.find_active_by_agent_id("agent-205-expirado") is None

--- a/packages/cnes_infra/tests/auth/test_refresh_tokens.py
+++ b/packages/cnes_infra/tests/auth/test_refresh_tokens.py
@@ -78,3 +78,30 @@ def test_validate_com_tenant_id_diferente_retorna_none(pg_engine):
         machine_fingerprint="fp:eeff00",
     )
     assert store.validate(token, tenant_id="tenant-b") is None
+
+
+@pytest.mark.postgres
+def test_has_active_retorna_true_quando_ha_linha_nao_revogada(pg_engine):
+    store = RefreshTokenStore(pg_engine)
+    store.create(
+        agent_id="agent-301", tenant_id="t1",
+        machine_fingerprint="fp:301",
+    )
+    assert store.has_active_for_agent("agent-301") is True
+
+
+@pytest.mark.postgres
+def test_has_active_retorna_false_quando_todas_revogadas(pg_engine):
+    store = RefreshTokenStore(pg_engine)
+    token = store.create(
+        agent_id="agent-302", tenant_id="t1",
+        machine_fingerprint="fp:302",
+    )
+    store.revoke(token)
+    assert store.has_active_for_agent("agent-302") is False
+
+
+@pytest.mark.postgres
+def test_has_active_retorna_false_quando_agent_sem_linhas(pg_engine):
+    store = RefreshTokenStore(pg_engine)
+    assert store.has_active_for_agent("agent-303-inexistente") is False


### PR DESCRIPTION
## Summary

Phase 2b of 8 for edge-agent P4 zero-trust auth. Adds \`POST /provision/cert/rotate\` to \`central_api\`, mTLS-gated via ingress headers (\`X-SSL-Client-Cert\` + \`X-SSL-Client-Verify\`).

## Changes

- **POST /provision/cert/rotate** — reads peer cert from ingress headers, extracts agent_id + tenant_id from custom OIDs, validates audit + refresh_token state, signs new 90-day cert. Refresh_token persists; old cert stays valid until natural expiry (overlap window).
- **peer_cert.py** new module — header parsing + custom OID extraction. 100% branch coverage.
- **provisioned_certs.find_active_by_agent_id** — most-recent non-revoked lookup.
- **refresh_tokens.has_active_for_agent** — predicate for revocation gate.
- **CertRotateResponse** Pydantic model (no refresh_token field).
- **OpenAPI** regenerated (19 paths total, 1 new).

## Auth checks (in order)

1. Ingress validated chain (\`X-SSL-Client-Verify=SUCCESS\`) — else 401 invalid_token
2. Cert custom OIDs present (agent_id, tenant_id) — else 401 invalid_token
3. Latest non-revoked \`auth_provisioned_certs\` row exists for agent_id — else 401 cert_revoked
4. Presented serial matches audit row \`ca_serial\` — else 401 cert_revoked
5. Agent has ≥1 non-revoked \`auth_refresh_tokens\` row — else 401 agent_revoked
6. \`app.state.cert_authority\` configured — else 500 server_error
7. CSR valid — else 400 invalid_request

## Test plan

- [x] All test names Portuguese.
- [x] 100% branch coverage on \`cnes_infra/auth/\` (375/375 statements).
- [x] 14 route tests (3 non-postgres + 10 postgres + 1 e2e).
- [x] End-to-end provision → rotate flow test (Phase 2 lifecycle then mTLS rotate).
- [x] Ruff clean (\`ruff check .\` global).
- [x] central_api full suite: 144/144 PASS (excluding pre-existing test_smoke).
- [ ] CI \`lint-test-linux\` passes (post-PR open).

## Phase context

- Phase 1 (PR #57, merged): cnes_infra/auth/ foundation.
- Phase 2 (PR #66, merged): server endpoints.
- **Phase 2b (this PR):** cert rotation.
- Phase 3-7: agent-side device-flow client + cert provisioning.
- Phase 8: agent apiclient mTLS wire-up.

## Out of scope

- Local docker-compose proxy (nginx/Caddy) for ingress mTLS testing — tests inject headers directly. PROD k8s manifests are separate concern.
- CRL/OCSP (parent spec defers; refresh_token blocklist suffices for v1).
- Refresh_token rotation on cert rotate (independent lifecycle).
- Cert revocation on rotate (overlap window).
- Agent-side rotation client (Phases 4-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)