### PR TITLE
docs(repo): update project documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,67 +1,85 @@
-# =============================================================================
-# CnesData — Variáveis de Ambiente
-# Copie este arquivo para .env e ajuste os valores.
-# NUNCA versione o .env com credenciais reais!
-# =============================================================================
+# CnesData local development environment.
+# Copy to `.env` and replace secrets/paths as needed.
+# Do not commit real credentials.
 
-# --- Opcional ---
-# FOLHA_HR_PATH=caminho/para/planilha_rh.xlsx
-# DATASUS_AUTH_TOKEN=bearer-token-aqui
+# ---------------------------------------------------------------------------
+# Central Postgres
+# ---------------------------------------------------------------------------
+DB_URL=postgresql+psycopg://cnesdata:cnesdata_test@localhost:5433/cnesdata_test
 
-# --- Banco de Dados Firebird (CNES Local) ---
+# ---------------------------------------------------------------------------
+# Tenant / municipality defaults
+# ---------------------------------------------------------------------------
+COD_MUN_IBGE=354130
+ID_MUNICIPIO_IBGE7=3541307
+CNPJ_MANTENEDORA=55293427000117
+COMPETENCIA_ANO=2026
+COMPETENCIA_MES=1
+
+# ---------------------------------------------------------------------------
+# Central API
+# ---------------------------------------------------------------------------
+API_HOST=0.0.0.0
+API_PORT=8000
+AUTH_REQUIRED=required
+DASHBOARD_OIDC_ISSUER=http://localhost:8080/realms/cnesdata
+DASHBOARD_OIDC_AUDIENCE=cnesdata-dashboard
+
+# Device flow + mTLS provisioning.
+# For local dev, point these to a test CA generated outside the repo.
+AUTH_CA_CERT_PATH=secrets/ca.crt
+AUTH_CA_KEY_PATH=secrets/ca.key
+AUTH_DEVICE_VERIFICATION_URI=http://localhost:5173/activate
+AUTH_DEVICE_CODE_TTL=600
+AUTH_ACCESS_TOKEN_TTL=300
+AUTH_CERT_TTL_DAYS=90
+
+# ---------------------------------------------------------------------------
+# Object storage
+# ---------------------------------------------------------------------------
+MINIO_ENDPOINT=localhost:9000
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin
+MINIO_BUCKET=cnesdata-landing
+MINIO_SECURE=false
+
+# ---------------------------------------------------------------------------
+# Data processor
+# ---------------------------------------------------------------------------
+PROCESSOR_ID=processor-01
+PROCESSOR_POLL_INTERVAL=5.0
+PROCESSOR_IDLE_POLL_INTERVAL=60.0
+
+# ---------------------------------------------------------------------------
+# Edge agent (Go)
+# ---------------------------------------------------------------------------
+CENTRAL_API_URL=http://localhost:8000
+TENANT_ID=354130
+MACHINE_ID=agent-01
+MAX_JITTER_SECONDS=5
+
+# Fleet rollout escape hatch. Remove for production.
+# AGENT_ALLOW_INSECURE=true
+
+# Override agent auth directory during local tests.
+# AGENT_AUTH_DIR=.cache/agent-auth
+
+# ---------------------------------------------------------------------------
+# Local source paths for edge/dev ingestion
+# ---------------------------------------------------------------------------
 DB_HOST=localhost
 DB_PATH=C:\Datasus\CNES\CNES.GDB
 DB_USER=SYSDBA
 DB_PASSWORD=masterkey
 FIREBIRD_DLL=C:\caminho\para\fbclient.dll
+# FIREBIRD_LIB=/path/to/libfbclient.so
 
-# --- PostgreSQL (esquema Gold — dados consolidados) ---
-DB_URL=postgresql+psycopg://usuario:senha@localhost:5432/cnes_db
+BPA_GDB_PATH=C:\Datasus\BPA\BPAMAG.GDB
+SIA_DIR=C:\Datasus\SIA
+FBCLIENT_PATH=C:\firebird-1.5.6\bin\fbclient.dll
 
-# --- Filtros do Município ---
-COD_MUN_IBGE=354130
-ID_MUNICIPIO_IBGE7=3541307
-CNPJ_MANTENEDORA=55293427000117
-
-# --- Google Cloud / BigQuery ---
+# National CNES / BigQuery.
 GCP_PROJECT_ID=seu-projeto-gcp
 
-# --- Saída de Dados ---
-OUTPUT_DIR=data/processed
-OUTPUT_FILENAME=Relatorio_Profissionais_CNES.csv
-
-# --- Object Storage (MinIO/S3) ---
-STORAGE_PROVIDER=minio
-STORAGE_ENDPOINT=http://localhost:9000
-STORAGE_ACCESS_KEY=minioadmin
-STORAGE_SECRET_KEY=minioadmin
-STORAGE_BUCKET_NAME=cnesdata-landing
-
-# --- Central API ---
-API_HOST=0.0.0.0
-API_PORT=8000
-
-# --- Dump Agent ---
-MACHINE_ID=agent-01
-API_BASE_URL=http://localhost:8000
-MAX_JITTER_SECONDS=5
-
-# --- Data Processor ---
-PROCESSOR_POLL_INTERVAL=5.0
-PROCESSOR_ID=processor-01
-MINIO_BUCKET=cnesdata-landing
-MINIO_ENDPOINT=localhost:9000
-MINIO_ACCESS_KEY=minioadmin
-MINIO_SECRET_KEY=minioadmin
-MINIO_SECURE=false
-
-# Edge agent P4 — OAuth Device Flow + mTLS provisioning (Phase 2)
-AUTH_CA_CERT_PATH=secrets/ca.crt
-AUTH_CA_KEY_PATH=secrets/ca.key
-AUTH_DEVICE_VERIFICATION_URI=http://localhost:5173/activate
-
-# Edge agent P4 — apiclient mTLS (Phase 8)
-# Fleet rollout escape hatch: when set to "true", agent boots in plain
-# HTTP mode if cert load fails (e.g., agent not yet registered).
-# Remove after fleet fully enrolled via `dumpagent register`.
-# AGENT_ALLOW_INSECURE=true
+# Optional OTel.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317

--- a/README.md
+++ b/README.md
@@ -1,219 +1,192 @@
 # CnesData
 
-Motor de reconciliação de dados CNES para secretarias municipais de saúde.
+Distributed data platform for municipal SUS data reconciliation.
 
-Recebe dados de profissionais e estabelecimentos via **agentes de dump locais** (HTTP POST) ou diretamente da base nacional via BigQuery, aplica 11 regras de auditoria e persiste os resultados em PostgreSQL.
+CnesData moves raw municipal health data from edge environments into a
+tenant-isolated central store. Edge agents extract source data as Parquet,
+the central API coordinates landing jobs and provisioning, and shared domain
+packages define the contracts that downstream processors and audit services
+consume.
 
-**Piloto:** Presidente Epitácio/SP (IBGE 354130, CNPJ 55.293.427/0001-17).  
-**Direção:** arquitetura multi-município — o mesmo engine serve qualquer prefeitura cujo agente de dump esteja configurado.
+Pilot tenant: Presidente Epitacio/SP (`tenant_id=354130`).
 
----
+## Current Status
 
-## Arquitetura
-
-```
-Município A               Município B
-┌───────────────────┐     ┌───────────────────┐
-│  CNES.GDB         │     │  CNES.GDB         │
-│  Firebird local   │     │  Firebird local   │
-│                   │     │                   │
-│  [ Dump Agent ]   │     │  [ Dump Agent ]   │
-│  extrai → parquet │     │  extrai → parquet │
-└────────┬──────────┘     └────────┬──────────┘
-         │ HTTP POST                │ HTTP POST
-         └──────────┬───────────────┘
-                    ▼
-         ┌──────────────────────────┐
-         │  CnesData API            │
-         │  Reconciliation Engine   │
-         │                          │
-         │  1. IngestaoLocalStage   │◄─ parquet do dump agent
-         │  2. ProcessamentoStage   │
-         │  3. IngestaoNacionalStage│◄─ BigQuery (DATASUS)
-         │  4. ExportacaoStage      │
-         └──────────┬───────────────┘
-                    ▼
-              PostgreSQL
-              (auditoria por município × competência)
-```
-
-### Dump Agents
-
-Agentes leves que rodam no ambiente do município:
-
-1. Conectam ao `CNES.GDB` Firebird local
-2. Extraem vínculos profissional-estabelecimento via queries parametrizadas
-3. Serializam para parquet e fazem POST para o endpoint de ingestão da API
-4. São stateless — agendados via cron ou Windows Task Scheduler
-
-O engine aceita dados locais via parquet no `HISTORICO_DIR` (implementado) ou via API endpoint (roadmap).
-
-### Seleção de Fonte (`--source`)
-
-| Valor | Comportamento |
+| Area | Status |
 |---|---|
