### PR TITLE
feat(FU1): sha256 propagation via post-upload register

### DIFF
--- a/apps/central_api/CLAUDE.md
+++ b/apps/central_api/CLAUDE.md
@@ -21,6 +21,7 @@ em 1 réplica (gate via env `ENABLE_REAPER`).
 - `GET /api/v1/jobs/next` — próximo job para `(tenant_id, machine_id)` com lease
 - `POST /api/v1/jobs/{id}/heartbeat` — estende lease
 - `POST /api/v1/jobs/{id}/artifact` — emite presigned PUT MinIO
+- `POST /api/v1/jobs/upload-url` — mint presigned PUT URL + create PENDING landing row (cnes/sihd post-upload register flow)
 - `POST /api/v1/jobs/{id}/complete` — marca job uploaded (processor pega depois)
 - `POST /api/v1/jobs/{id}/fail` — marca falha (retryable ou DLQ)
 - `POST /api/v1/admin/reap-leases` — libera jobs com lease expirado (admin)
@@ -78,7 +79,7 @@ em 1 réplica (gate via env `ENABLE_REAPER`).
 | `src/central_api/deps.py` | `get_engine()`, `lifespan`, `_lease_reaper_loop`, RLS listener install |
 | `src/central_api/middleware.py` | `TenantMiddleware` — extrai `X-Tenant-Id` header |
 | `src/central_api/routes/health.py` | `/api/v1/system/health` — ping DB |
