### PR TITLE
feat(dump_agent_go): Phase 8 apiclient mTLS wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@
 # NUNCA versione o .env com credenciais reais!
 # =============================================================================
 
+# --- Opcional ---
+# FOLHA_HR_PATH=caminho/para/planilha_rh.xlsx
+# DATASUS_AUTH_TOKEN=bearer-token-aqui
+
 # --- Banco de Dados Firebird (CNES Local) ---
 DB_HOST=localhost
 DB_PATH=C:\Datasus\CNES\CNES.GDB
@@ -51,11 +55,13 @@ MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin
 MINIO_SECURE=false
 
-# --- Opcional ---
-# FOLHA_HR_PATH=caminho/para/planilha_rh.xlsx
-# DATASUS_AUTH_TOKEN=bearer-token-aqui
-
 # Edge agent P4 — OAuth Device Flow + mTLS provisioning (Phase 2)
 AUTH_CA_CERT_PATH=secrets/ca.crt
 AUTH_CA_KEY_PATH=secrets/ca.key
 AUTH_DEVICE_VERIFICATION_URI=http://localhost:5173/activate
+
+# Edge agent P4 — apiclient mTLS (Phase 8)
+# Fleet rollout escape hatch: when set to "true", agent boots in plain
+# HTTP mode if cert load fails (e.g., agent not yet registered).
+# Remove after fleet fully enrolled via `dumpagent register`.
+# AGENT_ALLOW_INSECURE=true

--- a/apps/dump_agent_go/CLAUDE.md
+++ b/apps/dump_agent_go/CLAUDE.md
@@ -110,3 +110,24 @@ driver pure-Go).
   cert / mTLS init failure logs warn and continues without rotation
   (agent runs in non-mTLS mode until `dumpagent register`).
 - Phase 8 = wire `apiclient.Adapter` to use `mtlsClient.HTTPClient()`.
+
+## Phase 8: apiclient mTLS wiring (2026-04-30)
+
+- `cmd/dumpagent/cmd_run.go` — `runForeground` constructs single
+  `*transport.Client` after machine_id resolve, shares between
+  Phase 7 rotator and Phase 8 apiclient. Rotator's `Reload()`
+  hot-swaps cert for both via `atomic.Pointer[tls.Certificate]`
+  (Phase 5 contract).
+- `initMTLSClient(authDir)` returns `(mtls, nil)` on success,
+  `(nil, err)` fail-closed when `transport.NewMTLSClient` fails.
+  `AGENT_ALLOW_INSECURE=true` flips fail-closed → fallback `(nil, nil)`
+  (plain HTTP via `http.DefaultClient`). Boot logs `mtls_init_ok` or
+  `mtls_fallback_active` once; no per-job re-log.
+- `httpClientFor(mtls)` returns `mtls.HTTPClient()` or nil; threaded
+  to `buildAPIClient(machineID, httpClient)`. `apiclient.NewAdapter`
+  signature unchanged (already accepted `*http.Client`).
+- MinIO uploads (presigned PUT) untouched — `upload.NewHTTP(nil)`
+  remains plain HTTP, direct to MinIO not central_api.
+- 8-phase zero-trust migration COMPLETE. Agent runs mTLS by default;
+  unregistered agents must `dumpagent register` first OR set
+  `AGENT_ALLOW_INSECURE=true` for fleet rollout escape hatch.

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_run.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_run.go
@@ -174,6 +174,26 @@ func startRotatorIfPossible(ctx context.Context, machineID string) {
 	slog.Info("rotator_started", "machine_id", machineID)
 }
 