-| `LOCAL` (padrão) | Usa parquet do dump agent ou Firebird direto. `StageSkipError` se ausente — sem fallback silencioso. |
-| `NACIONAL` | Apenas BigQuery. Firebird nunca é consultado. |
-| `AMBOS` | Ingere as duas fontes; exporta com proveniência explícita (`FONTE=LOCAL` / `FONTE=NACIONAL`). |
+| Canonical contracts | Implemented in `packages/cnes_contracts` and exported to `docs/contracts/` |
+| Domain + infra packages | Implemented for contracts, tenant context, storage, auth, migrations, MinIO and ingestion clients |
+| Go edge agent | Active implementation in `apps/dump_agent_go` for CNES, SIHD, BPA-Mag and SIA sources |
+| Central API | Active FastAPI app for health, dashboard, OAuth/device activation, cert provisioning, extraction enqueue and job registration |
+| Web dashboard | Active Bun + React SPA with OIDC, activation, agent status, overview KPIs and access-request flow |
+| Data processor | Polling/downloading skeleton plus adapters/repositories exist; full Parquet-to-Gold ingestion wiring is still in progress |
+| Audit rules | Out of scope for this repo; external rules service consumes the Gold/landing schemas |
+| Production deploy | Target is Kubernetes plus on-prem edge agents; local development uses Docker Compose |
 
-Proveniência é imutável: dados locais e nacionais nunca se mesclam implicitamente.
+## Architecture
 
----
+```text
+Municipal edge
+  Firebird CNES.GDB / SIHD / BPAMAG.GDB / SIA DBF
+        |
+        v
+  dumpagent (Go)
+  - extracts raw rows
+  - writes parquet.gz manifests
+  - registers N-file manifests with object-storage keys
+        |
+        v
+Central platform
+  central_api (FastAPI)
+  - tenant middleware and auth
+  - extraction enqueue/register flow
+  - device activation and certificate provisioning
+        |
+        +--> MinIO / S3 landing bucket
+        |
+        +--> Postgres
+             - landing.extractions
+             - gold.* tables
+             - dashboard.* tables
+             - RLS per tenant
+        |
+        v
+  data_processor
+  - claims landing work
+  - ingestion path under active development
+```
 
-## API (Central API)
+Source types accepted by the landing contract:
 
-Com o servidor rodando (`docker compose up central-api`):
+| Source type | Meaning | File subtypes |
+|---|---|---|
+| `CNES_LOCAL` | Municipal CNES Firebird extract | `CNES_VINCULO` |
+| `CNES_NACIONAL` | National CNES source | `CNES_VINCULO` |
+| `SIHD` | Hospital AIH production | `SIHD_INTERNACAO`, `SIHD_PROC_AIH` |
+| `BPA_MAG` | BPA-Mag Firebird 1.5 extract | `BPA_C`, `BPA_I` |
+| `SIA_LOCAL` | SIA DBF extract | `DIM_SIGTAP`, `DIM_MUNICIPIO`, `SIA_APA`, `SIA_BPI`, `SIA_BPIHST` |
 
-- **Swagger UI**: http://localhost:8000/docs
-- **ReDoc**: http://localhost:8000/redoc
-- **OpenAPI JSON**: http://localhost:8000/openapi.json
+See [docs/architecture.md](docs/architecture.md) for the full system model.
 
-Schema exportado offline: [`docs/openapi.json`](docs/openapi.json).
+## Repository Map
 
-Para regenerar: `python scripts/export_openapi.py`
+| Path | Purpose |
+|---|---|
+| `packages/cnes_contracts/` | Pydantic contracts, Protocols and JSON Schema export |
+| `packages/cnes_domain/` | Pure domain layer: ports, models, validation, tenant context, processing primitives |
+| `packages/cnes_infra/` | SQLAlchemy storage, Alembic migrations, MinIO, auth, ingestion clients and telemetry |
+| `apps/central_api/` | FastAPI API for orchestration, dashboard data, OAuth/device flow and cert provisioning |
+| `apps/data_processor/` | Async worker skeleton for landing extraction processing |
+| `apps/cnes_db_migrator/` | Alembic migration runner for init-container/local migration use |
+| `apps/dump_agent_go/` | Go edge agent for municipal source extraction and upload |
+| `apps/web_dashboard/` | Bun + React dashboard |
+| `charts/web-dashboard/` | Helm chart for dashboard deployment |
+| `docs/` | Architecture, dictionaries, runbooks, contracts and performance notes |
+| `tests/` | Cross-cutting integration, property, memory, chaos, negative and perf suites |
 
----
+## Quick Start
 
-## Início Rápido
+Prerequisites:
 
-### Pré-requisitos
+- Python 3.13
+- `uv`
+- Docker + Docker Compose
+- Go 1.26 for `apps/dump_agent_go`
+- Bun 1.3 for `apps/web_dashboard`
+- Git LFS for Firebird fixture archives
 
-- Python 3.11+
-- uv (`pip install uv`)
-- (Opcional) `CNES.GDB` Firebird para execução local sem dump agent
-- (Opcional) Conta Google Cloud para cross-check nacional via BigQuery
+Install Python workspace dependencies:
 
-### Instalação
-
-```powershell
+```bash
 uv sync
-copy .env.example .env
-# Edite .env com seus valores (ver seção Configuração)
+cp .env.example .env
 ```
 
-### Primeira Execução
+Start the local dev stack:
 
-```powershell
-# Apenas dados nacionais (sem Firebird local)
-python src\main.py --source NACIONAL -c 2024-12 -v
-
-# Dados locais via Firebird direto (desenvolvimento)
-python src\main.py --source LOCAL -c 2024-12 -v
-
-# Ambas as fontes (reconciliação completa)
-python src\main.py --source AMBOS -c 2024-12
+```bash
+docker compose --profile dev up -d
 ```
 
----
+Local endpoints:
 
-## Uso via CLI
+| Service | URL |
+|---|---|
+| Central API Swagger | http://localhost:8000/docs |
+| Central API health | http://localhost:8000/api/v1/system/health |
+| Web dashboard | http://localhost:5173 |
+| Keycloak dev realm | http://localhost:8080 |
+| MinIO API | http://localhost:9000 |
+| MinIO console | http://localhost:9001 |
+| Postgres | `localhost:5433` |
 
-```
-python src\main.py [opções]
+Run the API directly during development:
 
-Opções:
-  -c, --competencia YYYY-MM    Competência (padrão: definido no .env)
-  -o, --output-dir CAMINHO     Diretório de saída (padrão: data/processed/)
-      --source {LOCAL,NACIONAL,AMBOS}
-                               Fonte de dados (padrão: LOCAL)
-  -v, --verbose                Log DEBUG no console
-  -h, --help                   Ajuda
-```
-
----
-
-## Configuração (`.env`)
-
-```ini
-# Banco Firebird (apenas para execução direta ou desenvolvimento)
-DB_HOST=localhost
-DB_PATH=C:\Datasus\CNES\CNES.GDB
-DB_USER=SYSDBA
-DB_PASSWORD=masterkey
-FIREBIRD_DLL=C:\caminho\para\fb_64\fbembed.dll
-
-# Filtros do município
-COD_MUN_IBGE=354130
-ID_MUNICIPIO_IBGE7=3541307
-CNPJ_MANTENEDORA=55293427000117
-
-# Saída
-OUTPUT_DIR=data/processed
-
-# Google Cloud / BigQuery (cross-check nacional)
-GCP_PROJECT_ID=seu-projeto-gcp
-
-# Competência padrão
-COMPETENCIA_ANO=2024
-COMPETENCIA_MES=12
-
-# PostgreSQL (persistência)
-DB_URL=postgresql+psycopg2://user:pass@localhost:5432/cnesdata
-
-# Folha de pagamento RH (opcional)
-FOLHA_HR_PATH=C:\caminho\para\hr_padronizado.csv
+```bash
+uv run uvicorn central_api.app:create_app --factory --reload
 ```
 
-Em modo API, `DB_PATH` e `FIREBIRD_DLL` são configurados no lado do dump agent, não do servidor.
+Regenerate API and schema contracts after contract changes:
 
----
-
-## Testes
-
-```powershell
-# Unitários (sem banco — padrão CI)
-.venv\Scripts\python.exe -m pytest tests/ -m "not integration" -q
-
-# Integração Firebird (requer banco ativo)
-.venv\Scripts\python.exe -m pytest tests/ -m "integration and not bigquery" -v
-
-# Todos
-.venv\Scripts\python.exe -m pytest tests/ -v
+```bash
+uv run python scripts/gen_openapi.py
+uv run python scripts/gen_contracts.py
 ```
 
-319+ testes unitários passando.
+The exported OpenAPI file used by clients is
+[docs/contracts/openapi.json](docs/contracts/openapi.json).
 
----
+## Common Commands
 
-## Estrutura do Projeto
+Python lint and tests:
 
