### PR TITLE
feat(dump_agent_go/auth): persistent storage + CSR generation (Phase 4/8)

### DIFF
--- a/apps/dump_agent_go/internal/auth/csr.go
+++ b/apps/dump_agent_go/internal/auth/csr.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+)
+
+// GenerateKeyAndCSR creates a fresh EC P-256 keypair + CSR.
+//
+// Subject CN = machineID; no extensions. Server-side CertAuthority adds
+// tenant_id + agent_id custom OIDs to the leaf cert (Phase 1).
+//
+// Caller persists the key via store.SaveKey(dir, pkcs8DER):
+//
+//	key, csrPEM, err := auth.GenerateKeyAndCSR(machineID)
+//	pkcs8DER, _ := x509.MarshalPKCS8PrivateKey(key)
+//	store.SaveKey(dir, pkcs8DER)
+//	// send csrPEM to /provision/cert
+func GenerateKeyAndCSR(machineID string) (*ecdsa.PrivateKey, []byte, error) {
+	if machineID == "" {
+		return nil, nil, fmt.Errorf("csr: machineID required")
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("csr: keygen: %w", err)
+	}
+	tmpl := &x509.CertificateRequest{
+		Subject:            pkix.Name{CommonName: machineID},
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+	}
+	derBytes, err := x509.CreateCertificateRequest(rand.Reader, tmpl, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("csr: create: %w", err)
+	}
+	csrPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: derBytes,
+	})
+	return key, csrPEM, nil
+}

--- a/apps/dump_agent_go/internal/auth/csr_test.go
+++ b/apps/dump_agent_go/internal/auth/csr_test.go
@@ -1,0 +1,76 @@
+package auth
+
+import (
+	"crypto/elliptic"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+)
+
+func TestGenerateKeyAndCSR_ReturnsECP256Key(t *testing.T) {
+	key, _, err := GenerateKeyAndCSR("test-machine-id")
+	if err != nil {
+		t.Fatalf("GenerateKeyAndCSR: %v", err)
+	}
+	if key == nil {
+		t.Fatal("nil key")
+	}
+	if key.Curve != elliptic.P256() {
+		t.Errorf("want P256 curve got %v", key.Curve)
+	}
+}
+
+func TestGenerateKeyAndCSR_SubjectCN_MatchesMachineID(t *testing.T) {
+	machineID := "abc12345"
+	_, csrPEM, err := GenerateKeyAndCSR(machineID)
+	if err != nil {
+		t.Fatalf("GenerateKeyAndCSR: %v", err)
+	}
+	block, _ := pem.Decode(csrPEM)
+	if block == nil {
+		t.Fatal("pem.Decode returned nil")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		t.Fatalf("ParseCertificateRequest: %v", err)
+	}
+	if csr.Subject.CommonName != machineID {
+		t.Errorf("want CN=%s got %s", machineID, csr.Subject.CommonName)
+	}
+}
+
+func TestGenerateKeyAndCSR_SignatureValid(t *testing.T) {
+	_, csrPEM, err := GenerateKeyAndCSR("test")
+	if err != nil {
+		t.Fatalf("GenerateKeyAndCSR: %v", err)
+	}
+	block, _ := pem.Decode(csrPEM)
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		t.Fatalf("ParseCertificateRequest: %v", err)
+	}
+	if err := csr.CheckSignature(); err != nil {
+		t.Errorf("CheckSignature: %v", err)
+	}
+}
+
+func TestGenerateKeyAndCSR_PEMBlockType(t *testing.T) {
+	_, csrPEM, err := GenerateKeyAndCSR("test")
+	if err != nil {
+		t.Fatalf("GenerateKeyAndCSR: %v", err)
+	}
+	if !strings.Contains(string(csrPEM), "BEGIN CERTIFICATE REQUEST") {
+		t.Errorf("expected CERTIFICATE REQUEST block, got: %s", csrPEM)
+	}
+}
+
+func TestGenerateKeyAndCSR_EmptyMachineID_ReturnsError(t *testing.T) {
+	_, _, err := GenerateKeyAndCSR("")
+	if err == nil {
+		t.Fatal("expected error for empty machineID")
+	}
+	if !strings.Contains(err.Error(), "machineID") {
+		t.Errorf("error should mention machineID, got: %v", err)
+	}
+}

--- a/apps/dump_agent_go/internal/auth/device_test.go
+++ b/apps/dump_agent_go/internal/auth/device_test.go
@@ -387,9 +387,11 @@ func TestPoll_ContextCancellation_ReturnsCtxErr(t *testing.T) {
 	})
 	c := NewClient(srv.URL, client)
 	cancelOnce := make(chan struct{}, 1)
