### PR TITLE
feat(dump_agent_go): P5.3 Backoff + Jitter

### DIFF
--- a/apps/dump_agent_go/CLAUDE.md
+++ b/apps/dump_agent_go/CLAUDE.md
@@ -196,5 +196,5 @@ fleets do not collide on `central_api` after a shared outage.
 - Breaker reset: `JitterAround(60s, 0.33)` → `[40s, 80s]`. Window snapshotted
   per fresh OPEN trip in `gateAfter`; `CircuitBreaker.SetClock`+`SetRand`.
 - Cert rotate retries: `DecorrelatedJitter(prev, 1s, 30s)` replaces fixed
-  `[1s, 2s, 4s]`; `maxAttempts=3`. Outer 6h ±10% `Rotator.NextWakeup`
+  `[1s, 2s, 4s]`; `maxAttempts=3`. Outer 6h ±10% `Rotator.nextSleep`
   untouched. Targets: filtered ≥ 80.5% (P5.2); `obs/jitter.go` 100%.

--- a/apps/dump_agent_go/CLAUDE.md
+++ b/apps/dump_agent_go/CLAUDE.md
@@ -182,3 +182,19 @@ transient central_api outages do not lose extraction outcomes.
   service per existing recovery policy.
 - Event ID catalog 2xxx queue (2004-2007) + 8xxx breaker (8001-8003);
   `expectedEventIDCount` 19 → 26.
+
+## Phase 5.3 — Backoff + Jitter (2026-05-02)
+
+Deterministic, test-injectable jitter on three timing sites so N-agent
+fleets do not collide on `central_api` after a shared outage.
+
+- `internal/obs/jitter.go` — `JitterAround(d, f, rand)` → `[d*(1-f), d*(1+f)]`
+  (1ms floor); `DecorrelatedJitter(prev, base, cap, rand)` →
+  `clamp(uniform(base, prev*3), base, cap)`. `rand=nil` → `math/rand/v2`. No deps.
+- Drain tick: `JitterAround(30s, 0.20)` → `[24s, 36s]` via `time.NewTimer`+
+  `Reset` in `internal/worker/drain.go`; `Drainer.SetRand` for tests.
+- Breaker reset: `JitterAround(60s, 0.33)` → `[40s, 80s]`. Window snapshotted
+  per fresh OPEN trip in `gateAfter`; `CircuitBreaker.SetClock`+`SetRand`.
+- Cert rotate retries: `DecorrelatedJitter(prev, 1s, 30s)` replaces fixed
+  `[1s, 2s, 4s]`; `maxAttempts=3`. Outer 6h ±10% `Rotator.NextWakeup`
+  untouched. Targets: filtered ≥ 80.5% (P5.2); `obs/jitter.go` 100%.

--- a/apps/dump_agent_go/internal/auth/export_test.go
+++ b/apps/dump_agent_go/internal/auth/export_test.go
@@ -28,12 +28,20 @@ func IsWithinWindowForTest(cert *x509.Certificate, fraction float64, now time.Ti
 	return isWithinWindow(cert, fraction, now)
 }
 