-```
-CnesData/
-├── src/
-│   ├── cli.py                    # Argparse CLI
-│   ├── config.py                 # Configuração centralizada (.env)
-│   ├── main.py                   # Ponto de entrada
-│   ├── ingestion/
-│   │   ├── schemas.py            # Schema canônico (fonte de verdade de colunas)
-│   │   ├── cnes_client.py        # Extração Firebird (charset WIN1252, 3 queries)
-│   │   ├── cnes_local_adapter.py # Firebird → schema canônico
-│   │   ├── cnes_nacional_adapter.py # BigQuery → schema canônico
-│   │   ├── hr_client.py          # Parser planilhas RH (.xlsx/.csv)
-│   │   └── web_client.py         # Cliente BigQuery via basedosdados
-│   ├── pipeline/
-│   │   ├── orchestrator.py       # PipelineOrchestrator + StageSkipError/StageFatalError
-│   │   ├── state.py              # PipelineState (target_source, DataFrames)
-│   │   └── stages/
-│   │       ├── ingestao_local.py    # Carrega parquet do dump agent ou Firebird direto
-│   │       ├── ingestao_nacional.py # Busca BigQuery com circuit breaker
-│   │       ├── processamento.py     # Limpeza CPF, datas ISO, dedup
-│   │       └── exportacao.py        # Persiste no PostgreSQL, deriva status
-│   ├── processing/
-│   │   └── transformer.py        # RQ-002, RQ-003, enriquecimento CBO
-│   └── storage/
-│       ├── ports.py              # StoragePort Protocol
-│       └── postgres_adapter.py   # PostgreSQL (upsert por competência)
-├── tests/
-├── data/
-│   ├── historico/              # Parquets dos dump agents (não vai ao Git)
-│   └── processed/              # Relatórios gerados (não vai ao Git)
-├── docs/
-├── scripts/                    # Run-CnesAudit.ps1, hr_pre_processor.py
-├── CLAUDE.md
-├── docs/project-context.md
-├── ROADMAP.md
-└── docs/data-dictionary-firebird-bigquery.md
+```bash
+uv run ruff check .
+uv run pytest packages/cnes_domain packages/cnes_infra -m "not bigquery and not e2e and not stress and not soak and not spike" --cov --cov-config=pyproject.toml
+uv run pytest apps/ -m "not integration and not bigquery and not e2e and not stress and not soak and not spike and not windows_only" --cov --cov-config=.coveragerc
 ```
 
----
+Go edge agent:
 
+```bash
+cd apps/dump_agent_go
+make install-tools
+make lint
+make test
+make build-windows
+```
+
+Web dashboard:
+
+```bash
+cd apps/web_dashboard
+bun install
+bun run codegen
+bun run lint
+bun run typecheck
+bun run test
+bun run build
+```
+
+More detail is in [docs/development.md](docs/development.md).
+
+## Documentation
+
+- [docs/architecture.md](docs/architecture.md) - system architecture, contracts and deploy shape
+- [docs/project-context.md](docs/project-context.md) - product/domain context and historical decisions
+- [docs/roadmap.md](docs/roadmap.md) - current priorities and removed scope
+- [docs/development.md](docs/development.md) - local setup, verification commands and CI mirrors
+- [docs/perf-testing.md](docs/perf-testing.md) - performance test tiers
+- [docs/data-dictionary-cnes.md](docs/data-dictionary-cnes.md) - canonical CNES/Gold dictionary
+- [docs/data-dictionary-firebird-bigquery.md](docs/data-dictionary-firebird-bigquery.md) - local/national CNES dictionary
+- [docs/data-dictionary-bpa.md](docs/data-dictionary-bpa.md) - BPA dictionary
+- [docs/data-dictionary-sia.md](docs/data-dictionary-sia.md) - SIA dictionary
+- [docs/data-dictionary-sihd-hospital.md](docs/data-dictionary-sihd-hospital.md) - SIHD dictionary
+- [docs/runbooks/](docs/runbooks/) - operational runbooks for agent setup, cutover and access requests
+
+## Notes for Contributors
+
+- Read the nearest `CLAUDE.md` before editing an app or package.
+- Keep tenant isolation explicit; Postgres access must run under the tenant context/RLS path.
+- Do not reintroduce the removed monolithic `src/main.py` CLI or Excel/CSV report flow.
+- Generated contract files in `docs/contracts/` must stay in sync with source models.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,13 +6,17 @@
 ## Visão macro
 
 Plataforma distribuída edge/central para reconciliação de dados de saúde
-pública. Edge Agents (`dumpagent_go`) rodam próximo às fontes municipais
-(Firebird CNES, SIHD hospitalar), extraem Parquet raw e fazem upload via
-URL pré-assinada para MinIO. O `central_api` (FastAPI) orquestra jobs e
-emite presigned URLs. O `data_processor` (worker) consome jobs, baixa
-Parquet do MinIO, aplica transformações canônicas e persiste no schema
-Gold Postgres com isolamento por tenant (RLS). Regras de auditoria são
-aplicadas por serviço externo via SQL JOINs contra o Gold.
+pública. Edge Agents (`apps/dump_agent_go`) rodam próximo às fontes
+municipais (Firebird CNES, SIHD hospitalar, BPA-Mag, SIA DBF), extraem
+Parquet raw e registram manifests N-arquivos. O `central_api` (FastAPI)
+orquestra cadastro/enfileiramento de extrações, dashboard, ativação de
+agentes e provisionamento de certificados. O Postgres guarda schemas
+`landing`, `gold`, `dashboard` e `auth` com isolamento por tenant (RLS).
+
+Estado atual: contratos, migrations, edge agent, API e dashboard estão
+ativos. O `data_processor` ainda é um esqueleto de polling/download; a
+ligação completa Parquet -> Gold está pendente. Regras de auditoria são
+aplicadas por serviço externo via SQL JOINs contra Gold/landing.
 
 ## Data flow
 
@@ -24,35 +28,34 @@ aplicadas por serviço externo via SQL JOINs contra o Gold.
 │         │                      │                              │
 │         └──────┬───────────────┘                              │
 │                ▼                                              │
-│          dump_agent (daemon)                                  │
+│          dump_agent_go (daemon)                               │
 │          - 3-query extraction + merge (CNES)                  │
 │          - streaming Parquet gzip                             │
 │          - single-instance lock                               │
 │                │                                              │
-│                │ HTTPS (long poll)                            │
+│                │ HTTPS + manifest register                    │
 └────────────────┼──────────────────────────────────────────────┘
                  │
 ┌────────────────┼──────────────────────────────────────────────┐
 │ CENTRAL        ▼                                              │
 │         central_api (FastAPI)                                 │
-│          - /jobs/next (lease)                                 │
-│          - /jobs/{id}/artifact (presigned PUT)                │
-│          - /jobs/{id}/heartbeat                               │
-│          - /jobs/{id}/complete                                │
+│          - /api/v1/extractions/enqueue                        │
+│          - /api/v1/jobs/register                              │
+│          - /oauth/device_authorization                        │
+│          - /provision/cert                                    │
 │          - TenantMiddleware (X-Tenant-Id)                     │
 │          - lease reaper (background task)                     │
 │                │                                              │
 │       ┌────────┴────────┐                                     │
 │       ▼                 ▼                                     │
-│  [Postgres queue]   [MinIO]  ← presigned GET/PUT              │
+│  [Postgres landing] [MinIO]                                   │
 │       │                 ▲                                     │
 │       │                 │                                     │
 │       ▼                 │                                     │
 │   data_processor ───────┘                                     │
-│   - download Parquet                                          │
-│   - transform (CPF pipeline, dedup, CH flag)                  │
-│   - row_mapper (dim/fato)                                     │
-│   - upsert Postgres Gold (merge JSONB fontes)                 │
+│   - polling/download skeleton                                 │
+│   - adapters + repos existem                                  │
+│   - Parquet -> Gold wiring pendente                           │
 │                │                                              │
 │                ▼                                              │
 │       [Postgres Gold]                                         │
@@ -81,36 +84,56 @@ aplicadas por serviço externo via SQL JOINs contra o Gold.
 Both emit **N-file manifests**: one `ClaimedJob` per
 `(source_type, competencia)` → N Parquets uploaded to MinIO via N presigned
 PUTs → single `POST /api/v1/jobs/register` with the manifest list.
-`data_processor` has BPA + SIA adapters downstream (see
-`apps/data_processor/CLAUDE.md`).
+`data_processor` has BPA + SIA mapping helpers downstream, but the current
+worker loop does not yet execute the full ingestion path.
 
-**Spike status:** T1 FB 1.5 wire-protocol validation via `nakagami/firebirdsql`
-is **DEFERRED**. Runtime validation blocked at fixture generation
-(fdb/FB1.5 symbol mismatch); pivot tracked in issue #51.
+**Spike status:** FB 1.5 runtime parity is validated in CI through synthetic
+schema coverage. Production nullability introspection against a real
+`BPAMAG.GDB` remains an operational follow-up.
 
 ## Contratos entre apps
 
-### Edge → Central (HTTPS)
+### API surface atual
 
-| Verb + Path | Payload | Response |
+| Verb + Path | Consumidor | Descrição |
 |---|---|---|
-| `GET /api/v1/jobs/next?machine_id=<id>` | header `X-Tenant-Id` | `{job_id, intent, lease_until}` ou 204 |
-| `POST /api/v1/jobs/{id}/heartbeat` | `{}` | `{lease_until}` |
-| `POST /api/v1/jobs/{id}/artifact` | `{filename, size}` | `{presigned_url, object_key}` |
-| `POST /api/v1/jobs/{id}/complete` | `{object_key, rows}` | 204 |
-| `POST /api/v1/jobs/{id}/fail` | `{reason, retryable}` | 204 |
+| `GET /api/v1/system/health` | ops / smoke | Health da API + Postgres |
+| `POST /api/v1/extractions/enqueue` | admin/dev | Cria jobs `landing.extractions` por `source_type` |
+| `POST /api/v1/jobs/register` | edge agent | Registra manifest N-arquivos extraído pelo agente |
+| `GET /api/v1/dashboard/auth/me` | dashboard | Identidade/tenant do usuário |
+| `GET /api/v1/dashboard/tenants` | dashboard | Tenants disponíveis |
+| `GET /api/v1/dashboard/agents/status` | dashboard | Status agregado de agentes |
+| `GET /api/v1/dashboard/agents/runs` | dashboard | Execuções recentes |
+| `GET /api/v1/dashboard/overview` | dashboard | KPIs do tenant |
+| `GET /api/v1/dashboard/overview/faturamento` | dashboard | Série de faturamento |
+| `GET /api/v1/dashboard/access-requests/mine` | dashboard | Solicitações do usuário |
+| `POST /api/v1/dashboard/access-requests` | dashboard | Cria solicitação de acesso |
+| `GET /api/v1/dashboard/access-requests/available-tenants` | dashboard | Tenants solicitáveis |
+| `POST /oauth/device_authorization` | edge agent | Inicia OAuth device flow |
+| `POST /oauth/token` | edge agent | Troca device code/refresh por token |
+| `POST /activate/confirm` | dashboard | Aprova device flow |
+| `POST /provision/cert` | edge agent | Emite certificado cliente |
+| `POST /provision/cert/rotate` | edge agent | Rotaciona certificado cliente |
+
+O fluxo antigo `/jobs/next`, `/jobs/{id}/artifact`, heartbeat e complete
+por rota HTTP não é a superfície atual do código. A forma ativa é
+`landing.extractions` + manifest via `/api/v1/jobs/register`.
 
 ### Central → MinIO
 
-- Presigned PUT URLs (validade: 1h) para upload de Parquet
-- Presigned GET URLs (validade: 1h) para download pelo `data_processor`
+- Fluxo alvo: URLs pré-assinadas para PUT/GET de Parquet
+- Código atual: manifests registram `minio_key`, `fato_subtype`, `size_bytes`
+  e `sha256`; emissão de presigned URLs não está exposta na API atual
 - Bucket único: `cnesdata-landing` (configurável via `MINIO_BUCKET`)
-- Key convention: `<tenant_id>/<intent>/<competencia>/<job_id>.parquet.gz`
+- Convenção recomendada de key:
+  `<tenant_id>/<source_type>/<competencia>/<job_id>.parquet.gz`
 
-### Processor → Central
+### Processor
 
-Mesmo pattern de polling dos edges — o processor consome da mesma fila,
-filtrando por `status=ready_to_process`.
+O processor atual não chama o `central_api` para polling. Ele acessa
+`landing.extractions` via `cnes_infra.storage.extractions_repo` e ainda
+possui funções finais (`complete`, `fail`, `heartbeat`, `mark_uploaded`,
+`reap_expired`) pendentes.
 
 ## Modelo de dados Gold
 
@@ -148,44 +171,38 @@ filtrando por `status=ready_to_process`.
 Todas as tabelas têm Row-Level Security ativa. Queries sem `tenant_id` no
 contexto (via `set_tenant_id()` do `cnes_domain.tenant`) retornam vazio.
 
-## Fluxo de jobs (estados)
+## Fluxo de jobs (landing.extractions)
 
-```
-   ┌─────────┐       lease       ┌────────┐
-   │ pending ├──────────────────▶│ leased │
-   └────┬────┘                   └───┬────┘
-        │                            │
-        │ lease expired              │ heartbeat
-        │ (reaper)                   │
-        ◀────────────────────────────┤
-        │                            │
-        │                            │ complete
-        │                            ▼
-        │                      ┌──────────┐
-        │                      │ uploaded │
-        │                      └────┬─────┘
-        │                           │ processor picks
-        │                           ▼
-        │                   ┌─────────────┐
-        │                   │ processing  │
-        │                   └──────┬──────┘
-        │                          │
-        │                          │ success
-        │                          ▼
-        │                   ┌─────────────┐
-        │                   │ completed   │
-        │                   └─────────────┘
-        │
-        │ fail (retryable)
-        ▼
-   ┌─────────┐  exceeded retries  ┌─────────────┐
-   │ pending │ ──────────────────▶│ dead_letter │
-   └─────────┘                    └─────────────┘
+Tabela principal: `landing.extractions`.
+
+Campos centrais: `job_id`, `tenant_id`, `source_type`, `competencia`,
+`files` JSONB, `depends_on` UUID[], `status`, `lease_until`,
+`agent_version`, `machine_id`.
+
+Status aceitos pela migration atual:
+
+```text
+PENDING, UPLOADED, PROCESSING, INGESTED, FAILED, DLQ,
+REGISTERED, CLAIMED, COMPLETED
 ```
 