+	cancelDone := make(chan struct{})
 	c.SetClockSleep(time.Now, func(time.Duration) {
 		select {
 		case cancelOnce <- struct{}{}:
+			<-cancelDone
 		default:
 		}
 	})
@@ -398,6 +400,7 @@ func TestPoll_ContextCancellation_ReturnsCtxErr(t *testing.T) {
 	go func() {
 		<-cancelOnce
 		cancel()
+		close(cancelDone)
 	}()
 	_, err := flow.Poll(ctx)
 	if !errors.Is(err, context.Canceled) {

--- a/apps/dump_agent_go/internal/auth/store.go
+++ b/apps/dump_agent_go/internal/auth/store.go
@@ -1,0 +1,135 @@
+// Package auth — store: persistent on-disk storage for cert + key + refresh.
+//
+// File layout under AuthDir():
+//
+//	cert.pem      plaintext PEM, mode 0644 (public)
+//	key.bin       DPAPI envelope (Windows) OR PKCS8 DER + 0600 (Unix)
+//	refresh.bin   DPAPI envelope (Windows) OR raw token + 0600 (Unix)
+//
+// `.bin` extension is OS-agnostic; content varies by OS. On Windows,
+// wrapBytes uses DPAPI per-user (no LOCAL_MACHINE flag). User profile
+// rebuild → ErrUnwrapFailed → caller triggers re-registration.
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cnesdata/dumpagent/internal/platform"
+)
+
+// Sentinels.
+var (
+	ErrNotFound     = errors.New("auth: file not found")
+	ErrUnwrapFailed = errors.New("auth: unwrap failed (DPAPI key mismatch?)")
+	ErrCorrupted    = errors.New("auth: file corrupted")
+)
+
+const (
+	certFileName    = "cert.pem"
+	keyFileName     = "key.bin"
+	refreshFileName = "refresh.bin"
+)
+
+// AuthDir resolves the on-disk directory for agent auth artifacts.
+// Honors AGENT_AUTH_DIR env var; otherwise platform.AppDataDir() + "/auth".
+// Creates the directory with mode 0700 on first call.
+func AuthDir() (string, error) { //nolint:revive // stutter is intentional: package is auth, exported type is AuthDir
+	if override := os.Getenv("AGENT_AUTH_DIR"); override != "" {
+		if err := os.MkdirAll(override, 0o700); err != nil {
+			return "", fmt.Errorf("auth: mkdir override: %w", err)
+		}
+		return override, nil
+	}
+	base, err := platform.AppDataDir()
+	if err != nil {
+		return "", fmt.Errorf("auth: app data dir: %w", err)
+	}
+	dir := filepath.Join(base, "auth")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("auth: mkdir auth: %w", err)
+	}
+	return dir, nil
+}
+
+// SaveCert writes pemBytes to <dir>/cert.pem (mode 0644). PEM is public.
+func SaveCert(dir string, pemBytes []byte) error {
+	return writeAtomic(filepath.Join(dir, certFileName), pemBytes, 0o644)
+}
+
+// LoadCert reads <dir>/cert.pem. Returns ErrNotFound if missing.
+func LoadCert(dir string) ([]byte, error) {
+	data, err := os.ReadFile(filepath.Join(dir, certFileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("auth: read cert: %w", err)
+	}
+	return data, nil
+}
+
+// SaveKey wraps pkcs8DER (DPAPI on Windows; identity on Unix), writes 0600.
+func SaveKey(dir string, pkcs8DER []byte) error {
+	wrapped, err := wrapBytes(pkcs8DER)
+	if err != nil {
+		return err
+	}
+	return writeAtomic(filepath.Join(dir, keyFileName), wrapped, 0o600)
+}
+
+// LoadKey reads + unwraps. Returns ErrNotFound | ErrUnwrapFailed | DER bytes.
+func LoadKey(dir string) ([]byte, error) {
+	enc, err := os.ReadFile(filepath.Join(dir, keyFileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("auth: read key: %w", err)
+	}
+	plain, err := unwrapBytes(enc)
+	if err != nil {
+		return nil, err
+	}
+	return plain, nil
+}
+
+// SaveRefreshToken wraps + writes the token string. 0600.
+func SaveRefreshToken(dir string, token string) error {
+	wrapped, err := wrapBytes([]byte(token))
+	if err != nil {
+		return err
+	}
+	return writeAtomic(filepath.Join(dir, refreshFileName), wrapped, 0o600)
+}
+
+// LoadRefreshToken reads + unwraps. Returns the token string.
+func LoadRefreshToken(dir string) (string, error) {
+	enc, err := os.ReadFile(filepath.Join(dir, refreshFileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("auth: read refresh: %w", err)
+	}
+	plain, err := unwrapBytes(enc)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}
+
+// writeAtomic writes via temp file + rename to avoid torn writes.
+func writeAtomic(path string, data []byte, mode os.FileMode) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, mode); err != nil {
+		return fmt.Errorf("auth: write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("auth: rename: %w", err)
+	}
+	return nil
+}

--- a/apps/dump_agent_go/internal/auth/store.go
+++ b/apps/dump_agent_go/internal/auth/store.go
@@ -41,6 +41,7 @@ func AuthDir() (string, error) { //nolint:revive // stutter is intentional: pack
 		if err := os.MkdirAll(override, 0o700); err != nil {
 			return "", fmt.Errorf("auth: mkdir override: %w", err)
 		}
+		_ = os.Chmod(override, 0o700)
 		return override, nil
 	}
 	base, err := platform.AppDataDir()
@@ -51,6 +52,7 @@ func AuthDir() (string, error) { //nolint:revive // stutter is intentional: pack
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("auth: mkdir auth: %w", err)
 	}
+	_ = os.Chmod(dir, 0o700)
 	return dir, nil
 }
 

--- a/apps/dump_agent_go/internal/auth/store_test.go
+++ b/apps/dump_agent_go/internal/auth/store_test.go
@@ -1,0 +1,161 @@
+package auth
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestAuthDir_DefaultsToAppDataDir(t *testing.T) {
+	t.Setenv("AGENT_AUTH_DIR", "")
+	dir, err := AuthDir()
+	if err != nil {
+		t.Fatalf("AuthDir: %v", err)
+	}
+	if !strings.HasSuffix(filepath.ToSlash(dir), "/auth") {
+		t.Errorf("expected dir suffix /auth, got %s", dir)
+	}
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		t.Errorf("expected dir to exist, stat err=%v", err)
+	}
+}
+
+func TestAuthDir_HonorsAGENT_AUTH_DIR(t *testing.T) {
+	override := t.TempDir()
+	t.Setenv("AGENT_AUTH_DIR", override)
+	dir, err := AuthDir()
+	if err != nil {
+		t.Fatalf("AuthDir: %v", err)
+	}
+	if dir != override {
+		t.Errorf("want %s got %s", override, dir)
+	}
+}
+
+func TestAuthDir_CreatesMissingDir(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "nested", "auth")
+	t.Setenv("AGENT_AUTH_DIR", target)
+	if _, err := AuthDir(); err != nil {
+		t.Fatalf("AuthDir: %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil || !info.IsDir() {
+		t.Errorf("expected dir created, err=%v", err)
+	}
+}
+
+func TestSaveCert_LoadCert_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := []byte("-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----\n")
+	if err := SaveCert(dir, want); err != nil {
+		t.Fatalf("SaveCert: %v", err)
+	}
+	got, err := LoadCert(dir)
+	if err != nil {
+		t.Fatalf("LoadCert: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("round-trip mismatch want=%q got=%q", want, got)
+	}
+}
+
+func TestLoadCert_NotFound_ReturnsErrNotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadCert(dir)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound got %v", err)
+	}
+}
+
+func TestSaveKey_LoadKey_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := []byte("PKCS8 DER bytes go here")
+	if err := SaveKey(dir, want); err != nil {
+		t.Fatalf("SaveKey: %v", err)
+	}
+	got, err := LoadKey(dir)
+	if err != nil {
+		t.Fatalf("LoadKey: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("round-trip mismatch want=%q got=%q", want, got)
+	}
+}
+
+func TestLoadKey_NotFound_ReturnsErrNotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadKey(dir)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound got %v", err)
+	}
+}
+
+func TestSaveRefreshToken_LoadRefreshToken_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := "rt-43-chars-padding-padding-padding-padding"
+	if err := SaveRefreshToken(dir, want); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+	got, err := LoadRefreshToken(dir)
+	if err != nil {
+		t.Fatalf("LoadRefreshToken: %v", err)
+	}
+	if got != want {
+		t.Errorf("round-trip mismatch want=%q got=%q", want, got)
+	}
+}
+
+func TestLoadRefreshToken_NotFound_ReturnsErrNotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadRefreshToken(dir)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound got %v", err)
+	}
+}
+
+func TestSaveKey_WriteIsAtomic_NoTmpLeftover(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveKey(dir, []byte("data")); err != nil {
+		t.Fatalf("SaveKey: %v", err)
+	}
+	tmp := filepath.Join(dir, "key.bin.tmp")
+	if _, err := os.Stat(tmp); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("tmp file should not exist after Save, stat err=%v", err)
+	}
+}
+
+func TestSaveKey_OverwriteExisting_Succeeds(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveKey(dir, []byte("first")); err != nil {
+		t.Fatalf("first SaveKey: %v", err)
+	}
+	if err := SaveKey(dir, []byte("second")); err != nil {
+		t.Fatalf("second SaveKey: %v", err)
+	}
+	got, err := LoadKey(dir)
+	if err != nil {
+		t.Fatalf("LoadKey: %v", err)
+	}
+	if string(got) != "second" {
+		t.Errorf("want second got %s", got)
+	}
+}
+
+func TestLoadKey_CorruptedDPAPI_ReturnsErrUnwrapFailed(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("DPAPI-only; on Unix wrap is identity so random bytes round-trip cleanly")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "key.bin"), []byte("not a real dpapi blob"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	_, err := LoadKey(dir)
+	if !errors.Is(err, ErrUnwrapFailed) {
+		t.Errorf("want ErrUnwrapFailed got %v", err)
+	}
+}