-// Phase 7 step 3 exports.
+// Phase 7 step 3 / P5.3 step 5 exports.
 func PostRotateForTest(
 	ctx context.Context, httpClient *http.Client, baseURL, csrPEM string,
-	backoff []time.Duration,
+	randSrc func() float64,
 ) (any, error) {
-	return postRotate(ctx, httpClient, baseURL, csrPEM, backoff)
+	return postRotateWithRand(ctx, httpClient, baseURL, csrPEM, randSrc)
+}
+
+// SetTimeAfterForTest replaces the package-level timeAfter seam for tests.
+// Returns a restore function that the test should defer-call.
+func SetTimeAfterForTest(fn func(time.Duration) <-chan time.Time) func() {
+	prev := timeAfter
+	timeAfter = fn
+	return func() { timeAfter = prev }
 }
 
 func PersistRotatedForTest(authDir string, resp any, pkcs8DER []byte) error {
@@ -62,7 +70,6 @@ func ExtractRotateRespForTest(resp any) (certPEM, expiresAt string) {
 
 // Phase 7 step 4 setters + extract.
 func (r *Rotator) SetIntervalForTest(d time.Duration)  { r.interval = d }
-func (r *Rotator) SetBackoffForTest(b []time.Duration) { r.backoff = b }
 func (r *Rotator) SetClockForTest(fn func() time.Time) { r.clock = fn }
 func (r *Rotator) SetRandForTest(fn func() float64)    { r.rand = fn }
 func (r *Rotator) SetLoggerForTest(l *slog.Logger)     { r.logger = l }

--- a/apps/dump_agent_go/internal/auth/rotate.go
+++ b/apps/dump_agent_go/internal/auth/rotate.go
@@ -24,6 +24,17 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/cnesdata/dumpagent/internal/obs"
+)
+
+// timeAfter is package-level for test injection of the sleep channel.
+var timeAfter = time.After
+
+const (
+	rotateBackoffBase = 1 * time.Second
+	rotateBackoffCap  = 30 * time.Second
+	rotateMaxAttempts = 3
 )
 
 var (
@@ -47,15 +58,14 @@ type Rotator struct {
 	machineID string
 	interval  time.Duration
 	fraction  float64
-	backoff   []time.Duration
 	clock     func() time.Time
 	rand      func() float64
 	logger    *slog.Logger
 }
 
 // NewRotator builds a Rotator with sane defaults: 6h interval, 1/3 TTL
-// fraction, [1s, 2s, 4s] backoff, time.Now clock, math/rand v2 jitter,
-// slog.Default() logger.
+// fraction, decorrelated retry [base=1s cap=30s 3 attempts], time.Now clock,
+// math/rand v2 jitter, slog.Default() logger.
 func NewRotator(client RotateClient, authDir, baseURL, machineID string) *Rotator {
 	return &Rotator{
 		client:    client,
@@ -64,7 +74,6 @@ func NewRotator(client RotateClient, authDir, baseURL, machineID string) *Rotato
 		machineID: machineID,
 		interval:  6 * time.Hour,
 		fraction:  1.0 / 3.0,
-		backoff:   []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second},
 		clock:     time.Now,
 		rand:      rand.Float64,
 		logger:    slog.Default(),
@@ -148,7 +157,7 @@ func (r *Rotator) RotateOnce(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("rotate: pkcs8: %w", err)
 	}
-	resp, err := postRotate(ctx, r.client.HTTPClient(), r.baseURL, string(csrPEM), r.backoff)
+	resp, err := postRotate(ctx, r.client.HTTPClient(), r.baseURL, string(csrPEM))
 	if err != nil {
 		return err
 	}
@@ -169,21 +178,30 @@ func (r *Rotator) nextSleep() time.Duration {
 
 func postRotate(
 	ctx context.Context, httpClient *http.Client, baseURL, csrPEM string,
-	backoff []time.Duration,
+) (*rotateResp, error) {
+	return postRotateWithRand(ctx, httpClient, baseURL, csrPEM, rand.Float64)
+}
+
+func postRotateWithRand(
+	ctx context.Context, httpClient *http.Client, baseURL, csrPEM string,
+	randSrc func() float64,
 ) (*rotateResp, error) {
 	body, err := json.Marshal(map[string]string{"csr_pem": csrPEM})
 	if err != nil {
 		return nil, fmt.Errorf("%w: marshal: %v", ErrRotateRetriesExhausted, err)
 	}
 	url := strings.TrimRight(baseURL, "/") + "/provision/cert/rotate"
+	prev := rotateBackoffBase
 	var lastErr error
-	for attempt := 0; attempt < len(backoff); attempt++ {
+	for attempt := 0; attempt < rotateMaxAttempts; attempt++ {
 		if attempt > 0 {
+			sleep := obs.DecorrelatedJitter(prev, rotateBackoffBase, rotateBackoffCap, randSrc)
 			select {
 			case <-ctx.Done():
 				return nil, fmt.Errorf("%w: %v", ErrRotateRetriesExhausted, ctx.Err())
-			case <-time.After(backoff[attempt-1]):
+			case <-timeAfter(sleep):
 			}
+			prev = sleep
 		}
 		raw, parsed, status, err := doRotateRequest(ctx, httpClient, url, body)
 		if err != nil {

--- a/apps/dump_agent_go/internal/auth/rotate_test.go
+++ b/apps/dump_agent_go/internal/auth/rotate_test.go
@@ -677,6 +677,9 @@ func TestPostRotate_CtxCancelDuringSleep(t *testing.T) {
 	rand := func() float64 { return 0.5 }
 	_, err := auth.PostRotateForTest(ctx, srv.Client(), srv.URL, "csr", rand)
 	if err == nil {
-		t.Errorf("expected error from ctx cancel, got nil")
+		t.Fatalf("expected error from ctx cancel, got nil")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("expected ctx propagation in err, got %v", err)
 	}
 }

--- a/apps/dump_agent_go/internal/auth/rotate_test.go
+++ b/apps/dump_agent_go/internal/auth/rotate_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -307,9 +308,15 @@ func TestPostRotate_Success_ReturnsParsedResp(t *testing.T) {
 	ca := seedRotateCA(t)
 	srv := mockRotateServer(t, ca, mockRotateOpts{})
 	httpClient := trustingClient(t, ca)
+	restore := auth.SetTimeAfterForTest(func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	defer restore()
 	resp, err := auth.PostRotateForTest(
 		t.Context(), httpClient, srv.URL, "fake-csr",
-		[]time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond},
+		func() float64 { return 0.5 },
 	)
 	if err != nil {
 		t.Fatalf("postRotate: %v", err)
@@ -331,9 +338,15 @@ func TestPostRotate_4xx_ReturnsErrRotateTerminal(t *testing.T) {
 		Attempts: &attempts,
 	})
 	httpClient := trustingClient(t, ca)
+	restore := auth.SetTimeAfterForTest(func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	defer restore()
 	_, err := auth.PostRotateForTest(
 		t.Context(), httpClient, srv.URL, "csr",
-		[]time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond},
+		func() float64 { return 0.5 },
 	)
 	if !errors.Is(err, auth.ErrRotateTerminal) {
 		t.Errorf("err = %v, want ErrRotateTerminal", err)
@@ -351,9 +364,15 @@ func TestPostRotate_5xxThrice_ReturnsErrRetriesExhausted(t *testing.T) {
 		Attempts: &attempts,
 	})
 	httpClient := trustingClient(t, ca)
+	restore := auth.SetTimeAfterForTest(func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	defer restore()
 	_, err := auth.PostRotateForTest(
 		t.Context(), httpClient, srv.URL, "csr",
-		[]time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond},
+		func() float64 { return 0.5 },
 	)
 	if !errors.Is(err, auth.ErrRotateRetriesExhausted) {
 		t.Errorf("err = %v, want ErrRotateRetriesExhausted", err)
@@ -371,9 +390,15 @@ func TestPostRotate_5xxThenSuccess_RetriesAndReturns(t *testing.T) {
 		Attempts: &attempts,
 	})
 	httpClient := trustingClient(t, ca)
+	restore := auth.SetTimeAfterForTest(func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	defer restore()
 	resp, err := auth.PostRotateForTest(
 		t.Context(), httpClient, srv.URL, "csr",
-		[]time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond},
+		func() float64 { return 0.5 },
 	)
 	if err != nil {
 		t.Fatalf("postRotate: %v", err)
@@ -431,7 +456,12 @@ func TestRotateOnce_NotDue_ReturnsErrRotateNotDue(t *testing.T) {
 		&fakeRotateClient{httpClient: trustingClient(t, ca)},
 		dir, srv.URL, "abc12345",
 	)
-	r.SetBackoffForTest([]time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond})
+	restore := auth.SetTimeAfterForTest(func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	defer restore()
 	err := r.RotateOnce(t.Context())
 	if !errors.Is(err, auth.ErrRotateNotDue) {
 		t.Errorf("err = %v, want ErrRotateNotDue", err)
@@ -450,7 +480,12 @@ func TestRotateOnce_WithinWindow_RotatesPersistsReloads(t *testing.T) {
 	srv := mockRotateServer(t, ca, mockRotateOpts{Attempts: &attempts})
 	rcv := &recordingFakeClient{httpClient: trustingClient(t, ca)}
 	r := auth.NewRotator(rcv, dir, srv.URL, "abc12345")
-	r.SetBackoffForTest([]time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond})
+	restore := auth.SetTimeAfterForTest(func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	defer restore()
 	r.SetClockForTest(func() time.Time { return time.Now().Add(4 * 24 * time.Hour) })
 	err := r.RotateOnce(t.Context())
 	if err != nil {
@@ -477,7 +512,12 @@ func TestRun_LoopExitsOnContextCancel(t *testing.T) {
 		dir, srv.URL, "abc12345",
 	)
 	r.SetIntervalForTest(10 * time.Millisecond)
-	r.SetBackoffForTest([]time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond})
+	restore := auth.SetTimeAfterForTest(func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	defer restore()
 	r.SetRandForTest(func() float64 { return 0.5 })
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
@@ -503,7 +543,12 @@ func TestRun_LoopExitsOnTerminalError(t *testing.T) {
 		dir, srv.URL, "abc12345",
 	)
 	r.SetIntervalForTest(10 * time.Millisecond)
-	r.SetBackoffForTest([]time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond})
+	restore := auth.SetTimeAfterForTest(func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	defer restore()
 	r.SetRandForTest(func() float64 { return 0.5 })
 	// Advance clock past most of cert lifetime so RotateOnce enters the
 	// rotation flow and hits the mock server's 401.
@@ -530,5 +575,108 @@ func TestNextSleep_JitterStaysInTenPercent(t *testing.T) {
 		if got < minD || got > maxD {
 			t.Errorf("nextSleep = %v, want in [%v, %v]", got, minD, maxD)
 		}
+	}
+}
+
+func TestPostRotate_DecorrelatedSequence(t *testing.T) {
+	// Simulate 3 consecutive 503 responses, capture sleep durations.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	sleeps := []time.Duration{}
+	mu := sync.Mutex{}
+	restore := auth.SetTimeAfterForTest(func(d time.Duration) <-chan time.Time {
+		mu.Lock()
+		sleeps = append(sleeps, d)
+		mu.Unlock()
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	defer restore()
+
+	rand := func() float64 { return 0.5 }
+	_, err := auth.PostRotateForTest(t.Context(), srv.Client(), srv.URL, "csr", rand)
+	if err == nil {
+		t.Fatalf("expected error after 3 503 responses")
+	}
+
+	// rand=0.5 + base=1s. Sleep happens BETWEEN attempts (not before attempt 0).
+	// 3 attempts → 2 sleeps:
+	// attempt 0: no sleep
+	// attempt 1: prev=base=1s, sleep = (1+3)/2 = 2s
+	// attempt 2: prev=2s, sleep = (1+6)/2 = 3.5s
+	want := []time.Duration{2 * time.Second, 3500 * time.Millisecond}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(sleeps) != len(want) {
+		t.Fatalf("got %d sleeps want %d: %v", len(sleeps), len(want), sleeps)
+	}
+	for i := range want {
+		if sleeps[i] != want[i] {
+			t.Errorf("sleep[%d] got %v want %v", i, sleeps[i], want[i])
+		}
+	}
+}
+
+func TestPostRotate_CappedAt30s(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	sleeps := []time.Duration{}
+	mu := sync.Mutex{}
+	restore := auth.SetTimeAfterForTest(func(d time.Duration) <-chan time.Time {
+		mu.Lock()
+		sleeps = append(sleeps, d)
+		mu.Unlock()
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	})
+	defer restore()
+
+	// rand=1.0 → upper bound of decorrelated formula every iteration
+	rand := func() float64 { return 1.0 }
+	_, _ = auth.PostRotateForTest(t.Context(), srv.Client(), srv.URL, "csr", rand)
+
+	// 3 attempts → 2 sleeps. rand=1.0 → upper bound:
+	// attempt 1: prev=base=1s, upper = min(3s, 30s) = 3s. sleep → 3s.
+	// attempt 2: prev=3s, upper = min(9s, 30s) = 9s. sleep → 9s.
+	mu.Lock()
+	defer mu.Unlock()
+	for _, s := range sleeps {
+		if s > 30*time.Second {
+			t.Errorf("sleep %v exceeds 30s cap", s)
+		}
+	}
+	// Last sleep should be ≤ 30s but > 1s (exponential growth observed).
+	if len(sleeps) > 1 && sleeps[len(sleeps)-1] <= sleeps[0] {
+		t.Errorf("expected monotonic growth, got %v", sleeps)
+	}
+}
+
+func TestPostRotate_CtxCancelDuringSleep(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	restore := auth.SetTimeAfterForTest(func(d time.Duration) <-chan time.Time {
+		// Never fire — let ctx cancel win
+		return make(chan time.Time)
+	})
+	defer restore()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	rand := func() float64 { return 0.5 }
+	_, err := auth.PostRotateForTest(ctx, srv.Client(), srv.URL, "csr", rand)
+	if err == nil {
+		t.Errorf("expected error from ctx cancel, got nil")
 	}
 }

--- a/apps/dump_agent_go/internal/breaker/breaker.go
+++ b/apps/dump_agent_go/internal/breaker/breaker.go
@@ -5,11 +5,14 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math/rand/v2"
 	"sync"
 	"time"
 
 	"github.com/cnesdata/dumpagent/internal/obs"
 )
+
+const breakerJitterFraction = 0.33
 
 // ErrOpen is returned when the breaker rejects a call (state == OPEN).
 var ErrOpen = errors.New("breaker: open")
@@ -29,21 +32,38 @@ type CircuitBreaker struct {
 	consecutive int
 	state       state
 	openedAt    time.Time
+	resetWindow time.Duration
 	threshold   int
 	resetAfter  time.Duration
 	name        string
 	nowFunc     func() time.Time
+	rand        func() float64
 }
 
 // New constructs a CLOSED breaker. threshold is consecutive failures to trip
-// OPEN; resetAfter is wait before HALF_OPEN probe.
+// OPEN; resetAfter is wait before HALF_OPEN probe (jittered ±33% per OPEN).
 func New(threshold int, resetAfter time.Duration, name string) *CircuitBreaker {
 	return &CircuitBreaker{
 		threshold:  threshold,
 		resetAfter: resetAfter,
 		name:       name,
 		nowFunc:    time.Now,
+		rand:       rand.Float64,
 	}
+}
+
+// SetClock replaces the time source. Used by tests.
+func (b *CircuitBreaker) SetClock(c func() time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.nowFunc = c
+}
+
+// SetRand replaces the rand source. Used by tests.
+func (b *CircuitBreaker) SetRand(r func() float64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.rand = r
 }
 
 // Call invokes fn, tracking success/failure. Returns ErrOpen when blocked.
@@ -64,7 +84,7 @@ func (b *CircuitBreaker) gateBefore() bool {
 	case stateClosed, stateHalfOpen:
 		return true
 	case stateOpen:
-		if b.nowFunc().Sub(b.openedAt) >= b.resetAfter {
+		if b.nowFunc().Sub(b.openedAt) >= b.resetWindow {
 			b.state = stateHalfOpen
 			slog.Info("breaker_half_open",
 				"event_id", obs.EventBreakerHalfOpen,
@@ -92,19 +112,23 @@ func (b *CircuitBreaker) gateAfter(err error) {
 	}
 	b.consecutive++
 	if b.state == stateHalfOpen {
-		b.state = stateOpen
-		b.openedAt = b.nowFunc()
-		slog.Error("breaker_reopened",
-			"event_id", obs.EventBreakerOpened,
-			"name", b.name)
+		b.openTrip("breaker_reopened")
 		return
 	}
 	if b.consecutive >= b.threshold && b.state == stateClosed {
-		b.state = stateOpen
-		b.openedAt = b.nowFunc()
-		slog.Error("breaker_opened",
-			"event_id", obs.EventBreakerOpened,
-			"name", b.name,
-			"consecutive", b.consecutive)
+		b.openTrip("breaker_opened")
 	}
+}
+
+// openTrip transitions to OPEN and snapshots a fresh resetWindow.
+// Caller must hold b.mu.
+func (b *CircuitBreaker) openTrip(msg string) {
+	b.state = stateOpen
+	b.openedAt = b.nowFunc()
+	b.resetWindow = obs.JitterAround(b.resetAfter, breakerJitterFraction, b.rand)
+	slog.Error(msg,
+		"event_id", obs.EventBreakerOpened,
+		"name", b.name,
+		"consecutive", b.consecutive,
+		"reset_window_ms", b.resetWindow.Milliseconds())
 }

--- a/apps/dump_agent_go/internal/breaker/breaker_test.go
+++ b/apps/dump_agent_go/internal/breaker/breaker_test.go
@@ -40,6 +40,7 @@ func TestBreaker_OpenToHalfOpenAfterReset(t *testing.T) {
 	now := time.Now()
 	b := newTestBreaker(2, 30*time.Second)
 	b.nowFunc = func() time.Time { return now }
+	b.rand = func() float64 { return 0.5 }
 	bang := errors.New("boom")
 	_ = b.Call(context.Background(), func(_ context.Context) error { return bang })
 	_ = b.Call(context.Background(), func(_ context.Context) error { return bang })
@@ -71,6 +72,7 @@ func TestBreaker_HalfOpenProbeFailReopens(t *testing.T) {
 	now := time.Now()
 	b := newTestBreaker(1, 30*time.Second)
 	b.nowFunc = func() time.Time { return now }
+	b.rand = func() float64 { return 0.5 }
 	bang := errors.New("boom")
 	_ = b.Call(context.Background(), func(_ context.Context) error { return bang })
 	// OPEN
@@ -110,5 +112,123 @@ func TestBreaker_CtxCancellation(t *testing.T) {
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("got %v want context.Canceled", err)
+	}
+}
+
+func TestBreaker_ResetWindowJittered_Low(t *testing.T) {
+	now := time.Now()
+	b := New(2, 60*time.Second, "test")
+	b.SetClock(func() time.Time { return now })
+	b.SetRand(func() float64 { return 0.0 })
+
+	// Trip OPEN
+	for i := 0; i < 2; i++ {
+		_ = b.Call(context.Background(), func(context.Context) error {
+			return errors.New("fail")
+		})
+	}
+
+	// At 39s, not eligible
+	b.SetClock(func() time.Time { return now.Add(39 * time.Second) })
+	if err := b.Call(context.Background(), func(context.Context) error { return nil }); !errors.Is(err, ErrOpen) {
+		t.Errorf("at 39s expected ErrOpen, got %v", err)
+	}
+
+	// At 40.2s, eligible (60s × (1 - 0.33) = 40.2s)
+	b.SetClock(func() time.Time { return now.Add(40200 * time.Millisecond) })
+	if err := b.Call(context.Background(), func(context.Context) error { return nil }); err != nil {
+		t.Errorf("at 40.2s expected pass, got %v", err)
+	}
+}
+
+func TestBreaker_ResetWindowJittered_High(t *testing.T) {
+	now := time.Now()
+	b := New(2, 60*time.Second, "test")
+	b.SetClock(func() time.Time { return now })
+	b.SetRand(func() float64 { return 1.0 })
+
+	for i := 0; i < 2; i++ {
+		_ = b.Call(context.Background(), func(context.Context) error {
+			return errors.New("fail")
+		})
+	}
+
+	// At 79s, not eligible
+	b.SetClock(func() time.Time { return now.Add(79 * time.Second) })
+	if err := b.Call(context.Background(), func(context.Context) error { return nil }); !errors.Is(err, ErrOpen) {
+		t.Errorf("at 79s expected ErrOpen, got %v", err)
+	}
+
+	// At 80s, eligible (60s × (1 + 0.33) = 79.8s)
+	b.SetClock(func() time.Time { return now.Add(80 * time.Second) })
+	if err := b.Call(context.Background(), func(context.Context) error { return nil }); err != nil {
+		t.Errorf("at 80s expected pass, got %v", err)
+	}
+}
+
+func TestBreaker_ResetWindowSnapshotStable(t *testing.T) {
+	now := time.Now()
+	calls := 0
+	rand := func() float64 {
+		calls++
+		// Different value each call so a buggy impl reading rand twice is detected.
+		if calls == 1 {
+			return 0.0
+		}
+		return 1.0
+	}
+	b := New(2, 60*time.Second, "test")
+	b.SetClock(func() time.Time { return now })
+	b.SetRand(rand)
+
+	for i := 0; i < 2; i++ {
+		_ = b.Call(context.Background(), func(context.Context) error {
+			return errors.New("fail")
+		})
+	}
+
+	// Window snapshot was taken at trip time with rand=0.0 (window ≈ 40.2s).
+	// 5 consecutive calls past the window should all see the SAME window.
+	for i := 0; i < 5; i++ {
+		b.SetClock(func() time.Time { return now.Add(50 * time.Second) })
+		err := b.Call(context.Background(), func(context.Context) error { return nil })
+		// HALF_OPEN probe permitted at 1st pass, then transitions to CLOSED on success.
+		// Subsequent CLOSED-state calls also permitted.
+		if err != nil {
+			t.Errorf("call %d at 50s expected pass, got %v", i, err)
+		}
+	}
+}
+
+func TestBreaker_ResetWindowRecomputedOnReopen(t *testing.T) {
+	now := time.Now()
+	randVals := []float64{0.0, 1.0} // first OPEN window low; second OPEN window high
+	idx := 0
+	rand := func() float64 {
+		v := randVals[idx]
+		idx++
+		return v
+	}
+	b := New(2, 60*time.Second, "test")
+	b.SetClock(func() time.Time { return now })
+	b.SetRand(rand)
+
+	// Trip OPEN (1st window: rand=0.0 → ≈ 40.2s)
+	for i := 0; i < 2; i++ {
+		_ = b.Call(context.Background(), func(context.Context) error {
+			return errors.New("fail")
+		})
+	}
+	// At 41s: half-open probe permitted; probe fails → reopen with fresh window
+	b.SetClock(func() time.Time { return now.Add(41 * time.Second) })
+	_ = b.Call(context.Background(), func(context.Context) error {
+		return errors.New("probe fail")
+	})
+
+	// Second OPEN at clock=41s with rand=1.0 → window ≈ 79.8s
+	// At clock=70s (29s into 2nd OPEN), still not eligible
+	b.SetClock(func() time.Time { return now.Add(70 * time.Second) })
+	if err := b.Call(context.Background(), func(context.Context) error { return nil }); !errors.Is(err, ErrOpen) {
+		t.Errorf("at 70s (29s into 2nd OPEN) expected ErrOpen due to fresh high-rand window, got %v", err)
 	}
 }

--- a/apps/dump_agent_go/internal/obs/jitter.go
+++ b/apps/dump_agent_go/internal/obs/jitter.go
@@ -61,10 +61,7 @@ func DecorrelatedJitter(prev, base, cap time.Duration, randSrc func() float64) t
 	if prev < base {
 		prev = base
 	}
-	upper := prev * 3
-	if upper > cap {
-		upper = cap
-	}
+	upper := min(prev*3, cap)
 	r := randSrc()
 	if r < 0 {
 		r = 0
@@ -73,11 +70,5 @@ func DecorrelatedJitter(prev, base, cap time.Duration, randSrc func() float64) t
 	}
 	span := upper - base
 	out := base + time.Duration(float64(span)*r)
-	if out < base {
-		return base
-	}
-	if out > cap {
-		return cap
-	}
 	return out
 }

--- a/apps/dump_agent_go/internal/obs/jitter.go
+++ b/apps/dump_agent_go/internal/obs/jitter.go
@@ -1,4 +1,3 @@
-// Package obs — JitterAround helper for periodic-interval noise.
 package obs
 
 import (
@@ -15,7 +14,7 @@ const jitterFloor = 1 * time.Millisecond
 // Floor:   1ms (returned even when arithmetic produces ≤ 0)
 //
 // Panics if d <= 0 or fraction < 0 or fraction > 1.
-// rand=nil → uses math/rand/v2.Float64.
+// randSrc=nil → uses math/rand/v2.Float64.
 func JitterAround(d time.Duration, fraction float64, randSrc func() float64) time.Duration {
 	if d <= 0 {
 		panic("obs.JitterAround: d must be > 0")

--- a/apps/dump_agent_go/internal/obs/jitter.go
+++ b/apps/dump_agent_go/internal/obs/jitter.go
@@ -38,3 +38,46 @@ func JitterAround(d time.Duration, fraction float64, randSrc func() float64) tim
 	}
 	return out
 }
+
+// DecorrelatedJitter returns the next sleep in an AWS-paper decorrelated
+// jitter retry sequence.
+//
+// Formula: out = clamp(uniform(base, prev*3), base, cap)
+// Floor:   base (when prev < base)
+// Ceiling: cap
+//
+// Panics if base <= 0 or cap < base.
+// randSrc=nil → uses math/rand/v2.Float64.
+func DecorrelatedJitter(prev, base, cap time.Duration, randSrc func() float64) time.Duration {
+	if base <= 0 {
+		panic("obs.DecorrelatedJitter: base must be > 0")
+	}
+	if cap < base {
+		panic("obs.DecorrelatedJitter: cap must be >= base")
+	}
+	if randSrc == nil {
+		randSrc = rand.Float64
+	}
+	if prev < base {
+		prev = base
+	}
+	upper := prev * 3
+	if upper > cap {
+		upper = cap
+	}
+	r := randSrc()
+	if r < 0 {
+		r = 0
+	} else if r > 1 {
+		r = 1
+	}
+	span := upper - base
+	out := base + time.Duration(float64(span)*r)
+	if out < base {
+		return base
+	}
+	if out > cap {
+		return cap
+	}
+	return out
+}

--- a/apps/dump_agent_go/internal/obs/jitter.go
+++ b/apps/dump_agent_go/internal/obs/jitter.go
@@ -1,0 +1,41 @@
+// Package obs — JitterAround helper for periodic-interval noise.
+package obs
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+const jitterFloor = 1 * time.Millisecond
+
+// JitterAround returns d perturbed by ±fraction × d × rand-bias.
+//
+// Formula: out = d + d * (rand()*2 - 1) * fraction
+// Range:   [d*(1-fraction), d*(1+fraction)]
+// Floor:   1ms (returned even when arithmetic produces ≤ 0)
+//
+// Panics if d <= 0 or fraction < 0 or fraction > 1.
+// rand=nil → uses math/rand/v2.Float64.
+func JitterAround(d time.Duration, fraction float64, randSrc func() float64) time.Duration {
+	if d <= 0 {
+		panic("obs.JitterAround: d must be > 0")
+	}
+	if fraction < 0 || fraction > 1 {
+		panic("obs.JitterAround: fraction must be in [0, 1]")
+	}
+	if randSrc == nil {
+		randSrc = rand.Float64
+	}
+	r := randSrc()
+	if r < 0 {
+		r = 0
+	} else if r > 1 {
+		r = 1
+	}
+	bias := (r*2 - 1) * fraction
+	out := d + time.Duration(float64(d)*bias)
+	if out < jitterFloor {
+		return jitterFloor
+	}
+	return out
+}

--- a/apps/dump_agent_go/internal/obs/jitter_test.go
+++ b/apps/dump_agent_go/internal/obs/jitter_test.go
@@ -78,3 +78,19 @@ func TestJitterAround_NilRandUsesDefault(t *testing.T) {
 		t.Errorf("nil rand got %v want in [%v, %v]", got, min, max)
 	}
 }
+
+func TestJitterAround_RandBelowZeroClampedToZero(t *testing.T) {
+	got := JitterAround(30*time.Second, 0.20, fixedRand(-0.1))
+	want := 24 * time.Second
+	if got != want {
+		t.Errorf("rand=-0.1 (clamped to 0) got %v want %v", got, want)
+	}
+}
+
+func TestJitterAround_RandAboveOneClampedToOne(t *testing.T) {
+	got := JitterAround(30*time.Second, 0.20, fixedRand(1.1))
+	want := 36 * time.Second
+	if got != want {
+		t.Errorf("rand=1.1 (clamped to 1) got %v want %v", got, want)
+	}
+}

--- a/apps/dump_agent_go/internal/obs/jitter_test.go
+++ b/apps/dump_agent_go/internal/obs/jitter_test.go
@@ -94,3 +94,86 @@ func TestJitterAround_RandAboveOneClampedToOne(t *testing.T) {
 		t.Errorf("rand=1.1 (clamped to 1) got %v want %v", got, want)
 	}
 }
+
+func TestDecorrelatedJitter_BaseAtRandZero(t *testing.T) {
+	got := DecorrelatedJitter(1*time.Second, 1*time.Second, 30*time.Second, fixedRand(0.0))
+	want := 1 * time.Second
+	if got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+}
+
+func TestDecorrelatedJitter_TripleAtRandOne(t *testing.T) {
+	got := DecorrelatedJitter(2*time.Second, 1*time.Second, 30*time.Second, fixedRand(1.0))
+	want := 6 * time.Second
+	if got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+}
+
+func TestDecorrelatedJitter_CappedAtRandOne(t *testing.T) {
+	got := DecorrelatedJitter(20*time.Second, 1*time.Second, 30*time.Second, fixedRand(1.0))
+	want := 30 * time.Second
+	if got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+}
+
+func TestDecorrelatedJitter_FloorWhenPrevBelowBase(t *testing.T) {
+	got := DecorrelatedJitter(500*time.Millisecond, 1*time.Second, 30*time.Second, fixedRand(0.5))
+	if got < 1*time.Second {
+		t.Errorf("got %v want >= 1s (base floor)", got)
+	}
+}
+
+func TestDecorrelatedJitter_PanicsOnInvalidCap(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic for cap < base")
+		}
+	}()
+	DecorrelatedJitter(1*time.Second, 1*time.Second, 500*time.Millisecond, fixedRand(0.5))
+}
+
+func TestDecorrelatedJitter_PanicsOnInvalidBase(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic for base <= 0")
+		}
+	}()
+	DecorrelatedJitter(1*time.Second, 0, 30*time.Second, fixedRand(0.5))
+}
+
+func TestDecorrelatedJitter_MidpointFormula(t *testing.T) {
+	// rand=0.5 + base=1s + prev=2s → mid = (1s + 6s) / 2 = 3.5s
+	got := DecorrelatedJitter(2*time.Second, 1*time.Second, 30*time.Second, fixedRand(0.5))
+	want := 3500 * time.Millisecond
+	if got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+}
+
+func TestDecorrelatedJitter_NilRandUsesDefault(t *testing.T) {
+	got := DecorrelatedJitter(2*time.Second, 1*time.Second, 30*time.Second, nil)
+	if got < 1*time.Second || got > 6*time.Second {
+		t.Errorf("got %v want in [1s, 6s]", got)
+	}
+}
+
+func TestDecorrelatedJitter_RandBelowZeroClampedToZero(t *testing.T) {
+	// rand returns -0.1 → clamp to 0 → low-bound result = base
+	got := DecorrelatedJitter(2*time.Second, 1*time.Second, 30*time.Second, fixedRand(-0.1))
+	want := 1 * time.Second
+	if got != want {
+		t.Errorf("rand=-0.1 (clamped to 0) got %v want %v", got, want)
+	}
+}
+
+func TestDecorrelatedJitter_RandAboveOneClampedToOne(t *testing.T) {
+	// rand returns 1.1 → clamp to 1 → upper-bound result = prev*3 (or cap)
+	got := DecorrelatedJitter(2*time.Second, 1*time.Second, 30*time.Second, fixedRand(1.1))
+	want := 6 * time.Second
+	if got != want {
+		t.Errorf("rand=1.1 (clamped to 1) got %v want %v", got, want)
+	}
+}

--- a/apps/dump_agent_go/internal/obs/jitter_test.go
+++ b/apps/dump_agent_go/internal/obs/jitter_test.go
@@ -1,0 +1,80 @@
+package obs
+
+import (
+	"testing"
+	"time"
+)
+
+func fixedRand(v float64) func() float64 {
+	return func() float64 { return v }
+}
+
+func TestJitterAround_BoundsAtRandZero(t *testing.T) {
+	got := JitterAround(30*time.Second, 0.20, fixedRand(0.0))
+	want := 24 * time.Second
+	if got != want {
+		t.Errorf("rand=0.0 got %v want %v", got, want)
+	}
+}
+
+func TestJitterAround_BoundsAtRandOne(t *testing.T) {
+	got := JitterAround(30*time.Second, 0.20, fixedRand(1.0))
+	want := 36 * time.Second
+	if got != want {
+		t.Errorf("rand=1.0 got %v want %v", got, want)
+	}
+}
+
+func TestJitterAround_MidpointIdentity(t *testing.T) {
+	got := JitterAround(30*time.Second, 0.20, fixedRand(0.5))
+	want := 30 * time.Second
+	if got != want {
+		t.Errorf("rand=0.5 got %v want %v", got, want)
+	}
+}
+
+func TestJitterAround_ZeroFractionIdentity(t *testing.T) {
+	for _, r := range []float64{0.0, 0.25, 0.5, 0.75, 1.0} {
+		got := JitterAround(30*time.Second, 0.0, fixedRand(r))
+		if got != 30*time.Second {
+			t.Errorf("rand=%v fraction=0 got %v want 30s", r, got)
+		}
+	}
+}
+
+func TestJitterAround_FloorAt1ms(t *testing.T) {
+	got := JitterAround(1*time.Millisecond, 1.0, fixedRand(0.0))
+	if got < 1*time.Millisecond {
+		t.Errorf("got %v want >= 1ms", got)
+	}
+}
+
+func TestJitterAround_PanicsOnNegativeD(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic for d=-1s")
+		}
+	}()
+	JitterAround(-1*time.Second, 0.2, fixedRand(0.5))
+}
+
+func TestJitterAround_PanicsOnInvalidFraction(t *testing.T) {
+	for _, f := range []float64{-0.1, 1.1} {
+		func() {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic for fraction=%v", f)
+				}
+			}()
+			JitterAround(30*time.Second, f, fixedRand(0.5))
+		}()
+	}
+}
+
+func TestJitterAround_NilRandUsesDefault(t *testing.T) {
+	got := JitterAround(30*time.Second, 0.20, nil)
+	min, max := 24*time.Second, 36*time.Second
+	if got < min || got > max {
+		t.Errorf("nil rand got %v want in [%v, %v]", got, min, max)
+	}
+}

--- a/apps/dump_agent_go/internal/worker/drain.go
+++ b/apps/dump_agent_go/internal/worker/drain.go
@@ -14,11 +14,12 @@ import (
 )
 
 const (
-	drainTickInterval  = 30 * time.Second
-	drainBatchSize     = 20
-	drainEvictAge      = 90 * 24 * time.Hour
-	drainEvictMaxCount = 10000
-	dispatchTimeout    = 30 * time.Second
+	drainTickInterval   = 30 * time.Second
+	drainJitterFraction = 0.20
+	drainBatchSize      = 20
+	drainEvictAge       = 90 * 24 * time.Hour
+	drainEvictMaxCount  = 10000
+	dispatchTimeout     = 30 * time.Second
 )
 
 // Drainer ships persisted envelopes to the central_api in FIFO order,
@@ -28,6 +29,7 @@ type Drainer struct {
 	breaker  *breaker.CircuitBreaker
 	inner    JobAPIClient
 	interval time.Duration
+	rand     func() float64
 }
 
 // NewDrainer constructs a Drainer with default cadence (30s).
@@ -37,19 +39,31 @@ func NewDrainer(out *queue.Outbox, br *breaker.CircuitBreaker, inner JobAPIClien
 		breaker:  br,
 		inner:    inner,
 		interval: drainTickInterval,
+		rand:     nil, // nil → JitterAround uses math/rand/v2.Float64
 	}
+}
+
+// SetRand replaces the rand source. Used by tests for deterministic jitter.
+func (d *Drainer) SetRand(r func() float64) {
+	d.rand = r
+}
+
+// NextInterval returns the next tick wait, jittered by ±drainJitterFraction.
+func (d *Drainer) NextInterval() time.Duration {
+	return obs.JitterAround(d.interval, drainJitterFraction, d.rand)
 }
 
 // Run loops until ctx is cancelled.
 func (d *Drainer) Run(ctx context.Context) error {
-	ticker := time.NewTicker(d.interval)
-	defer ticker.Stop()
+	timer := time.NewTimer(d.NextInterval())
+	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-ticker.C:
+		case <-timer.C:
 			d.tick(ctx)
+			timer.Reset(d.NextInterval())
 		}
 	}
 }

--- a/apps/dump_agent_go/internal/worker/drain_test.go
+++ b/apps/dump_agent_go/internal/worker/drain_test.go
@@ -134,3 +134,33 @@ func TestDrain_RunRespectsCtxCancel(t *testing.T) {
 		t.Fatal("Run did not exit on ctx cancel")
 	}
 }
+
+func TestDrainer_TickIntervalJittered_Low(t *testing.T) {
+	d, _, _ := newDrainFixture(t, nil)
+	d.SetRand(func() float64 { return 0.0 }) // bottom of jitter window
+	got := d.NextInterval()
+	want := 24 * time.Second
+	if got != want {
+		t.Errorf("rand=0.0 got %v want %v", got, want)
+	}
+}
+
+func TestDrainer_TickIntervalJittered_High(t *testing.T) {
+	d, _, _ := newDrainFixture(t, nil)
+	d.SetRand(func() float64 { return 1.0 })
+	got := d.NextInterval()
+	want := 36 * time.Second
+	if got != want {
+		t.Errorf("rand=1.0 got %v want %v", got, want)
+	}
+}
+
+func TestDrainer_TickIntervalJittered_Mid(t *testing.T) {
+	d, _, _ := newDrainFixture(t, nil)
+	d.SetRand(func() float64 { return 0.5 })
+	got := d.NextInterval()
+	want := 30 * time.Second
+	if got != want {
+		t.Errorf("rand=0.5 got %v want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `obs.JitterAround` + `obs.DecorrelatedJitter` pure helpers
- Wire jitter into drain ticks (±20%), breaker reset (±33%), cert rotate retries (decorrelated)
- All consumers accept injectable `rand func() float64` for deterministic tests
- Zero new external dependencies
- `obs/jitter.go` 100% covered; filtered total ≥ 80.5% (P5.2 baseline)

## Test plan

- [ ] CI lint-test-linux passes
- [ ] CI bench-gate passes
- [ ] `go vet` clean on linux + windows targets
- [ ] No `go.mod` / `go.sum` drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)