-Tabelas: `public.jobs` (fila), `public.job_retries`, `public.job_leases`.
-Reaper do `central_api` roda a cada `_REAPER_INTERVAL=60s` e volta leases
-expirados para `pending`.
+Fluxo implementado no código atual:
+
+```text
+POST /api/v1/extractions/enqueue
+  -> cria landing.extractions status=PENDING
+
+POST /api/v1/jobs/register
+  -> atualiza PENDING/CLAIMED para REGISTERED
+  -> grava files, agent_version, machine_id
+
+data_processor.poll
+  -> claim_next tenta mover PENDING para CLAIMED
+  -> complete/fail ainda pendentes em extractions_repo
+```
+
+Fluxo alvo: `REGISTERED`/`UPLOADED` -> `PROCESSING` -> `INGESTED` ou
+`FAILED`/`DLQ`, preservando `depends_on` para dimensões SIA antes dos fatos.
 
 ## Multi-tenancy
 
@@ -261,7 +278,7 @@ python scripts/fb156_setup.py   # extract FB 1.5.6 client to .cache/
 
 Single `docker-compose.yml` com 3 profiles:
 
-- **`dev`** — postgres, minio, migrator, central-api, data-processor, pg-seed, minio-init. Portas 5433/9000/8000.
+- **`dev`** — postgres, minio, migrator, central-api, data-processor, pg-seed, minio-init, web_dashboard, keycloak. Portas 5433/9000/9001/8000/5173/8080.
 - **`perf`** — postgres_perf (tuned), firebird_perf. Portas 5434/3051.
 - **`shadow`** — firebird-shadow (FB 2.5-ss), minio-shadow. Portas 3052/9100. Usado por `.github/workflows/shadow-e2e.yml`.
 