--- a/apps/dump_agent_go/internal/auth/store_test.go
+++ b/apps/dump_agent_go/internal/auth/store_test.go
@@ -159,3 +159,23 @@ func TestLoadKey_CorruptedDPAPI_ReturnsErrUnwrapFailed(t *testing.T) {
 		t.Errorf("want ErrUnwrapFailed got %v", err)
 	}
 }
+
+
+func TestWriteAtomic_RenameFailure_RemovesTmp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Rename behavior over directory differs on Windows")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.bin")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("setup mkdir: %v", err)
+	}
+	err := writeAtomic(target, []byte("data"), 0o600)
+	if err == nil {
+		t.Fatal("expected rename to fail when target is a directory")
+	}
+	tmp := target + ".tmp"
+	if _, err := os.Stat(tmp); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("tmp leftover after rename failure, stat err=%v", err)
+	}
+}

--- a/apps/dump_agent_go/internal/auth/store_unix.go
+++ b/apps/dump_agent_go/internal/auth/store_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package auth
+
+// wrapBytes is identity on Unix; encryption-at-rest delegated to filesystem
+// permissions (mode 0600 set in Save* functions).
+func wrapBytes(plain []byte) ([]byte, error) {
+	cp := make([]byte, len(plain))
+	copy(cp, plain)
+	return cp, nil
+}
+
+// unwrapBytes is identity on Unix.
+func unwrapBytes(enc []byte) ([]byte, error) {
+	cp := make([]byte, len(enc))
+	copy(cp, enc)
+	return cp, nil
+}