+// initMTLSClient constructs the shared mTLS http.Client used by both
+// the rotator (Phase 7) and apiclient (Phase 8). Fail-closed by
+// default: cert load failures abort boot. Set AGENT_ALLOW_INSECURE=true
+// to fall back to plain HTTP during fleet rollout. Logs the outcome
+// once at boot; callers do NOT re-log.
+func initMTLSClient(authDir string) (*transport.Client, error) {
+	mtls, err := transport.NewMTLSClient(authDir, auth.CAPinPEM)
+	if err == nil {
+		slog.Info("mtls_init_ok")
+		return mtls, nil
+	}
+	if os.Getenv("AGENT_ALLOW_INSECURE") == "true" {
+		slog.Warn("mtls_fallback_active",
+			"reason", err.Error(),
+			"AGENT_ALLOW_INSECURE", "true")
+		return nil, nil
+	}
+	return nil, err
+}
+
 func preFlightClockCheck(ctx context.Context) error {
 	skew, err := platform.CheckClockSkew(ctx, nil, 5*time.Second)
 	if err != nil {

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_run.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_run.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -192,6 +193,16 @@ func initMTLSClient(authDir string) (*transport.Client, error) {
 		return nil, nil
 	}
 	return nil, err
+}
+
+// httpClientFor returns mtls.HTTPClient() or nil. nil-handling lets
+// apiclient.NewAdapter fall back to http.DefaultClient (plain HTTP)
+// when AGENT_ALLOW_INSECURE=true permitted insecure boot.
+func httpClientFor(mtls *transport.Client) *http.Client {
+	if mtls == nil {
+		return nil
+	}
+	return mtls.HTTPClient()
 }
 
 func preFlightClockCheck(ctx context.Context) error {

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_run.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_run.go
@@ -80,7 +80,21 @@ func runForeground(ctx context.Context, verbose bool, flags RunFlags) int {
 	}
 	slog.Info("machine_id_resolved", "machine_id", machineID)
 
-	startRotatorIfPossible(ctx, machineID)
+	authDir, err := auth.AuthDir()
+	if err != nil {
+		slog.Error("auth_dir_init", "err", err.Error())
+		return 1
+	}
+
+	mtlsClient, err := initMTLSClient(authDir)
+	if err != nil {
+		slog.Error("mtls_init_fatal",
+			"err", err.Error(),
+			"hint", "run 'dumpagent register' or set AGENT_ALLOW_INSECURE=true")
+		return 1
+	}
+
+	startRotatorIfPossible(ctx, mtlsClient, authDir, machineID)
 
 	slog.Info("run_flags",
 		"bpa_gdb", flags.BPAGDBPath,
@@ -115,7 +129,7 @@ func runForeground(ctx context.Context, verbose bool, flags RunFlags) int {
 	}
 	defer db.Close()
 
-	apiClient, err := buildAPIClient(machineID)
+	apiClient, err := buildAPIClient(machineID, httpClientFor(mtlsClient))
 	if err != nil {
 		slog.Error("api_client_init", "err", err.Error())
 		return 1
@@ -151,21 +165,15 @@ func runForeground(ctx context.Context, verbose bool, flags RunFlags) int {
 	return 0
 }
 
-func startRotatorIfPossible(ctx context.Context, machineID string) {
-	authDir, err := auth.AuthDir()
-	if err != nil {
-		slog.Warn("auth_dir_init", "err", err.Error())
-		return
-	}
-	mtlsClient, err := transport.NewMTLSClient(authDir, auth.CAPinPEM)
-	if err != nil {
-		slog.Warn("mtls_client_init_skipping_rotation",
-			"err", err.Error(),
-			"hint", "agent not yet registered? run 'dumpagent register'")
+func startRotatorIfPossible(
+	ctx context.Context, mtls *transport.Client, authDir, machineID string,
+) {
+	if mtls == nil {
+		slog.Info("rotator_skipped", "reason", "no_mtls")
 		return
 	}
 	baseURL := envOr("CENTRAL_API_URL", "http://localhost:8000")
-	rotator := auth.NewRotator(mtlsClient, authDir, baseURL, machineID)
+	rotator := auth.NewRotator(mtls, authDir, baseURL, machineID)
 	_ = obs.SafeGo(func() error {
 		if rerr := rotator.Run(ctx); rerr != nil {
 			slog.Error("rotator_terminal", "err", rerr.Error())
@@ -283,13 +291,13 @@ func envOr(k, def string) string {
 	return def
 }
 
-func buildAPIClient(machineID string) (*apiclient.Adapter, error) {
+func buildAPIClient(machineID string, httpClient *http.Client) (*apiclient.Adapter, error) {
 	baseURL := envOr("CENTRAL_API_URL", "http://localhost:8000")
 	tenantID := os.Getenv("TENANT_ID")
 	if tenantID == "" {
 		return nil, &stubErr{msg: "env_required var=TENANT_ID"}
 	}
-	return apiclient.NewAdapter(baseURL, tenantID, machineID, nil)
+	return apiclient.NewAdapter(baseURL, tenantID, machineID, httpClient)
 }
 
 func buildJobSource() (worker.JobSpecSource, error) {

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_run_mtls_test.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_run_mtls_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/cnesdata/dumpagent/internal/auth"
+)
+
+// mtlsCA is a self-signed CA used to sign leaf certs in mtls-init tests.
+type mtlsCA struct {
+	cert    *x509.Certificate
+	key     *rsa.PrivateKey
+	pinPEM  []byte
+}
+
+func seedMTLSCA(t *testing.T) *mtlsCA {
+	t.Helper()
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("ca rsa keygen: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "phase8-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("ca CreateCertificate: %v", err)
+	}
+	cert, _ := x509.ParseCertificate(der)
+	pinPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return &mtlsCA{cert: cert, key: caKey, pinPEM: pinPEM}
+}
+
+// seedMTLSAuthDir writes a valid cert.pem + PKCS8 key.bin pair into a
+// fresh temp dir. Returns the dir path. Cert is signed by ca and valid
+// for 24h.
+func seedMTLSAuthDir(t *testing.T, ca *mtlsCA) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("AGENT_AUTH_DIR", dir)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("leaf keygen: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-agent"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &leafKey.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("sign leaf: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := auth.SaveCert(dir, certPEM); err != nil {
+		t.Fatalf("save cert: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	if err := auth.SaveKey(dir, keyDER); err != nil {
+		t.Fatalf("save key: %v", err)
+	}
+	if err := auth.SaveRefreshToken(dir, "ph"); err != nil {
+		t.Fatalf("save refresh: %v", err)
+	}
+	return dir
+}
+
+// withCAPinOverride swaps auth.CAPinPEM for the duration of t and
+// restores it on cleanup.
+func withCAPinOverride(t *testing.T, pinPEM []byte) {
+	t.Helper()
+	orig := auth.CAPinPEM
+	auth.CAPinPEM = pinPEM
+	t.Cleanup(func() { auth.CAPinPEM = orig })
+}
+
+func TestInitMTLS_CertValid_ReturnsClient(t *testing.T) {
+	ca := seedMTLSCA(t)
+	dir := seedMTLSAuthDir(t, ca)
+	withCAPinOverride(t, ca.pinPEM)
+
+	mtls, err := initMTLSClient(dir)
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if mtls == nil {
+		t.Fatal("expected non-nil mtls client")
+	}
+	if mtls.HTTPClient() == nil {
+		t.Fatal("expected non-nil HTTPClient")
+	}
+}

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_run_mtls_test.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_run_mtls_test.go
@@ -9,6 +9,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -110,5 +112,75 @@ func TestInitMTLS_CertValid_ReturnsClient(t *testing.T) {
 	}
 	if mtls.HTTPClient() == nil {
 		t.Fatal("expected non-nil HTTPClient")
+	}
+}
+
+func TestInitMTLS_CertMissing_FailClosed(t *testing.T) {
+	ca := seedMTLSCA(t)
+	dir := t.TempDir()
+	t.Setenv("AGENT_AUTH_DIR", dir)
+	t.Setenv("AGENT_ALLOW_INSECURE", "")
+	withCAPinOverride(t, ca.pinPEM)
+
+	mtls, err := initMTLSClient(dir)
+	if err == nil {
+		t.Fatal("expected err for missing cert, got nil")
+	}
+	if mtls != nil {
+		t.Fatal("expected nil mtls when cert missing")
+	}
+}
+
+func TestInitMTLS_CertMissing_FallbackHonored(t *testing.T) {
+	ca := seedMTLSCA(t)
+	dir := t.TempDir()
+	t.Setenv("AGENT_AUTH_DIR", dir)
+	t.Setenv("AGENT_ALLOW_INSECURE", "true")
+	withCAPinOverride(t, ca.pinPEM)
+
+	mtls, err := initMTLSClient(dir)
+	if err != nil {
+		t.Fatalf("expected nil err with fallback flag, got %v", err)
+	}
+	if mtls != nil {
+		t.Fatal("expected nil mtls in fallback mode")
+	}
+}
+
+func TestInitMTLS_KeyParseFails_FailClosed(t *testing.T) {
+	ca := seedMTLSCA(t)
+	dir := seedMTLSAuthDir(t, ca)
+	t.Setenv("AGENT_ALLOW_INSECURE", "")
+	withCAPinOverride(t, ca.pinPEM)
+
+	if err := os.WriteFile(filepath.Join(dir, "key.bin"), []byte("not-pkcs8"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	mtls, err := initMTLSClient(dir)
+	if err == nil {
+		t.Fatal("expected err for malformed key, got nil")
+	}
+	if mtls != nil {
+		t.Fatal("expected nil mtls when key parse fails")
+	}
+}
+
+func TestInitMTLS_KeyParseFails_FallbackHonored(t *testing.T) {
+	ca := seedMTLSCA(t)
+	dir := seedMTLSAuthDir(t, ca)
+	t.Setenv("AGENT_ALLOW_INSECURE", "true")
+	withCAPinOverride(t, ca.pinPEM)
+
+	if err := os.WriteFile(filepath.Join(dir, "key.bin"), []byte("not-pkcs8"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	mtls, err := initMTLSClient(dir)
+	if err != nil {
+		t.Fatalf("expected nil err with fallback flag, got %v", err)
+	}
+	if mtls != nil {
+		t.Fatal("expected nil mtls in fallback mode")
 	}
 }

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_run_mtls_test.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_run_mtls_test.go
@@ -184,3 +184,28 @@ func TestInitMTLS_KeyParseFails_FallbackHonored(t *testing.T) {
 		t.Fatal("expected nil mtls in fallback mode")
 	}
 }
+
+func TestHTTPClientFor_NilMTLS_ReturnsNil(t *testing.T) {
+	got := httpClientFor(nil)
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestHTTPClientFor_NonNil_ReturnsHTTPClient(t *testing.T) {
+	ca := seedMTLSCA(t)
+	dir := seedMTLSAuthDir(t, ca)
+	withCAPinOverride(t, ca.pinPEM)
+	mtls, err := initMTLSClient(dir)
+	if err != nil || mtls == nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	got := httpClientFor(mtls)
+	if got == nil {
+		t.Fatal("expected non-nil http.Client")
+	}
+	if got != mtls.HTTPClient() {
+		t.Fatal("expected got == mtls.HTTPClient() (same pointer)")
+	}
+}

--- a/apps/dump_agent_go/internal/apiclient/adapter_test.go
+++ b/apps/dump_agent_go/internal/apiclient/adapter_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cnesdata/dumpagent/internal/apiclient"
@@ -35,10 +37,34 @@ func TestNewAdapter_SetsFields(t *testing.T) {
 	require.NotNil(t, a.Inner)
 }
 
+// recordingTransport captures all RoundTrip calls for inspection.
+type recordingTransport struct {
+	visited []string
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.visited = append(rt.visited, req.URL.Path)
+	return &http.Response{
+		StatusCode: 500,
+		Body:       io.NopCloser(strings.NewReader(`{"detail":"test-shortcircuit"}`)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
 func TestNewAdapter_UsesCustomHTTPClient(t *testing.T) {
-	a, err := apiclient.NewAdapter("http://localhost:1", "t", "m", http.DefaultClient)
+	rt := &recordingTransport{}
+	httpClient := &http.Client{Transport: rt}
+
+	a, err := apiclient.NewAdapter("http://test.invalid", "tenant-1", "machine-1", httpClient)
 	require.NoError(t, err)
-	require.NotNil(t, a.Inner)
+	require.NotNil(t, a)
+
+	jobUUID := uuid.NewString()
+	_ = a.SendHeartbeat(context.Background(), jobUUID)
+
+	require.NotEmpty(t, rt.visited, "expected RoundTrip to be invoked; injected client unused")
+	require.Contains(t, rt.visited[0], "/heartbeat")
 }
 
 func newTestAdapter(t *testing.T, handler http.HandlerFunc) *apiclient.Adapter {


### PR DESCRIPTION
## Summary
- Wires `apiclient.Adapter` to use shared `*transport.Client` (mTLS) for all central_api calls
- Single mtls instance shared between Phase 7 rotator and Phase 8 apiclient — `Reload()` propagates atomically
- Fail-closed by default; `AGENT_ALLOW_INSECURE=true` permits plain-HTTP fallback during fleet rollout
- 8-phase zero-trust authorization migration COMPLETE

## Test plan
- [x] `initMTLSClient` happy path + 4-case error matrix (cert missing/key parse, fail-closed/fallback)
- [x] `httpClientFor` nil + non-nil
- [x] `apiclient.NewAdapter` injected `*http.Client` actually routes requests (RoundTripper recorder)
- [x] Filtered coverage ≥ 65%
- [x] golangci-lint clean (Phase 8 packages)
- [x] No regression in existing CNES/SIHD/BPA/SIA jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)