@@ -271,6 +288,9 @@ docker compose --profile dev up -d
 docker compose --profile perf up -d
 docker compose --profile shadow up -d
 ```
+
+Nota: na branch atual, `data-processor` pode logar erros das funções
+pendentes em `extractions_repo` se houver jobs a processar.
 
 ## web_dashboard (2026-04 — v1.0 + v1.1)
 
@@ -289,7 +309,7 @@ docker compose --profile shadow up -d
   procedimentos competência atual, % cobertura) + faturamento area chart
   12m por estabelecimento via `@tremor/react` lazy-loaded
 - `/access-pending` — fluxo JIT de signup self-service: usuário sem tenant
-  preenche solicitação (`POST /api/v1/access-requests`), grava em
+  preenche solicitação (`POST /api/v1/dashboard/access-requests`), grava em
   `dashboard.access_requests` (status `pending`); aprovação manual via
   SQL admin v1.1 (UI em v1.2 — ver `docs/runbooks/access-request-approval.md`)
 - Dark mode 3-state (light/dark/system) via `ThemeProvider` + matchMedia +

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,175 @@
+# CnesData — Development
+
+This page keeps local setup and verification commands in one place. It mirrors
+the CI workflows where practical.
+
+## Toolchain
+
+| Tool | Version / source |
+|---|---|
+| Python | 3.13 |
+| Python package manager | `uv` |
+| Go | 1.26 |
+| Frontend runtime | Bun 1.3 |
+| Database | PostgreSQL 16 via Docker Compose |
+| Object storage | MinIO via Docker Compose |
+
+For Firebird fixture archives, run:
+
+```bash
+git lfs pull
+uv run python scripts/fb156_setup.py
+```
+
+## Local Stack
+
+Start all local development services:
+
+```bash
+docker compose --profile dev up -d
+```
+
+Useful endpoints:
+
+| Service | URL |
+|---|---|
+| Central API | http://localhost:8000 |
+| Swagger UI | http://localhost:8000/docs |
+| Health | http://localhost:8000/api/v1/system/health |
+| Web dashboard | http://localhost:5173 |
+| Keycloak | http://localhost:8080 |
+| MinIO console | http://localhost:9001 |
+| Postgres | `localhost:5433` |
+
+Run only the API from the workspace:
+
+```bash
+uv run uvicorn central_api.app:create_app --factory --reload
+```
+
+Run Alembic migrations manually:
+
+```bash
+cd packages/cnes_infra
+uv run alembic -c alembic.ini upgrade head
+```
+
+## Contract Generation
+
+The central API OpenAPI document and Pydantic JSON Schemas are generated
+artifacts. Regenerate them after changing routes or contracts:
+
+```bash
+uv run python scripts/gen_openapi.py
+uv run python scripts/gen_contracts.py
+```
+
+CI checks that:
+
+- `docs/contracts/openapi.json` matches `scripts/gen_openapi.py`
+- `docs/contracts/schemas/` matches `scripts/gen_contracts.py`
+- `apps/web_dashboard/src/api/generated.ts` matches `docs/contracts/openapi.json`
+
+For the dashboard client:
+
+```bash
+cd apps/web_dashboard
+bun run codegen
+```
+
+## Python Verification
+
+Lint everything:
+
+```bash
+uv run ruff check .
+```
+
+Core packages with coverage:
+
+```bash
+uv run pytest \
+  packages/cnes_domain packages/cnes_infra \
+  -m "not bigquery and not e2e and not stress and not soak and not spike" \
+  --cov --cov-config=pyproject.toml \
+  --cov-report=term-missing
+```
+
+Apps with coverage:
+
+```bash
+uv run pytest \
+  apps/ \
+  -m "not integration and not bigquery and not e2e and not stress and not soak and not spike and not windows_only" \
+  --cov --cov-config=.coveragerc \
+  --cov-report=term-missing
+```
+
+Quality suites:
+
+```bash
+uv run pytest tests/property/ -m race --hypothesis-show-statistics -v
+uv run pytest tests/memory/ -m memleak --memray --memray-bin-path=/tmp/memray/
+uv run pytest tests/chaos/ -m "chaos and not chaos_infra" -v
+uv run pytest tests/negative/ -m negative -v
+```
+
+## Go Edge Agent
+
+```bash
+cd apps/dump_agent_go
+make install-tools
+make lint
+make test
+make build-linux
+make build-windows
+```
+
+Filtered coverage gate used by CI:
+
+```bash
+go test -race -count=1 -coverprofile=coverage.out ./...
+grep -v -E "internal/apiclient/generated\.go|cmd/|internal/service/|_windows\.go:" \
+  coverage.out > coverage.filtered.out
+go tool cover -func=coverage.filtered.out | tail -1
+```
+
+Integration test labels in GitHub:
+
+| Label | Effect |
+|---|---|
+| `run-windows-integration` | Runs Windows Firebird integration |
+| `run-integration` | Runs Linux SIA integration |
+
+## Web Dashboard
+
+```bash
+cd apps/web_dashboard
+bun install
+bun run codegen
+bun run lint
+bun run format:check
+bun run typecheck
+bun run test --coverage
+bun run e2e
+bun run build
+bun run bundle:check
+```
+
+Playwright may need browser dependencies locally:
+
+```bash
+bunx playwright install --with-deps chromium
+```
+
+## Performance Suites
+
+See [perf-testing.md](perf-testing.md) for thresholds and interpretation.
+
+```bash
+uv run pytest tests/perf/micro -m perf_micro --benchmark-only
+uv run pytest tests/perf/macro -m perf_macro --benchmark-only
+uv run pytest tests/perf/stress -m stress -v
+uv run pytest tests/perf/soak -m soak -v
+uv run pytest tests/perf/spike -m spike -v
+```

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -1,316 +1,180 @@
 # CnesData — Project Context
 
-> Living document. Last updated: 2026-04-18.
-> Audience: the developer (Vinícius), colleagues who will run the pipeline,
-> and any future AI session that needs to understand this project deeply.
+> Living document. Last updated: 2026-07-08.
+> Audience: developers, operators, and future AI sessions that need the
+> project shape without rediscovering the whole repository.
 
----
+## What This Project Is
 
-## 1. What This Project Is
+CnesData is a distributed data platform for Brazilian public-health data
+reconciliation. It captures raw municipal SUS data at the edge, lands it in a
+central multi-tenant platform, and exposes canonical contracts for downstream
+processing and audit services.
 
-CnesData is a **deterministic data reconciliation engine** for public health workforce data. It receives data from municipal CNES databases, cross-references it against the national CNES via BigQuery, and produces structured audit reports identifying inconsistencies, ghost registrations, and allocation errors.
+Pilot municipality: Presidente Epitacio/SP (`tenant_id=354130`, CNPJ
+`55.293.427/0001-17`). The architecture is multi-municipality by design:
+tenant isolation is enforced with `X-Tenant-Id`, `cnes_domain.tenant`, and
+Postgres RLS.
 
-**Pilot municipality:** Presidente Epitácio/SP (IBGE 354130, CNPJ 55.293.427/0001-17, population ~42,000).  
-**Architecture direction:** multi-municipality API engine fed by lightweight **dump agents** that run locally at each municipality and send data via HTTP.
+Current repository scope:
 
-The output is a single Excel workbook with a summary dashboard and one tab per violated audit rule, each containing actionable recommendations in Portuguese. The file is designed to be opened by a health department coordinator with no technical background.
+- Edge extraction agent in Go (`apps/dump_agent_go`)
+- Central API and dashboard (`apps/central_api`, `apps/web_dashboard`)
+- Canonical contracts and storage/adapters (`packages/cnes_contracts`,
+  `packages/cnes_domain`, `packages/cnes_infra`)
+- Migration runner (`apps/cnes_db_migrator`)
+- Data processor skeleton plus source adapters/repositories
 
-**In one sentence:** CnesData tells the municipality "here are the professionals who shouldn't be where they are, aren't where they should be, or don't exist in the system they're supposed to be in."
+Out of scope for this repo: the rules/audit service that consumes the central
+Gold or landing schemas through SQL.
 
-### Current Operational Mode vs. Target Architecture
+## Why It Exists
 
-**Current architecture (2026-04):** monorepo distribuído com 2 packages
-(`cnes_domain`, `cnes_infra`) e 4 apps (`dump_agent` edge, `central_api`
-FastAPI, `data_processor` worker, `cnes_db_migrator` init-container). Ver
-`docs/architecture.md` para diagrama completo e contratos.
+Municipal CNES data and national DATASUS/CNES data often diverge. Those
+differences affect SUS funding, workforce planning, legal compliance, and audit
+readiness. Before this project, reconciliation was manual: operators exported
+local Firebird data, checked national data by hand, and assembled findings in
+spreadsheets.
 
-Migração concluída: a CLI monolítica `src/main.py` + `pipeline/orchestrator.py`
-+ `rules_engine.py` + exporters Excel/CSV foram removidos. Extração, orquestração
-e persistência agora vivem em apps separados; regras de auditoria ficaram em
-serviço externo (fora deste repo) que consome o schema Gold via SQL JOINs.
+CnesData exists to make that process deterministic and repeatable:
 
----
+- Capture source data near the municipality instead of requiring central
+  Firebird access.
+- Preserve provenance by source (`CNES_LOCAL`, `CNES_NACIONAL`, `SIHD`,
+  `BPA_MAG`, `SIA_LOCAL`).
+- Store raw landing manifests and canonical facts under tenant isolation.
+- Let audit rules run downstream against stable contracts instead of raw source
+  schemas.
 
-## 2. Why This Project Exists
+## Current Architecture
 
-### The Problem
+The current implementation is a monorepo with shared packages and deployable
+apps.
 
-Brazil's public health system (SUS) requires every municipality to maintain accurate records of health professionals in the CNES system. These records determine:
-
-- **Federal funding allocation** — funding is tied to registered professionals and teams.
-- **Workforce planning** — which health units are understaffed, which have ghost staff.
-- **Legal compliance** — professionals must be registered before providing SUS-funded care.
-
-In practice, the local CNES database (Firebird, maintained by the municipality) and the national CNES database (DATASUS, published via BigQuery) frequently **diverge**. Professionals appear in one system but not the other. CBO codes (job classifications) don't match. Workload hours differ. Establishments exist locally but were never sent to the national database.
-
-These inconsistencies have real consequences:
-
-- **Ghost Payroll** — professionals registered in CNES but absent from the payroll system may indicate diversion of public funds ("profissional fantasma").
-- **Missing Registration** — professionals working and receiving salary but missing from CNES means the municipality can't claim federal funding for their work.
-- **Allocation Errors** — community health agents (ACS) must be linked to specific unit types. Wrong assignments violate federal guidelines and risk audit findings from oversight bodies (TCE-SP, Controladoria).
-
-Before CnesData, this reconciliation was done **manually** — someone would open the Firebird database, export to Excel, and visually compare against printouts from the national system. This process took days, was error-prone, and happened at best once per quarter.
-
-### The Solution
-
-CnesData automates this entire process into a single command:
-
-```powershell
-python src\main.py -c 2024-12 -v
+```text
+Municipal edge sources
+  CNES Firebird / SIHD / BPA-Mag Firebird / SIA DBF
+        |
+        v
+  dump_agent_go
+  - extracts raw rows
+  - writes parquet.gz files
+  - registers N-file manifests with object-storage keys
+  - registers N-file manifests with central_api
+        |
+        v
+  central_api
+  - tenant middleware
+  - extraction enqueue/register endpoints
+  - dashboard read APIs
+  - OAuth device activation
+  - certificate provisioning and rotation
+        |
+        +--> MinIO/S3 landing bucket
+        +--> Postgres schemas: landing, gold, dashboard, auth
+        |
+        v
+  data_processor
+  - polling skeleton exists
+  - full Parquet-to-Gold ingestion wiring is still pending
 ```
 
-Or, with the scheduled task, it runs unattended on the 15th of every month.
+See `docs/architecture.md` for the more detailed system model, route map, job
+state, and deploy target.
 
----
+## Source Contracts
 
-## 3. Architecture — How It Works
+Landing source types are defined in `packages/cnes_contracts/src/cnes_contracts/landing.py`.
 