--- a/apps/dump_agent_go/internal/auth/store_windows.go
+++ b/apps/dump_agent_go/internal/auth/store_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package auth
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// newBlob converts a byte slice into a DataBlob for the DPAPI calls.
+func newBlob(data []byte) *windows.DataBlob {
+	if len(data) == 0 {
+		return &windows.DataBlob{}
+	}
+	return &windows.DataBlob{
+		Size: uint32(len(data)), //nolint:gosec // len is always non-negative
+		Data: &data[0],
+	}
+}
+
+// blobToSlice converts a DataBlob output back to a Go byte slice.
+func blobToSlice(blob *windows.DataBlob) []byte {
+	if blob.Size == 0 || blob.Data == nil {
+		return []byte{}
+	}
+	return unsafe.Slice(blob.Data, blob.Size)
+}
+
+// wrapBytes encrypts plain using DPAPI (per-user, no LOCAL_MACHINE flag).
+func wrapBytes(plain []byte) ([]byte, error) {
+	var out windows.DataBlob
+	if err := windows.CryptProtectData(newBlob(plain), nil, nil, 0, nil, 0, &out); err != nil {
+		return nil, fmt.Errorf("auth: DPAPI protect: %w", err)
+	}
+	defer windows.LocalFree(windows.Handle(unsafe.Pointer(out.Data))) //nolint:errcheck
+	result := blobToSlice(&out)
+	cp := make([]byte, len(result))
+	copy(cp, result)
+	return cp, nil
+}
+
+// unwrapBytes decrypts a DPAPI blob. Returns ErrUnwrapFailed if the blob is
+// invalid or was encrypted under a different user profile.
+func unwrapBytes(enc []byte) ([]byte, error) {
+	var out windows.DataBlob
+	if err := windows.CryptUnprotectData(newBlob(enc), nil, nil, 0, nil, 0, &out); err != nil {
+		return nil, fmt.Errorf("%w: DPAPI unprotect: %v", ErrUnwrapFailed, err)
+	}
+	defer windows.LocalFree(windows.Handle(unsafe.Pointer(out.Data))) //nolint:errcheck
+	result := blobToSlice(&out)
+	cp := make([]byte, len(result))
+	copy(cp, result)
+	return cp, nil
+}

