### PR TITLE
feat(dump_agent_go/auth): RFC 8628 OAuth Device Flow client (Phase 3/8)

### DIFF
--- a/apps/dump_agent_go/internal/auth/device.go
+++ b/apps/dump_agent_go/internal/auth/device.go
@@ -1,0 +1,267 @@
+// Package auth implements RFC 8628 OAuth Device Flow client for the agent.
+//
+// The agent calls Client.Authorize() to start the flow (gets device_code +
+// user_code), prints the user_code + verification URI to the tech, then
+// loops on (*DeviceFlow).Poll() until a Token resolves or a terminal error
+// fires.
+//
+// Server-side trust: caller must use HTTPS and verify the central_api root
+// CA cert. This package does not enforce TLS settings.
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Sentinel errors mapped from RFC 8628 §3.5 server responses.
+var (
+	ErrExpiredToken     = errors.New("oauth: device code expired")
+	ErrAccessDenied     = errors.New("oauth: user denied authorization")
+	ErrInvalidGrant     = errors.New("oauth: invalid grant")
+	ErrUnsupportedGrant = errors.New("oauth: unsupported grant type")
+	ErrInvalidClient    = errors.New("oauth: invalid client")
+)
+
+const (
+	deviceCodeGrant = "urn:ietf:params:oauth:grant-type:device_code"
+	maxInterval     = 60 * time.Second
+)
+
+// Client is a stateless OAuth Device Flow client.
+//
+// Construct via NewClient. Safe for concurrent use across multiple
+// independent device flows; not safe to call Poll concurrently on the
+// same DeviceFlow.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	clock      func() time.Time
+	sleep      func(time.Duration)
+}
+
+// DeviceFlow holds state for one device flow lifecycle.
+//
+// NOT goroutine-safe — single caller assumption.
+type DeviceFlow struct {
+	client                  *Client
+	deviceCode              string
+	UserCode                string
+	VerificationURI         string
+	VerificationURIComplete string
+	ExpiresAt               time.Time
+	interval                time.Duration
+}
+
+// Token is the result of a successful device flow.
+type Token struct {
+	AccessToken  string
+	TokenType    string
+	ExpiresIn    time.Duration
+	RefreshToken string
+}
+
+// NewClient builds an OAuth Device Flow client.
+//
+// baseURL: central_api root (e.g. "https://central.example").
+// httpClient: pass nil to use http.DefaultClient.
+func NewClient(baseURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
+		clock:      time.Now,
+		sleep:      time.Sleep,
+	}
+}
+
+// Authorize calls POST /oauth/device_authorization. Returns a populated
+// DeviceFlow on success.
+func (c *Client) Authorize(ctx context.Context, scope string) (*DeviceFlow, error) {
+	body, err := json.Marshal(map[string]string{
+		"client_id": "agent",
+		"scope":     scope,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("oauth: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/oauth/device_authorization", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("oauth: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: network: %w", err)
+	}
+	defer resp.Body.Close()
+	rawBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("oauth: device_authorization failed status=%d body=%s",
+			resp.StatusCode, rawBody)
+	}
+	var parsed struct {
+		DeviceCode              string `json:"device_code"`
+		UserCode                string `json:"user_code"`
+		VerificationURI         string `json:"verification_uri"`
+		VerificationURIComplete string `json:"verification_uri_complete"`
+		ExpiresIn               int    `json:"expires_in"`
+		Interval                int    `json:"interval"`
+	}
+	if err := json.Unmarshal(rawBody, &parsed); err != nil {
+		return nil, fmt.Errorf("oauth: malformed response body=%s: %w", rawBody, err)
+	}
+	return &DeviceFlow{
+		client:                  c,
+		deviceCode:              parsed.DeviceCode,
+		UserCode:                parsed.UserCode,
+		VerificationURI:         parsed.VerificationURI,
+		VerificationURIComplete: parsed.VerificationURIComplete,
+		ExpiresAt:               c.clock().Add(time.Duration(parsed.ExpiresIn) * time.Second),
+		interval:                time.Duration(parsed.Interval) * time.Second,
+	}, nil
+}
+
+// Poll loops until the device flow resolves. Returns Token on success or
+// terminal error: ErrExpiredToken, ErrAccessDenied, ErrInvalidGrant,
+// ErrUnsupportedGrant, ErrInvalidClient.
+//
+// Honors RFC 8628 §3.5 polling rules:
+//   - sleep `interval` between polls
+//   - on slow_down: server-supplied interval (or 2x local), capped at 60s
+//   - on authorization_pending: continue
+//   - on 200: return Token
+//   - on terminal error: return wrapped sentinel
+//
+// Respects context cancellation between polls.
+// NOT goroutine-safe.
+func (d *DeviceFlow) Poll(ctx context.Context) (*Token, error) {
+	for {
+		if d.client.clock().After(d.ExpiresAt) {
+			return nil, ErrExpiredToken
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		d.client.sleep(d.interval)
+
+		tok, retryAfter, err := d.pollOnce(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if tok != nil {
+			return tok, nil
+		}
+		if retryAfter > 0 {
+			d.interval = retryAfter
+			if d.interval > maxInterval {
+				d.interval = maxInterval
+			}
+		}
+	}
+}
+
+// pollOnce returns (token, retryAfter, err):
+//   - token != nil    → success, caller returns
+//   - retryAfter > 0  → slow_down with new interval to apply
+//   - retryAfter == 0 + err == nil → authorization_pending, caller loops
+//   - err != nil      → terminal error
+func (d *DeviceFlow) pollOnce(ctx context.Context) (*Token, time.Duration, error) {
+	rawBody, status, err := d.doTokenRequest(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	if status == http.StatusOK {
+		return parseTokenResponse(rawBody)
+	}
+	if status != http.StatusBadRequest {
+		return nil, 0, fmt.Errorf("oauth: server error status=%d body=%s", status, rawBody)
+	}
+	return d.classifyErrorResponse(rawBody)
+}
+
+// doTokenRequest executes POST /oauth/token and returns (body, statusCode, err).
+func (d *DeviceFlow) doTokenRequest(ctx context.Context) ([]byte, int, error) {
+	form := url.Values{}
+	form.Set("grant_type", deviceCodeGrant)
+	form.Set("device_code", d.deviceCode)
+	form.Set("client_id", "agent")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		d.client.baseURL+"/oauth/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, 0, fmt.Errorf("oauth: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := d.client.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("oauth: network: %w", err)
+	}
+	defer resp.Body.Close()
+	rawBody, _ := io.ReadAll(resp.Body)
+	return rawBody, resp.StatusCode, nil
+}
+
+// parseTokenResponse decodes a 200 OK body into a Token.
+func parseTokenResponse(rawBody []byte) (*Token, time.Duration, error) {
+	var t struct {
+		AccessToken  string `json:"access_token"`
+		TokenType    string `json:"token_type"`
+		ExpiresIn    int    `json:"expires_in"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(rawBody, &t); err != nil {
+		return nil, 0, fmt.Errorf("oauth: malformed token response body=%s: %w", rawBody, err)
+	}
+	return &Token{
+		AccessToken:  t.AccessToken,
+		TokenType:    t.TokenType,
+		ExpiresIn:    time.Duration(t.ExpiresIn) * time.Second,
+		RefreshToken: t.RefreshToken,
+	}, 0, nil
+}
+
+// classifyErrorResponse decodes a 400 error body and maps it to sentinel errors.
+func (d *DeviceFlow) classifyErrorResponse(rawBody []byte) (*Token, time.Duration, error) {
+	var eb struct {
+		Error    string `json:"error"`
+		Interval int    `json:"interval"`
+	}
+	if err := json.Unmarshal(rawBody, &eb); err != nil {
+		return nil, 0, fmt.Errorf("oauth: malformed error response body=%s: %w", rawBody, err)
+	}
+	switch eb.Error {
+	case "authorization_pending":
+		return nil, 0, nil
+	case "slow_down":
+		next := time.Duration(eb.Interval) * time.Second
+		if next == 0 {
+			next = d.interval * 2
+		}
+		return nil, next, nil
+	case "expired_token":
+		return nil, 0, fmt.Errorf("%w: body=%s", ErrExpiredToken, rawBody)
+	case "access_denied":
+		return nil, 0, fmt.Errorf("%w: body=%s", ErrAccessDenied, rawBody)
+	case "invalid_grant":
+		return nil, 0, fmt.Errorf("%w: body=%s", ErrInvalidGrant, rawBody)
+	case "unsupported_grant_type":
+		return nil, 0, fmt.Errorf("%w: body=%s", ErrUnsupportedGrant, rawBody)
+	case "invalid_client":
+		return nil, 0, fmt.Errorf("%w: body=%s", ErrInvalidClient, rawBody)
+	default:
+		return nil, 0, fmt.Errorf("oauth: unknown error code=%s body=%s", eb.Error, rawBody)
+	}
+}

--- a/apps/dump_agent_go/internal/auth/device.go
+++ b/apps/dump_agent_go/internal/auth/device.go
@@ -157,6 +157,11 @@ func (d *DeviceFlow) Poll(ctx context.Context) (*Token, error) {
 		default:
 		}
 		d.client.sleep(d.interval)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 
 		tok, retryAfter, err := d.pollOnce(ctx)
 		if err != nil {
@@ -224,6 +229,9 @@ func parseTokenResponse(rawBody []byte) (*Token, time.Duration, error) {
 	}
 	if err := json.Unmarshal(rawBody, &t); err != nil {
 		return nil, 0, fmt.Errorf("oauth: malformed token response body=%s: %w", rawBody, err)
+	}
+	if t.AccessToken == "" {
+		return nil, 0, fmt.Errorf("oauth: token response missing access_token body=%s", rawBody)
 	}
 	return &Token{
 		AccessToken:  t.AccessToken,

--- a/apps/dump_agent_go/internal/auth/device_test.go
+++ b/apps/dump_agent_go/internal/auth/device_test.go
@@ -123,7 +123,7 @@ func pollHandler(t *testing.T, script []func(http.ResponseWriter, *http.Request)
 	}
 }
 
-func devAuthHandler(expiresIn, interval int) http.HandlerFunc {
+func devAuthHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -131,8 +131,8 @@ func devAuthHandler(expiresIn, interval int) http.HandlerFunc {
 			"user_code":                 "WDJB-MJHT",
 			"verification_uri":          "https://x/activate",
 			"verification_uri_complete": "https://x/activate?code=WDJB-MJHT",
-			"expires_in":                expiresIn,
-			"interval":                  interval,
+			"expires_in":                600,
+			"interval":                  5,
 		})
 	}
 }
@@ -150,7 +150,7 @@ func nullSleep(time.Duration) {}
 
 func TestPoll_AuthorizationPending_ThenAuthorized(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
@@ -186,7 +186,7 @@ func TestPoll_AuthorizationPending_ThenAuthorized(t *testing.T) {
 
 func TestPoll_SlowDown_DoublesInterval(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
@@ -222,7 +222,7 @@ func TestPoll_SlowDown_DoublesInterval(t *testing.T) {
 
 func TestPoll_SlowDown_HonorsServerInterval(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
@@ -264,7 +264,7 @@ func TestPoll_SlowDown_CapsAt60Seconds(t *testing.T) {
 		})
 	})
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token":                pollHandler(t, script),
 	})
 	c := NewClient(srv.URL, client)
@@ -285,7 +285,7 @@ func TestPoll_SlowDown_CapsAt60Seconds(t *testing.T) {
 
 func TestPoll_ExpiredToken_ReturnsErrExpiredToken(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
@@ -304,7 +304,7 @@ func TestPoll_ExpiredToken_ReturnsErrExpiredToken(t *testing.T) {
 
 func TestPoll_AccessDenied_ReturnsErrAccessDenied(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
@@ -323,7 +323,7 @@ func TestPoll_AccessDenied_ReturnsErrAccessDenied(t *testing.T) {
 
 func TestPoll_InvalidGrant_ReturnsErrInvalidGrant(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
@@ -342,7 +342,7 @@ func TestPoll_InvalidGrant_ReturnsErrInvalidGrant(t *testing.T) {
 
 func TestPoll_UnsupportedGrant_ReturnsErrUnsupportedGrant(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
@@ -361,7 +361,7 @@ func TestPoll_UnsupportedGrant_ReturnsErrUnsupportedGrant(t *testing.T) {
 
 func TestPoll_InvalidClient_ReturnsErrInvalidClient(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
@@ -380,7 +380,7 @@ func TestPoll_InvalidClient_ReturnsErrInvalidClient(t *testing.T) {
 
 func TestPoll_ContextCancellation_ReturnsCtxErr(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("token endpoint should NOT be called after context cancel")
 		},
@@ -407,7 +407,7 @@ func TestPoll_ContextCancellation_ReturnsCtxErr(t *testing.T) {
 
 func TestPoll_ExpiresAtElapsed_ReturnsErrExpiredToken(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("token endpoint should NOT be called when ExpiresAt elapsed")
 		},
@@ -426,7 +426,7 @@ func TestPoll_ExpiresAtElapsed_ReturnsErrExpiredToken(t *testing.T) {
 
 func TestPoll_UnknownErrorCode_ReturnsGenericError(t *testing.T) {
 	srv, client := newMockServer(t, map[string]http.HandlerFunc{
-		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/device_authorization": devAuthHandler(),
 		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
@@ -448,5 +448,44 @@ func TestPoll_UnknownErrorCode_ReturnsGenericError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "totally_made_up") {
 		t.Errorf("error should mention unknown code, got: %v", err)
+	}
+}
+
+
+func TestNewClient_NilHTTPClient_UsesDefault(t *testing.T) {
+	c := NewClient("https://x", nil)
+	if c == nil {
+		t.Fatal("NewClient returned nil")
+	}
+	if c.httpClient == nil {
+		t.Error("expected default httpClient to be set")
+	}
+	if c.httpClient != http.DefaultClient {
+		t.Error("expected http.DefaultClient")
+	}
+}
+
+func TestPoll_TokenResponseMissingAccessToken_ReturnsError(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(),
+		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"token_type": "Bearer",
+					"expires_in": 300,
+				})
+			},
+		}),
+	})
+	c := NewClient(srv.URL, client)
+	c.SetClockSleep(time.Now, nullSleep)
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	_, err := flow.Poll(context.Background())
+	if err == nil {
+		t.Fatal("expected error got nil")
+	}
+	if !strings.Contains(err.Error(), "missing access_token") {
+		t.Errorf("error should mention missing access_token, got: %v", err)
 	}
 }

--- a/apps/dump_agent_go/internal/auth/device_test.go
+++ b/apps/dump_agent_go/internal/auth/device_test.go
@@ -1,0 +1,452 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newMockServer(t *testing.T, handlers map[string]http.HandlerFunc) (*httptest.Server, *http.Client) {
+	t.Helper()
+	mux := http.NewServeMux()
+	for path, h := range handlers {
+		mux.HandleFunc(path, h)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, srv.Client()
+}
+
+func TestAuthorize_Success_ReturnsDeviceFlow(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Fatalf("want POST got %s", r.Method)
+			}
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["client_id"] != "agent" || body["scope"] != "agent.provision" {
+				t.Fatalf("unexpected body %+v", body)
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code":               "dc-43-chars-padding-padding-padding-padding",
+				"user_code":                 "WDJB-MJHT",
+				"verification_uri":          "https://central/activate",
+				"verification_uri_complete": "https://central/activate?code=WDJB-MJHT",
+				"expires_in":                600,
+				"interval":                  5,
+			})
+		},
+	})
+
+	c := NewClient(srv.URL, client)
+	flow, err := c.Authorize(context.Background(), "agent.provision")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if flow.UserCode != "WDJB-MJHT" {
+		t.Errorf("want user_code WDJB-MJHT got %s", flow.UserCode)
+	}
+	if flow.VerificationURI != "https://central/activate" {
+		t.Errorf("want verification_uri https://central/activate got %s", flow.VerificationURI)
+	}
+	if !strings.HasSuffix(flow.VerificationURIComplete, "WDJB-MJHT") {
+		t.Errorf("want suffix WDJB-MJHT got %s", flow.VerificationURIComplete)
+	}
+}
+
+func TestAuthorize_Non200_ReturnsError(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+		},
+	})
+	c := NewClient(srv.URL, client)
+	_, err := c.Authorize(context.Background(), "agent.provision")
+	if err == nil {
+		t.Fatal("expected error got nil")
+	}
+	if !strings.Contains(err.Error(), "status=400") {
+		t.Errorf("error should mention status=400, got: %v", err)
+	}
+}
+
+func TestAuthorize_NetworkError_ReturnsWrappedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	client := srv.Client()
+	srv.Close()
+	c := NewClient(srv.URL, client)
+	_, err := c.Authorize(context.Background(), "agent.provision")
+	if err == nil {
+		t.Fatal("expected error got nil")
+	}
+	if !strings.Contains(err.Error(), "network") {
+		t.Errorf("error should mention network, got: %v", err)
+	}
+}
+
+func TestAuthorize_MalformedJSON_ReturnsError(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not json"))
+		},
+	})
+	c := NewClient(srv.URL, client)
+	_, err := c.Authorize(context.Background(), "agent.provision")
+	if err == nil {
+		t.Fatal("expected error got nil")
+	}
+	if !strings.Contains(err.Error(), "malformed") && !strings.Contains(err.Error(), "decode") {
+		t.Errorf("error should mention malformed/decode, got: %v", err)
+	}
+}
+
+func pollHandler(t *testing.T, script []func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
+	t.Helper()
+	calls := 0
+	return func(w http.ResponseWriter, r *http.Request) {
+		if calls >= len(script) {
+			t.Fatalf("token endpoint called more times than scripted (%d)", calls+1)
+		}
+		script[calls](w, r)
+		calls++
+	}
+}
+
+func devAuthHandler(expiresIn, interval int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code":               "dc-test-43-chars-padding-padding-padding-padding",
+			"user_code":                 "WDJB-MJHT",
+			"verification_uri":          "https://x/activate",
+			"verification_uri_complete": "https://x/activate?code=WDJB-MJHT",
+			"expires_in":                expiresIn,
+			"interval":                  interval,
+		})
+	}
+}
+
+func errorBody(code string, extra map[string]any) []byte {
+	body := map[string]any{"error": code}
+	for k, v := range extra {
+		body[k] = v
+	}
+	out, _ := json.Marshal(body)
+	return out
+}
+
+func nullSleep(time.Duration) {}
+
+func TestPoll_AuthorizationPending_ThenAuthorized(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(errorBody("authorization_pending", nil))
+			},
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "at-43-chars-padding-padding-padding-padding",
+					"token_type":   "Bearer",
+					"expires_in":   300,
+				})
+			},
+		}),
+	})
+	c := NewClient(srv.URL, client)
+	c.SetClockSleep(time.Now, nullSleep)
+	flow, err := c.Authorize(context.Background(), "agent.provision")
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	tok, err := flow.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if tok.AccessToken == "" || tok.TokenType != "Bearer" {
+		t.Errorf("unexpected token: %+v", tok)
+	}
+	if tok.ExpiresIn != 300*time.Second {
+		t.Errorf("want 300s expires_in got %v", tok.ExpiresIn)
+	}
+}
+
+func TestPoll_SlowDown_DoublesInterval(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(errorBody("slow_down", nil))
+			},
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "at-x", "token_type": "Bearer", "expires_in": 300,
+				})
+			},
+		}),
+	})
+	c := NewClient(srv.URL, client)
+	var sleeps []time.Duration
+	recorder := func(d time.Duration) { sleeps = append(sleeps, d) }
+	c.SetClockSleep(time.Now, recorder)
+	flow, err := c.Authorize(context.Background(), "agent.provision")
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	_, err = flow.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(sleeps) < 2 {
+		t.Fatalf("want >=2 sleeps got %d", len(sleeps))
+	}
+	if sleeps[1] != 10*time.Second {
+		t.Errorf("want 10s after slow_down, got %v", sleeps[1])
+	}
+}
+
+func TestPoll_SlowDown_HonorsServerInterval(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(errorBody("slow_down", map[string]any{"interval": 30}))
+			},
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "at-x", "token_type": "Bearer", "expires_in": 300,
+				})
+			},
+		}),
+	})
+	c := NewClient(srv.URL, client)
+	var sleeps []time.Duration
+	c.SetClockSleep(time.Now, func(d time.Duration) { sleeps = append(sleeps, d) })
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	_, err := flow.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if sleeps[1] != 30*time.Second {
+		t.Errorf("want server-supplied 30s, got %v", sleeps[1])
+	}
+}
+
+func TestPoll_SlowDown_CapsAt60Seconds(t *testing.T) {
+	script := []func(http.ResponseWriter, *http.Request){}
+	for i := 0; i < 5; i++ {
+		script = append(script, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write(errorBody("slow_down", nil))
+		})
+	}
+	script = append(script, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "at-x", "token_type": "Bearer", "expires_in": 300,
+		})
+	})
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token":                pollHandler(t, script),
+	})
+	c := NewClient(srv.URL, client)
+	var sleeps []time.Duration
+	c.SetClockSleep(time.Now, func(d time.Duration) { sleeps = append(sleeps, d) })
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	_, err := flow.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	want := []time.Duration{5, 10, 20, 40, 60, 60}
+	for i, w := range want {
+		if sleeps[i] != w*time.Second {
+			t.Errorf("sleeps[%d] want %ds got %v", i, w, sleeps[i])
+		}
+	}
+}
+
+func TestPoll_ExpiredToken_ReturnsErrExpiredToken(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(errorBody("expired_token", nil))
+			},
+		}),
+	})
+	c := NewClient(srv.URL, client)
+	c.SetClockSleep(time.Now, nullSleep)
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	_, err := flow.Poll(context.Background())
+	if !errors.Is(err, ErrExpiredToken) {
+		t.Errorf("want ErrExpiredToken got %v", err)
+	}
+}
+
+func TestPoll_AccessDenied_ReturnsErrAccessDenied(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(errorBody("access_denied", nil))
+			},
+		}),
+	})
+	c := NewClient(srv.URL, client)
+	c.SetClockSleep(time.Now, nullSleep)
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	_, err := flow.Poll(context.Background())
+	if !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("want ErrAccessDenied got %v", err)
+	}
+}
+
+func TestPoll_InvalidGrant_ReturnsErrInvalidGrant(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(errorBody("invalid_grant", nil))
+			},
+		}),
+	})
+	c := NewClient(srv.URL, client)
+	c.SetClockSleep(time.Now, nullSleep)
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	_, err := flow.Poll(context.Background())
+	if !errors.Is(err, ErrInvalidGrant) {
+		t.Errorf("want ErrInvalidGrant got %v", err)
+	}
+}
+
+func TestPoll_UnsupportedGrant_ReturnsErrUnsupportedGrant(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(errorBody("unsupported_grant_type", nil))
+			},
+		}),
+	})
+	c := NewClient(srv.URL, client)
+	c.SetClockSleep(time.Now, nullSleep)
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	_, err := flow.Poll(context.Background())
+	if !errors.Is(err, ErrUnsupportedGrant) {
+		t.Errorf("want ErrUnsupportedGrant got %v", err)
+	}
+}
+
+func TestPoll_InvalidClient_ReturnsErrInvalidClient(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(errorBody("invalid_client", nil))
+			},
+		}),
+	})
+	c := NewClient(srv.URL, client)
+	c.SetClockSleep(time.Now, nullSleep)
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	_, err := flow.Poll(context.Background())
+	if !errors.Is(err, ErrInvalidClient) {
+		t.Errorf("want ErrInvalidClient got %v", err)
+	}
+}
+
+func TestPoll_ContextCancellation_ReturnsCtxErr(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("token endpoint should NOT be called after context cancel")
+		},
+	})
+	c := NewClient(srv.URL, client)
+	cancelOnce := make(chan struct{}, 1)
+	c.SetClockSleep(time.Now, func(time.Duration) {
+		select {
+		case cancelOnce <- struct{}{}:
+		default:
+		}
+	})
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-cancelOnce
+		cancel()
+	}()
+	_, err := flow.Poll(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("want context.Canceled got %v", err)
+	}
+}
+
+func TestPoll_ExpiresAtElapsed_ReturnsErrExpiredToken(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("token endpoint should NOT be called when ExpiresAt elapsed")
+		},
+	})
+	c := NewClient(srv.URL, client)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	c.SetClockSleep(func() time.Time { return now }, nullSleep)
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	now = flow.ExpiresAt.Add(time.Second)
+	c.SetClockSleep(func() time.Time { return now }, nullSleep)
+	_, err := flow.Poll(context.Background())
+	if !errors.Is(err, ErrExpiredToken) {
+		t.Errorf("want ErrExpiredToken got %v", err)
+	}
+}
+
+func TestPoll_UnknownErrorCode_ReturnsGenericError(t *testing.T) {
+	srv, client := newMockServer(t, map[string]http.HandlerFunc{
+		"/oauth/device_authorization": devAuthHandler(600, 5),
+		"/oauth/token": pollHandler(t, []func(http.ResponseWriter, *http.Request){
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write(errorBody("totally_made_up", nil))
+			},
+		}),
+	})
+	c := NewClient(srv.URL, client)
+	c.SetClockSleep(time.Now, nullSleep)
+	flow, _ := c.Authorize(context.Background(), "agent.provision")
+	_, err := flow.Poll(context.Background())
+	if err == nil {
+		t.Fatal("expected error got nil")
+	}
+	if errors.Is(err, ErrExpiredToken) || errors.Is(err, ErrAccessDenied) ||
+		errors.Is(err, ErrInvalidGrant) || errors.Is(err, ErrUnsupportedGrant) ||
+		errors.Is(err, ErrInvalidClient) {
+		t.Errorf("unknown error should NOT match any sentinel, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "totally_made_up") {
+		t.Errorf("error should mention unknown code, got: %v", err)
+	}
+}

--- a/apps/dump_agent_go/internal/auth/export_test.go
+++ b/apps/dump_agent_go/internal/auth/export_test.go
@@ -1,0 +1,10 @@
+package auth
+
+import "time"
+
+// SetClockSleep is a test-only helper to inject deterministic clock + sleep.
+// Same package as Client; available only during `go test`.
+func (c *Client) SetClockSleep(now func() time.Time, sleep func(time.Duration)) {
+	c.clock = now
+	c.sleep = sleep
+}


### PR DESCRIPTION
## Summary

Phase 3 of 8 for edge-agent P4 zero-trust auth. Adds the agent-side OAuth Device Flow client in Go. Pure HTTP + state machine — no subcommand wiring, no cert provisioning, no mTLS, no storage. Those land in Phases 4-7.

## Changes

- **\`apps/dump_agent_go/internal/auth/device.go\` (new package, 287 LOC):**
  - \`Client\` + \`DeviceFlow\` + \`Token\` types
  - \`NewClient\`, \`Authorize\`, \`(*DeviceFlow).Poll\`
  - 5 sentinel errors (\`ErrExpiredToken\`, \`ErrAccessDenied\`, \`ErrInvalidGrant\`, \`ErrUnsupportedGrant\`, \`ErrInvalidClient\`)
  - RFC 8628 §3.5 polling rules (interval doubling, server-supplied interval, 60s cap)
  - Context cancellation + ExpiresAt guard
- **\`apps/dump_agent_go/internal/auth/device_test.go\`:** 16 tests (httptest mock OAuth server)
- **\`apps/dump_agent_go/internal/auth/export_test.go\`:** \`SetClockSleep\` helper for deterministic tests

## Test plan

- [x] 16 tests pass with \`go test -race -count=1\`.
- [x] \`go vet ./internal/auth/...\` clean.
- [x] Filtered project coverage gate >= 65% retained (77.2% achieved).
- [x] Per-function coverage on \`internal/auth/device.go\` avg ~85%+.
- [x] Zero new go.mod dependencies (stdlib only).
- [ ] CI passes (post-PR open).

## Phase context

- Phase 1 (PR #57, merged): cnes_infra/auth/ foundation.
- Phase 2 (PR #66, merged): server endpoints.
- Phase 2b (PR #67): cert rotation (server-side).
- **Phase 3 (this PR):** agent-side device flow client.
- Phase 4 (next): \`internal/auth/{store,csr}.go\` — DPAPI wrap + EC P-256 keypair + CSR builder.
- Phase 5: \`internal/transport/mtls.go\` mTLS http.Client.
- Phase 6: \`cmd_register.go\` subcommand wires device flow + cert provisioning.
- Phase 7: \`internal/auth/rotate.go\` background rotation loop.
- Phase 8: agent apiclient mTLS wire-up + transition flag.

## Out of scope

- Subcommand wiring (Phase 6).
- Cert provisioning, mTLS, storage (Phases 4-7).
- OpenAPI codegen regen (Phase 8).
- Real network integration test (Phase 8 manual smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)