-### Data Flow
-
-```
-[ Dump Agent ]                      BigQuery (national)
-  (runs at municipality)                    │
-  Firebird CNES.GDB                         │
-        │                                   │
-        │ parquet → HTTP POST               │
-        ▼                                   ▼
-  CnesLocalAdapter                 CnesNacionalAdapter
-        │                                   │
-        └──────────────┬────────────────────┘
-                       ▼
-           Schema Padronizado (schemas.py)
-                       │
-                       ├──► transformer.py (CPF validation, zero-hours flag)
-                       │
-                       ▼
-               PostgreSQL (upsert por competência)
-```
-
-**Current state:** `IngestaoLocalStage` connects to Firebird directly. In production, dump agents will POST parquet to the API endpoint.
-
-**Audit rules:** removed from the pipeline — applied by a separate service via SQL JOINs on the PostgreSQL tables.
-
-### Key Design Decisions
-
-**Deterministic source selection (`target_source`)** — The data source is declared at invocation time (`--source LOCAL|NACIONAL|AMBOS`), never inferred from availability. If `LOCAL` is requested but no parquet exists, `StageSkipError` is raised — no silent fallback to national data. This preserves audit provenance: `FONTE=LOCAL` and `FONTE=NACIONAL` data must never be silently mixed.
-
-**Repository/Protocol Pattern (PEP 544)** — The analysis layer never sees Firebird column names or BigQuery column names. Both adapters translate to a canonical schema (`schemas.py`). Adding a third data source (e.g., dump agent JSON, e-SUS) requires only a new adapter — zero changes to business rules.
-
-**CNS as cross-check key, not CPF** — The national BigQuery database does not expose CPF (privacy). The Cartão Nacional de Saúde (CNS, 15 digits) is the only reliable identifier available in both sources for professional-level reconciliation. This was discovered empirically, not assumed upfront.
-
-**WIN1252 charset + NFKD normalization** — Firebird CNES.GDB is encoded in WIN1252. The `fdb.connect()` call explicitly passes `charset="WIN1252"`. String columns with accented names (e.g., "Atenção Básica") are NFKD-normalized in `cnes_local_adapter.py` before any merge operations to prevent false non-matches against national data.
-
-**Three Firebird queries instead of one** — The original single query with LEFT JOINs to team tables (LFCES048 → LFCES060) produced all NULLs due to a Firebird 2.5 embedded engine bug with mismatched join keys. The solution splits extraction into three queries (professionals, team members, teams) and merges in Python via a 4-character prefix match on `SEQ_EQUIPE`. Documented in `cnes_client.py` and `docs/data-dictionary-firebird-bigquery.md`.
-
-**Competência lag** — DATASUS publishes national data ~2 months delayed. The pipeline accounts for this: CLI auto-detects competência as `current month - 2`, configurable via PowerShell automation.
-
-### Module Inventory
-
-Ver `apps/<app>/CLAUDE.md` e `packages/<pkg>/CLAUDE.md` para inventário
-de módulos atualizado. Arquivos do layout antigo (`src/cli.py`,
-`src/main.py`, `src/pipeline/orchestrator.py`, `src/ingestion/cnes_client.py`,
-etc.) foram removidos em 2026-04 com a migração para monorepo.
-
----
-
-## 4. The 11 Audit Rules
-
-> **Histórico (2026-04):** a camada de regras de auditoria foi removida
-> deste repo. Regras RQ-* listadas abaixo são aplicadas por serviço externo
-> que consome o schema Gold (`gold.dim_estabelecimento`, `gold.dim_profissional`,
-> `gold.fato_vinculo`) via SQL JOINs. Documentação mantida aqui como
-> referência histórica.
-
-### Local Rules (Firebird only)
-
-| Rule | What It Detects | Key | Action |
-|---|---|---|---|
-| RQ-002 | Invalid CPF (null, wrong length) | CPF | Exclude from analysis + log |
-| RQ-003 | Zero workload hours ("zombie link") | CH_TOTAL | Flag as ATIVO_SEM_CH |
-| RQ-003-B | Professional linked to 2+ health units | CPF × CNES | Review with HR if structural |
-| RQ-005 ACS/TACS | Community health agent in wrong unit type | CBO × TIPO_UNIDADE | Transfer to correct unit |
-| RQ-005 ACE/TACE | Endemic control agent in wrong unit type | CBO × TIPO_UNIDADE | Transfer to correct unit |
-
-### Cross-Check Rules (Local × National)
-
-| Rule | What It Detects | Key | Severity |
-|---|---|---|---|
-| RQ-006 | Establishment in local but not in national | CNES | ALTA |
-| RQ-007 | Establishment in national but not in local | CNES | ALTA | Excludes tipo 22 (private clinics, other maintainers) |
-| RQ-008 | Professional in local but not in national | CNS | CRÍTICA |
-| RQ-009 | Professional in national but not in local | CNS | ALTA | Cascade-filters professionals from RQ-007 missing establishments |
-| RQ-010 | Same professional+establishment, different CBO | CNS+CNES | MÉDIA | Includes DESCRICAO_CBO_LOCAL/NACIONAL columns |
-| RQ-011 | Same professional+establishment, workload delta > 0h | CNS+CNES | BAIXA |
-
-### HR Cross-Check Rules (Local × Payroll — suspended, requires `hr_padronizado.csv`)
-
-| Rule | What It Detects | Key |
+| Source type | Meaning | File subtypes |
 |---|---|---|
-| Ghost Payroll | Active in CNES, absent/inactive in payroll | CPF | CRÍTICA |
-| Missing Registration | Active in payroll, absent in CNES | CPF | ALTA |
+| `CNES_LOCAL` | Municipal CNES Firebird extract | `CNES_VINCULO` |
+| `CNES_NACIONAL` | National CNES extract | `CNES_VINCULO` |
+| `SIHD` | Hospital AIH production | `SIHD_INTERNACAO`, `SIHD_PROC_AIH` |
+| `BPA_MAG` | BPA-Mag Firebird extract | `BPA_C`, `BPA_I` |
+| `SIA_LOCAL` | Local SIA DBF extract | `DIM_SIGTAP`, `DIM_MUNICIPIO`, `SIA_APA`, `SIA_BPI`, `SIA_BPIHST` |
 
----
+Contract artifacts:
 
-## 5. The Data Sources — What We Know
+- OpenAPI: `docs/contracts/openapi.json`
+- JSON Schemas: `docs/contracts/schemas/`
+- Regeneration scripts: `scripts/gen_openapi.py`, `scripts/gen_contracts.py`
 
-### Firebird Local (CNES.GDB)
+## Historical Audit Context
 
-- **Engine:** Firebird 2.5 embedded (accessed via `fdb` + `fbembed.dll`)
-- **Key tables:** LFCES018 (professionals), LFCES004 (establishments), LFCES021 (links), LFCES048 (team members), LFCES060 (teams), NFCES026 (CBO domain — job title lookup)
-- **Municipality filter:** `CODMUNGEST = '354130'` AND `CNPJ_MANT = '55293427000117'`
-- **Current data:** ~357 professional-establishment links, ~330 unique professionals, ~20 establishments
-- **Quirks:** No declared foreign keys between LFCES048 and LFCES060. LEFT JOIN via fdb's `pd.read_sql()` fails with error -501. TRIM() unavailable in embedded engine. `CD_SEGMENT`/`DS_SEGMENT` columns return error -206 via alias in nested LEFT JOIN.
+Earlier versions of this project produced Excel/CSV reconciliation reports from
+a monolithic CLI (`src/main.py`). That flow was removed during the monorepo
+migration. The audit concepts remain useful domain context, but the rules now
+belong to an external service.
 
-### BigQuery National (basedosdados)
+Historical rule families:
 
-- **Access:** `basedosdados.read_sql()` with OAuth browser flow on first run
-- **Project:** `basedosdados` (public dataset), billing via `bd-prof-cnes`
-- **Tables:** `br_ms_cnes.profissional`, `br_ms_cnes.estabelecimento`, `br_ms_cnes.equipe`
-- **Municipality filter:** `id_municipio = '3541307'` (7-digit IBGE code with check digit)
-- **Partition columns:** `ano`, `mes` — MUST be in every WHERE clause (quota: 1TB/month free)
-- **Current data:** ~808 professional links, ~85 establishments (competência 2024-12)
-- **Key limitation:** No CPF field. CNS (`cartao_nacional_saude`) is the only cross-check key.
-- **Schema gotchas:** Column is `cbo_2002` (not `id_cbo`), `indicador_atende_sus` (not `indicador_sus`), integer 1/0 (not string S/N). All confirmed empirically against real schema.
+| Family | Examples | Current home |
+|---|---|---|
+| Local CNES quality | invalid CPF, zero workload, duplicate professional allocation | External rules service |
+| Local vs national CNES | establishment/professional missing on either side, CBO mismatch, workload delta | External rules service |
+| HR/payroll cross-check | ghost payroll, missing CNES registration | Planned external workflow |
+| Team-level audit | ESF/EAP/ESB composition and INE mismatches | Conceptual, blocked by source mapping |
 
-### HR Spreadsheet (not yet available)
+Important historical discoveries still matter:
 
