### PR TITLE
feat(dump_agent_go): P5.1 Windows Event Log sink

### DIFF
--- a/apps/dump_agent_go/CLAUDE.md
+++ b/apps/dump_agent_go/CLAUDE.md
@@ -131,3 +131,26 @@ driver pure-Go).
 - 8-phase zero-trust migration COMPLETE. Agent runs mTLS by default;
   unregistered agents must `dumpagent register` first OR set
   `AGENT_ALLOW_INSECURE=true` for fleet rollout escape hatch.
+
+## Phase 5.1 — Windows Event Log sink (2026-05-01)
+
+WARN+ slog records routed to Application log under source `DumpAgent`.
+Linux/Mac: no-op stub via build tags. Existing rotating-file handler
+unchanged — eventlog is fan-out sibling under `obs.MultiHandler`.
+
+- Source name: `service.EventSourceName` constant ("DumpAgent"). No env override.
+- Registration: `agent.exe install` calls `service.RegisterEventSource`;
+  `agent.exe uninstall` calls `service.RemoveEventSource`. Both idempotent.
+  Best-effort: install succeeds even if registration fails.
+- Event IDs: `internal/obs/events.go` banded catalog (1xxx auth, 2xxx queue,
+  3xxx extract, 4xxx upload, 5xxx diagnose, 9xxx generic). P4 reserved
+  1003/1004. Add `event_id` attr to slog calls that should map to a
+  specific Event Viewer entry; missing attr defaults to `EventUnknown`.
+- Format: `obs.FormatCompact` renders `level=… msg=… k1=v1 k2=v2`
+  single-line, UTF-8-safe truncation at 8KB, ASCII control bytes escaped.
+- Rollback knob: `AGENT_EVENTLOG_DISABLED=true` makes handler no-op without
+  uninstall. Not in `.env.example` (emergency switch only).
+- Locale-independent: `RemoveEventSource` uses `errors.Is(err,
+  syscall.ERROR_FILE_NOT_FOUND)` — works on pt-BR Windows hosts.
+- Cross-tag check: CI runs `go vet` on both `GOOS=linux` and
+  `GOOS=windows` to catch tag leaks before merge.

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_install.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_install.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cnesdata/dumpagent/internal/service"
 )
@@ -12,8 +13,8 @@ func cmdInstall(args []string) int {
 		return rc
 	}
 	if err := service.RegisterEventSource(service.EventSourceName); err != nil {
-		fmt.Printf("warn: eventlog source registration failed: %v\n", err)
-		fmt.Println("warn: continuing without eventlog sink (file logs unaffected)")
+		fmt.Fprintf(os.Stderr, "warn: eventlog source registration failed: %v\n", err)
+		fmt.Fprintln(os.Stderr, "warn: continuing without eventlog sink (file logs unaffected)")
 	} else {
 		fmt.Printf("eventlog source registered: %s\n", service.EventSourceName)
 	}

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_install.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_install.go
@@ -1,7 +1,21 @@
 package main
 
-import "github.com/cnesdata/dumpagent/internal/service"
+import (
+	"fmt"
+
+	"github.com/cnesdata/dumpagent/internal/service"
+)
 
 func cmdInstall(args []string) int {
-	return service.Install(args)
+	rc := service.Install(args)
+	if rc != 0 {
+		return rc
+	}
+	if err := service.RegisterEventSource(service.EventSourceName); err != nil {
+		fmt.Printf("warn: eventlog source registration failed: %v\n", err)
+		fmt.Println("warn: continuing without eventlog sink (file logs unaffected)")
+	} else {
+		fmt.Printf("eventlog source registered: %s\n", service.EventSourceName)
+	}
+	return 0
 }

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_install_test.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_install_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cnesdata/dumpagent/internal/service"
+)
+
+func TestCmdInstall_EventSourceConstantsMatch(t *testing.T) {
+	if service.EventSourceName != "DumpAgent" {
+		t.Fatalf("source name drift: got %q want DumpAgent", service.EventSourceName)
+	}
+}

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_run.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cnesdata/dumpagent/internal/fbdriver"
 	"github.com/cnesdata/dumpagent/internal/obs"
 	"github.com/cnesdata/dumpagent/internal/platform"
+	"github.com/cnesdata/dumpagent/internal/service"
 	"github.com/cnesdata/dumpagent/internal/transport"
 	"github.com/cnesdata/dumpagent/internal/upload"
 	"github.com/cnesdata/dumpagent/internal/worker"
@@ -61,7 +62,7 @@ func runForeground(ctx context.Context, verbose bool, flags RunFlags) int {
 		slog.Error("logs_dir_init", "err", err.Error())
 		return 1
 	}
-	handler, closer := obs.NewRotatingHandler(filepath.Join(logsDir, "dumpagent.log"), level)
+	handler, closer := buildLoggerHandler(filepath.Join(logsDir, "dumpagent.log"), level)
 	defer closer()
 	slog.SetDefault(slog.New(handler))
 
@@ -349,5 +350,18 @@ func buildDispatchConfig(flags RunFlags, adapter *apiclient.Adapter) worker.Disp
 			Uploader: upload.NewHTTP(nil),
 			Register: register,
 		},
+	}
+}
+
+// buildLoggerHandler composes the rotating-file handler with the Windows
+// Event Log handler under a MultiHandler. EventLogHandler is a no-op
+// on non-Windows. Both Close functions are tied to the returned closer.
+func buildLoggerHandler(logPath string, level slog.Level) (slog.Handler, func()) {
+	rotating, rotatingCloser := obs.NewRotatingHandler(logPath, level)
+	eventlog, _ := obs.NewEventLogHandler(service.EventSourceName)
+	multi := obs.NewMultiHandler(rotating, eventlog)
+	return multi, func() {
+		rotatingCloser()
+		_ = eventlog.Close()
 	}
 }

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_run_mtls_test.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_run_mtls_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"log/slog"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cnesdata/dumpagent/internal/auth"
+	"github.com/cnesdata/dumpagent/internal/obs"
 )
 
 // mtlsCA is a self-signed CA used to sign leaf certs in mtls-init tests.
@@ -207,5 +209,18 @@ func TestHTTPClientFor_NonNil_ReturnsHTTPClient(t *testing.T) {
 	}
 	if got != mtls.HTTPClient() {
 		t.Fatal("expected got == mtls.HTTPClient() (same pointer)")
+	}
+}
+
+func TestRunForegroundLogger_MultiHandlerComposition(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "test.log")
+	h, closer := buildLoggerHandler(logPath, slog.LevelInfo)
+	defer closer()
+	if h == nil {
+		t.Fatal("expected non-nil handler")
+	}
+	if _, ok := h.(*obs.MultiHandler); !ok {
+		t.Fatalf("expected *obs.MultiHandler, got %T", h)
 	}
 }

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_uninstall.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_uninstall.go
@@ -1,7 +1,14 @@
 package main
 
