### PR TITLE
fix(compose): cnes_contracts in central_api/data_processor + writable /logs

### DIFF
--- a/apps/central_api/Dockerfile
+++ b/apps/central_api/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 COPY pyproject.toml pyproject.toml
 COPY packages/ packages/
 COPY apps/central_api/ apps/central_api/
-RUN uv build --wheel --out-dir /wheels packages/cnes_domain && \
+RUN uv build --wheel --out-dir /wheels packages/cnes_contracts && \
+    uv build --wheel --out-dir /wheels packages/cnes_domain && \
     uv build --wheel --out-dir /wheels packages/cnes_infra && \
     uv build --wheel --out-dir /wheels apps/central_api && \
     uv pip install --system /wheels/*.whl

--- a/apps/data_processor/Dockerfile
+++ b/apps/data_processor/Dockerfile
@@ -4,13 +4,15 @@ WORKDIR /app
 COPY pyproject.toml pyproject.toml
 COPY packages/ packages/
 COPY apps/data_processor/ apps/data_processor/
-RUN uv build --wheel --out-dir /wheels packages/cnes_domain && \
+RUN uv build --wheel --out-dir /wheels packages/cnes_contracts && \
+    uv build --wheel --out-dir /wheels packages/cnes_domain && \
     uv build --wheel --out-dir /wheels packages/cnes_infra && \
     uv build --wheel --out-dir /wheels apps/data_processor && \
     uv pip install --system /wheels/*.whl
 
 FROM python:3.13-slim
 RUN groupadd -r app && useradd -r -g app app
+RUN mkdir -p /logs /data && chown -R app:app /logs /data
 COPY --from=builder /usr/local/lib/python3.13/site-packages \
      /usr/local/lib/python3.13/site-packages
 USER app


### PR DESCRIPTION
## Summary

Two pre-existing dev-compose breakages surfaced when bringing up the `dev` profile:

1. **`central_api` + `data_processor` failed to start** with `ModuleNotFoundError: No module named 'cnes_contracts'`.
   - `central_api/routes/extractions.py` and `routes/jobs.py` import `cnes_contracts.landing` at runtime.
   - `data_processor/adapters/{bpa,sia}_adapter.py` import `cnes_contracts.fatos` at runtime.
   - Neither Dockerfile bundled the `cnes_contracts` wheel — only `cnes_domain` and `cnes_infra`.

2. **`data_processor` failed with** `PermissionError: [Errno 13] Permission denied: '/logs'`.
   - `cnes_infra.config.LOGS_DIR = RAIZ_PROJETO / "logs"` resolves to `/logs` inside the container (no project root).
   - Container runs as non-root `app` user, who cannot write to `/`.

## Fix

- Add `uv build --wheel ... packages/cnes_contracts` to both Dockerfile build stages (before `cnes_domain` for alphabetical wheel install order).
- Pre-create `/logs` and `/data` with `app:app` ownership in the `data_processor` runtime stage.

## Out of scope (pre-existing, separate)

- `pg-seed` service still fails: `cnes_infra.storage.schema` was renamed to `schema_v2.py` and `fato_vinculo` to `fato_vinculo_cnes`; the seed script wasn't updated. Tracked separately.
- `cnes_db_migrator` did not need this fix — alembic-only, no `cnes_contracts` runtime use.

## Verified

- `docker compose --profile dev up -d` brings up all services.
- `migrator`: `Exited (0)` after running 001-017 successfully.
- `central-api`: `Up (healthy)`.
- `data-processor`: `Up`, no permission errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)