-- **Parser ready:** `hr_client.py` accepts `.xlsx` or `.csv` with columns `CPF`, `NOME`, `STATUS`
-- **STATUS values:** `ATIVO`, `INATIVO`, `AFASTADO`
-- **Integration:** When `FOLHA_HR_PATH` is set in `.env`, Ghost Payroll and Missing Registration rules activate automatically
-- **Current state:** Direct HR integration (WP-003/WP-004) suspended. The system now requires a pre-processed `hr_padronizado.csv` generated by `scripts/hr_pre_processor.py` (Epic 3), which uses PIS-based cross-walking against LFCES018 to discover CPFs from raw HR spreadsheets.
+- Firebird CNES uses legacy WIN1252 data; sanitize before writing UTF-8 Parquet.
+- CNES extraction cannot be simplified into a single join because of the known
+  Firebird 2.5 join issue around team tables; keep the three-query merge.
+- National CNES does not expose CPF; CNS is the cross-source professional key.
+- Provenance must stay explicit. Do not silently merge local and national data.
 
----
+## Technical Environment
 
-## 6. Where It's Headed (Near-Term Roadmap)
-
-Ver `docs/roadmap.md` — fonte única de prioridades. Resumo: CNES+SIHD
-ativos, multi-tenant pronto, perf tests prontos. Próximo: BPA, Esus PEC,
-HR PIS→CPF, rules service.
-
----
-
-## 7. Where It Is Going (Architecture Direction)
-
-The engine is transitioning from a local CLI pipeline to a multi-municipality API reconciliation service. The architectural decisions made in 2026-04 (deterministic `target_source`, `StageSkipError` instead of silent fallback, proveniência imutável) are pre-requisites for this transition.
-
-### Active Direction: Dump Agent + API Model
-
-Each municipality runs a lightweight **dump agent** that:
-1. Connects to the local Firebird (`CNES.GDB`) with `charset=WIN1252`
-2. Extracts and serializes to parquet (`firebird_dump_YYYY-MM.parquet`)
-3. POSTs to the CnesData API endpoint
-4. Is stateless — no local state beyond the parquet file
-
-The API receives the parquet, validates via contracts, and persists in PostgreSQL with `(municipio, competencia)` as composite key. Audit rules are applied by a separate service via SQL JOINs.
-
-This means **no Firebird access from the server** — the engine never reaches into a remote database. Data arrives as structured artifacts.
-
-### Remaining Possibilities
-
-### 7.1 — Team-Level Audit
-
-The pipeline currently audits professionals and establishments. The next logical entity is **equipes de saúde** (health teams — ESF, EAP, ESB). Rules would include:
-
-- Team exists in local but not in national (analogous to RQ-006/007)
-- Team composition doesn't match minimum requirements (e.g., ESF must have at least 1 doctor, 1 nurse, 1 ACS per area)
-- INE (team identifier) format mismatch between Firebird (10 chars) and BigQuery (18 chars) — requires prefix matching analysis
-
-**Blocked by:** INE format incompatibility. The `docs/data-dictionary-firebird-bigquery.md` documents this gap. Needs investigation of how `id_equipe` in BigQuery maps to `INE` in Firebird.
-
-### 7.2 — Multi-Municipality
-
-The architecture already supports this — the `config.py` takes `COD_MUN_IBGE` and `ID_MUNICIPIO_IBGE7` as parameters. Running for a different municipality means:
-
-1. Access to their Firebird CNES.GDB file
-2. Changing two environment variables
-3. Running the same pipeline
-
-A regional health department (DRS) could run this for all municipalities in their jurisdiction. The limiting factor is **access to Firebird files** — each municipality maintains their own.
-
-### 7.3 — Web Dashboard
-
-Replace the Excel output with a web interface (Streamlit, Metabase, or custom). Would enable:
-
-- Interactive filtering by establishment, CBO, team
-- Drill-down from summary to individual records
-- Historical trend visualization (via PostgreSQL queries)
-- Multi-user access without distributing Excel files
-
-**Complexity:** High. The Excel report works well for the current audience (1-3 people). A dashboard makes sense when the audience grows or when managers want self-service analysis.
-
-### 7.4 — Automated DATASUS Submission Check
-
-After running the pipeline, automatically check whether the municipality's latest data has been successfully sent to DATASUS by comparing the local competência against the latest available in BigQuery. If the national data is stale (e.g., local is 2026-03 but national is 2025-11), alert that submissions may be failing.
-
-**Complexity:** Low (just compare competência dates). High operational value.
-
-> **Nota:** Epic 1 (CnesOficialWebAdapter) implementa acesso direto à API DATASUS para validação de estabelecimentos. Este adapter pode ser estendido para comparação de competência (detecção de envios faltantes).
-
-### 7.5 — Integration with e-SUS / SISAB
-
-e-SUS (Sistema Único de Saúde) and SISAB (Sistema de Informação em Saúde para a Atenção Básica) contain production data — actual patient visits, procedures performed. Cross-referencing CNES registration data against e-SUS production data would answer: "this professional is registered for 40h/week at this unit — do they actually produce 40h of patient care?" This is the deepest level of audit and the hardest to game.
-
-**Blocked by:** e-SUS data access (usually via API or local database, varies by municipality). Significant scope expansion.
-
----
-
-## 8. Technical Environment
-
-| Component | Value |
+| Component | Current value |
 |---|---|
-| Language | Python 3.11+ |
-| OS | Windows (development and production) |
-| Firebird | 2.5 embedded via `fdb` + `fbembed.dll` (64-bit) |
-| BigQuery | Via `basedosdados` package (OAuth browser flow) |
-| GCP Project | `bd-prof-cnes` |
-| IDE | VS Code |
-| AI Tooling | Claude Code (CLI) for development, Claude (web) for prompt design |
-| Test Framework | pytest (345 unit tests, integration tests with live Firebird) |
-| Automation | PowerShell (scripts/Run-CnesAudit.ps1 + Windows Task Scheduler via Schedule-CnesAudit.ps1) |
-| Excel Engine | openpyxl |
-| Task Scheduler | Windows Task Scheduler via PowerShell script |
-| Version Control | Git (local, not yet on remote) |
+| Python | 3.13 |
+| Python workspace | `uv` monorepo |
+| Go edge agent | Go 1.26 |
+| Frontend | Bun 1.3, React, Vite, TanStack Router/Query |
+| Central API | FastAPI + SQLAlchemy + MinIO + Keycloak/OIDC |
+| Database | PostgreSQL 16 locally; Kubernetes target for central services |
+| Object storage | MinIO locally; S3-compatible interface |
+| Edge runtime | Windows Service target, Linux supported for dev/CI |
+| Observability | stdlib structured logs; optional OTel |
+| Generated contracts | OpenAPI + JSON Schema under `docs/contracts/` |
 
-### Key Configuration (.env)
+## Current Operational State
 
-```ini
-DB_HOST=localhost
-DB_PATH=C:\Datasus\CNES\CNES.GDB
-DB_USER=SYSDBA
-DB_PASSWORD=masterkey
-FIREBIRD_DLL=C:\...\fb_64\fbembed.dll
-COD_MUN_IBGE=354130              # Firebird (6 digits)
-ID_MUNICIPIO_IBGE7=3541307       # BigQuery (7 digits)
-CNPJ_MANTENEDORA=55293427000117
-GCP_PROJECT_ID=bd-prof-cnes
-COMPETENCIA_ANO=2024
-COMPETENCIA_MES=12
-```
+Implemented and useful now:
 
----
+- Go edge extractors and Parquet writers for the active source families.
+- Central API route surface for health, dashboard, activation, provisioning,
+  extraction enqueue, and job registration.
+- Postgres migrations through `017_agent_metadata`.
+- Dashboard v1.1 for tenant overview, agent status, activation, dark mode, and
+  access-request flow.
+- Quality suites for Python, Go and frontend paths.
 
-## 9. What a New Session Needs to Know
+Known boundaries:
 
-If starting a new Claude Code or Claude session for this project:
+- `data_processor` has polling/download utilities and adapters, but the full
+  ingestion path from landing files to Gold tables is not fully wired.
+- `extractions_repo.complete`, `fail`, `heartbeat`, `mark_uploaded`, and
+  `reap_expired` are still deferred.
+- Rules/audit output is intentionally external to this repository.
+- Production Kubernetes manifests are incomplete outside the dashboard chart.
 
-1. **Entry point por app:** `apps/<app>/src/<app>/main.py` (central_api:
-   `app.py`). Começar lendo `apps/<app>/CLAUDE.md` para executive summary
-   + funcionalidades + env vars.
-2. **Arquitetura macro:** `docs/architecture.md` — data flow edge→central,
-   contratos HTTP, modelo Gold, fluxo de jobs.
-3. **Source of truth para colunas:** `packages/cnes_domain/contracts/` —
-   nunca referencie raw Firebird ou BigQuery column names em código de domínio.
-4. **Source of truth para regras:** `docs/data-dictionary-firebird-bigquery.md`
-   (histórico — regras aplicadas por serviço externo agora).
-5. **Test command (rápido):**
-   `pytest -m "not integration and not postgres and not bigquery and not e2e and not stress and not soak and not spike" -q`
-   — todos devem passar sem docker.
-6. **Firebird LEFT JOIN bug é real** — não simplificar `CnesExtractor`
-   para 1 query. Ver `apps/dump_agent/CLAUDE.md` gotchas.
-7. **Multi-tenant obrigatório:** toda query Postgres passa por
-   `set_tenant_id()` via middleware (`central_api`) ou direto no worker
-   (`data_processor`).
-8. **Gold schema é canônico:** `dim_estabelecimento`, `dim_profissional`,
-   `fato_vinculo` com `fontes` JSONB-object. Multi-fonte via merge `||`.
-9. **Deploy target k8s** — não em produção ainda. Ver `docs/architecture.md`
-   seção "Deploy target".
+## New Session Guide
+
+When starting work:
+
+1. Read `README.md` for the current repo map and quick start.
+2. Read `docs/architecture.md` for system contracts and data flow.
+3. Read the nearest `apps/<app>/CLAUDE.md` or `packages/<pkg>/CLAUDE.md`
+   before editing inside an app/package.
+4. Use `docs/development.md` for commands that mirror CI.
+5. Consult data dictionaries before changing source mappings or test fixtures:
+   `docs/data-dictionary-cnes.md`,
+   `docs/data-dictionary-firebird-bigquery.md`,
+   `docs/data-dictionary-bpa.md`,
+   `docs/data-dictionary-sia.md`,
+   `docs/data-dictionary-sihd-hospital.md`.
+
+Do not reintroduce the removed monolithic CLI, implicit source fallback, or
+Excel/CSV report generation as current architecture.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,47 +1,51 @@
 # CnesData — Roadmap
 
 > Fonte única da verdade sobre prioridades. Atualizar ao fechar/abrir escopo.