-import "github.com/cnesdata/dumpagent/internal/service"
+import (
+	"fmt"
+
+	"github.com/cnesdata/dumpagent/internal/service"
+)
 
 func cmdUninstall() int {
+	if err := service.RemoveEventSource(service.EventSourceName); err != nil {
+		fmt.Printf("warn: eventlog source removal failed: %v\n", err)
+	}
 	return service.Uninstall()
 }

--- a/apps/dump_agent_go/cmd/dumpagent/cmd_uninstall.go
+++ b/apps/dump_agent_go/cmd/dumpagent/cmd_uninstall.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cnesdata/dumpagent/internal/service"
 )
 
 func cmdUninstall() int {
 	if err := service.RemoveEventSource(service.EventSourceName); err != nil {
-		fmt.Printf("warn: eventlog source removal failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "warn: eventlog source removal failed: %v\n", err)
 	}
 	return service.Uninstall()
 }

--- a/apps/dump_agent_go/internal/auth/event_ids_test.go
+++ b/apps/dump_agent_go/internal/auth/event_ids_test.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEventIDAttrsOnP4CallSites enforces P5.1 spec acceptance:
+// every slog call that emits dpapi_unwrap_failed or cert_rotation_halt
+// must carry obs.EventDPAPIUnwrapFailed or obs.EventCertRotationHalted.
+// If the call site is not present in current source, the test skips.
+// This serves as a forward drift guard for when those slog calls land.
+func TestEventIDAttrsOnP4CallSites(t *testing.T) {
+	cases := []struct {
+		file    string
+		msg     string
+		attrVal string
+	}{
+		{"store.go", "dpapi_unwrap_failed", "obs.EventDPAPIUnwrapFailed"},
+		{"rotate.go", "cert_rotation_halt", "obs.EventCertRotationHalted"},
+	}
+	for _, c := range cases {
+		path := filepath.Join(c.file)
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", c.file, err)
+		}
+		text := string(body)
+		if !strings.Contains(text, c.msg) {
+			t.Skipf("call site %s not present in %s; drift guard inactive", c.msg, c.file)
+		}
+		if !strings.Contains(text, c.attrVal) {
+			t.Errorf("%s: emits %q without %q event_id attr",
+				c.file, c.msg, c.attrVal)
+		}
+	}
+}

--- a/apps/dump_agent_go/internal/auth/event_ids_test.go
+++ b/apps/dump_agent_go/internal/auth/event_ids_test.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -22,8 +21,7 @@ func TestEventIDAttrsOnP4CallSites(t *testing.T) {
 		{"rotate.go", "cert_rotation_halt", "obs.EventCertRotationHalted"},
 	}
 	for _, c := range cases {
-		path := filepath.Join(c.file)
-		body, err := os.ReadFile(path)
+		body, err := os.ReadFile(c.file)
 		if err != nil {
 			t.Fatalf("read %s: %v", c.file, err)
 		}

--- a/apps/dump_agent_go/internal/obs/eventlog.go
+++ b/apps/dump_agent_go/internal/obs/eventlog.go
@@ -1,0 +1,11 @@
+package obs
+
+import "log/slog"
+
+// EventLogHandler is a slog.Handler with an explicit Close.
+// Real impl on Windows talks to the Windows Event Log;
+// no-op stub on POSIX so cross-platform code can wire unconditionally.
+type EventLogHandler interface {
+	slog.Handler
+	Close() error
+}

--- a/apps/dump_agent_go/internal/obs/eventlog_unix.go
+++ b/apps/dump_agent_go/internal/obs/eventlog_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package obs
+
+import (
+	"context"
+	"log/slog"
+)
+
+type unixEventLogHandler struct{}
+
+// NewEventLogHandler returns a no-op handler on non-Windows platforms.
+func NewEventLogHandler(_ string) (EventLogHandler, error) {
+	return &unixEventLogHandler{}, nil
+}
+
+func (*unixEventLogHandler) Enabled(_ context.Context, _ slog.Level) bool   { return false }
+func (*unixEventLogHandler) Handle(_ context.Context, _ slog.Record) error { return nil }
+func (h *unixEventLogHandler) WithAttrs(_ []slog.Attr) slog.Handler         { return h }
+func (h *unixEventLogHandler) WithGroup(_ string) slog.Handler              { return h }
+func (*unixEventLogHandler) Close() error                                   { return nil }

--- a/apps/dump_agent_go/internal/obs/eventlog_unix_test.go
+++ b/apps/dump_agent_go/internal/obs/eventlog_unix_test.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package obs
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestEventLogHandler_UnixIsNoOp(t *testing.T) {
+	h, err := NewEventLogHandler("DumpAgent")
+	if err != nil {
+		t.Fatalf("unix stub must not error, got %v", err)
+	}
+	if h == nil {
+		t.Fatal("unix stub must return non-nil handler")
+	}
+	if h.Enabled(context.Background(), slog.LevelError) {
+		t.Fatal("unix stub Enabled must be false")
+	}
+	rec := slog.NewRecord(time.Time{}, slog.LevelError, "x", 0)
+	if err := h.Handle(context.Background(), rec); err != nil {
+		t.Fatalf("unix stub Handle must not error, got %v", err)
+	}
+	if err := h.Close(); err != nil {
+		t.Fatalf("unix stub Close must not error, got %v", err)
+	}
+}

--- a/apps/dump_agent_go/internal/obs/eventlog_windows.go
+++ b/apps/dump_agent_go/internal/obs/eventlog_windows.go
@@ -1,0 +1,107 @@
+//go:build windows
+
+package obs
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+// eventlogWriter is the surface satisfied by *eventlog.Log and the
+// fake used in tests. Restricts the imported package to what the
+// handler actually uses.
+type eventlogWriter interface {
+	Info(eid uint32, msg string) error
+	Warning(eid uint32, msg string) error
+	Error(eid uint32, msg string) error
+	Close() error
+}
+
+// Compile-time interface assertion: ensure winEventLogHandler implements
+// EventLogHandler so future signature drift fails at build, not runtime.
+var _ EventLogHandler = (*winEventLogHandler)(nil)
+
+type winEventLogHandler struct {
+	w        eventlogWriter
+	source   string
+	disabled bool
+	attrs    []slog.Attr
+}
+
+// NewEventLogHandler opens the Application log under source. If
+// AGENT_EVENTLOG_DISABLED=true or eventlog.Open fails (eventlog service
+// down, source unregistered), returns a non-nil handler with disabled=true
+// so MultiHandler can skip silently. The error return is reserved for
+// future use; v1 always returns nil.
+func NewEventLogHandler(source string) (EventLogHandler, error) {
+	if os.Getenv("AGENT_EVENTLOG_DISABLED") == "true" {
+		return &winEventLogHandler{source: source, disabled: true}, nil
+	}
+	w, err := eventlog.Open(source)
+	if err != nil {
+		slog.Warn("eventlog_open_failed",
+			"source", source,
+			"err", err.Error(),
+			"hint", "run 'agent.exe install' to register source")
+		return &winEventLogHandler{source: source, disabled: true}, nil
+	}
+	return &winEventLogHandler{w: w, source: source}, nil
+}
+
+func (h *winEventLogHandler) Enabled(_ context.Context, l slog.Level) bool {
+	if h.disabled {
+		return false
+	}
+	return l >= slog.LevelWarn
+}
+
+func (h *winEventLogHandler) Handle(_ context.Context, r slog.Record) error {
+	if h.disabled || h.w == nil {
+		return nil
+	}
+	for _, a := range h.attrs {
+		r.AddAttrs(a)
+	}
+	eid := extractEventID(r)
+	msg := FormatCompact(r)
+	switch {
+	case r.Level >= slog.LevelError:
+		_ = h.w.Error(uint32(eid), msg)
+	case r.Level >= slog.LevelWarn:
+		_ = h.w.Warning(uint32(eid), msg)
+	}
+	return nil
+}
+
+func (h *winEventLogHandler) WithAttrs(a []slog.Attr) slog.Handler {
+	cp := *h
+	cp.attrs = append(append([]slog.Attr{}, h.attrs...), a...)
+	return &cp
+}
+
+func (h *winEventLogHandler) WithGroup(_ string) slog.Handler { return h }
+
+func (h *winEventLogHandler) Close() error {
+	if h.w == nil {
+		return nil
+	}
+	return h.w.Close()
+}
+
+func extractEventID(r slog.Record) EventID {
+	id := EventUnknown
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key != "event_id" {
+			return true
+		}
+		if v, ok := a.Value.Any().(EventID); ok {
+			id = v
+			return false
+		}
+		return true
+	})
+	return id
+}