-| `src/central_api/routes/jobs.py` | `/api/v1/jobs/*` — fila, artifact, heartbeat, complete, fail |
+| `src/central_api/routes/jobs.py` | `/api/v1/jobs/upload-url` (mint URL + create PENDING) + `/api/v1/jobs/register` (UPDATE → REGISTERED with sha256) |
 | `src/central_api/routes/admin.py` | `/api/v1/admin/*` — reap-leases, ops |
 | `routes/dashboard.py` | /api/v1/dashboard/* |
 | `routes/oauth.py`     | /activate/confirm (rate-limited via slowapi) |
@@ -100,3 +101,6 @@ em 1 réplica (gate via env `ENABLE_REAPER`).
   Sem isso, queries via SQLAlchemy não setam `app.tenant_id` e RLS bloqueia
   tudo. Teste de regressão: qualquer query em integration test deve passar
   (se bloquear, listener não foi instalado).
+- **`/jobs/{id}/complete` and `/jobs/{id}/fail` routes do not exist** —
+  edge no longer calls /complete (FU1 dropped). /fail is documented as
+  follow-up gap; today extract/upload failures leave PENDING orphan rows.

--- a/apps/central_api/src/central_api/routes/jobs.py
+++ b/apps/central_api/src/central_api/routes/jobs.py
@@ -7,8 +7,12 @@ from typing import TYPE_CHECKING, Annotated, Any
 from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import ValidationError
 
-from central_api.deps import get_engine
-from cnes_contracts.landing import ExtractionRegisterPayload
+from central_api.deps import get_engine, get_minio
+from cnes_contracts.landing import (
+    ExtractionRegisterPayload,
+    UploadUrlRequest,
+    UploadUrlResponse,
+)
 from cnes_infra.storage import extractions_repo
 
 if TYPE_CHECKING:
@@ -17,6 +21,71 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["jobs"])
+
+
+_FATO_SUBTYPE_FOR: dict[tuple[str, str], str] = {
+    ("CNES_LOCAL", "cnes_profissionais"): "CNES_VINCULO",
+    ("CNES_LOCAL", "cnes_estabelecimentos"): "CNES_VINCULO",
+    ("CNES_LOCAL", "cnes_equipes"): "CNES_VINCULO",
+    ("CNES_NACIONAL", "cnes_profissionais"): "CNES_VINCULO",
+    ("SIHD", "sihd_producao"): "SIHD_INTERNACAO",
+}
+
+
+def _object_storage():
+    return get_minio()
+
+
+def _resolve_fato_subtype(source_type: str, intent: str) -> str:
+    subtype = _FATO_SUBTYPE_FOR.get((source_type, intent))
+    if subtype is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"unsupported_source_intent={source_type}/{intent}",
+        )
+    return subtype
+
+
+def _build_minio_key(payload: UploadUrlRequest, fato_subtype: str) -> str:
+    return (
+        f"{payload.tenant_id}/{fato_subtype}/{payload.competencia}/"
+        f"{payload.job_id}.parquet.gz"
+    )
+
+
+@router.post("/jobs/upload-url", status_code=201)
+def mint_upload_url(
+    body: Annotated[dict[str, Any], Body()],
+    engine: Engine = Depends(get_engine),
+) -> dict:
+    try:
+        payload = UploadUrlRequest.model_validate(body, strict=False)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
+
+    fato_subtype = _resolve_fato_subtype(payload.source_type, payload.intent)
+    minio_key = _build_minio_key(payload, fato_subtype)
+    inserted = extractions_repo.mint_upload_url(
+        engine,
+        job_id=payload.job_id,
+        tenant_id=payload.tenant_id,
+        source_type=payload.source_type,
+        competencia=payload.competencia,
+        fato_subtype=fato_subtype,
+        minio_key=minio_key,
+        agent_version=payload.agent_version,
+        machine_id=payload.machine_id,
+    )
+    if inserted is None:
+        raise HTTPException(status_code=409, detail="duplicate_job_id")
+
+    upload_url = _object_storage().presigned_put(minio_key, expires=3600)
+    response = UploadUrlResponse(
+        extraction_id=payload.job_id,
+        upload_url=upload_url,
+        minio_key=minio_key,
+    )
+    return response.model_dump(mode="json")
 
 
 @router.post("/jobs/register")

--- a/apps/central_api/src/central_api/routes/jobs.py
+++ b/apps/central_api/src/central_api/routes/jobs.py
@@ -31,6 +31,8 @@ _FATO_SUBTYPE_FOR: dict[tuple[str, str], str] = {
     ("SIHD", "sihd_producao"): "SIHD_INTERNACAO",
 }
 
+_UPLOAD_URL_TTL_SECONDS: int = 3600
+
 
 def _object_storage():
     return get_minio()
@@ -79,7 +81,7 @@ def mint_upload_url(
     if inserted is None:
         raise HTTPException(status_code=409, detail="duplicate_job_id")
 
-    upload_url = _object_storage().presigned_put(minio_key, expires=3600)
+    upload_url = _object_storage().presigned_put(minio_key, expires=_UPLOAD_URL_TTL_SECONDS)
     response = UploadUrlResponse(
         extraction_id=payload.job_id,
         upload_url=upload_url,

--- a/apps/central_api/tests/routes/test_e2e_upload_register.py
+++ b/apps/central_api/tests/routes/test_e2e_upload_register.py
@@ -31,17 +31,8 @@ def _cleanup_extractions(pg_engine):
         conn.execute(text("TRUNCATE landing.extractions CASCADE"))
 
 
-@pytest.mark.usefixtures("_cleanup_extractions")
-def test_e2e_aceita_mint_upload_register_persiste_sha256(
-    api_client: TestClient, pg_engine, monkeypatch,
-) -> None:
-    monkeypatch.setattr(
-        "central_api.routes.jobs._object_storage",
-        lambda: _FakeStorage(),
-    )
-
-    job_id = str(uuid4())
-    mint_resp = api_client.post(
+def _mint_upload_url(client: TestClient, job_id: str) -> str:
+    resp = client.post(
         "/api/v1/jobs/upload-url",
         headers={"X-Tenant-Id": _TENANT},
         json={
@@ -55,16 +46,18 @@ def test_e2e_aceita_mint_upload_register_persiste_sha256(
             "machine_id": "EDGE-01",
         },
     )
-    assert mint_resp.status_code == 201, mint_resp.text
-    mint_body = mint_resp.json()
-    assert mint_body["extraction_id"] == job_id
-    minio_key = mint_body["minio_key"]
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["extraction_id"] == job_id
+    minio_key = body["minio_key"]
     assert minio_key.endswith(".parquet.gz")
+    return minio_key
 
-    parquet_bytes = b"\x00\x01\x02\x03"
-    sha = hashlib.sha256(parquet_bytes).hexdigest()
 
-    register_resp = api_client.post(
+def _register_extraction(
+    client: TestClient, job_id: str, minio_key: str, sha: str, size: int,
+) -> dict:
+    resp = client.post(
         "/api/v1/jobs/register",
         headers={"X-Tenant-Id": _TENANT},
         json={
@@ -72,7 +65,7 @@ def test_e2e_aceita_mint_upload_register_persiste_sha256(
             "files": [{
                 "minio_key": minio_key,
                 "fato_subtype": "CNES_VINCULO",
-                "size_bytes": len(parquet_bytes),
+                "size_bytes": size,
                 "sha256": sha,
             }],
             "agent_version": "0.5.0",
@@ -80,8 +73,27 @@ def test_e2e_aceita_mint_upload_register_persiste_sha256(
             "sha256": sha,
         },
     )
-    assert register_resp.status_code == 200, register_resp.text
-    assert register_resp.json()["status"] == "REGISTERED"
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+@pytest.mark.usefixtures("_cleanup_extractions")
+def test_e2e_aceita_mint_upload_register_persiste_sha256(
+    api_client: TestClient, pg_engine, monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "central_api.routes.jobs._object_storage",
+        lambda: _FakeStorage(),
+    )
+    job_id = str(uuid4())
+    minio_key = _mint_upload_url(api_client, job_id)
+
+    parquet_bytes = b"\x00\x01\x02\x03"
+    sha = hashlib.sha256(parquet_bytes).hexdigest()
+    body = _register_extraction(
+        api_client, job_id, minio_key, sha, len(parquet_bytes),
+    )
+    assert body["status"] == "REGISTERED"
 
     with pg_engine.begin() as conn:
         conn.execute(text("SET LOCAL row_security = off"))

--- a/apps/central_api/tests/routes/test_e2e_upload_register.py
+++ b/apps/central_api/tests/routes/test_e2e_upload_register.py
@@ -1,0 +1,98 @@
+"""E2E: mint -> fake MinIO PUT -> register; sha256 lands em landing.extractions."""
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.postgres
+
+
+_TENANT = "354130"
+
+
+class _FakeStorage:
+    def presigned_put(self, key: str, expires: int = 3600) -> str:
+        return f"https://minio/fake?key={key}&exp={expires}"
+
+
+@pytest.fixture
+def _cleanup_extractions(pg_engine):
+    with pg_engine.begin() as conn:
+        conn.execute(text("TRUNCATE landing.extractions CASCADE"))
+    yield
+    with pg_engine.begin() as conn:
+        conn.execute(text("TRUNCATE landing.extractions CASCADE"))
+
+
+@pytest.mark.usefixtures("_cleanup_extractions")
+def test_e2e_aceita_mint_upload_register_persiste_sha256(
+    api_client: TestClient, pg_engine, monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "central_api.routes.jobs._object_storage",
+        lambda: _FakeStorage(),
+    )
+
+    job_id = str(uuid4())
+    mint_resp = api_client.post(
+        "/api/v1/jobs/upload-url",
+        headers={"X-Tenant-Id": _TENANT},
+        json={
+            "job_id": job_id,
+            "tenant_id": _TENANT,
+            "source_type": "CNES_LOCAL",
+            "tipo_extracao": "profissionais",
+            "competencia": "2026-01-01",
+            "intent": "cnes_profissionais",
+            "agent_version": "0.5.0",
+            "machine_id": "EDGE-01",
+        },
+    )
+    assert mint_resp.status_code == 201, mint_resp.text
+    mint_body = mint_resp.json()
+    assert mint_body["extraction_id"] == job_id
+    minio_key = mint_body["minio_key"]
+    assert minio_key.endswith(".parquet.gz")
+
+    parquet_bytes = b"\x00\x01\x02\x03"
+    sha = hashlib.sha256(parquet_bytes).hexdigest()
+
+    register_resp = api_client.post(
+        "/api/v1/jobs/register",
+        headers={"X-Tenant-Id": _TENANT},
+        json={
+            "job_id": job_id,
+            "files": [{
+                "minio_key": minio_key,
+                "fato_subtype": "CNES_VINCULO",
+                "size_bytes": len(parquet_bytes),
+                "sha256": sha,
+            }],
+            "agent_version": "0.5.0",
+            "machine_id": "EDGE-01",
+            "sha256": sha,
+        },
+    )
+    assert register_resp.status_code == 200, register_resp.text
+    assert register_resp.json()["status"] == "REGISTERED"
+
+    with pg_engine.begin() as conn:
+        conn.execute(text("SET LOCAL row_security = off"))
+        row = conn.execute(
+            text(
+                "SELECT status, sha256, agent_version, machine_id "
+                "FROM landing.extractions WHERE job_id = :j",
+            ),
+            {"j": job_id},
+        ).one()
+    assert row.status == "REGISTERED"
+    assert row.sha256 == sha
+    assert row.agent_version == "0.5.0"
+    assert row.machine_id == "EDGE-01"

--- a/apps/central_api/tests/test_routes_jobs_upload_url.py
+++ b/apps/central_api/tests/test_routes_jobs_upload_url.py
@@ -1,0 +1,90 @@
+"""Testes da rota POST /api/v1/jobs/upload-url."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _make_app():
+    with (
+        patch("central_api.app.init_telemetry"),
+        patch("central_api.deps.install_rls_listener"),
+        patch("central_api.deps.instrument_engine"),
+        patch("central_api.deps.install_query_counter"),
+        patch("central_api.deps.create_engine"),
+    ):
+        from central_api.app import create_app
+        return create_app()
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app = _make_app()
+    fake_storage = MagicMock()
+    fake_storage.presigned_put.return_value = "https://minio/presigned?sig=x"
+    monkeypatch.setattr(
+        "central_api.routes.jobs._object_storage",
+        lambda: fake_storage,
+    )
+    from central_api.deps import get_engine
+    app.dependency_overrides[get_engine] = lambda: MagicMock()
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def test_aceita_request_valido(client, monkeypatch):
+    job_id = str(uuid4())
+    monkeypatch.setattr(
+        "central_api.routes.jobs.extractions_repo.mint_upload_url",
+        lambda *a, **kw: kw["job_id"],
+    )
+    resp = client.post(
+        "/api/v1/jobs/upload-url",
+        headers={"X-Tenant-Id": "354130"},
+        json={
+            "job_id": job_id,
+            "tenant_id": "354130",
+            "source_type": "CNES_LOCAL",
+            "tipo_extracao": "profissionais",
+            "competencia": "2026-01-01",
+            "intent": "cnes_profissionais",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["extraction_id"] == job_id
+    assert body["upload_url"].startswith("https://minio/presigned")
+    assert body["minio_key"].endswith(".parquet.gz")
+
+
+def test_rejeita_duplicate_job_id(client, monkeypatch):
+    monkeypatch.setattr(
+        "central_api.routes.jobs.extractions_repo.mint_upload_url",
+        lambda *a, **kw: None,
+    )
+    resp = client.post(
+        "/api/v1/jobs/upload-url",
+        headers={"X-Tenant-Id": "354130"},
+        json={
+            "job_id": str(uuid4()),
+            "tenant_id": "354130",
+            "source_type": "CNES_LOCAL",
+            "tipo_extracao": "profissionais",
+            "competencia": "2026-01-01",
+            "intent": "cnes_profissionais",
+        },
+    )
+    assert resp.status_code == 409
+
+
+def test_rejeita_payload_invalido(client):
+    resp = client.post(
+        "/api/v1/jobs/upload-url",
+        headers={"X-Tenant-Id": "354130"},
+        json={"job_id": "not-a-uuid"},
+    )
+    assert resp.status_code == 422

--- a/apps/central_api/tests/test_routes_jobs_upload_url.py
+++ b/apps/central_api/tests/test_routes_jobs_upload_url.py
@@ -88,3 +88,20 @@ def test_rejeita_payload_invalido(client):
         json={"job_id": "not-a-uuid"},
     )
     assert resp.status_code == 422
+
+
+def test_rejeita_source_intent_desconhecido(client, monkeypatch):
+    resp = client.post(
+        "/api/v1/jobs/upload-url",
+        headers={"X-Tenant-Id": "354130"},
+        json={
+            "job_id": str(uuid4()),
+            "tenant_id": "354130",
+            "source_type": "CNES_LOCAL",
+            "tipo_extracao": "profissionais",
+            "competencia": "2026-01-01",
+            "intent": "cnes_unknown",
+        },
+    )
+    assert resp.status_code == 422
+    assert "unsupported_source_intent" in resp.text

--- a/apps/dump_agent_go/CLAUDE.md
+++ b/apps/dump_agent_go/CLAUDE.md
@@ -132,57 +132,12 @@ driver pure-Go).
   unregistered agents must `dumpagent register` first OR set
   `AGENT_ALLOW_INSECURE=true` for fleet rollout escape hatch.
 
-## Phase 5.1 — Windows Event Log sink (2026-05-01)
+## Phase 5: hardening (2026-05-01/02)
 
-WARN+ slog records routed to Application log under source `DumpAgent`.
-Linux/Mac: no-op stub via build tags. Existing rotating-file handler
-unchanged — eventlog is fan-out sibling under `obs.MultiHandler`.
-
-- Source name: `service.EventSourceName` constant ("DumpAgent"). No env override.
-- Registration: `agent.exe install` calls `service.RegisterEventSource`;
-  `agent.exe uninstall` calls `service.RemoveEventSource`. Both idempotent.
-  Best-effort: install succeeds even if registration fails.
-- Event IDs: `internal/obs/events.go` banded catalog (1xxx auth, 2xxx queue,
-  3xxx extract, 4xxx upload, 5xxx diagnose, 9xxx generic). P4 reserved
-  1003/1004. Add `event_id` attr to slog calls that should map to a
-  specific Event Viewer entry; missing attr defaults to `EventUnknown`.
-- Format: `obs.FormatCompact` renders `level=… msg=… k1=v1 k2=v2`
-  single-line, UTF-8-safe truncation at 8KB, ASCII control bytes escaped.
-- Rollback knob: `AGENT_EVENTLOG_DISABLED=true` makes handler no-op without
-  uninstall. Not in `.env.example` (emergency switch only).
-- Locale-independent: `RemoveEventSource` uses `errors.Is(err,
-  syscall.ERROR_FILE_NOT_FOUND)` — works on pt-BR Windows hosts.
-- Cross-tag check: CI runs `go vet` on both `GOOS=linux` and
-  `GOOS=windows` to catch tag leaks before merge.
-
-## Phase 5.2 — Outbox queue + Circuit Breaker (2026-05-02)
-
-Persistent outbox for `CompleteJob`/`FailJob` so transient central_api outages do not lose extraction outcomes.
-- `internal/queue/` — bbolt outbox (`go.etcd.io/bbolt v1.3.10`); single bucket, time-ordered uint64 keys (8B ns + 4B seq), JSON envelopes. Path `%PROGRAMDATA%\dumpagent\queue\outbox.db`. 10k cap, 90-day TTL drop-oldest, fsync per Append. `RegisterJob` + `SendHeartbeat` stay direct.
-- `internal/breaker/` — CLOSED→OPEN→HALF_OPEN, threshold 5 consecutive failures, reset 60s, shared `central_api` instance gating drain + RegisterJob; logs 8001/8002/8003.
-- `internal/worker/{outbox_adapter,drain}.go` — `Drainer.Run` ticks 30s, peeks 20, dispatches via breaker, classifies (`queue/classify.go`): 2xx delete; 4xx drop; 5xx retry; 429 honors `Retry-After`.
-- `cmd/dumpagent/cmd_run.go` `startDrainWithWatcher` spawns drain under `obs.SafeGo` + relaunches with 5s backoff on panic-recovery exit. Outbox open failure aborts boot fail-closed (exit 1).
-- Event ID catalog 2xxx queue (2004-2007) + 8xxx breaker (8001-8003); `expectedEventIDCount` 19 → 26.
-
-## Phase 5.3 — Backoff + Jitter (2026-05-02)
-
-Test-injectable jitter so N-agent fleet does not collide post-outage.
-- `internal/obs/jitter.go` — `JitterAround(d, fraction, rand)` periodic noise; `DecorrelatedJitter(prev, base, cap, rand)` AWS retry sequence.
-- Drain tick `[24s, 36s]`; breaker reset `[40s, 80s]`; rotate retries `DecorrelatedJitter(_, 1s, 30s)` replaces `[1s, 2s, 4s]`.
-- All consumers default `math/rand/v2.Float64`; tests inject `func() float64` via `SetRand`/`SetClock`.
-- `Rotator.nextSleep` outer 6h ±10% untouched. Filtered cov ≥ 81.5%; `obs/jitter.go` 100%.
-
-## Phase 5.4 — Diagnose CLI (2026-05-02)
-
-`dumpagent diagnose [--probe] [--json]` runs read-only health checklist.
-
-- Static (always): `cert`, `auth_dir`, `outbox`, `log_dir`. Probe (--probe): `central_api` mTLS, `firebird` SELECT 1, `minio` TCP dial.
-- 3-level severity PASS/WARN/FAIL; binary exit 0 (no FAIL) or 1.
-- `internal/diagnose/` — `Check{Name,Severity,Message,Fields}`; `Run(ctx, cfg) []Check` per-check 5s timeout + panic recovery; `Text` / `JSON` reporters; `AnyFail` drives exit code.
-- Outbox check uses `bbolt.Open(_, _, &Options{ReadOnly: true, Timeout: 1s})` — never blocks running agent. `outbox.db` missing = PASS `state=uninitialized`.
-- Disk-free via `golang.org/x/sys/{unix,windows}` (build-tag split `disk_unix.go` / `disk_windows.go`).
-- FB live probe gated by `FB_TEST_DSN` env in tests; production reads `FB_DSN`.
-- Read-only — never mutates state. P5.5 web dashboard deferred indefinitely.
+- **5.1 Windows Event Log sink** — WARN+ slog fan-out under source `DumpAgent` via `obs.MultiHandler`; build-tag no-op on Linux/Mac. `agent.exe install/uninstall` registers idempotently. Banded event IDs (`internal/obs/events.go`: 1xxx auth, 2xxx queue, 3xxx extract, 4xxx upload, 5xxx diagnose, 8xxx breaker, 9xxx generic). `obs.FormatCompact` single-line UTF-8-safe truncated at 8KB. Rollback: `AGENT_EVENTLOG_DISABLED=true`. Locale-independent unregister via `errors.Is(syscall.ERROR_FILE_NOT_FOUND)`.
+- **5.2 Outbox + Circuit Breaker** — `internal/queue/` bbolt persistent queue at `%PROGRAMDATA%\dumpagent\queue\outbox.db` for `CompleteJob`/`FailJob`; uint64 time-ordered keys, fsync per Append, 10k cap, 90-day TTL. `internal/breaker/` CLOSED/OPEN/HALF_OPEN (threshold 5, reset 60s) gates drain + RegisterJob. `Drainer.Run` 30s tick, peek 20, classify 2xx delete / 4xx drop / 5xx retry / 429 Retry-After. `startDrainWithWatcher` re-spawns under `SafeGo`; outbox open fail = exit 1.
+- **5.3 Backoff + Jitter** — `internal/obs/jitter.go` `JitterAround` + `DecorrelatedJitter`. Drain tick [24s,36s], breaker reset [40s,80s], rotate retries decorrelated 1s→30s. `math/rand/v2.Float64` default; `SetRand`/`SetClock` for tests. Filtered cov ≥ 81.5%.
+- **5.4 Diagnose CLI** — `dumpagent diagnose [--probe] [--json]` read-only health: static (cert/auth_dir/outbox/log_dir) + probe (central_api mTLS / FB SELECT 1 / MinIO TCP). PASS/WARN/FAIL severity, exit 0 or 1. Outbox check via `bbolt.Open(ReadOnly: true)`; missing = PASS. Disk-free via `golang.org/x/sys`.
 
 ## Phase 9 — Path discovery + per-source secrets (2026-05-03)
 
@@ -195,3 +150,18 @@ Delta is the only execution path (no flag, no legacy snapshot). SHA-256 row-fing
 ## Phase 11 — Integrity + Audit (P2, 2026-05-04)
 
 `RunDelta` tees Parquet upload through `integrity.SHA256TeeReader`; sha256 hex flows in CompletePayload + landing.extractions.sha256. data_processor `verify_and_route_delta` recomputes on download; mismatch raises IntegrityError. Edge writes 4-state HMAC-signed JSONL audit at `%PROGRAMDATA%\dumpagent\audit\events-YYYY-MM-DD.jsonl`. Lifecycle: extracted → uploaded → committed (or aborted). HMAC-SHA256 over CanonicalJSON-without-hmac (sorted keys via Go stdlib map sort). Key 32B random, DPAPI-wrapped at `secrets/audit_hmac.dpapi` (P1 secrets store reused). CLI `dumpagent audit verify <path>` exit 0/1/2. Boot HMAC fail → audit no-op + WARN; cycle continues.
+
+## Phase 12 — Post-upload register normalization (FU1, 2026-05-04)
+
+Cnes/sihd path normalized to BPA/SIA's post-upload register pattern.
+`Adapter.MintUploadURL` calls new `POST /api/v1/jobs/upload-url` to create
+landing.extractions PENDING + presigned PUT URL. Edge uploads Parquet,
+captures sha256 via `integrity.SHA256TeeReader`, then calls existing
+`POST /api/v1/jobs/register` with `RegisterRequest.Sha256` set. `CompleteJob`
+removed entirely from edge code (dead /complete route never existed).
+`audit.LifecycleCommitted` emitted by Consumer.processJob after RegisterJob
+ack via new `JobExecutorIface.EmitCommitted` method. `Job.MinioKey` field
+added (returned from upload-url mint). Outbox now queues `RegisterJob`
+envelopes (sha256 + minio_key + size_bytes); `MintUploadURL` is direct
+(caller needs returned values). No DB migration. landing.extractions.sha256
+column populated on every cycle (not NULL like P2).

--- a/apps/dump_agent_go/internal/apiclient/adapter.go
+++ b/apps/dump_agent_go/internal/apiclient/adapter.go
@@ -56,39 +56,34 @@ func combineEditors(eds []RequestEditorFn) RequestEditorFn {
 	}
 }
 
-// RegisterJob cria extraction via /jobs/register e devolve Job com extraction_id + upload_url.
-func (a *Adapter) RegisterJob(ctx context.Context, spec worker.JobSpec) (*worker.Job, error) {
-	jobUUID, err := parseJobUUID(spec.JobID)
+// RegisterJob confirma upload completo via POST /api/v1/jobs/register.
+// Threadea sha256 (computado pós-upload via SHA256TeeReader) para que
+// landing.extractions.sha256 seja persistido.
+func (a *Adapter) RegisterJob(ctx context.Context, job worker.Job, sizeBytes int64) error {
+	jobUUID, err := parseJobUUID(job.ID)
 	if err != nil {
-		return nil, err
+		return err
 	}
+	sha := job.Sha256
 	body := RegisterExtractionApiV1JobsRegisterPostJSONRequestBody{
 		AgentVersion: a.AgentVersion,
-		Competencia:  spec.Competencia,
-		FonteSistema: RegisterRequestFonteSistema(spec.FonteSistema),
+		Competencia:  job.Params.CompetenciaInt(),
+		FonteSistema: RegisterRequestFonteSistema(job.Params.SourceType()),
 		JobId:        jobUUID,
 		MachineId:    a.MachineID,
+		Sha256:       &sha,
 		TenantId:     a.TenantID,
-		TipoExtracao: spec.TipoExtracao,
+		TipoExtracao: job.Params.Intent,
 	}
+	_ = sizeBytes
 	resp, err := a.Inner.RegisterExtractionApiV1JobsRegisterPostWithResponse(ctx, body)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if resp.StatusCode() != http.StatusCreated || resp.JSON201 == nil {
-		return nil, &obs.HTTPError{StatusCode: resp.StatusCode(), Body: string(resp.Body)}
+	if resp.StatusCode() != http.StatusOK {
+		return &obs.HTTPError{StatusCode: resp.StatusCode(), Body: string(resp.Body)}
 	}
-	extID := resp.JSON201.ExtractionId.String()
-	return &worker.Job{
-		ID:        extID,
-		TenantID:  a.TenantID,
-		UploadURL: resp.JSON201.UploadUrl,
-		Params: extractor.ExtractionParams{
-			Intent:      spec.Intent,
-			Competencia: competenciaString(spec.Competencia),
-			CodMunGest:  envOr("COD_MUN_IBGE", a.TenantID),
-		},
-	}, nil
+	return nil
 }
 
 // MintUploadURL chama POST /api/v1/jobs/upload-url para criar
@@ -127,25 +122,6 @@ func (a *Adapter) MintUploadURL(ctx context.Context, spec worker.JobSpec) (*work
 			CodMunGest:  envOr("COD_MUN_IBGE", a.TenantID),
 		},
 	}, nil
-}
-
-// CompleteJob sinaliza sucesso ao central com sha256 + row_count.
-func (a *Adapter) CompleteJob(ctx context.Context, job worker.Job, sizeBytes int64) error {
-	id, err := parseJobUUID(job.ID)
-	if err != nil {
-		return err
-	}
-	_ = sizeBytes
-	resp, err := a.Inner.CompleteExtractionApiV1JobsExtractionIdCompletePostWithResponse(
-		ctx, id, CompleteExtractionApiV1JobsExtractionIdCompletePostJSONRequestBody{
-			Sha256:   job.Sha256,
-			RowCount: job.RowCount,
-		},
-	)
-	if err != nil {
-		return err
-	}
-	return statusError(resp.StatusCode(), resp.Body)
 }
 
 // FailJob marca extraction como FAILED via /jobs/{id}/fail.

--- a/apps/dump_agent_go/internal/apiclient/adapter.go
+++ b/apps/dump_agent_go/internal/apiclient/adapter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
@@ -82,6 +83,44 @@ func (a *Adapter) RegisterJob(ctx context.Context, spec worker.JobSpec) (*worker
 		ID:        extID,
 		TenantID:  a.TenantID,
 		UploadURL: resp.JSON201.UploadUrl,
+		Params: extractor.ExtractionParams{
+			Intent:      spec.Intent,
+			Competencia: competenciaString(spec.Competencia),
+			CodMunGest:  envOr("COD_MUN_IBGE", a.TenantID),
+		},
+	}, nil
+}
+
+// MintUploadURL chama POST /api/v1/jobs/upload-url para criar
+// landing.extractions PENDING + obter presigned PUT URL.
+func (a *Adapter) MintUploadURL(ctx context.Context, spec worker.JobSpec) (*worker.Job, error) {
+	jobUUID, err := parseJobUUID(spec.JobID)
+	if err != nil {
+		return nil, err
+	}
+	body := MintUploadUrlApiV1JobsUploadUrlPostJSONRequestBody{
+		AgentVersion: &a.AgentVersion,
+		Competencia:  competenciaToDate(spec.Competencia),
+		Intent:       spec.Intent,
+		JobId:        jobUUID,
+		MachineId:    &a.MachineID,
+		SourceType:   UploadUrlRequestSourceType(spec.FonteSistema),
+		TenantId:     a.TenantID,
+		TipoExtracao: spec.TipoExtracao,
+	}
+	resp, err := a.Inner.MintUploadUrlApiV1JobsUploadUrlPostWithResponse(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != http.StatusCreated || resp.JSON201 == nil {
+		return nil, &obs.HTTPError{StatusCode: resp.StatusCode(), Body: string(resp.Body)}
+	}
+	extID := resp.JSON201.ExtractionId.String()
+	return &worker.Job{
+		ID:        extID,
+		TenantID:  a.TenantID,
+		UploadURL: resp.JSON201.UploadUrl,
+		MinioKey:  resp.JSON201.MinioKey,
 		Params: extractor.ExtractionParams{
 			Intent:      spec.Intent,
 			Competencia: competenciaString(spec.Competencia),
@@ -210,4 +249,10 @@ func competenciaString(c int) string {
 		return ""
 	}
 	return fmt.Sprintf("%06d", c)
+}
+
+func competenciaToDate(yyyymm int) openapi_types.Date {
+	year := yyyymm / 100
+	month := yyyymm % 100
+	return openapi_types.Date{Time: time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)}
 }

--- a/apps/dump_agent_go/internal/apiclient/adapter_bench_test.go
+++ b/apps/dump_agent_go/internal/apiclient/adapter_bench_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func BenchmarkRegisterJob(b *testing.B) {
-	body := []byte(`{"extraction_id":"00000000-0000-0000-0000-000000000001",` +
-		`"upload_url":"https://example.invalid/upload"}`)
+	body := []byte(`{"job_id":"11111111-1111-1111-1111-111111111111",` +
+		`"status":"REGISTERED"}`)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
+		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(body)
 	}))
 	defer srv.Close()
@@ -26,17 +26,18 @@ func BenchmarkRegisterJob(b *testing.B) {
 		b.Fatal(err)
 	}
 	ctx := context.Background()
-	spec := worker.JobSpec{
-		JobID:        "11111111-1111-1111-1111-111111111111",
-		FonteSistema: "CNES_LOCAL",
-		TipoExtracao: "estabelecimentos",
-		Competencia:  202601,
-		Intent:       extractor.IntentCnesEstabelecimentos,
+	job := worker.Job{
+		ID:     "11111111-1111-1111-1111-111111111111",
+		Sha256: "deadbeef",
+		Params: extractor.ExtractionParams{
+			Intent:      extractor.IntentCnesEstabelecimentos,
+			Competencia: "202601",
+		},
 	}
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, err := adapter.RegisterJob(ctx, spec); err != nil {
+		if err := adapter.RegisterJob(ctx, job, 4096); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/apps/dump_agent_go/internal/apiclient/adapter_test.go
+++ b/apps/dump_agent_go/internal/apiclient/adapter_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cnesdata/dumpagent/internal/apiclient"
+	"github.com/cnesdata/dumpagent/internal/extractor"
 	"github.com/cnesdata/dumpagent/internal/obs"
 	"github.com/cnesdata/dumpagent/internal/worker"
 )
@@ -75,77 +76,53 @@ func newTestAdapter(t *testing.T, handler http.HandlerFunc) *apiclient.Adapter {
 	return a
 }
 
-func TestRegisterJob_Created(t *testing.T) {
-	a := newTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"extraction_id": "11111111-1111-1111-1111-111111111111",
-			"upload_url":    "https://minio.example/put",
-		})
+func TestRegisterJob_PostUploadWithSha(t *testing.T) {
+	var got apiclient.RegisterRequest
+	a := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &got)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(
+			`{"job_id":"11111111-2222-3333-4444-555555555555","status":"REGISTERED"}`,
+		))
 	})
-	job, err := a.RegisterJob(context.Background(), worker.JobSpec{
-		JobID:        "22222222-2222-2222-2222-222222222222",
-		Competencia:  202601,
-		FonteSistema: "CNES",
-		TipoExtracao: "FULL",
-		Intent:       "cnes_profissionais",
-	})
+	job := worker.Job{
+		ID:       "11111111-2222-3333-4444-555555555555",
+		Sha256:   "a" + strings.Repeat("0", 63),
+		MinioKey: "354130/CNES_VINCULO/2026-01-01/abc.parquet.gz",
+		Params: extractor.ExtractionParams{
+			Intent:      "cnes_profissionais",
+			Competencia: "202601",
+		},
+	}
+	err := a.RegisterJob(context.Background(), job, 4096)
 	require.NoError(t, err)
-	require.Equal(t, "11111111-1111-1111-1111-111111111111", job.ID)
-	require.Equal(t, "https://minio.example/put", job.UploadURL)
-	require.Equal(t, "tenant-1", job.TenantID)
-	require.Equal(t, "202601", job.Params.Competencia)
-}
-
-func TestRegisterJob_InvalidJobID(t *testing.T) {
-	a := newTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusCreated)
-	})
-	_, err := a.RegisterJob(context.Background(), worker.JobSpec{
-		JobID:        "not-a-uuid",
-		Competencia:  202601,
-		FonteSistema: "CNES",
-		TipoExtracao: "FULL",
-	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid_job_uuid")
+	require.NotNil(t, got.Sha256)
+	require.Equal(t, "a"+strings.Repeat("0", 63), *got.Sha256)
 }
 
 func TestRegisterJob_5xxReturnsHTTPError(t *testing.T) {
 	a := newTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte("kaboom"))
 	})
-	_, err := a.RegisterJob(context.Background(), worker.JobSpec{
-		JobID:        "33333333-3333-3333-3333-333333333333",
-		Competencia:  202601,
-		FonteSistema: "CNES",
-		TipoExtracao: "FULL",
-	})
+	err := a.RegisterJob(
+		context.Background(),
+		worker.Job{ID: "11111111-2222-3333-4444-555555555555"},
+		100,
+	)
 	require.Error(t, err)
 	var httpErr *obs.HTTPError
 	require.True(t, errors.As(err, &httpErr))
 	require.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
 }
 
-func TestCompleteJob_InvalidID(t *testing.T) {
+func TestRegisterJob_InvalidJobID(t *testing.T) {
 	a := newTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 	})
-	err := a.CompleteJob(context.Background(), worker.Job{ID: "garbage"}, 100)
+	err := a.RegisterJob(context.Background(), worker.Job{ID: "not-a-uuid"}, 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid_job_uuid")
-}
-
-func TestCompleteJob_Success(t *testing.T) {
-	a := newTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
-	err := a.CompleteJob(context.Background(), worker.Job{
-		ID: "44444444-4444-4444-4444-444444444444", Sha256: "abc", RowCount: 10,
-	}, 100)
-	require.NoError(t, err)
 }
 
 func TestFailJob_NilCauseUsesDefault(t *testing.T) {

--- a/apps/dump_agent_go/internal/apiclient/adapter_test.go
+++ b/apps/dump_agent_go/internal/apiclient/adapter_test.go
@@ -242,3 +242,45 @@ func TestSendHeartbeat_5xx(t *testing.T) {
 	require.True(t, errors.As(err, &httpErr))
 	require.Equal(t, http.StatusServiceUnavailable, httpErr.StatusCode)
 }
+
+func TestMintUploadURL_Created(t *testing.T) {
+	a := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/jobs/upload-url" {
+			t.Fatalf("path = %s want /api/v1/jobs/upload-url", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"extraction_id": "11111111-2222-3333-4444-555555555555",
+			"upload_url": "https://minio/sig",
+			"minio_key": "354130/CNES_VINCULO/2026-01-01/abc.parquet.gz"
+		}`))
+	})
+	job, err := a.MintUploadURL(context.Background(), worker.JobSpec{
+		JobID:        "11111111-2222-3333-4444-555555555555",
+		FonteSistema: "CNES_LOCAL",
+		TipoExtracao: "profissionais",
+		Competencia:  202601,
+		Intent:       "cnes_profissionais",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://minio/sig", job.UploadURL)
+	require.Equal(t, "354130/CNES_VINCULO/2026-01-01/abc.parquet.gz", job.MinioKey)
+}
+
+func TestMintUploadURL_4xx(t *testing.T) {
+	a := newTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	})
+	_, err := a.MintUploadURL(context.Background(), worker.JobSpec{
+		JobID:        "11111111-2222-3333-4444-555555555555",
+		FonteSistema: "CNES_LOCAL",
+		TipoExtracao: "profissionais",
+		Competencia:  202601,
+		Intent:       "cnes_profissionais",
+	})
+	require.Error(t, err)
+	var httpErr *obs.HTTPError
+	require.True(t, errors.As(err, &httpErr))
+	require.Equal(t, http.StatusConflict, httpErr.StatusCode)
+}

--- a/apps/dump_agent_go/internal/apiclient/generated.go
+++ b/apps/dump_agent_go/internal/apiclient/generated.go
@@ -45,6 +45,39 @@ type CompletePayload struct {
 	Sha256   string `json:"sha256"`
 }
 
+// UploadUrlRequest defines model for UploadUrlRequest.
+type UploadUrlRequest struct {
+	AgentVersion *string                    `json:"agent_version,omitempty"`
+	Competencia  openapi_types.Date         `json:"competencia"`
+	Intent       string                     `json:"intent"`
+	JobId        openapi_types.UUID         `json:"job_id"`
+	MachineId    *string                    `json:"machine_id,omitempty"`
+	SourceType   UploadUrlRequestSourceType `json:"source_type"`
+	TenantId     string                     `json:"tenant_id"`
+	TipoExtracao string                     `json:"tipo_extracao"`
+}
+
+// UploadUrlRequestSourceType defines model for UploadUrlRequest.SourceType.
+type UploadUrlRequestSourceType string
+
+const (
+	UploadUrlBPAMAG       UploadUrlRequestSourceType = "BPA_MAG"
+	UploadUrlCNESLOCAL    UploadUrlRequestSourceType = "CNES_LOCAL"
+	UploadUrlCNESNACIONAL UploadUrlRequestSourceType = "CNES_NACIONAL"
+	UploadUrlSIALOCAL     UploadUrlRequestSourceType = "SIA_LOCAL"
+	UploadUrlSIHD         UploadUrlRequestSourceType = "SIHD"
+)
+
+// UploadUrlResponse defines model for UploadUrlResponse.
+type UploadUrlResponse struct {
+	ExtractionId openapi_types.UUID `json:"extraction_id"`
+	MinioKey     string             `json:"minio_key"`
+	UploadUrl    string             `json:"upload_url"`
+}
+
+// MintUploadUrlApiV1JobsUploadUrlPostJSONRequestBody defines body for the upload-url request.
+type MintUploadUrlApiV1JobsUploadUrlPostJSONRequestBody = UploadUrlRequest
+
 // FailPayload defines model for FailPayload.
 type FailPayload struct {
 	Error string `json:"error"`
@@ -317,6 +350,11 @@ type ClientInterface interface {
 
 	RegisterExtractionApiV1JobsRegisterPost(ctx context.Context, body RegisterExtractionApiV1JobsRegisterPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// MintUploadUrlApiV1JobsUploadUrlPostWithBody request with arbitrary body.
+	MintUploadUrlApiV1JobsUploadUrlPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	MintUploadUrlApiV1JobsUploadUrlPost(ctx context.Context, body MintUploadUrlApiV1JobsUploadUrlPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// CompleteExtractionApiV1JobsExtractionIdCompletePostWithBody request with any body
 	CompleteExtractionApiV1JobsExtractionIdCompletePostWithBody(ctx context.Context, extractionId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -392,6 +430,26 @@ func (c *Client) RegisterExtractionApiV1JobsRegisterPost(ctx context.Context, bo
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+func (c *Client) MintUploadUrlApiV1JobsUploadUrlPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMintUploadUrlApiV1JobsUploadUrlPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) MintUploadUrlApiV1JobsUploadUrlPost(ctx context.Context, body MintUploadUrlApiV1JobsUploadUrlPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	return c.MintUploadUrlApiV1JobsUploadUrlPostWithBody(ctx, "application/json", bytes.NewReader(buf), reqEditors...)
 }
 
 func (c *Client) CompleteExtractionApiV1JobsExtractionIdCompletePostWithBody(ctx context.Context, extractionId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -652,6 +710,28 @@ func NewRegisterExtractionApiV1JobsRegisterPostRequestWithBody(server string, co
 	return req, nil
 }
 
+// NewMintUploadUrlApiV1JobsUploadUrlPostRequestWithBody generates requests for MintUploadUrlApiV1JobsUploadUrlPost with any type of body
+func NewMintUploadUrlApiV1JobsUploadUrlPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := "/api/v1/jobs/upload-url"
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", contentType)
+	return req, nil
+}
+
 // NewCompleteExtractionApiV1JobsExtractionIdCompletePostRequest calls the generic CompleteExtractionApiV1JobsExtractionIdCompletePost builder with application/json body
 func NewCompleteExtractionApiV1JobsExtractionIdCompletePostRequest(server string, extractionId openapi_types.UUID, body CompleteExtractionApiV1JobsExtractionIdCompletePostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -882,6 +962,9 @@ type ClientWithResponsesInterface interface {
 
 	RegisterExtractionApiV1JobsRegisterPostWithResponse(ctx context.Context, body RegisterExtractionApiV1JobsRegisterPostJSONRequestBody, reqEditors ...RequestEditorFn) (*RegisterExtractionApiV1JobsRegisterPostResponse, error)
 
+	// MintUploadUrlApiV1JobsUploadUrlPostWithResponse request returning *MintUploadUrlApiV1JobsUploadUrlPostResponse
+	MintUploadUrlApiV1JobsUploadUrlPostWithResponse(ctx context.Context, body MintUploadUrlApiV1JobsUploadUrlPostJSONRequestBody, reqEditors ...RequestEditorFn) (*MintUploadUrlApiV1JobsUploadUrlPostResponse, error)
+
 	// CompleteExtractionApiV1JobsExtractionIdCompletePostWithBodyWithResponse request with any body
 	CompleteExtractionApiV1JobsExtractionIdCompletePostWithBodyWithResponse(ctx context.Context, extractionId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CompleteExtractionApiV1JobsExtractionIdCompletePostResponse, error)
 
@@ -984,6 +1067,28 @@ func (r RegisterExtractionApiV1JobsRegisterPostResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RegisterExtractionApiV1JobsRegisterPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type MintUploadUrlApiV1JobsUploadUrlPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *UploadUrlResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r MintUploadUrlApiV1JobsUploadUrlPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r MintUploadUrlApiV1JobsUploadUrlPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1147,6 +1252,15 @@ func (c *ClientWithResponses) RegisterExtractionApiV1JobsRegisterPostWithRespons
 		return nil, err
 	}
 	return ParseRegisterExtractionApiV1JobsRegisterPostResponse(rsp)
+}
+
+// MintUploadUrlApiV1JobsUploadUrlPostWithResponse POST /api/v1/jobs/upload-url returning *MintUploadUrlApiV1JobsUploadUrlPostResponse
+func (c *ClientWithResponses) MintUploadUrlApiV1JobsUploadUrlPostWithResponse(ctx context.Context, body MintUploadUrlApiV1JobsUploadUrlPostJSONRequestBody, reqEditors ...RequestEditorFn) (*MintUploadUrlApiV1JobsUploadUrlPostResponse, error) {
+	rsp, err := c.MintUploadUrlApiV1JobsUploadUrlPost(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMintUploadUrlApiV1JobsUploadUrlPostResponse(rsp)
 }
 
 // CompleteExtractionApiV1JobsExtractionIdCompletePostWithBodyWithResponse request with arbitrary body returning *CompleteExtractionApiV1JobsExtractionIdCompletePostResponse
@@ -1356,6 +1470,30 @@ func ParseRegisterExtractionApiV1JobsRegisterPostResponse(rsp *http.Response) (*
 		}
 		response.JSON422 = &dest
 
+	}
+
+	return response, nil
+}
+
+// ParseMintUploadUrlApiV1JobsUploadUrlPostResponse parses an HTTP response from a MintUploadUrlApiV1JobsUploadUrlPostWithResponse call
+func ParseMintUploadUrlApiV1JobsUploadUrlPostResponse(rsp *http.Response) (*MintUploadUrlApiV1JobsUploadUrlPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MintUploadUrlApiV1JobsUploadUrlPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	if rsp.StatusCode == 201 {
+		var dest UploadUrlResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
 	}
 
 	return response, nil

--- a/apps/dump_agent_go/internal/apiclient/overlay.yaml
+++ b/apps/dump_agent_go/internal/apiclient/overlay.yaml
@@ -77,3 +77,67 @@ actions:
             type: string
             nullable: true
             pattern: "^[0-9a-f]{64}$"
+      UploadUrlRequest:
+        type: object
+        required: [job_id, tenant_id, source_type, tipo_extracao, competencia, intent]
+        properties:
+          job_id:
+            type: string
+            format: uuid
+          tenant_id:
+            type: string
+            maxLength: 64
+          source_type:
+            type: string
+            enum: [CNES_LOCAL, CNES_NACIONAL, SIHD, BPA_MAG, SIA_LOCAL]
+          tipo_extracao:
+            type: string
+            maxLength: 32
+          competencia:
+            type: string
+            format: date
+          intent:
+            type: string
+            maxLength: 64
+          agent_version:
+            type: string
+            nullable: true
+            maxLength: 64
+          machine_id:
+            type: string
+            nullable: true
+            maxLength: 128
+      UploadUrlResponse:
+        type: object
+        required: [extraction_id, upload_url, minio_key]
+        properties:
+          extraction_id:
+            type: string
+            format: uuid
+          upload_url:
+            type: string
+          minio_key:
+            type: string
+            pattern: "^[\\w\\-./]+\\.parquet\\.gz$"
+  - target: $.paths
+    update:
+      /api/v1/jobs/upload-url:
+        post:
+          operationId: mint_upload_url_api_v1_jobs_upload_url_post
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UploadUrlRequest'
+          responses:
+            '201':
+              description: Created
+              content:
+                application/json:
+                  schema:
+                    $ref: '#/components/schemas/UploadUrlResponse'
+            '409':
+              description: Conflict
+            '422':
+              description: Validation Error

--- a/apps/dump_agent_go/internal/extractor/params.go
+++ b/apps/dump_agent_go/internal/extractor/params.go
@@ -1,0 +1,25 @@
+package extractor
+
+import (
+	"strconv"
+	"strings"
+)
+
+// CompetenciaInt converte Competencia "YYYYMM" para int.
+// Retorna 0 se vazio ou inválido.
+func (p ExtractionParams) CompetenciaInt() int {
+	yyyymm, _ := strconv.Atoi(p.Competencia)
+	return yyyymm
+}
+
+// SourceType deriva fonte_sistema a partir do prefixo do Intent.
+// "cnes_*" → CNES_LOCAL; "sihd_*" → SIHD; outros → "".
+func (p ExtractionParams) SourceType() string {
+	switch {
+	case strings.HasPrefix(p.Intent, "cnes_"):
+		return "CNES_LOCAL"
+	case strings.HasPrefix(p.Intent, "sihd_"):
+		return "SIHD"
+	}
+	return ""
+}

--- a/apps/dump_agent_go/internal/queue/envelope.go
+++ b/apps/dump_agent_go/internal/queue/envelope.go
@@ -13,10 +13,14 @@ const (
 
 // Envelope is a single outbound API call persisted in the outbox.
 // SizeBytes is set for complete; Cause is set for fail.
+// SHA256 + MinioKey are set for TypeComplete (FU1 RegisterJob dispatch)
+// so drain replay after agent restart can rebuild the full Job payload.
 type Envelope struct {
 	Type       EnvelopeType `json:"type"`
 	JobUUID    string       `json:"job_uuid"`
 	SizeBytes  int64        `json:"size_bytes,omitempty"`
+	SHA256     string       `json:"sha256,omitempty"`
+	MinioKey   string       `json:"minio_key,omitempty"`
 	Cause      string       `json:"cause,omitempty"`
 	EnqueuedAt time.Time    `json:"enqueued_at"`
 	Attempts   int          `json:"attempts"`

--- a/apps/dump_agent_go/internal/queue/envelope_test.go
+++ b/apps/dump_agent_go/internal/queue/envelope_test.go
@@ -12,6 +12,8 @@ func TestEnvelope_RoundTripComplete(t *testing.T) {
 		Type:       TypeComplete,
 		JobUUID:    "abc-123",
 		SizeBytes:  4096,
+		SHA256:     "deadbeef",
+		MinioKey:   "354130/CNES_VINCULO/2026-01-01/abc.parquet.gz",
 		EnqueuedAt: now,
 	}
 	b, err := json.Marshal(in)
@@ -23,7 +25,8 @@ func TestEnvelope_RoundTripComplete(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if out.Type != TypeComplete || out.JobUUID != in.JobUUID ||
-		out.SizeBytes != in.SizeBytes || !out.EnqueuedAt.Equal(now) {
+		out.SizeBytes != in.SizeBytes || out.SHA256 != in.SHA256 ||
+		out.MinioKey != in.MinioKey || !out.EnqueuedAt.Equal(now) {
 		t.Fatalf("round-trip lost fields: %+v", out)
 	}
 }
@@ -48,7 +51,7 @@ func TestEnvelope_OmitsZeroFields(t *testing.T) {
 	in := Envelope{Type: TypeComplete, JobUUID: "x"}
 	b, _ := json.Marshal(in)
 	s := string(b)
-	for _, banned := range []string{"size_bytes", "cause", "last_error"} {
+	for _, banned := range []string{"size_bytes", "cause", "last_error", "sha256", "minio_key"} {
 		if contains(s, banned) {
 			t.Errorf("expected omitempty for %q in %s", banned, s)
 		}

--- a/apps/dump_agent_go/internal/worker/consumer.go
+++ b/apps/dump_agent_go/internal/worker/consumer.go
@@ -10,17 +10,18 @@ import (
 )
 
 // JobAPIClient contrato que Consumer precisa.
-// v2: agent registra extraction em vez de long-poll por jobs prontos.
+// FU1: agent mint→run→register. MintUploadURL cria landing.extractions
+// PENDING + presigned URL. RegisterJob confirma após upload com sha256.
 type JobAPIClient interface {
-	RegisterJob(ctx context.Context, spec JobSpec) (*Job, error)
-	CompleteJob(ctx context.Context, job Job, sizeBytes int64) error
+	MintUploadURL(ctx context.Context, spec JobSpec) (*Job, error)
+	RegisterJob(ctx context.Context, job Job, sizeBytes int64) error
 	FailJob(ctx context.Context, job Job, cause error) error
 	HeartbeatClient
 }
 
 // JobExecutorIface permite injetar stub em testes. Run pode mutar
 // job.Sha256 (preenchido pelo caminho delta após upload) para que o
-// caller envie o digest em CompleteJob.
+// caller envie o digest em RegisterJob.
 type JobExecutorIface interface {
 	Run(ctx context.Context, job *Job) (int64, error)
 }
@@ -51,7 +52,7 @@ func NewConsumer(api JobAPIClient, source JobSpecSource, executor JobExecutorIfa
 	return &Consumer{api: api, source: source, executor: executor, config: cfg}
 }
 
-// Loop executa next_spec → register → exec → complete/fail repetidamente.
+// Loop executa next_spec → mint_upload_url → exec → register/fail repetidamente.
 // Exit em ctx.Done(). Panic recovered.
 func (c *Consumer) Loop(ctx context.Context) (err error) {
 	defer func() {
@@ -79,9 +80,9 @@ func (c *Consumer) Loop(ctx context.Context) (err error) {
 			continue
 		}
 
-		job, regErr := c.api.RegisterJob(ctx, *spec)
-		if regErr != nil {
-			slog.Warn("register_failed", "err", regErr.Error())
+		job, mintErr := c.api.MintUploadURL(ctx, *spec)
+		if mintErr != nil {
+			slog.Warn("mint_upload_url_failed", "err", mintErr.Error())
 			c.sleep(ctx, c.config.PollInterval)
 			continue
 		}
@@ -113,8 +114,8 @@ func (c *Consumer) processJob(ctx context.Context, job Job) {
 		}
 		return
 	}
-	if err := c.api.CompleteJob(ctx, job, size); err != nil {
-		slog.Error("complete_job_api_error", "job_id", job.ID, "err", err.Error())
+	if err := c.api.RegisterJob(ctx, job, size); err != nil {
+		slog.Error("register_job_api_error", "job_id", job.ID, "err", err.Error())
 	}
 }
 

--- a/apps/dump_agent_go/internal/worker/consumer.go
+++ b/apps/dump_agent_go/internal/worker/consumer.go
@@ -21,9 +21,11 @@ type JobAPIClient interface {
 
 // JobExecutorIface permite injetar stub em testes. Run pode mutar
 // job.Sha256 (preenchido pelo caminho delta após upload) para que o
-// caller envie o digest em RegisterJob.
+// caller envie o digest em RegisterJob. EmitCommitted grava o evento
+// audit.LifecycleCommitted após RegisterJob ack (delivery confirmed).
 type JobExecutorIface interface {
 	Run(ctx context.Context, job *Job) (int64, error)
+	EmitCommitted(job Job, size int64)
 }
 
 // JobSpecSource produz o próximo JobSpec a ser registrado, ou nil/err.
@@ -116,7 +118,9 @@ func (c *Consumer) processJob(ctx context.Context, job Job) {
 	}
 	if err := c.api.RegisterJob(ctx, job, size); err != nil {
 		slog.Error("register_job_api_error", "job_id", job.ID, "err", err.Error())
+		return
 	}
+	c.executor.EmitCommitted(job, size)
 }
 
 func (c *Consumer) sleep(ctx context.Context, d time.Duration) {

--- a/apps/dump_agent_go/internal/worker/consumer_test.go
+++ b/apps/dump_agent_go/internal/worker/consumer_test.go
@@ -13,22 +13,36 @@ import (
 )
 
 type apiStub struct {
-	registerFn func(ctx context.Context, spec worker.JobSpec) (*worker.Job, error)
-	completeFn func(ctx context.Context, job worker.Job, size int64) error
+	mintFn     func(ctx context.Context, spec worker.JobSpec) (*worker.Job, error)
+	registerFn func(ctx context.Context, job worker.Job, size int64) error
 	failFn     func(ctx context.Context, job worker.Job, err error) error
 	hbFn       func(ctx context.Context, jobID string) error
+
+	mintCalls     int32
+	registerCalls int32
 }
 
-func (a *apiStub) RegisterJob(ctx context.Context, spec worker.JobSpec) (*worker.Job, error) {
-	return a.registerFn(ctx, spec)
+func (a *apiStub) MintUploadURL(ctx context.Context, spec worker.JobSpec) (*worker.Job, error) {
+	atomic.AddInt32(&a.mintCalls, 1)
+	return a.mintFn(ctx, spec)
 }
-func (a *apiStub) CompleteJob(ctx context.Context, job worker.Job, size int64) error {
-	return a.completeFn(ctx, job, size)
+func (a *apiStub) RegisterJob(ctx context.Context, job worker.Job, size int64) error {
+	atomic.AddInt32(&a.registerCalls, 1)
+	if a.registerFn == nil {
+		return nil
+	}
+	return a.registerFn(ctx, job, size)
 }
 func (a *apiStub) FailJob(ctx context.Context, job worker.Job, err error) error {
+	if a.failFn == nil {
+		return nil
+	}
 	return a.failFn(ctx, job, err)
 }
 func (a *apiStub) SendHeartbeat(ctx context.Context, jobID string) error {
+	if a.hbFn == nil {
+		return nil
+	}
 	return a.hbFn(ctx, jobID)
 }
 
@@ -50,8 +64,7 @@ func (s *sourceStub) Next(ctx context.Context) (*worker.JobSpec, error) {
 
 func TestConsumerLoop_ExitsOnContextDone(t *testing.T) {
 	api := &apiStub{
-		registerFn: func(_ context.Context, _ worker.JobSpec) (*worker.Job, error) { return nil, nil },
-		hbFn:       func(_ context.Context, _ string) error { return nil },
+		mintFn: func(_ context.Context, _ worker.JobSpec) (*worker.Job, error) { return nil, nil },
 	}
 	src := &sourceStub{nextFn: func(_ context.Context) (*worker.JobSpec, error) { return nil, nil }}
 	cons := worker.NewConsumer(api, src, &execStub{}, worker.ConsumerConfig{
@@ -64,22 +77,16 @@ func TestConsumerLoop_ExitsOnContextDone(t *testing.T) {
 	require.NoError(t, cons.Loop(ctx))
 }
 
-func TestConsumerLoop_CompletesSuccessfulJob(t *testing.T) {
+func TestConsumerLoop_RegistersAfterSuccessfulRun(t *testing.T) {
 	job := &worker.Job{ID: "11111111-1111-1111-1111-111111111111", TenantID: "354130", Params: extractor.ExtractionParams{Intent: extractor.IntentCnesEstabelecimentos}}
-	var registerCalls, completeCalls int32
+	var mintCalls int32
 	api := &apiStub{
-		registerFn: func(_ context.Context, _ worker.JobSpec) (*worker.Job, error) {
-			if atomic.AddInt32(&registerCalls, 1) == 1 {
+		mintFn: func(_ context.Context, _ worker.JobSpec) (*worker.Job, error) {
+			if atomic.AddInt32(&mintCalls, 1) == 1 {
 				return job, nil
 			}
 			return nil, nil
 		},
-		completeFn: func(_ context.Context, _ worker.Job, _ int64) error {
-			atomic.AddInt32(&completeCalls, 1)
-			return nil
-		},
-		failFn: func(_ context.Context, _ worker.Job, _ error) error { return nil },
-		hbFn:   func(_ context.Context, _ string) error { return nil },
 	}
 	spec := &worker.JobSpec{JobID: "22222222-2222-2222-2222-222222222222", Intent: extractor.IntentCnesEstabelecimentos}
 	src := &sourceStub{nextFn: func(_ context.Context) (*worker.JobSpec, error) {
@@ -95,22 +102,20 @@ func TestConsumerLoop_CompletesSuccessfulJob(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
 	require.NoError(t, cons.Loop(ctx))
-	require.GreaterOrEqual(t, atomic.LoadInt32(&completeCalls), int32(1))
+	require.GreaterOrEqual(t, atomic.LoadInt32(&api.registerCalls), int32(1))
 }
 
 func TestConsumerLoop_FailsJobOnError(t *testing.T) {
 	job := &worker.Job{ID: "11111111-1111-1111-1111-111111111111", Params: extractor.ExtractionParams{Intent: extractor.IntentCnesEstabelecimentos}}
 	var failCalls int32
 	api := &apiStub{
-		registerFn: func(_ context.Context, _ worker.JobSpec) (*worker.Job, error) {
+		mintFn: func(_ context.Context, _ worker.JobSpec) (*worker.Job, error) {
 			return job, nil
 		},
 		failFn: func(_ context.Context, _ worker.Job, _ error) error {
 			atomic.AddInt32(&failCalls, 1)
 			return nil
 		},
-		completeFn: func(_ context.Context, _ worker.Job, _ int64) error { return nil },
-		hbFn:       func(_ context.Context, _ string) error { return nil },
 	}
 	spec := &worker.JobSpec{JobID: "22222222-2222-2222-2222-222222222222", Intent: extractor.IntentCnesEstabelecimentos}
 	src := &sourceStub{nextFn: func(_ context.Context) (*worker.JobSpec, error) {
@@ -128,4 +133,38 @@ func TestConsumerLoop_FailsJobOnError(t *testing.T) {
 	defer cancel()
 	require.NoError(t, cons.Loop(ctx))
 	require.GreaterOrEqual(t, atomic.LoadInt32(&failCalls), int32(1))
+}
+
+func TestLoop_SequenceMintRunRegister(t *testing.T) {
+	api := &apiStub{
+		mintFn: func(_ context.Context, spec worker.JobSpec) (*worker.Job, error) {
+			return &worker.Job{
+				ID:        spec.JobID,
+				UploadURL: "http://fake",
+				Params:    extractor.ExtractionParams{Intent: spec.Intent},
+			}, nil
+		},
+	}
+	exec := &execStub{runFn: func(_ context.Context, j *worker.Job) (int64, error) {
+		j.Sha256 = "abc"
+		return 100, nil
+	}}
+	spec := &worker.JobSpec{
+		JobID:  "11111111-2222-3333-4444-555555555555",
+		Intent: extractor.IntentCnesEstabelecimentos,
+	}
+	src := &sourceStub{nextFn: func(_ context.Context) (*worker.JobSpec, error) { return spec, nil }}
+	cons := worker.NewConsumer(api, src, exec, worker.ConsumerConfig{
+		PollInterval:      time.Millisecond,
+		HeartbeatInterval: time.Hour,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.NoError(t, cons.Loop(ctx))
+
+	mint := atomic.LoadInt32(&api.mintCalls)
+	register := atomic.LoadInt32(&api.registerCalls)
+	if mint < 1 || register < 1 {
+		t.Errorf("mint=%d register=%d, want both >= 1", mint, register)
+	}
 }

--- a/apps/dump_agent_go/internal/worker/consumer_test.go
+++ b/apps/dump_agent_go/internal/worker/consumer_test.go
@@ -47,11 +47,16 @@ func (a *apiStub) SendHeartbeat(ctx context.Context, jobID string) error {
 }
 
 type execStub struct {
-	runFn func(ctx context.Context, job *worker.Job) (int64, error)
+	runFn         func(ctx context.Context, job *worker.Job) (int64, error)
+	committedCalls int32
 }
 
 func (e *execStub) Run(ctx context.Context, job *worker.Job) (int64, error) {
 	return e.runFn(ctx, job)
+}
+
+func (e *execStub) EmitCommitted(_ worker.Job, _ int64) {
+	atomic.AddInt32(&e.committedCalls, 1)
 }
 
 type sourceStub struct {

--- a/apps/dump_agent_go/internal/worker/drain.go
+++ b/apps/dump_agent_go/internal/worker/drain.go
@@ -165,16 +165,21 @@ func (d *Drainer) dispatchOne(ctx context.Context, item queue.Item) bool {
 // Returns a synthesized *http.Response when the inner call returns
 // *obs.HTTPError so Classify can read the status code.
 //
-// FU1: TypeComplete envelopes now dispatch via RegisterJob (post-upload
-// confirmation). Envelope schema does not yet carry sha256/minio_key
-// — T10 extends queue.Envelope to thread these fields end-to-end.
+// FU1: TypeComplete envelopes dispatch via RegisterJob (post-upload
+// confirmation) and rebuild Job{ID, Sha256, MinioKey} from the persisted
+// envelope so replays after agent restart preserve sha256/minio_key.
 func (d *Drainer) callInner(ctx context.Context, env queue.Envelope) (*http.Response, error) {
-	job := Job{ID: env.JobUUID}
 	var apiErr error
 	switch env.Type {
 	case queue.TypeComplete:
+		job := Job{
+			ID:       env.JobUUID,
+			Sha256:   env.SHA256,
+			MinioKey: env.MinioKey,
+		}
 		apiErr = d.inner.RegisterJob(ctx, job, env.SizeBytes)
 	case queue.TypeFail:
+		job := Job{ID: env.JobUUID}
 		apiErr = d.inner.FailJob(ctx, job, errors.New(env.Cause))
 	default:
 		return nil, fmt.Errorf("unknown envelope type: %s", env.Type)

--- a/apps/dump_agent_go/internal/worker/drain.go
+++ b/apps/dump_agent_go/internal/worker/drain.go
@@ -164,12 +164,16 @@ func (d *Drainer) dispatchOne(ctx context.Context, item queue.Item) bool {
 // callInner translates Envelope into the right JobAPIClient method.
 // Returns a synthesized *http.Response when the inner call returns
 // *obs.HTTPError so Classify can read the status code.
+//
+// FU1: TypeComplete envelopes now dispatch via RegisterJob (post-upload
+// confirmation). Envelope schema does not yet carry sha256/minio_key
+// — T10 extends queue.Envelope to thread these fields end-to-end.
 func (d *Drainer) callInner(ctx context.Context, env queue.Envelope) (*http.Response, error) {
 	job := Job{ID: env.JobUUID}
 	var apiErr error
 	switch env.Type {
 	case queue.TypeComplete:
-		apiErr = d.inner.CompleteJob(ctx, job, env.SizeBytes)
+		apiErr = d.inner.RegisterJob(ctx, job, env.SizeBytes)
 	case queue.TypeFail:
 		apiErr = d.inner.FailJob(ctx, job, errors.New(env.Cause))
 	default:

--- a/apps/dump_agent_go/internal/worker/drain_test.go
+++ b/apps/dump_agent_go/internal/worker/drain_test.go
@@ -13,18 +13,22 @@ import (
 )
 
 type stubJobAPI struct {
-	completeResp error
+	registerResp error
 	failResp     error
-	completeN    int
+	registerN    int
 	failN        int
+	lastJob      Job
+	lastSize     int64
 }
 
 func (s *stubJobAPI) MintUploadURL(_ context.Context, _ JobSpec) (*Job, error) {
 	return nil, nil
 }
-func (s *stubJobAPI) RegisterJob(_ context.Context, _ Job, _ int64) error {
-	s.completeN++
-	return s.completeResp
+func (s *stubJobAPI) RegisterJob(_ context.Context, job Job, sizeBytes int64) error {
+	s.registerN++
+	s.lastJob = job
+	s.lastSize = sizeBytes
+	return s.registerResp
 }
 func (s *stubJobAPI) FailJob(_ context.Context, _ Job, _ error) error {
 	s.failN++
@@ -32,14 +36,14 @@ func (s *stubJobAPI) FailJob(_ context.Context, _ Job, _ error) error {
 }
 func (s *stubJobAPI) SendHeartbeat(_ context.Context, _ string) error { return nil }
 
-func newDrainFixture(t *testing.T, completeResp error) (*Drainer, *queue.Outbox, *stubJobAPI) {
+func newDrainFixture(t *testing.T, registerResp error) (*Drainer, *queue.Outbox, *stubJobAPI) {
 	t.Helper()
 	ob, err := queue.Open(filepath.Join(t.TempDir(), "ob.db"))
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
 	t.Cleanup(func() { _ = ob.Close() })
-	stub := &stubJobAPI{completeResp: completeResp}
+	stub := &stubJobAPI{registerResp: registerResp}
 	br := breaker.New(5, 60*time.Second, "test")
 	d := NewDrainer(ob, br, stub)
 	return d, ob, stub
@@ -49,12 +53,39 @@ func TestDrain_HappyPathDeletesEnvelope(t *testing.T) {
 	d, ob, stub := newDrainFixture(t, nil)
 	_ = ob.Append(queue.Envelope{Type: queue.TypeComplete, JobUUID: "uuid-1", SizeBytes: 100})
 	d.tick(context.Background())
-	if stub.completeN != 1 {
-		t.Errorf("inner RegisterJob calls=%d want 1", stub.completeN)
+	if stub.registerN != 1 {
+		t.Errorf("inner RegisterJob calls=%d want 1", stub.registerN)
 	}
 	items, _ := ob.Peek(10)
 	if len(items) != 0 {
 		t.Errorf("envelope still present after success: %+v", items)
+	}
+}
+
+func TestDrain_ReplaysSha256AndMinioKey(t *testing.T) {
+	d, ob, stub := newDrainFixture(t, nil)
+	_ = ob.Append(queue.Envelope{
+		Type:      queue.TypeComplete,
+		JobUUID:   "uuid-replay",
+		SizeBytes: 2048,
+		SHA256:    "deadbeef",
+		MinioKey:  "354130/CNES_VINCULO/2026-01-01/x.parquet.gz",
+	})
+	d.tick(context.Background())
+	if stub.registerN != 1 {
+		t.Fatalf("RegisterJob calls=%d want 1", stub.registerN)
+	}
+	if stub.lastJob.ID != "uuid-replay" {
+		t.Errorf("Job.ID=%q want uuid-replay", stub.lastJob.ID)
+	}
+	if stub.lastJob.Sha256 != "deadbeef" {
+		t.Errorf("Job.Sha256=%q want deadbeef", stub.lastJob.Sha256)
+	}
+	if stub.lastJob.MinioKey != "354130/CNES_VINCULO/2026-01-01/x.parquet.gz" {
+		t.Errorf("Job.MinioKey=%q lost on replay", stub.lastJob.MinioKey)
+	}
+	if stub.lastSize != 2048 {
+		t.Errorf("sizeBytes=%d want 2048", stub.lastSize)
 	}
 }
 

--- a/apps/dump_agent_go/internal/worker/drain_test.go
+++ b/apps/dump_agent_go/internal/worker/drain_test.go
@@ -19,10 +19,10 @@ type stubJobAPI struct {
 	failN        int
 }
 
-func (s *stubJobAPI) RegisterJob(_ context.Context, _ JobSpec) (*Job, error) {
+func (s *stubJobAPI) MintUploadURL(_ context.Context, _ JobSpec) (*Job, error) {
 	return nil, nil
 }
-func (s *stubJobAPI) CompleteJob(_ context.Context, _ Job, _ int64) error {
+func (s *stubJobAPI) RegisterJob(_ context.Context, _ Job, _ int64) error {
 	s.completeN++
 	return s.completeResp
 }
@@ -50,7 +50,7 @@ func TestDrain_HappyPathDeletesEnvelope(t *testing.T) {
 	_ = ob.Append(queue.Envelope{Type: queue.TypeComplete, JobUUID: "uuid-1", SizeBytes: 100})
 	d.tick(context.Background())
 	if stub.completeN != 1 {
-		t.Errorf("inner CompleteJob calls=%d want 1", stub.completeN)
+		t.Errorf("inner RegisterJob calls=%d want 1", stub.completeN)
 	}
 	items, _ := ob.Peek(10)
 	if len(items) != 0 {

--- a/apps/dump_agent_go/internal/worker/executor.go
+++ b/apps/dump_agent_go/internal/worker/executor.go
@@ -40,6 +40,7 @@ type Job struct {
 	ID        string
 	TenantID  string
 	UploadURL string
+	MinioKey  string
 	Params    extractor.ExtractionParams
 	Sha256    string
 	RowCount  int

--- a/apps/dump_agent_go/internal/worker/executor.go
+++ b/apps/dump_agent_go/internal/worker/executor.go
@@ -107,7 +107,8 @@ func (e *JobExecutor) runSnapshot(ctx context.Context, job Job) (sizeBytes int64
 // runDeltaWithCommit invoca RunDelta e gerencia o ciclo Commit/Abort do
 // PendingTx. Falha em Commit aborta o pending sub-bucket implicitamente
 // (bbolt revert na tx) e devolve erro ao caller (Consumer disparará FailJob).
-// Emite audit.LifecycleCommitted após commit ack.
+// O evento audit.LifecycleCommitted é emitido pelo Consumer após
+// RegisterJob ack (delivery confirmed) via EmitCommitted.
 func (e *JobExecutor) runDeltaWithCommit(ctx context.Context, job *Job) (int64, error) {
 	size, pending, _, err := e.RunDelta(ctx, job)
 	if err != nil {
@@ -116,15 +117,25 @@ func (e *JobExecutor) runDeltaWithCommit(ctx context.Context, job *Job) (int64, 
 	if cerr := pending.Commit(); cerr != nil {
 		return 0, fmt.Errorf("delta_commit: %w", cerr)
 	}
+	return size, nil
+}
+
+// EmitCommitted é chamado pelo Consumer após RegisterJob ack para gravar
+// o evento lifecycle final no audit log. No-op seguro quando AuditLogger
+// nil ou DeltaStore nil (snapshot legacy não emite Committed).
+func (e *JobExecutor) EmitCommitted(job Job, size int64) {
+	if e.AuditLogger == nil || e.DeltaStore == nil {
+		return
+	}
 	key := deltaKeyFromParams(job.Params)
 	e.appendAudit(audit.Event{
 		Source: key.Source, Intent: key.Intent,
-		Competencia: key.Competencia,
+		Competencia:  key.Competencia,
 		ExtractionID: job.ID, JobID: job.ID,
-		SHA256: job.Sha256, SizeBytes: size,
+		SHA256:    job.Sha256,
+		SizeBytes: size,
 		Lifecycle: audit.LifecycleCommitted,
 	})
-	return size, nil
 }
 
 // RunDelta executa job em modo delta: extract → materialize → compute →

--- a/apps/dump_agent_go/internal/worker/executor.go
+++ b/apps/dump_agent_go/internal/worker/executor.go
@@ -129,7 +129,7 @@ func (e *JobExecutor) runDeltaWithCommit(ctx context.Context, job *Job) (int64, 
 
 // RunDelta executa job em modo delta: extract → materialize → compute →
 // stage pending → write delta parquet → upload (com tee SHA-256). Caller
-// DEVE invocar PendingTx.Commit() após CompleteJob ack OU
+// DEVE invocar PendingTx.Commit() após RegisterJob ack OU
 // PendingTx.Abort() em falha. Em caso de erro interno, RunDelta aborta
 // o pending e devolve pending=nil. Emite audit Extracted (start) e
 // Uploaded/Aborted (após Put). job.Sha256 preenchido em sucesso.
@@ -276,7 +276,7 @@ type DeltaStageRequest struct {
 
 // ComputeAndStagePending loads the committed snapshot, computes the delta,
 // stages new fingerprints in a pending bbolt tx, and returns the Set
-// + PendingTx. Caller must call PendingTx.Commit() after CompleteJob ack
+// + PendingTx. Caller must call PendingTx.Commit() after RegisterJob ack
 // or PendingTx.Abort() on failure.
 //
 // ctx is unused today (delta package does not propagate cancellation

--- a/apps/dump_agent_go/internal/worker/executor_audit_test.go
+++ b/apps/dump_agent_go/internal/worker/executor_audit_test.go
@@ -1,13 +1,17 @@
 package worker
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cnesdata/dumpagent/internal/audit"
+	"github.com/cnesdata/dumpagent/internal/delta"
+	"github.com/cnesdata/dumpagent/internal/extractor"
 )
 
 func TestAppendAudit_NilLoggerNoOp(t *testing.T) {
@@ -31,4 +35,56 @@ func TestAppendAudit_LoggerWritesEvent(t *testing.T) {
 	files, err := filepath.Glob(filepath.Join(dir, "events-*.jsonl"))
 	require.NoError(t, err)
 	require.Len(t, files, 1)
+}
+
+func TestEmitCommitted_NilAuditLoggerNoOp(t *testing.T) {
+	e := &JobExecutor{AuditLogger: nil, DeltaStore: &delta.Store{}}
+	job := Job{ID: "job-1"}
+	e.EmitCommitted(job, 0)
+}
+
+func TestEmitCommitted_NilDeltaStoreNoOp(t *testing.T) {
+	dir := t.TempDir()
+	logger := audit.New(dir, "m", "t",
+		[]byte("0123456789abcdef0123456789abcdef"))
+	e := &JobExecutor{AuditLogger: logger, DeltaStore: nil}
+	job := Job{ID: "job-1", Params: extractor.ExtractionParams{
+		Intent: extractor.IntentCnesEstabelecimentos, Competencia: "202605",
+	}}
+	e.EmitCommitted(job, 1024)
+	files, _ := filepath.Glob(filepath.Join(dir, "events-*.jsonl"))
+	require.Empty(t, files, "snapshot path must not emit Committed audit")
+}
+
+func TestEmitCommitted_WritesCommittedEvent(t *testing.T) {
+	dir := t.TempDir()
+	logger := audit.New(dir, "machine-1", "tenant-1",
+		[]byte("0123456789abcdef0123456789abcdef"))
+	logger.SetTimeNow(func() time.Time {
+		return time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+	})
+	e := &JobExecutor{AuditLogger: logger, DeltaStore: &delta.Store{}}
+	job := Job{
+		ID:     "11111111-2222-3333-4444-555555555555",
+		Sha256: "deadbeef",
+		Params: extractor.ExtractionParams{
+			Intent:      extractor.IntentCnesEstabelecimentos,
+			Competencia: "202605",
+		},
+	}
+	e.EmitCommitted(job, 1024)
+
+	files, err := filepath.Glob(filepath.Join(dir, "events-*.jsonl"))
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	content, err := os.ReadFile(files[0])
+	require.NoError(t, err)
+	body := string(content)
+	require.Contains(t, body, "\"lifecycle\":\"committed\"")
+	require.Contains(t, body, "\"sha256\":\"deadbeef\"")
+	require.Contains(t, body, "\"source\":\"cnes\"")
+	require.Contains(t, body, "\"intent\":\"estabelecimentos\"")
+	require.Contains(t, body, "\"competencia\":\"202605\"")
+	require.Contains(t, body, "\"job_id\":\""+job.ID+"\"")
+	require.Equal(t, 1, strings.Count(body, "\n"), "exactly one event line")
 }

--- a/apps/dump_agent_go/internal/worker/outbox_adapter.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter.go
@@ -27,12 +27,15 @@ func (a *OutboxAdapter) MintUploadURL(ctx context.Context, spec JobSpec) (*Job, 
 }
 
 // RegisterJob persists envelope; drain dispatches asynchronously.
-// FU1: post-upload register threads sha256 from job.Sha256.
+// FU1: post-upload register threads sha256/minio_key so drain replay
+// after agent restart can reconstruct the full Job payload.
 func (a *OutboxAdapter) RegisterJob(_ context.Context, job Job, sizeBytes int64) error {
 	return a.out.Append(queue.Envelope{
 		Type:      queue.TypeComplete,
 		JobUUID:   job.ID,
 		SizeBytes: sizeBytes,
+		SHA256:    job.Sha256,
+		MinioKey:  job.MinioKey,
 	})
 }
 

--- a/apps/dump_agent_go/internal/worker/outbox_adapter.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter.go
@@ -6,9 +6,10 @@ import (
 	"github.com/cnesdata/dumpagent/internal/queue"
 )
 
-// OutboxAdapter persists CompleteJob/FailJob calls to a bbolt outbox
-// (fire-and-forget for the caller) and delegates RegisterJob/SendHeartbeat
-// directly to the inner JobAPIClient. Drain goroutine reads the outbox.
+// OutboxAdapter persists RegisterJob/FailJob (terminal outcomes) to a
+// bbolt outbox (fire-and-forget for the caller) and delegates
+// MintUploadURL/SendHeartbeat directly to the inner JobAPIClient. Drain
+// goroutine reads the outbox.
 type OutboxAdapter struct {
 	inner JobAPIClient
 	out   *queue.Outbox
@@ -19,13 +20,15 @@ func NewOutboxAdapter(inner JobAPIClient, out *queue.Outbox) *OutboxAdapter {
 	return &OutboxAdapter{inner: inner, out: out}
 }
 
-// RegisterJob delegates directly: caller needs the returned Job.
-func (a *OutboxAdapter) RegisterJob(ctx context.Context, spec JobSpec) (*Job, error) {
-	return a.inner.RegisterJob(ctx, spec)
+// MintUploadURL delegates directly: caller needs the returned Job
+// (presigned upload URL is single-use + time-limited).
+func (a *OutboxAdapter) MintUploadURL(ctx context.Context, spec JobSpec) (*Job, error) {
+	return a.inner.MintUploadURL(ctx, spec)
 }
 
-// CompleteJob persists envelope; drain dispatches asynchronously.
-func (a *OutboxAdapter) CompleteJob(_ context.Context, job Job, sizeBytes int64) error {
+// RegisterJob persists envelope; drain dispatches asynchronously.
+// FU1: post-upload register threads sha256 from job.Sha256.
+func (a *OutboxAdapter) RegisterJob(_ context.Context, job Job, sizeBytes int64) error {
 	return a.out.Append(queue.Envelope{
 		Type:      queue.TypeComplete,
 		JobUUID:   job.ID,

--- a/apps/dump_agent_go/internal/worker/outbox_adapter_test.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cnesdata/dumpagent/internal/queue"
@@ -99,6 +100,34 @@ func TestOutboxAdapter_MintUploadURLDelegates(t *testing.T) {
 	items, _ := ob.Peek(10)
 	if len(items) != 0 {
 		t.Fatalf("unexpected envelope from MintUploadURL: %+v", items)
+	}
+}
+
+func TestOutboxAdapter_RegisterJob_PersistsSha256AndMinioKey(t *testing.T) {
+	mock := &mockJobAPI{}
+	ob := newOutbox(t)
+	a := NewOutboxAdapter(mock, ob)
+	job := Job{
+		ID:       "11111111-2222-3333-4444-555555555555",
+		Sha256:   "a" + strings.Repeat("0", 63),
+		MinioKey: "354130/CNES_VINCULO/2026-01-01/abc.parquet.gz",
+	}
+	if err := a.RegisterJob(context.Background(), job, 4096); err != nil {
+		t.Fatalf("RegisterJob: %v", err)
+	}
+	items, _ := ob.Peek(10)
+	if len(items) != 1 {
+		t.Fatalf("envelope count = %d want 1", len(items))
+	}
+	env := items[0].Envelope
+	if env.SHA256 != job.Sha256 {
+		t.Errorf("SHA256 = %q want %q", env.SHA256, job.Sha256)
+	}
+	if env.MinioKey != job.MinioKey {
+		t.Errorf("MinioKey = %q want %q", env.MinioKey, job.MinioKey)
+	}
+	if env.SizeBytes != 4096 {
+		t.Errorf("SizeBytes = %d want 4096", env.SizeBytes)
 	}
 }
 

--- a/apps/dump_agent_go/internal/worker/outbox_adapter_test.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter_test.go
@@ -10,20 +10,20 @@ import (
 )
 
 type mockJobAPI struct {
+	mintCalls      int
 	registerCalls  int
-	completeCalls  int
 	failCalls      int
 	heartbeatCalls int
-	registerErr    error
-	registerJob    *Job
+	mintErr        error
+	mintJob        *Job
 }
 
-func (m *mockJobAPI) RegisterJob(_ context.Context, _ JobSpec) (*Job, error) {
-	m.registerCalls++
-	return m.registerJob, m.registerErr
+func (m *mockJobAPI) MintUploadURL(_ context.Context, _ JobSpec) (*Job, error) {
+	m.mintCalls++
+	return m.mintJob, m.mintErr
 }
-func (m *mockJobAPI) CompleteJob(_ context.Context, _ Job, _ int64) error {
-	m.completeCalls++
+func (m *mockJobAPI) RegisterJob(_ context.Context, _ Job, _ int64) error {
+	m.registerCalls++
 	return nil
 }
 func (m *mockJobAPI) FailJob(_ context.Context, _ Job, _ error) error {
@@ -45,16 +45,16 @@ func newOutbox(t *testing.T) *queue.Outbox {
 	return ob
 }
 
-func TestOutboxAdapter_CompleteWritesEnvelopeNotInner(t *testing.T) {
+func TestOutboxAdapter_RegisterWritesEnvelopeNotInner(t *testing.T) {
 	mock := &mockJobAPI{}
 	ob := newOutbox(t)
 	a := NewOutboxAdapter(mock, ob)
 	job := Job{ID: "uuid-1"}
-	if err := a.CompleteJob(context.Background(), job, 4096); err != nil {
-		t.Fatalf("CompleteJob: %v", err)
+	if err := a.RegisterJob(context.Background(), job, 4096); err != nil {
+		t.Fatalf("RegisterJob: %v", err)
 	}
-	if mock.completeCalls != 0 {
-		t.Errorf("inner.CompleteJob called %d times, want 0", mock.completeCalls)
+	if mock.registerCalls != 0 {
+		t.Errorf("inner.RegisterJob called %d times, want 0", mock.registerCalls)
 	}
 	items, _ := ob.Peek(10)
 	if len(items) != 1 || items[0].Envelope.Type != queue.TypeComplete ||
@@ -82,23 +82,23 @@ func TestOutboxAdapter_FailWritesEnvelopeNotInner(t *testing.T) {
 	}
 }
 
-func TestOutboxAdapter_RegisterJobDelegates(t *testing.T) {
-	mock := &mockJobAPI{registerJob: &Job{ID: "back"}}
+func TestOutboxAdapter_MintUploadURLDelegates(t *testing.T) {
+	mock := &mockJobAPI{mintJob: &Job{ID: "back"}}
 	ob := newOutbox(t)
 	a := NewOutboxAdapter(mock, ob)
-	job, err := a.RegisterJob(context.Background(), JobSpec{})
+	job, err := a.MintUploadURL(context.Background(), JobSpec{})
 	if err != nil {
-		t.Fatalf("RegisterJob: %v", err)
+		t.Fatalf("MintUploadURL: %v", err)
 	}
 	if job == nil || job.ID != "back" {
 		t.Fatalf("got %+v, want delegated Job", job)
 	}
-	if mock.registerCalls != 1 {
-		t.Fatalf("inner.RegisterJob called %d times, want 1", mock.registerCalls)
+	if mock.mintCalls != 1 {
+		t.Fatalf("inner.MintUploadURL called %d times, want 1", mock.mintCalls)
 	}
 	items, _ := ob.Peek(10)
 	if len(items) != 0 {
-		t.Fatalf("unexpected envelope from RegisterJob: %+v", items)
+		t.Fatalf("unexpected envelope from MintUploadURL: %+v", items)
 	}
 }
 

--- a/apps/dump_agent_go/internal/worker/shadow.go
+++ b/apps/dump_agent_go/internal/worker/shadow.go
@@ -59,5 +59,9 @@ func (s *ShadowExecutor) Run(ctx context.Context, job *Job) (sizeBytes int64, er
 	return info.Size(), nil
 }
 
+// EmitCommitted é no-op no ShadowExecutor — modo shadow não emite
+// audit lifecycle (sem AuditLogger configurado nesse caminho).
+func (s *ShadowExecutor) EmitCommitted(_ Job, _ int64) {}
+
 // ErrShadowDirMissing sinaliza config inválida.
 var ErrShadowDirMissing = errors.New("shadow_output_dir_missing")

--- a/apps/dump_agent_go/test/e2e/foreground_test.go
+++ b/apps/dump_agent_go/test/e2e/foreground_test.go
@@ -35,11 +35,11 @@ func TestForeground_SmokeEndToEnd(t *testing.T) {
 	}))
 	defer minioSrv.Close()
 
-	var registered, completed, heartbeats int32
+	var minted, registered, heartbeats int32
 	central := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/api/v1/jobs/register":
-			if atomic.AddInt32(&registered, 1) > 1 {
+		case r.URL.Path == "/api/v1/jobs/upload-url":
+			if atomic.AddInt32(&minted, 1) > 1 {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
@@ -48,10 +48,16 @@ func TestForeground_SmokeEndToEnd(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"extraction_id": testExtractionUUID,
 				"upload_url":    minioSrv.URL,
+				"minio_key":     "354130/CNES_VINCULO/2026-01/abc.parquet.gz",
 			})
-		case strings.HasSuffix(r.URL.Path, "/complete"):
-			atomic.AddInt32(&completed, 1)
+		case r.URL.Path == "/api/v1/jobs/register":
+			atomic.AddInt32(&registered, 1)
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"job_id": testExtractionUUID,
+				"status": "REGISTERED",
+			})
 		case strings.HasSuffix(r.URL.Path, "/heartbeat"):
 			atomic.AddInt32(&heartbeats, 1)
 			w.WriteHeader(http.StatusOK)
@@ -90,7 +96,7 @@ func TestForeground_SmokeEndToEnd(t *testing.T) {
 	defer cancel()
 	require.NoError(t, cons.Loop(ctx))
 
+	require.GreaterOrEqual(t, atomic.LoadInt32(&minted), int32(1))
 	require.GreaterOrEqual(t, atomic.LoadInt32(&registered), int32(1))
-	require.Equal(t, int32(1), atomic.LoadInt32(&completed))
 	require.Greater(t, atomic.LoadInt64(&uploadedBytes), int64(0))
 }

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -1416,6 +1416,51 @@
         ]
       }
     },
+    "/api/v1/jobs/upload-url": {
+      "post": {
+        "operationId": "mint_upload_url_api_v1_jobs_upload_url_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Mint Upload Url Api V1 Jobs Upload Url Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mint Upload Url",
+        "tags": [
+          "jobs"
+        ]
+      }
+    },
     "/api/v1/system/health": {
       "get": {
         "operationId": "health_check_api_v1_system_health_get",

--- a/docs/contracts/schemas/uploadurlrequest.json
+++ b/docs/contracts/schemas/uploadurlrequest.json
@@ -1,0 +1,79 @@
+{
+  "properties": {
+    "agent_version": {
+      "anyOf": [
+        {
+          "maxLength": 64,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Agent Version"
+    },
+    "competencia": {
+      "format": "date",
+      "title": "Competencia",
+      "type": "string"
+    },
+    "intent": {
+      "maxLength": 64,
+      "minLength": 1,
+      "title": "Intent",
+      "type": "string"
+    },
+    "job_id": {
+      "format": "uuid",
+      "title": "Job Id",
+      "type": "string"
+    },
+    "machine_id": {
+      "anyOf": [
+        {
+          "maxLength": 128,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Machine Id"
+    },
+    "source_type": {
+      "enum": [
+        "CNES_LOCAL",
+        "CNES_NACIONAL",
+        "SIHD",
+        "BPA_MAG",
+        "SIA_LOCAL"
+      ],
+      "title": "Source Type",
+      "type": "string"
+    },
+    "tenant_id": {
+      "maxLength": 64,
+      "minLength": 1,
+      "title": "Tenant Id",
+      "type": "string"
+    },
+    "tipo_extracao": {
+      "maxLength": 32,
+      "minLength": 1,
+      "title": "Tipo Extracao",
+      "type": "string"
+    }
+  },
+  "required": [
+    "job_id",
+    "tenant_id",
+    "source_type",
+    "tipo_extracao",
+    "competencia",
+    "intent"
+  ],
+  "title": "UploadUrlRequest",
+  "type": "object"
+}

--- a/docs/contracts/schemas/uploadurlresponse.json
+++ b/docs/contracts/schemas/uploadurlresponse.json
@@ -1,0 +1,26 @@
+{
+  "properties": {
+    "extraction_id": {
+      "format": "uuid",
+      "title": "Extraction Id",
+      "type": "string"
+    },
+    "minio_key": {
+      "pattern": "^[\\w\\-./]+\\.parquet\\.gz$",
+      "title": "Minio Key",
+      "type": "string"
+    },
+    "upload_url": {
+      "minLength": 1,
+      "title": "Upload Url",
+      "type": "string"
+    }
+  },
+  "required": [
+    "extraction_id",
+    "upload_url",
+    "minio_key"
+  ],
+  "title": "UploadUrlResponse",
+  "type": "object"
+}

--- a/packages/cnes_contracts/src/cnes_contracts/export.py
+++ b/packages/cnes_contracts/src/cnes_contracts/export.py
@@ -24,6 +24,8 @@ from cnes_contracts.landing import (
     Extraction,
     ExtractionRegisterPayload,
     FileManifest,
+    UploadUrlRequest,
+    UploadUrlResponse,
 )
 
 if TYPE_CHECKING:
@@ -46,6 +48,8 @@ MODELS: list[tuple[type, str]] = [
     (ExtractionRegisterPayload, "extractionregisterpayload.json"),
     (FileManifest, "file_manifest.json"),
     (JobTransitionEvent, "jobtransitionevent.json"),
+    (UploadUrlRequest, "uploadurlrequest.json"),
+    (UploadUrlResponse, "uploadurlresponse.json"),
 ]
 
 

--- a/packages/cnes_contracts/src/cnes_contracts/landing.py
+++ b/packages/cnes_contracts/src/cnes_contracts/landing.py
@@ -56,6 +56,27 @@ class ExtractionRegisterPayload(BaseModel):
     sha256: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
 
 
+class UploadUrlRequest(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    job_id: UUID
+    tenant_id: str = Field(min_length=1, max_length=64)
+    source_type: SOURCE_TYPE
+    tipo_extracao: str = Field(min_length=1, max_length=32)
+    competencia: date
+    intent: str = Field(min_length=1, max_length=64)
+    agent_version: str | None = Field(default=None, max_length=64)
+    machine_id: str | None = Field(default=None, max_length=128)
+
+
+class UploadUrlResponse(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    extraction_id: UUID
+    upload_url: str = Field(min_length=1)
+    minio_key: str = Field(pattern=r"^[\w\-./]+\.parquet\.gz$")
+
+
 @dataclass(frozen=True, slots=True)
 class ClaimedExtraction:
     job_id: UUID

--- a/packages/cnes_contracts/tests/test_landing_uploadurl.py
+++ b/packages/cnes_contracts/tests/test_landing_uploadurl.py
@@ -1,4 +1,6 @@
 """Tests for UploadUrlRequest + UploadUrlResponse contracts."""
+from __future__ import annotations
+
 from datetime import date
 from uuid import uuid4
 
@@ -8,7 +10,7 @@ from pydantic import ValidationError
 from cnes_contracts.landing import UploadUrlRequest, UploadUrlResponse
 
 
-def test_upload_url_request_minimal_required_fields():
+def test_aceita_request_minimo():
     req = UploadUrlRequest(
         job_id=uuid4(),
         tenant_id="354130",
@@ -21,7 +23,7 @@ def test_upload_url_request_minimal_required_fields():
     assert req.machine_id is None
 
 
-def test_upload_url_request_rejects_invalid_source_type():
+def test_rejeita_source_type_desconhecido():
     with pytest.raises(ValidationError):
         UploadUrlRequest(
             job_id=uuid4(),
@@ -33,7 +35,7 @@ def test_upload_url_request_rejects_invalid_source_type():
         )
 
 
-def test_upload_url_request_max_length_machine_id():
+def test_rejeita_machine_id_acima_de_128_chars():
     with pytest.raises(ValidationError):
         UploadUrlRequest(
             job_id=uuid4(),
@@ -46,7 +48,7 @@ def test_upload_url_request_max_length_machine_id():
         )
 
 
-def test_upload_url_response_required_fields():
+def test_aceita_response_valido():
     extraction_id = uuid4()
     resp = UploadUrlResponse(
         extraction_id=extraction_id,
@@ -56,10 +58,33 @@ def test_upload_url_response_required_fields():
     assert resp.extraction_id == extraction_id
 
 
-def test_upload_url_response_rejects_invalid_minio_key():
+def test_rejeita_minio_key_sem_extensao_parquet_gz():
     with pytest.raises(ValidationError):
         UploadUrlResponse(
             extraction_id=uuid4(),
             upload_url="https://minio.example/key",
             minio_key="not_a_parquet",
         )
+
+
+def test_request_frozen_rejeita_mutacao():
+    req = UploadUrlRequest(
+        job_id=uuid4(),
+        tenant_id="354130",
+        source_type="CNES_LOCAL",
+        tipo_extracao="profissionais",
+        competencia=date(2026, 1, 1),
+        intent="cnes_profissionais",
+    )
+    with pytest.raises(ValidationError):
+        req.tenant_id = "999999"
+
+
+def test_response_frozen_rejeita_mutacao():
+    resp = UploadUrlResponse(
+        extraction_id=uuid4(),
+        upload_url="https://minio.example/key?sig=abc",
+        minio_key="354130/CNES_VINCULO/2026-01-01/foo.parquet.gz",
+    )
+    with pytest.raises(ValidationError):
+        resp.minio_key = "other.parquet.gz"

--- a/packages/cnes_contracts/tests/test_landing_uploadurl.py
+++ b/packages/cnes_contracts/tests/test_landing_uploadurl.py
@@ -1,0 +1,65 @@
+"""Tests for UploadUrlRequest + UploadUrlResponse contracts."""
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from cnes_contracts.landing import UploadUrlRequest, UploadUrlResponse
+
+
+def test_upload_url_request_minimal_required_fields():
+    req = UploadUrlRequest(
+        job_id=uuid4(),
+        tenant_id="354130",
+        source_type="CNES_LOCAL",
+        tipo_extracao="profissionais",
+        competencia=date(2026, 1, 1),
+        intent="cnes_profissionais",
+    )
+    assert req.agent_version is None
+    assert req.machine_id is None
+
+
+def test_upload_url_request_rejects_invalid_source_type():
+    with pytest.raises(ValidationError):
+        UploadUrlRequest(
+            job_id=uuid4(),
+            tenant_id="354130",
+            source_type="UNKNOWN_SOURCE",
+            tipo_extracao="profissionais",
+            competencia=date(2026, 1, 1),
+            intent="cnes_profissionais",
+        )
+
+
+def test_upload_url_request_max_length_machine_id():
+    with pytest.raises(ValidationError):
+        UploadUrlRequest(
+            job_id=uuid4(),
+            tenant_id="354130",
+            source_type="CNES_LOCAL",
+            tipo_extracao="profissionais",
+            competencia=date(2026, 1, 1),
+            intent="cnes_profissionais",
+            machine_id="x" * 129,
+        )
+
+
+def test_upload_url_response_required_fields():
+    extraction_id = uuid4()
+    resp = UploadUrlResponse(
+        extraction_id=extraction_id,
+        upload_url="https://minio.example/bucket/key?sig=abc",
+        minio_key="354130/CNES_VINCULO/2026-01-01/foo.parquet.gz",
+    )
+    assert resp.extraction_id == extraction_id
+
+
+def test_upload_url_response_rejects_invalid_minio_key():
+    with pytest.raises(ValidationError):
+        UploadUrlResponse(
+            extraction_id=uuid4(),
+            upload_url="https://minio.example/key",
+            minio_key="not_a_parquet",
+        )

--- a/packages/cnes_infra/src/cnes_infra/storage/extractions_repo.py
+++ b/packages/cnes_infra/src/cnes_infra/storage/extractions_repo.py
@@ -152,6 +152,54 @@ def register(
     return result.job_id if result else None
 
 
+def mint_upload_url(
+    engine: Engine,
+    *,
+    job_id: UUID,
+    tenant_id: str,
+    source_type: str,
+    competencia: date,
+    fato_subtype: str,
+    minio_key: str,
+    agent_version: str | None = None,
+    machine_id: str | None = None,
+) -> UUID | None:
+    placeholder = [{
+        "minio_key": minio_key,
+        "fato_subtype": fato_subtype,
+        "size_bytes": 1,
+        "sha256": "0" * 64,
+    }]
+    sql = text("""
+        INSERT INTO landing.extractions (
+            job_id, tenant_id, source_type, competencia,
+            files, depends_on, status,
+            agent_version, machine_id, created_at
+        ) VALUES (
+            :j, :t, :s, :c, CAST(:f AS jsonb),
+            CAST(:d AS uuid[]), 'PENDING',
+            :av, :mid, NOW()
+        )
+        ON CONFLICT (job_id) DO NOTHING
+        RETURNING job_id
+    """)
+    with engine.begin() as conn:
+        result = conn.execute(
+            sql,
+            {
+                "j": str(job_id),
+                "t": tenant_id,
+                "s": source_type,
+                "c": competencia,
+                "f": json.dumps(placeholder),
+                "d": "{}",
+                "av": agent_version,
+                "mid": machine_id,
+            },
+        ).one_or_none()
+    return result.job_id if result else None
+
+
 def reap_expired(engine: Engine) -> int:
     sql = text("""
         UPDATE landing.extractions

--- a/packages/cnes_infra/tests/test_extractions_repo_mint.py
+++ b/packages/cnes_infra/tests/test_extractions_repo_mint.py
@@ -1,0 +1,79 @@
+"""Tests for extractions_repo.mint_upload_url (FU1 T2)."""
+from __future__ import annotations
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+from cnes_infra.storage import extractions_repo
+
+pytestmark = pytest.mark.postgres
+
+
+@pytest.fixture
+def _cleanup_extractions(pg_engine):
+    with pg_engine.begin() as conn:
+        conn.execute(text("TRUNCATE landing.extractions CASCADE"))
+    yield
+    with pg_engine.begin() as conn:
+        conn.execute(text("TRUNCATE landing.extractions CASCADE"))
+
+
+@pytest.mark.usefixtures("_cleanup_extractions")
+def test_aceita_insere_pending_row(pg_engine) -> None:
+    job_id = uuid4()
+    minio_key = "354130/CNES_VINCULO/2026-01-01/foo.parquet.gz"
+    result = extractions_repo.mint_upload_url(
+        pg_engine,
+        job_id=job_id,
+        tenant_id="354130",
+        source_type="CNES_LOCAL",
+        competencia=date(2026, 1, 1),
+        fato_subtype="CNES_VINCULO",
+        minio_key=minio_key,
+        agent_version="0.5.0",
+        machine_id="EDGE-01",
+    )
+    assert result == job_id
+
+    with pg_engine.begin() as conn:
+        conn.execute(text("SET LOCAL row_security = off"))
+        row = conn.execute(
+            text(
+                "SELECT status, agent_version, machine_id, files "
+                "FROM landing.extractions WHERE job_id = :j"
+            ),
+            {"j": str(job_id)},
+        ).one()
+    assert row.status == "PENDING"
+    assert row.agent_version == "0.5.0"
+    assert row.machine_id == "EDGE-01"
+    assert row.files[0]["minio_key"] == minio_key
+    assert row.files[0]["fato_subtype"] == "CNES_VINCULO"
+    assert row.files[0]["sha256"] == "0" * 64
+
+
+@pytest.mark.usefixtures("_cleanup_extractions")
+def test_rejeita_duplicate_job_id(pg_engine) -> None:
+    job_id = uuid4()
+    extractions_repo.mint_upload_url(
+        pg_engine,
+        job_id=job_id,
+        tenant_id="354130",
+        source_type="CNES_LOCAL",
+        competencia=date(2026, 1, 1),
+        fato_subtype="CNES_VINCULO",
+        minio_key="a.parquet.gz",
+    )
+    second = extractions_repo.mint_upload_url(
+        pg_engine,
+        job_id=job_id,
+        tenant_id="354130",
+        source_type="CNES_LOCAL",
+        competencia=date(2026, 1, 1),
+        fato_subtype="CNES_VINCULO",
+        minio_key="a.parquet.gz",
+    )
+    assert second is None


### PR DESCRIPTION
## Summary

Closes the P2 PR #85 follow-up gap: `landing.extractions.sha256` column now populates on every cnes/sihd cycle.

**Architecture change:** cnes/sihd path normalized to BPA/SIA's post-upload register pattern.

- Edge: `MintUploadURL` (new endpoint) → upload Parquet → `RegisterJob` (post-upload, threads sha256 captured via `integrity.SHA256TeeReader`)
- Server: new `POST /api/v1/jobs/upload-url` route + `extractions_repo.mint_upload_url` repo function
- `CompleteJob` removed entirely from edge — dead `/complete` route never existed
- `audit.LifecycleCommitted` emitted by Consumer post-RegisterJob ack via new `JobExecutorIface.EmitCommitted`
- `Job.MinioKey` field + outbox envelope extended with SHA256 + MinioKey for drain replay

No DB migration (sha256 column from migration 018). No field agents → clean removal of CompleteJob code.

## Acceptance criteria met

- [x] Cnes/sihd cycle persists `landing.extractions.sha256` (verified by E2E test `test_e2e_aceita_mint_upload_register_persiste_sha256`)
- [x] data_processor `verify_and_route_delta` no longer skipping with `expected_sha256 None`
- [x] Edge code contains no `CompleteJob` references
- [x] Audit log emits `Committed` lifecycle after RegisterJob ack
- [x] All Go unit tests pass (filtered coverage 83.8% ≥ 65%)
- [x] All Python unit + integration tests pass (1 pre-existing chaos test fail unrelated)
- [x] New unit + integration tests cover happy + retry + race paths

## Out of scope (explicit)

- `/fail` route — deferred to follow-up PR (orphan PENDING rows accumulate until shipped)
- data_processor poll filter mismatch (PENDING vs REGISTERED interplay) — separate concern
- oapi-codegen exclusiveMinimum bug fix (FU2) — manual generated.go patch shipped per P2 T12 pattern
- BPA/SIA path — already correctly post-upload register

## Test plan

- [x] Python: `pytest -m "not integration and not postgres ..." --ignore=tests/perf` → 565 PASS
- [x] Postgres: `pytest -m postgres apps/central_api/ packages/cnes_infra/` (e2e mint→register cycle)
- [x] Go: `go test -race -count=1 ./...` (21 packages)
- [x] Go E2E: `go test -tags=e2e ./test/e2e/...` (foreground harness aligned)
- [x] Go filtered coverage gate ≥ 65% → 83.8%
- [x] Lint: `ruff check .` + `go vet ./...` clean

## Spec

`docs/superpowers/specs/2026-05-04-edge-agent-fu1-sha256-post-upload-register-design.md` (gitignored, local).

## Plan

`docs/superpowers/plans/2026-05-04-edge-agent-fu1-sha256-post-upload-register.md` (gitignored, local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)