-> Histórico detalhado em `docs/project-context.md`.
+> Contexto narrativo em `docs/project-context.md`; arquitetura em
+> `docs/architecture.md`.
 
-## Now (em produção / ativo)
+## Now (implementado / útil)
 
 | Item | Estado | Evidência |
 |---|---|---|
-| CNES local via Firebird | Ativo | `dump_agent` extractors + data_processor adapter |
-| CNES nacional via BigQuery | Ativo | `cnes_infra.ingestion.web_client` + data_processor adapter |
-| CNES via DATASUS API | Ativo | `cnes_infra.ingestion.cnes_oficial_web_adapter` |
-| SIHD hospitalar | Ativo | `dump_agent.extractors.sihd_extractor` + data_processor adapter |
-| BPA (Boletim Produção Ambulatorial) | Ativo | `dump_agent_go.internal.extractor.ExtractBPA` + `data_processor.adapters.bpa_adapter` |
-| SIA (Sistema Info Ambulatorial) | Ativo | `dump_agent_go.internal.extractor.ExtractSIA` + `data_processor.adapters.sia_adapter` + `sia_dim_sync` |
-| Multi-tenant (RLS + Middleware) | Pronto, piloto PE/SP | `cnes_infra.storage.rls` + `central_api.middleware` |
-| Perf test pipeline (5 tiers) | Pronto | `tests/perf/{micro,macro,stress,soak,spike}/` + nightly workflow |
-| CI com gates triplos (Python packages 100% branch, apps 90% line; Go agent 65% filtered) | Pronto | `.github/workflows/ci.yml` + `.github/workflows/dump-agent-go.yml` |
-| Web dashboard v1.0 | Ativo | `apps/web_dashboard/` (Bun+React+OIDC), `/activate` para P4 device flow + status agentes via landing.extractions |
-| Web dashboard v1.1 | Ativo | `/overview` (KPIs + faturamento area chart 12m via Tremor lazy), `/access-pending` (signup JIT + admin SQL — runbook em `docs/runbooks/access-request-approval.md`), dark mode 3-state |
+| Contratos canônicos | Ativo | `packages/cnes_contracts/` + `docs/contracts/` |
+| CNES local edge | Ativo | `apps/dump_agent_go/internal/extractor/cnes.go` |
+| CNES nacional clients/adapters | Ativo em biblioteca | `cnes_infra.ingestion.web_client`, `cnes_infra.ingestion.cnes_oficial_web_adapter`, `data_processor.adapters.cnes_nacional_adapter` |
+| SIHD edge | Ativo | `apps/dump_agent_go/internal/extractor/sihd.go` |
+| BPA-Mag edge | Ativo | `apps/dump_agent_go/internal/extractor/bpa.go` |
+| SIA edge | Ativo | `apps/dump_agent_go/internal/extractor/sia.go` |
+| Landing N-file manifest | Ativo parcial | `landing.extractions`, `/api/v1/extractions/enqueue`, `/api/v1/jobs/register` |
+| Multi-tenant RLS + middleware | Pronto para piloto | `cnes_infra.storage.rls` + `central_api.middleware` |
+| OAuth device activation + mTLS provisioning | Ativo | `central_api.routes.oauth`, `central_api.routes.provision`, `apps/dump_agent_go/internal/auth` |
+| Web dashboard v1.1 | Ativo | `apps/web_dashboard/` (`/activate`, `/overview`, `/access-pending`, agent status, dark mode) |
+| Quality/perf suites | Ativo | `.github/workflows/ci.yml`, `python-quality.yml`, `dump-agent-go.yml`, `web-dashboard.yml`, `tests/perf/` |
 
-## Next (planejado, sem código ainda)
+## Next (planejado / pendente)
 
 | Item | Prioridade | Bloqueio / Pré-req |
 |---|---|---|
-| Esus PEC (Prontuário Eletrônico Cidadão) | Alta | Acesso ao DB municipal varia; negociação política |
-| HR PIS→CPF cross-walking | Média | `scripts/hr_pre_processor.py` existia em iteração anterior (61% cobertura) — reativar/reescrever no monorepo |
-| Rules service (serviço externo) | Média | Repo separado; consome Gold via SQL JOINs |
-| Automated DATASUS submission check | Baixa | Alert quando competência local > BigQuery nacional por > 2 meses |
-| Web dashboard v1.2 (faturamento+regressão, drill estab, admin UI approve/reject) | Média | substitui SQL manual de `docs/runbooks/access-request-approval.md` |
+| Completar `data_processor` landing -> Gold | Alta | Implementar `extractions_repo.complete/fail/heartbeat/mark_uploaded/reap_expired` e ligar download/adapters/repos |
+| End-to-end extraction lifecycle | Alta | Reconciliar status `PENDING/CLAIMED/REGISTERED/UPLOADED/PROCESSING/INGESTED` e presigned URL ownership |
+| Rules service externo | Média | Repo separado; consome Gold/landing via SQL JOINs |
+| HR PIS->CPF cross-walking | Média | Reativar/reescrever fluxo em monorepo |
+| Esus PEC | Alta | Acesso ao DB municipal varia; negociação política |
+| Automated DATASUS submission check | Baixa | Alertar quando competência local > nacional por mais de 2 meses |
+| Web dashboard v1.2 | Média | Faturamento+regressão, drill estabelecimento, admin UI approve/reject |
+| Kubernetes central stack | Média | Completar manifests/charts para API, processor, migrator, Postgres/MinIO ou serviços gerenciados |
 
-## Later (conceitual — sem comprometimento de escopo)
+## Later (conceitual)
 
 | Item | Motivação |
 |---|---|
-| Team-level audit | Audit de equipes ESF/EAP/ESB. Bloqueado por INE format gap (FB 10 chars vs BQ 18) |
-| Apps de fontes adicionais | SIGTAP e outros módulos DATASUS |
+| Team-level audit | Audit de equipes ESF/EAP/ESB; bloqueado por gap de formato INE (FB 10 chars vs BQ 18) |
+| Fontes DATASUS adicionais | SIGTAP e outros módulos |
 | Integração Pro-Saúde / CNES-WEB | Validação em tempo real de envios ao DATASUS |
 
-## Removido definitivamente (2026-04)
+## Removido definitivamente
 
 | Item | Razão |
 |---|---|
-| Camada de regras de auditoria (RQ-002 a RQ-011) | Movida para serviço externo que consome Gold via SQL JOINs |
-| Excel/CSV exporters (`csv_exporter`, `report_generator`) | Obsoleto com rules service externo; dashboards futuros substituem |
-| CLI monolítico `src/main.py` | Substituído por apps distribuídos (edge + central + processor) |
-| `pipeline/orchestrator.py` | Substituído por job queue em `central_api` + workers stateless |
+| CLI monolítico `src/main.py` | Substituído por apps distribuídos edge + central + processor |
+| `pipeline/orchestrator.py` | Substituído por landing queue e workers stateless |
+| Camada interna de regras RQ-002 a RQ-011 | Movida para serviço externo |
+| Excel/CSV exporters (`csv_exporter`, `report_generator`) | Obsoleto com rules service/dashboard |


### PR DESCRIPTION
## Summary

- Rewrites the root README around the current monorepo, central API, dashboard, Go edge agent, source contracts, and current `data_processor` boundary.
- Refreshes architecture, project context, and roadmap docs so they no longer describe the removed monolithic CLI/Excel flow as current.
- Adds `docs/development.md` with local setup, CI-mirror verification commands, contract generation, Go agent, dashboard, and perf commands.
- Updates `.env.example` to match the current central API, MinIO, dashboard auth, data processor, and Go edge-agent variables.

## Why

The existing README and parts of the docs still described the old `src/main.py` pipeline and Excel/CSV output path. This PR aligns the public project docs with the current distributed edge/central/dashboard architecture and calls out incomplete processor work explicitly.

## Impact

Developers and operators get a clearer entrypoint for local setup, current service boundaries, source contracts, and verification commands. No runtime code changes are included.

## Validation

- `rtk git diff --check`
- Stale-reference scan for removed CLI/Excel/current-state wording in the updated docs
- Trailing-whitespace scan for updated docs and `.env.example`