--- a/apps/dump_agent_go/internal/obs/eventlog_windows_test.go
+++ b/apps/dump_agent_go/internal/obs/eventlog_windows_test.go
@@ -4,6 +4,7 @@ package obs
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
@@ -116,5 +117,32 @@ func TestWinEventLog_RespectsAGENT_EVENTLOG_DISABLED(t *testing.T) {
 	}
 	if h.Enabled(context.Background(), slog.LevelError) {
 		t.Fatal("env-disabled handler must be Enabled=false")
+	}
+}
+
+type erroringEventlogWriter struct {
+	fakeEventlogWriter
+	failOn error
+}
+
+func (e *erroringEventlogWriter) Warning(eid uint32, msg string) error {
+	_ = e.fakeEventlogWriter.Warning(eid, msg)
+	return e.failOn
+}
+
+func (e *erroringEventlogWriter) Error(eid uint32, msg string) error {
+	_ = e.fakeEventlogWriter.Error(eid, msg)
+	return e.failOn
+}
+
+func TestWinEventLog_SwallowsWriteErrors(t *testing.T) {
+	w := &erroringEventlogWriter{failOn: errors.New("ENOSPC")}
+	h := newTestHandler(w)
+
+	for _, level := range []slog.Level{slog.LevelWarn, slog.LevelError} {
+		rec := slog.NewRecord(time.Time{}, level, "x", 0)
+		if err := h.Handle(context.Background(), rec); err != nil {
+			t.Fatalf("level %v: write error must be swallowed, got %v", level, err)
+		}
 	}
 }

--- a/apps/dump_agent_go/internal/obs/eventlog_windows_test.go
+++ b/apps/dump_agent_go/internal/obs/eventlog_windows_test.go
@@ -1,0 +1,120 @@
+//go:build windows
+
+package obs
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+type capturedWrite struct {
+	level string
+	eid   uint32
+	msg   string
+}
+
+type fakeEventlogWriter struct {
+	writes []capturedWrite
+}
+
+func (f *fakeEventlogWriter) Info(eid uint32, msg string) error {
+	f.writes = append(f.writes, capturedWrite{"info", eid, msg})
+	return nil
+}
+func (f *fakeEventlogWriter) Warning(eid uint32, msg string) error {
+	f.writes = append(f.writes, capturedWrite{"warning", eid, msg})
+	return nil
+}
+func (f *fakeEventlogWriter) Error(eid uint32, msg string) error {
+	f.writes = append(f.writes, capturedWrite{"error", eid, msg})
+	return nil
+}
+func (f *fakeEventlogWriter) Close() error { return nil }
+
+func newTestHandler(w eventlogWriter) *winEventLogHandler {
+	return &winEventLogHandler{w: w, source: "DumpAgentTest"}
+}
+
+func TestWinEventLog_DropsBelowWarn(t *testing.T) {
+	w := &fakeEventlogWriter{}
+	h := newTestHandler(w)
+	if h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("Enabled must be false at INFO")
+	}
+	if h.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("Enabled must be false at DEBUG")
+	}
+}
+
+func TestWinEventLog_RoutesWarnToWarning(t *testing.T) {
+	w := &fakeEventlogWriter{}
+	h := newTestHandler(w)
+	rec := slog.NewRecord(time.Time{}, slog.LevelWarn, "upload_failed", 0)
+	rec.AddAttrs(slog.Any("event_id", EventUploadFailed),
+		slog.String("job_uuid", "abc"))
+	if err := h.Handle(context.Background(), rec); err != nil {
+		t.Fatalf("Handle err: %v", err)
+	}
+	if len(w.writes) != 1 {
+		t.Fatalf("expected 1 write, got %d", len(w.writes))
+	}
+	got := w.writes[0]
+	if got.level != "warning" {
+		t.Errorf("level got %s want warning", got.level)
+	}
+	if got.eid != uint32(EventUploadFailed) {
+		t.Errorf("eid got %d want %d", got.eid, EventUploadFailed)
+	}
+	if !strings.Contains(got.msg, "msg=upload_failed") {
+		t.Errorf("msg missing payload: %q", got.msg)
+	}
+	if !strings.Contains(got.msg, "job_uuid=abc") {
+		t.Errorf("msg missing job_uuid: %q", got.msg)
+	}
+}
+
+func TestWinEventLog_RoutesErrorToError(t *testing.T) {
+	w := &fakeEventlogWriter{}
+	h := newTestHandler(w)
+	rec := slog.NewRecord(time.Time{}, slog.LevelError, "extract_failed", 0)
+	rec.AddAttrs(slog.Any("event_id", EventExtractFailed))
+	_ = h.Handle(context.Background(), rec)
+	if w.writes[0].level != "error" {
+		t.Fatalf("level got %s want error", w.writes[0].level)
+	}
+}
+
+func TestWinEventLog_DefaultsToEventUnknown(t *testing.T) {
+	w := &fakeEventlogWriter{}
+	h := newTestHandler(w)
+	rec := slog.NewRecord(time.Time{}, slog.LevelWarn, "no_id", 0)
+	_ = h.Handle(context.Background(), rec)
+	if w.writes[0].eid != uint32(EventUnknown) {
+		t.Fatalf("expected EventUnknown=%d, got %d", EventUnknown, w.writes[0].eid)
+	}
+}
+
+func TestWinEventLog_DisabledHandlerIsNoop(t *testing.T) {
+	h := &winEventLogHandler{disabled: true}
+	if h.Enabled(context.Background(), slog.LevelError) {
+		t.Fatal("disabled must be false")
+	}
+	rec := slog.NewRecord(time.Time{}, slog.LevelError, "x", 0)
+	if err := h.Handle(context.Background(), rec); err != nil {
+		t.Fatalf("disabled Handle: %v", err)
+	}
+}
+
+func TestWinEventLog_RespectsAGENT_EVENTLOG_DISABLED(t *testing.T) {
+	t.Setenv("AGENT_EVENTLOG_DISABLED", "true")
+	h, err := NewEventLogHandler("DumpAgentTest")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if h.Enabled(context.Background(), slog.LevelError) {
+		t.Fatal("env-disabled handler must be Enabled=false")
+	}
+}