--- a/apps/dump_agent_go/internal/auth/store_windows_test.go
+++ b/apps/dump_agent_go/internal/auth/store_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package auth
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWrapBytes_OutputIsNotIdentity(t *testing.T) {
+	plain := []byte("secret-pkcs8-bytes-here")
+	enc, err := wrapBytes(plain)
+	if err != nil {
+		t.Fatalf("wrapBytes: %v", err)
+	}
+	if bytes.Equal(plain, enc) {
+		t.Error("DPAPI envelope should differ from input")
+	}
+	if len(enc) <= len(plain) {
+		t.Errorf("DPAPI envelope expected to grow input, got %d <= %d", len(enc), len(plain))
+	}
+}
+
+func TestUnwrapBytes_RoundTripWithRealDPAPI(t *testing.T) {
+	plain := []byte("round-trip-test-payload")
+	enc, err := wrapBytes(plain)
+	if err != nil {
+		t.Fatalf("wrapBytes: %v", err)
+	}
+	got, err := unwrapBytes(enc)
+	if err != nil {
+		t.Fatalf("unwrapBytes: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Errorf("round-trip mismatch want=%q got=%q", plain, got)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 4 of 8 for edge-agent P4 zero-trust auth. Adds agent-side persistent storage (cert.pem plaintext, key.bin DPAPI-wrapped, refresh.bin DPAPI-wrapped) + CSR generation (EC P-256, CN=machineID).

## Changes

- **\`store.go\`** — public API: \`AuthDir()\`, \`SaveCert\`/\`LoadCert\`, \`SaveKey\`/\`LoadKey\`, \`SaveRefreshToken\`/\`LoadRefreshToken\`. Sentinels: \`ErrNotFound\`, \`ErrUnwrapFailed\`, \`ErrCorrupted\`. Atomic write via temp + rename.
- **\`store_unix.go\`** (\`//go:build !windows\`) — identity wrap; mode 0600 protection.
- **\`store_windows.go\`** (\`//go:build windows\`) — DPAPI per-user via \`golang.org/x/sys/windows\`. \`defer LocalFree\` on output blobs.
- **\`csr.go\`** — \`GenerateKeyAndCSR(machineID)\` returns EC P-256 key + CSR PEM with subject CN. No extensions (server adds OIDs).
- **19 tests** (12 store + 2 Windows DPAPI + 5 CSR; 1 skipped on Unix for DPAPI corruption path).

## Test plan

- [x] Tests pass with \`go test -race -count=1\`.
- [x] \`go vet ./internal/auth/...\` clean (Linux + GOOS=windows cross-compile).
- [x] golangci-lint clean.
- [x] Filtered project coverage 77.3% (gate >= 65%).
- [x] Per-file: \`store.go\` 57-100% per-function, \`csr.go\` 81.8%, \`store_unix.go\` 100%.
- [x] Zero new go.mod dependencies.
- [ ] CI passes (post-PR open).

## Phase context

- Phase 1-2b (PRs #57, #66, #67): server-side foundation + endpoints.
- Phase 3 (PR #68): agent-side device flow client.
- **Phase 4 (this PR):** storage + CSR.
- Phase 5 (next): \`internal/transport/mtls.go\` mTLS \`http.Client\`.
- Phase 6: \`cmd_register.go\` subcommand wires device flow + CSR + cert provisioning + storage.
- Phase 7: \`internal/auth/rotate.go\` background rotation loop.
- Phase 8: agent apiclient mTLS wire-up + transition flag.

## Out of scope

- Subcommand wiring (Phase 6).
- mTLS http.Client (Phase 5).
- Rotation loop (Phase 7).
- ca_pin.go root CA pin (Phase 5 when mTLS needs it).
- HSM / TPM-bound keys (future hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)