--- a/apps/dump_agent_go/internal/obs/events.go
+++ b/apps/dump_agent_go/internal/obs/events.go
@@ -13,11 +13,11 @@ type EventID uint32
 
 const (
 	// 1xxx auth.
-	EventDPAPIUnwrapFailed   EventID = 1003
-	EventCertRotationHalted  EventID = 1004
-	EventCertExpiringSoon    EventID = 1005
-	EventOAuthRefreshDenied  EventID = 1006
-	EventClockSkewExcessive  EventID = 1007
+	EventDPAPIUnwrapFailed  EventID = 1003
+	EventCertRotationHalted EventID = 1004
+	EventCertExpiringSoon   EventID = 1005
+	EventOAuthRefreshDenied EventID = 1006
+	EventClockSkewExcessive EventID = 1007
 
 	// 2xxx queue (placeholders for P5.2).
 	EventQueueOpenFailed EventID = 2001

--- a/apps/dump_agent_go/internal/obs/events.go
+++ b/apps/dump_agent_go/internal/obs/events.go
@@ -1,0 +1,45 @@
+package obs
+
+// EventID identifies a DumpAgent event in Windows Event Log.
+// Bands are append-only; never recycle. ~95 IDs slack per band.
+//
+//	1xxx  auth (P4 — OAuth, mTLS, cert lifecycle)
+//	2xxx  queue (P5.2 — bbolt persistence)
+//	3xxx  extraction (Firebird/SIA/BPA jobs)
+//	4xxx  upload (MinIO PUT, presigned URL)
+//	5xxx  diagnose (P5.4)
+//	9xxx  generic (panic, startup, shutdown, unknown)
+type EventID uint32
+
+const (
+	// 1xxx auth.
+	EventDPAPIUnwrapFailed   EventID = 1003
+	EventCertRotationHalted  EventID = 1004
+	EventCertExpiringSoon    EventID = 1005
+	EventOAuthRefreshDenied  EventID = 1006
+	EventClockSkewExcessive  EventID = 1007
+
+	// 2xxx queue (placeholders for P5.2).
+	EventQueueOpenFailed EventID = 2001
+	EventQueueCorrupted  EventID = 2002
+	EventQueueDrained    EventID = 2003
+
+	// 3xxx extraction.
+	EventExtractFailed      EventID = 3001
+	EventExtractEmpty       EventID = 3002
+	EventFirebirdConnFailed EventID = 3003
+
+	// 4xxx upload.
+	EventUploadFailed        EventID = 4001
+	EventUploadRetryExceeded EventID = 4002
+	EventPresignedURLExpired EventID = 4003
+
+	// 5xxx diagnose (placeholders for P5.4).
+	EventDiagnoseFailed EventID = 5001
+
+	// 9xxx generic.
+	EventStartup        EventID = 9001
+	EventShutdown       EventID = 9002
+	EventPanicRecovered EventID = 9003
+	EventUnknown        EventID = 9999
+)

--- a/apps/dump_agent_go/internal/obs/events_test.go
+++ b/apps/dump_agent_go/internal/obs/events_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 )
 
+const expectedEventIDCount = 19
+
 func TestEventID_NoDuplicates(t *testing.T) {
 	all := allEventIDs()
 	seen := map[EventID]string{}
@@ -55,6 +57,14 @@ func TestEventID_BandsRespected(t *testing.T) {
 				t.Errorf("band=%s id=%d out of [%d..%d]", b.name, id, b.min, b.max)
 			}
 		}
+	}
+}
+
+func TestEventID_AllConstantsAreInMap(t *testing.T) {
+	if got := len(allEventIDs()); got != expectedEventIDCount {
+		t.Fatalf("allEventIDs has %d entries; expected %d. "+
+			"Did you add a new EventID constant in events.go without "+
+			"updating allEventIDs()?", got, expectedEventIDCount)
 	}
 }
 

--- a/apps/dump_agent_go/internal/obs/events_test.go
+++ b/apps/dump_agent_go/internal/obs/events_test.go
@@ -1,0 +1,85 @@
+package obs
+
+import (
+	"testing"
+)
+
+func TestEventID_NoDuplicates(t *testing.T) {
+	all := allEventIDs()
+	seen := map[EventID]string{}
+	for name, id := range all {
+		if prior, ok := seen[id]; ok {
+			t.Fatalf("duplicate event id %d: %s and %s", id, prior, name)
+		}
+		seen[id] = name
+	}
+}
+
+func TestEventID_P4ReservationsPreserved(t *testing.T) {
+	if EventDPAPIUnwrapFailed != 1003 {
+		t.Fatalf("EventDPAPIUnwrapFailed must remain 1003 (P4 reserved), got %d", EventDPAPIUnwrapFailed)
+	}
+	if EventCertRotationHalted != 1004 {
+		t.Fatalf("EventCertRotationHalted must remain 1004 (P4 reserved), got %d", EventCertRotationHalted)
+	}
+}
+
+func TestEventID_BandsRespected(t *testing.T) {
+	bands := []struct {
+		name string
+		min  EventID
+		max  EventID
+		ids  []EventID
+	}{
+		{"auth", 1000, 1999, []EventID{
+			EventDPAPIUnwrapFailed, EventCertRotationHalted, EventCertExpiringSoon,
+			EventOAuthRefreshDenied, EventClockSkewExcessive,
+		}},
+		{"queue", 2000, 2999, []EventID{
+			EventQueueOpenFailed, EventQueueCorrupted, EventQueueDrained,
+		}},
+		{"extract", 3000, 3999, []EventID{
+			EventExtractFailed, EventExtractEmpty, EventFirebirdConnFailed,
+		}},
+		{"upload", 4000, 4999, []EventID{
+			EventUploadFailed, EventUploadRetryExceeded, EventPresignedURLExpired,
+		}},
+		{"diagnose", 5000, 5999, []EventID{EventDiagnoseFailed}},
+		{"generic", 9000, 9999, []EventID{
+			EventStartup, EventShutdown, EventPanicRecovered, EventUnknown,
+		}},
+	}
+	for _, b := range bands {
+		for _, id := range b.ids {
+			if id < b.min || id > b.max {
+				t.Errorf("band=%s id=%d out of [%d..%d]", b.name, id, b.min, b.max)
+			}
+		}
+	}
+}
+
+// allEventIDs is exported via the test for duplicate detection.
+// Keep in sync with constants in events.go.
+func allEventIDs() map[string]EventID {
+	return map[string]EventID{
+		"EventDPAPIUnwrapFailed":   EventDPAPIUnwrapFailed,
+		"EventCertRotationHalted":  EventCertRotationHalted,
+		"EventCertExpiringSoon":    EventCertExpiringSoon,
+		"EventOAuthRefreshDenied":  EventOAuthRefreshDenied,
+		"EventClockSkewExcessive":  EventClockSkewExcessive,
+		"EventQueueOpenFailed":     EventQueueOpenFailed,
+		"EventQueueCorrupted":      EventQueueCorrupted,
+		"EventQueueDrained":        EventQueueDrained,
+		"EventExtractFailed":       EventExtractFailed,
+		"EventExtractEmpty":        EventExtractEmpty,
+		"EventFirebirdConnFailed":  EventFirebirdConnFailed,
+		"EventUploadFailed":        EventUploadFailed,
+		"EventUploadRetryExceeded": EventUploadRetryExceeded,
+		"EventPresignedURLExpired": EventPresignedURLExpired,
+		"EventDiagnoseFailed":      EventDiagnoseFailed,
+		"EventStartup":             EventStartup,
+		"EventShutdown":            EventShutdown,
+		"EventPanicRecovered":      EventPanicRecovered,
+		"EventUnknown":             EventUnknown,
+	}
+}

--- a/apps/dump_agent_go/internal/obs/format.go
+++ b/apps/dump_agent_go/internal/obs/format.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 const maxValueLen = 8000
@@ -62,7 +63,7 @@ func appendAttr(out []string, prefix string, a slog.Attr) []string {
 
 func formatValue(s string) string {
 	if len(s) > maxValueLen {
-		s = s[:maxValueLen] + "...truncated"
+		s = truncateAtRuneBoundary(s, maxValueLen) + "...truncated"
 	}
 	if needsQuote(s) {
 		return fmt.Sprintf("%q", s)
@@ -70,10 +71,20 @@ func formatValue(s string) string {
 	return s
 }
 
+func truncateAtRuneBoundary(s string, n int) string {
+	if n >= len(s) {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
+}
+
 func needsQuote(s string) bool {
 	for i := 0; i < len(s); i++ {
 		c := s[i]
-		if c == ' ' || c == '"' || c == '\n' || c == '\t' || c == '\\' {
+		if c < 0x20 || c == 0x7F || c == ' ' || c == '"' || c == '\\' {
 			return true
 		}
 	}

--- a/apps/dump_agent_go/internal/obs/format.go
+++ b/apps/dump_agent_go/internal/obs/format.go
@@ -1,0 +1,81 @@
+package obs
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+)
+
+const maxValueLen = 8000
+
+// FormatCompact renders a slog.Record as a single-line key=value string.
+// Order: level, msg, then attrs sorted alphabetically. Group attrs flatten
+// to dotted keys (db.host). Special chars escaped via Go quoted form.
+// Values longer than maxValueLen are truncated with "...truncated" suffix.
+func FormatCompact(r slog.Record) string {
+	var b strings.Builder
+	b.WriteString("level=")
+	b.WriteString(levelString(r.Level))
+	b.WriteString(" msg=")
+	b.WriteString(formatValue(r.Message))
+
+	pairs := make([]string, 0, r.NumAttrs())
+	r.Attrs(func(a slog.Attr) bool {
+		pairs = appendAttr(pairs, "", a)
+		return true
+	})
+	sort.Strings(pairs)
+	for _, p := range pairs {
+		b.WriteByte(' ')
+		b.WriteString(p)
+	}
+	return b.String()
+}
+
+func levelString(l slog.Level) string {
+	switch {
+	case l >= slog.LevelError:
+		return "error"
+	case l >= slog.LevelWarn:
+		return "warn"
+	case l >= slog.LevelInfo:
+		return "info"
+	default:
+		return "debug"
+	}
+}
+
+func appendAttr(out []string, prefix string, a slog.Attr) []string {
+	key := a.Key
+	if prefix != "" {
+		key = prefix + "." + key
+	}
+	if a.Value.Kind() == slog.KindGroup {
+		for _, sub := range a.Value.Group() {
+			out = appendAttr(out, key, sub)
+		}
+		return out
+	}
+	return append(out, key+"="+formatValue(a.Value.String()))
+}
+
+func formatValue(s string) string {
+	if len(s) > maxValueLen {
+		s = s[:maxValueLen] + "...truncated"
+	}
+	if needsQuote(s) {
+		return fmt.Sprintf("%q", s)
+	}
+	return s
+}
+
+func needsQuote(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ' ' || c == '"' || c == '\n' || c == '\t' || c == '\\' {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/dump_agent_go/internal/obs/format_test.go
+++ b/apps/dump_agent_go/internal/obs/format_test.go
@@ -1,11 +1,11 @@
 package obs
 
 import (
-	"context"
 	"log/slog"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func makeRecord(level slog.Level, msg string, attrs ...slog.Attr) slog.Record {
@@ -61,4 +61,34 @@ func TestFormatCompact_TruncatesAt8KB(t *testing.T) {
 	}
 }
 
-var _ = context.Background // silence unused import in stripped scenarios
+func TestFormatCompact_DebugLevel(t *testing.T) {
+	r := makeRecord(slog.LevelDebug, "ping")
+	got := FormatCompact(r)
+	want := `level=debug msg=ping`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestFormatCompact_EscapesCarriageReturn(t *testing.T) {
+	r := makeRecord(slog.LevelWarn, "rec",
+		slog.String("body", "line1\rline2"),
+	)
+	got := FormatCompact(r)
+	want := `level=warn msg=rec body="line1\rline2"`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestFormatCompact_TruncatesAtRuneBoundary(t *testing.T) {
+	// Build a string with multi-byte runes (Brazilian Portuguese 'ã' = 2 bytes 0xc3 0xa3)
+	// such that the 8000-byte cut would land mid-rune.
+	prefix := strings.Repeat("a", 7999)
+	body := prefix + "ã" + strings.Repeat("b", 100)
+	r := makeRecord(slog.LevelWarn, "x", slog.String("v", body))
+	got := FormatCompact(r)
+	if !utf8.ValidString(got) {
+		t.Fatalf("output not valid UTF-8: %q", got[:80])
+	}
+}

--- a/apps/dump_agent_go/internal/obs/format_test.go
+++ b/apps/dump_agent_go/internal/obs/format_test.go
@@ -1,0 +1,64 @@
+package obs
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func makeRecord(level slog.Level, msg string, attrs ...slog.Attr) slog.Record {
+	r := slog.NewRecord(time.Time{}, level, msg, 0)
+	r.AddAttrs(attrs...)
+	return r
+}
+
+func TestFormatCompact_StableKeyOrder(t *testing.T) {
+	r := makeRecord(slog.LevelWarn, "upload_failed",
+		slog.String("zeta", "1"),
+		slog.String("alpha", "2"),
+		slog.Int("middle", 3),
+	)
+	got := FormatCompact(r)
+	want := `level=warn msg=upload_failed alpha=2 middle=3 zeta=1`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestFormatCompact_EscapesSpecialChars(t *testing.T) {
+	r := makeRecord(slog.LevelError, "err",
+		slog.String("reason", "line1\nline2 \"quoted\"\ttab"),
+	)
+	got := FormatCompact(r)
+	want := `level=error msg=err reason="line1\nline2 \"quoted\"\ttab"`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestFormatCompact_GroupFlatten(t *testing.T) {
+	r := makeRecord(slog.LevelInfo, "boot",
+		slog.Group("db", slog.String("host", "h"), slog.Int("port", 5432)),
+	)
+	got := FormatCompact(r)
+	want := `level=info msg=boot db.host=h db.port=5432`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestFormatCompact_TruncatesAt8KB(t *testing.T) {
+	big := strings.Repeat("x", 9000)
+	r := makeRecord(slog.LevelWarn, "big", slog.String("blob", big))
+	got := FormatCompact(r)
+	if len(got) > 8200 {
+		t.Fatalf("expected <=8200 chars, got %d", len(got))
+	}
+	if !strings.Contains(got, "...truncated") {
+		t.Fatalf("expected truncation marker, got %q", got[:80])
+	}
+}
+
+var _ = context.Background // silence unused import in stripped scenarios

--- a/apps/dump_agent_go/internal/obs/multi.go
+++ b/apps/dump_agent_go/internal/obs/multi.go
@@ -1,0 +1,56 @@
+package obs
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+// MultiHandler fans slog.Handler operations to N children.
+// Errors from children are collected via errors.Join.
+type MultiHandler struct {
+	children []slog.Handler
+}
+
+// NewMultiHandler returns a Handler that dispatches to each child.
+func NewMultiHandler(children ...slog.Handler) *MultiHandler {
+	return &MultiHandler{children: children}
+}
+
+func (m *MultiHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	for _, c := range m.children {
+		if c.Enabled(ctx, l) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MultiHandler) Handle(ctx context.Context, r slog.Record) error {
+	var errs []error
+	for _, c := range m.children {
+		if !c.Enabled(ctx, r.Level) {
+			continue
+		}
+		if err := c.Handle(ctx, r.Clone()); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *MultiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	derived := make([]slog.Handler, len(m.children))
+	for i, c := range m.children {
+		derived[i] = c.WithAttrs(attrs)
+	}
+	return &MultiHandler{children: derived}
+}
+
+func (m *MultiHandler) WithGroup(name string) slog.Handler {
+	derived := make([]slog.Handler, len(m.children))
+	for i, c := range m.children {
+		derived[i] = c.WithGroup(name)
+	}
+	return &MultiHandler{children: derived}
+}

--- a/apps/dump_agent_go/internal/obs/multi_test.go
+++ b/apps/dump_agent_go/internal/obs/multi_test.go
@@ -1,0 +1,118 @@
+package obs
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+type recordingHandler struct {
+	enabled  bool
+	records  []slog.Record
+	attrs    []slog.Attr
+	groups   []string
+	failWith error
+}
+
+func (h *recordingHandler) Enabled(_ context.Context, _ slog.Level) bool { return h.enabled }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return h.failWith
+}
+
+func (h *recordingHandler) WithAttrs(a []slog.Attr) slog.Handler {
+	cp := *h
+	cp.attrs = append(cp.attrs[:0:0], h.attrs...)
+	cp.attrs = append(cp.attrs, a...)
+	return &cp
+}
+
+func (h *recordingHandler) WithGroup(name string) slog.Handler {
+	cp := *h
+	cp.groups = append(cp.groups[:0:0], h.groups...)
+	cp.groups = append(cp.groups, name)
+	return &cp
+}
+
+func TestMultiHandler_FansOutToAll(t *testing.T) {
+	a := &recordingHandler{enabled: true}
+	b := &recordingHandler{enabled: true}
+	c := &recordingHandler{enabled: true}
+	mh := NewMultiHandler(a, b, c)
+
+	rec := slog.NewRecord(time.Time{}, slog.LevelWarn, "x", 0)
+	if err := mh.Handle(context.Background(), rec); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	for i, h := range []*recordingHandler{a, b, c} {
+		if got := len(h.records); got != 1 {
+			t.Errorf("child[%d] received %d records, want 1", i, got)
+		}
+	}
+}
+
+func TestMultiHandler_OneChildErrorDoesNotDropOthers(t *testing.T) {
+	boom := errors.New("boom")
+	a := &recordingHandler{enabled: true, failWith: boom}
+	b := &recordingHandler{enabled: true}
+	mh := NewMultiHandler(a, b)
+
+	rec := slog.NewRecord(time.Time{}, slog.LevelError, "x", 0)
+	err := mh.Handle(context.Background(), rec)
+	if err == nil || !errors.Is(err, boom) {
+		t.Fatalf("want errors.Is boom, got %v", err)
+	}
+	if len(b.records) != 1 {
+		t.Fatalf("sibling child must still receive record, got %d", len(b.records))
+	}
+}
+
+func TestMultiHandler_EnabledTrueIfAnyChild(t *testing.T) {
+	a := &recordingHandler{enabled: false}
+	b := &recordingHandler{enabled: true}
+	mh := NewMultiHandler(a, b)
+	if !mh.Enabled(context.Background(), slog.LevelWarn) {
+		t.Fatal("expected Enabled=true when any child enabled")
+	}
+}
+
+func TestMultiHandler_EnabledFalseWhenNoChild(t *testing.T) {
+	a := &recordingHandler{enabled: false}
+	b := &recordingHandler{enabled: false}
+	mh := NewMultiHandler(a, b)
+	if mh.Enabled(context.Background(), slog.LevelWarn) {
+		t.Fatal("expected Enabled=false when no child enabled")
+	}
+}
+
+func TestMultiHandler_WithAttrsPropagates(t *testing.T) {
+	a := &recordingHandler{enabled: true}
+	b := &recordingHandler{enabled: true}
+	mh := NewMultiHandler(a, b)
+	derived := mh.WithAttrs([]slog.Attr{slog.String("k", "v")})
+
+	mh2, ok := derived.(*MultiHandler)
+	if !ok {
+		t.Fatalf("expected *MultiHandler, got %T", derived)
+	}
+	for i, child := range mh2.children {
+		rh := child.(*recordingHandler)
+		if len(rh.attrs) != 1 || rh.attrs[0].Key != "k" {
+			t.Errorf("child[%d]: WithAttrs not propagated, got %+v", i, rh.attrs)
+		}
+	}
+}
+
+func TestMultiHandler_WithGroupPropagates(t *testing.T) {
+	a := &recordingHandler{enabled: true}
+	mh := NewMultiHandler(a)
+	derived := mh.WithGroup("g1")
+	mh2, _ := derived.(*MultiHandler)
+	rh := mh2.children[0].(*recordingHandler)
+	if len(rh.groups) != 1 || rh.groups[0] != "g1" {
+		t.Fatalf("WithGroup not propagated: %+v", rh.groups)
+	}
+}

--- a/apps/dump_agent_go/internal/service/eventlog_register.go
+++ b/apps/dump_agent_go/internal/service/eventlog_register.go
@@ -1,0 +1,5 @@
+package service
+
+// EventSourceName is the Windows Event Log source name registered at
+// `agent.exe install`. Compiled-in constant; no env override (security).
+const EventSourceName = "DumpAgent"

--- a/apps/dump_agent_go/internal/service/eventlog_register_unix.go
+++ b/apps/dump_agent_go/internal/service/eventlog_register_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package service
+
+// RegisterEventSource is a no-op on POSIX.
+func RegisterEventSource(_ string) error { return nil }
+
+// RemoveEventSource is a no-op on POSIX.
+func RemoveEventSource(_ string) error { return nil }

--- a/apps/dump_agent_go/internal/service/eventlog_register_unix_test.go
+++ b/apps/dump_agent_go/internal/service/eventlog_register_unix_test.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package service
+
+import "testing"
+
+func TestRegisterEventSource_UnixNoOp(t *testing.T) {
+	if err := RegisterEventSource("DumpAgent"); err != nil {
+		t.Fatalf("unix stub must return nil, got %v", err)
+	}
+}
+
+func TestRemoveEventSource_UnixNoOp(t *testing.T) {
+	if err := RemoveEventSource("DumpAgent"); err != nil {
+		t.Fatalf("unix stub must return nil, got %v", err)
+	}
+}

--- a/apps/dump_agent_go/internal/service/eventlog_register_windows.go
+++ b/apps/dump_agent_go/internal/service/eventlog_register_windows.go
@@ -3,7 +3,9 @@
 package service
 
 import (
+	"errors"
 	"strings"
+	"syscall"
 
 	"golang.org/x/sys/windows/svc/eventlog"
 )
@@ -23,6 +25,9 @@ func (defaultRegistryWriter) Remove(name string) error {
 	return eventlog.Remove(name)
 }
 
+// Compile-time assertion: signature drift on registryWriter fails at build.
+var _ registryWriter = defaultRegistryWriter{}
+
 // registryWriterFactory is overridable in tests.
 var registryWriterFactory = func() registryWriter { return defaultRegistryWriter{} }
 
@@ -31,27 +36,33 @@ const eventTypesSupported = eventlog.Info | eventlog.Warning | eventlog.Error
 // RegisterEventSource creates the named source under the Application log.
 // Idempotent: a "registry key already exists" error is treated as success.
 // Requires Admin (HKLM write); call from elevated install path only.
+//
+// Note: upstream eventlog.InstallAsEventCreate constructs the "already exists"
+// error via errors.New() with a fixed English string (see
+// golang.org/x/sys/windows/svc/eventlog.InstallAsEventCreate). Substring
+// match is locale-independent for the same reason.
 func RegisterEventSource(name string) error {
 	rw := registryWriterFactory()
 	err := rw.Install(name, eventTypesSupported)
 	if err == nil {
 		return nil
 	}
-	if strings.Contains(err.Error(), "already exists") {
+	if strings.Contains(err.Error(), "registry key already exists") {
 		return nil
 	}
 	return err
 }
 
-// RemoveEventSource deletes the named source. Not-found = success.
+// RemoveEventSource deletes the named source. Not-found = success (idempotent).
+//
+// Uses errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) for locale-independence:
+// upstream eventlog.Remove propagates the raw syscall.Errno from
+// registry.DeleteKey, so the comparison works on any Windows locale
+// (English, Portuguese, etc.). Production target is pt-BR Windows.
 func RemoveEventSource(name string) error {
 	rw := registryWriterFactory()
 	err := rw.Remove(name)
-	if err == nil {
-		return nil
-	}
-	low := strings.ToLower(err.Error())
-	if strings.Contains(low, "cannot find") || strings.Contains(low, "not exist") {
+	if err == nil || errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
 		return nil
 	}
 	return err

--- a/apps/dump_agent_go/internal/service/eventlog_register_windows.go
+++ b/apps/dump_agent_go/internal/service/eventlog_register_windows.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package service
+
+import (
+	"strings"
+
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+type registryWriter interface {
+	Install(name string, eventsSupported uint32) error
+	Remove(name string) error
+}
+
+type defaultRegistryWriter struct{}
+
+func (defaultRegistryWriter) Install(name string, types uint32) error {
+	return eventlog.InstallAsEventCreate(name, types)
+}
+
+func (defaultRegistryWriter) Remove(name string) error {
+	return eventlog.Remove(name)
+}
+
+// registryWriterFactory is overridable in tests.
+var registryWriterFactory = func() registryWriter { return defaultRegistryWriter{} }
+
+const eventTypesSupported = eventlog.Info | eventlog.Warning | eventlog.Error
+
+// RegisterEventSource creates the named source under the Application log.
+// Idempotent: a "registry key already exists" error is treated as success.
+// Requires Admin (HKLM write); call from elevated install path only.
+func RegisterEventSource(name string) error {
+	rw := registryWriterFactory()
+	err := rw.Install(name, eventTypesSupported)
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "already exists") {
+		return nil
+	}
+	return err
+}
+
+// RemoveEventSource deletes the named source. Not-found = success.
+func RemoveEventSource(name string) error {
+	rw := registryWriterFactory()
+	err := rw.Remove(name)
+	if err == nil {
+		return nil
+	}
+	low := strings.ToLower(err.Error())
+	if strings.Contains(low, "cannot find") || strings.Contains(low, "not exist") {
+		return nil
+	}
+	return err
+}

--- a/apps/dump_agent_go/internal/service/eventlog_register_windows_test.go
+++ b/apps/dump_agent_go/internal/service/eventlog_register_windows_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"errors"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -40,7 +41,7 @@ func TestRegisterEventSource_HappyPath(t *testing.T) {
 
 func TestRegisterEventSource_AlreadyExistsIsIdempotent(t *testing.T) {
 	fake := &fakeRegistryWriter{
-		installErr: errors.New("registry key already exists"),
+		installErr: errors.New("Application/DumpAgent registry key already exists"),
 	}
 	prev := registryWriterFactory
 	registryWriterFactory = func() registryWriter { return fake }
@@ -67,14 +68,26 @@ func TestRegisterEventSource_OtherErrorPropagates(t *testing.T) {
 
 func TestRemoveEventSource_NotFoundIsOK(t *testing.T) {
 	fake := &fakeRegistryWriter{
-		removeErr: errors.New("the system cannot find the file specified"),
+		removeErr: syscall.ERROR_FILE_NOT_FOUND,
 	}
 	prev := registryWriterFactory
 	registryWriterFactory = func() registryWriter { return fake }
 	t.Cleanup(func() { registryWriterFactory = prev })
 
 	if err := RemoveEventSource("DumpAgent"); err != nil {
-		t.Fatalf("not-found should be nil, got %v", err)
+		t.Fatalf("typed errno ERROR_FILE_NOT_FOUND should be nil, got %v", err)
+	}
+}
+
+func TestRemoveEventSource_WrappedNotFoundIsOK(t *testing.T) {
+	wrapped := errors.Join(errors.New("registry delete failed"), syscall.ERROR_FILE_NOT_FOUND)
+	fake := &fakeRegistryWriter{removeErr: wrapped}
+	prev := registryWriterFactory
+	registryWriterFactory = func() registryWriter { return fake }
+	t.Cleanup(func() { registryWriterFactory = prev })
+
+	if err := RemoveEventSource("DumpAgent"); err != nil {
+		t.Fatalf("wrapped ERROR_FILE_NOT_FOUND should be nil, got %v", err)
 	}
 }
 

--- a/apps/dump_agent_go/internal/service/eventlog_register_windows_test.go
+++ b/apps/dump_agent_go/internal/service/eventlog_register_windows_test.go
@@ -1,0 +1,93 @@
+//go:build windows
+
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeRegistryWriter struct {
+	installed  []string
+	removed    []string
+	installErr error
+	removeErr  error
+}
+
+func (f *fakeRegistryWriter) Install(name string, _ uint32) error {
+	f.installed = append(f.installed, name)
+	return f.installErr
+}
+func (f *fakeRegistryWriter) Remove(name string) error {
+	f.removed = append(f.removed, name)
+	return f.removeErr
+}
+
+func TestRegisterEventSource_HappyPath(t *testing.T) {
+	fake := &fakeRegistryWriter{}
+	prev := registryWriterFactory
+	registryWriterFactory = func() registryWriter { return fake }
+	t.Cleanup(func() { registryWriterFactory = prev })
+
+	if err := RegisterEventSource("DumpAgent"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(fake.installed) != 1 || fake.installed[0] != "DumpAgent" {
+		t.Fatalf("Install not called for DumpAgent: %+v", fake.installed)
+	}
+}
+
+func TestRegisterEventSource_AlreadyExistsIsIdempotent(t *testing.T) {
+	fake := &fakeRegistryWriter{
+		installErr: errors.New("registry key already exists"),
+	}
+	prev := registryWriterFactory
+	registryWriterFactory = func() registryWriter { return fake }
+	t.Cleanup(func() { registryWriterFactory = prev })
+
+	if err := RegisterEventSource("DumpAgent"); err != nil {
+		t.Fatalf("idempotent register must return nil, got %v", err)
+	}
+}
+
+func TestRegisterEventSource_OtherErrorPropagates(t *testing.T) {
+	fake := &fakeRegistryWriter{
+		installErr: errors.New("access denied"),
+	}
+	prev := registryWriterFactory
+	registryWriterFactory = func() registryWriter { return fake }
+	t.Cleanup(func() { registryWriterFactory = prev })
+
+	err := RegisterEventSource("DumpAgent")
+	if err == nil || !strings.Contains(err.Error(), "access denied") {
+		t.Fatalf("expected access denied propagation, got %v", err)
+	}
+}
+
+func TestRemoveEventSource_NotFoundIsOK(t *testing.T) {
+	fake := &fakeRegistryWriter{
+		removeErr: errors.New("the system cannot find the file specified"),
+	}
+	prev := registryWriterFactory
+	registryWriterFactory = func() registryWriter { return fake }
+	t.Cleanup(func() { registryWriterFactory = prev })
+
+	if err := RemoveEventSource("DumpAgent"); err != nil {
+		t.Fatalf("not-found should be nil, got %v", err)
+	}
+}
+
+func TestRemoveEventSource_PropagatesOtherErrors(t *testing.T) {
+	fake := &fakeRegistryWriter{
+		removeErr: errors.New("access denied"),
+	}
+	prev := registryWriterFactory
+	registryWriterFactory = func() registryWriter { return fake }
+	t.Cleanup(func() { registryWriterFactory = prev })
+
+	err := RemoveEventSource("DumpAgent")
+	if err == nil || !strings.Contains(err.Error(), "access denied") {
+		t.Fatalf("expected access denied, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

First phase of P5 (offline resilience + local diagnostics). Routes slog WARN+ records to Windows Event Log under source `DumpAgent` so hospital IT can diagnose agent failures via standard Event Viewer without central log access.

- `obs.MultiHandler` — slog fan-out aggregator (errors collected via `errors.Join`, child failure does not drop siblings).
- `obs.EventLogHandler` — Windows real impl over `golang.org/x/sys/windows/svc/eventlog`; Linux/Mac no-op stub via build tags.
- `obs.EventID` — banded catalog (1xxx auth, 2xxx queue, 3xxx extract, 4xxx upload, 5xxx diagnose, 9xxx generic). P4 reserved 1003/1004 preserved.
- `obs.FormatCompact` — UTF-8-safe single-line `level=… msg=… k=v` renderer with 8KB truncation and ASCII control-byte escape.
- `service.RegisterEventSource` / `RemoveEventSource` — wired from `agent.exe install` / `uninstall`. Locale-independent error match (`errors.Is(err, syscall.ERROR_FILE_NOT_FOUND)`) for pt-BR Windows production hosts.
- `runForeground` boots a MultiHandler combining the existing rotating-file handler with the eventlog sibling. Both close on shutdown.
- Drift-guard tests: `expectedEventIDCount` count assertion catches missing entries in `allEventIDs()` map; `TestEventIDAttrsOnP4CallSites` asserts P4 call sites carry `event_id` attr (skips until call sites land).

## Spec

`docs/superpowers/specs/2026-05-01-edge-agent-p5-1-eventlog-design.md` (gitignored, local).

## Test plan

- [x] Linux unit tests pass (`go test -race ./...`).
- [x] Windows unit tests pass (host: `go test -race ./...`).
- [x] `go vet` clean on both `GOOS=linux` and `GOOS=windows`.
- [x] Filtered coverage 79.2% (gate ≥ 65%).
- [ ] Manual Windows smoke (post-merge): `agent.exe install` → trigger WARN → `Get-WinEvent -ProviderName DumpAgent` returns event.
- [ ] Manual Windows smoke (post-merge): `agent.exe uninstall` → `Get-WinEvent -ProviderName DumpAgent` returns "no events found" or "provider not found".

## Rollback

`AGENT_EVENTLOG_DISABLED=true` env makes the handler no-op without uninstall (emergency switch only; not in `.env.example`).