### PR TITLE
docs(planning): define CnesData redesign execution backlog

### DIFF
--- a/docs/superpowers/specs/2026-08-16-parquet-data-plane-orchestration-design.md
+++ b/docs/superpowers/specs/2026-08-16-parquet-data-plane-orchestration-design.md
@@ -1,0 +1,678 @@
+# CnesData — Data Plane Parquet e Orquestração — V2
+
+**Status:** aprovado para planejamento
+
+**Versão:** V2
+
+**Data:** 2026-08-16
+
+**Base de código:** `develop`
+
+## 1. Objetivo
+
+Redesenhar o CnesData como núcleo local-first com dois perfis operacionais:
+
+- `local`: instalação single-tenant por município, sem dependência de cloud;
+- `aws`: plataforma multi-tenant com serviços gerenciados da AWS.
+
+O desenho remove PostgreSQL, MinIO, Keycloak e BigQuery da arquitetura-alvo.
+Parquet versionado armazena dados raw, normalizados e reconciliados. JSON
+materializado atende o dashboard. SQLite e DynamoDB implementam o mesmo contrato
+de control plane nos perfis local e AWS, respectivamente.
+
+## 2. Decisões centrais
+
+| Tema | Decisão |
+|---|---|
+| Perfil local | Uma instalação e um diretório de dados por município |
+| Control plane local | SQLite em `state/cnesdata.sqlite3` |
+| Control plane AWS | DynamoDB multi-tenant; sem PostgreSQL/RDS |
+| Modelo canônico do control plane | `Tenant`, `Membership`, `Agent`, `Job`, `Run`, `RunUnit`, `DatasetVersion`, `DatasetPointer`, `AccessRequest` |
+| Primitivas internas do control plane | `IdempotencyRecord` e `OutboxEvent` |
+| Object store local | Filesystem |
+| Object store AWS | Amazon S3 |
+| Dados canônicos | Parquet versionado e imutável por execução |
+| Serving do dashboard | JSON materializado por `run_id` |
+| Analytics local | DuckDB embutido, não um serviço |
+| Analytics AWS | Athena opcional, fora do request path normal |
+| Formato de tabela inicial | Plain Parquet com manifestos e publicação atômica |
+| Iceberg | Adiado até existir necessidade de mutação concorrente |
+| Semântica de execução | At-least-once com idempotência e fencing |
+| TTL | Apenas garbage collection; expiração lógica é validada pela aplicação |
+| Índices DynamoDB | GSIs servem descoberta/listagem; autorização e commits usam chave base + conditional write |
+| SQS | Não é dependência mínima; se adotado, é transporte/wakeup, nunca fonte canônica de estado |
+| Reconciliação | Executada nos processadores centrais |
+| Delta no edge | Otimização de transporte, nunca única fonte recuperável |
+| Autenticação local | `AUTH_MODE=local` por default; OIDC opcional |
+| Autenticação AWS | OIDC genérico; Cognito é apenas um provider opcional |
+| Fonte nacional | Adapter DATASUS aprovado, sem runtime ou staging no BigQuery |
+
+### 2.1 Perfis de autenticação
+
+No perfil `local`, `AUTH_MODE=local` mantém usuários e hashes de senha no SQLite.
+`AUTH_MODE=oidc` permite SSO sem alterar o modelo de dados. O `tenant_id` é fixado
+pela instalação e nunca aceito de parâmetros ou claims enviados pelo navegador.
+
+No perfil `aws`, `AUTH_MODE=oidc` valida tokens de um issuer configurado e resolve o
+tenant por mapeamento server-side. Amazon Cognito pode ser oferecido como preset de
+deployment, mas não aparece nos contratos de domínio e não é uma dependência do
+produto. Keycloak não integra a arquitetura-alvo.
+
+### 2.2 Ingestão do CNES nacional
+
+`CNES_NACIONAL` entra por um adapter central que consulta a distribuição oficial do
+DATASUS, incluindo o adapter web já existente quando compatível com o source
+contract. Outros adapters aprovados podem ser adicionados, mas todos devem produzir
+o mesmo `RawManifest` e os mesmos objetos raw imutáveis usados pelas fontes de edge.
+
+BigQuery não é fonte canônica, staging area nem runtime dessa ingestão. Credenciais,
+datasets, jobs e configuração GCP são removidos após o cutover e a validação do novo
+adapter.
+
+### 2.3 Modelo canônico do control plane
+
+O contrato de domínio do control plane é explícito e independe do armazenamento físico:
+
+| Entidade | Responsabilidade |
+|---|---|
+| `Tenant` | configuração do município e políticas server-side |
+| `Membership` | vínculo de usuário, tenant e papel; base de autorização |
+| `Agent` | registro, identidade/certificado, versão, estado e `last_seen_at` |
+| `Job` | trabalho destinado ao Edge Agent, incluindo lease, tentativas e fencing |
+| `Run` | execução central de normalização/reconciliação/publicação |
+| `RunUnit` | unidade determinística de processamento pertencente a um `Run` |
+| `DatasetVersion` | metadados imutáveis de uma versão publicada |
+| `DatasetPointer` | alias mutável, como `CURRENT`, que aponta para uma versão publicada |
+| `AccessRequest` | solicitação e decisão de concessão de acesso |
+| `IdempotencyRecord` | primitiva interna para deduplicar operações por escopo e payload |
+| `OutboxEvent` | primitiva interna para entrega confiável de eventos de domínio/auditoria |
+
+`Job`, `Run` e `RunUnit` não são sinônimos. `Job` coordena trabalho solicitado a um
+Edge Agent. `Run` representa uma execução central de data processing. `RunUnit`
+representa o fan-out interno de um `Run`.
+
+`IdempotencyRecord` e `OutboxEvent` não são entidades de negócio expostas ao
+frontend. São primitivas de consistência do adapter de control plane.
+
+`DatasetVersion` nunca muda depois de publicada. A ativação de uma nova versão é
+feita alterando condicionalmente o `DatasetPointer`; histórico não é sobrescrito.
+
+## 3. Não objetivos
+
+- Não executar regras de negócio ou reconciliação no Edge Agent.
+- Não consultar Athena em cada interação do dashboard.
+- Não conceder ao frontend acesso direto aos Parquets raw ou normalizados.
+- Não oferecer uma instalação local multi-tenant no primeiro release.
+- Não prometer exactly-once entre agente, object store e processadores.
+- Não introduzir Iceberg, Spark, Redis, Kafka ou Kubernetes como dependências mínimas.
+- Não manter compatibilidade runtime com MinIO, PostgreSQL ou BigQuery após o cutover.
+
+## 4. Fronteira do Edge Agent
+
+### 4.1 Responsabilidades permitidas
+
+O agente executa somente transformações necessárias para ler e transportar a fonte
+com fidelidade:
+
+- descobrir caminhos e configurações das fontes locais;
+- acessar Firebird e DBF próximos à origem;
+- executar a extração específica de cada produto DATASUS;
+- preservar o merge técnico das três consultas CNES exigido pela fonte;
+- converter encoding legado para UTF-8 sem alterar significado;
+- tipar valores para o source contract versionado;
+- escrever Parquet comprimido e particionado;
+- calcular `row_count`, tamanho, SHA-256 e manifesto;
+- manter outbox local e retries;
+- detectar deltas para reduzir transmissão;
+- emitir diagnósticos e evidências de proveniência.
+
+### 4.2 Responsabilidades proibidas
+
+O agente não executa:
+
+- precedência entre CNES local, nacional ou outras fontes;
+- joins de negócio entre source types;
+- regras de auditoria ou classificação de divergências;
+- derivação de indicadores do dashboard;
+- mascaramento condicionado por plano ou assinatura;
+- publicação de datasets de serving;
+- decisões de acesso, quota ou faturamento.
+
+Transformações que alteram significado ou precisam ser reproduzidas historicamente
+pertencem ao processador central.
+
+## 5. Contrato raw e delta chain
+
+Cada upload possui um `RawManifest` imutável com, no mínimo:
+
+```json
+{
+  "manifest_version": 1,
+  "tenant_id": "354130",
+  "source_type": "CNES_LOCAL",
+  "file_subtype": "CNES_VINCULO",
+  "competencia": "2026-07",
+  "agent_id": "agent-01",
+  "agent_version": "1.0.0",
+  "schema_version": "cnes-local-v1",
+  "snapshot_mode": "FULL",
+  "snapshot_id": "01J...",
+  "base_snapshot_id": null,
+  "sequence": 1,
+  "previous_manifest_sha256": null,
+  "object_sha256": "...",
+  "row_count": 1000,
+  "object_key": "..."
+}
+```
+
+Um delta usa `snapshot_mode=DELTA`, informa `base_snapshot_id`, incrementa
+`sequence` e encadeia `previous_manifest_sha256`.
+
+O servidor rejeita o delta e solicita full snapshot quando:
+
+- houver gap de sequência;
+- o snapshot base não for conhecido ou não estiver publicado;
+- o hash chain divergir;
+- o source contract mudar de forma incompatível;
+- a versão do agente exigir ressincronização;
+- a base tiver mais de sete dias;
+- a cadeia atingir trinta deltas.
+
+Os limites iniciais são defaults de deployment e nunca podem ser desabilitados.
+Uma `PlanVersion` pode exigir full snapshots mais frequentes, mas não menos seguros.
+O modelo e a aplicação de planos estão definidos na especificação de
+[Stripe Billing, Entitlements e Revogação](2026-08-16-stripe-billing-entitlements-design.md).
+
+## 6. Camadas de dados
+
+### 6.1 Layout lógico
+
+```text
+raw/<tenant>/<source>/<competencia>/<snapshot_id>/
+normalized/<tenant>/<source>/<competencia>/<run_id>/
+reconciliation/<tenant>/<competencia>/<run_id>/
+serving/<tenant>/<run_id>/
+audit/<tenant>/<yyyy>/<mm>/<dd>/
+tmp/<tenant>/<run_id>/<unit_id>/<attempt>/
+```
+
+No filesystem, o prefixo parte do data directory da instalação. No S3, parte de
+um bucket privado por ambiente. O layout lógico e os manifestos são idênticos.
+
+### 6.2 Raw
+
+- Imutável e fiel ao source contract.
+- Sempre preserva proveniência e hashes.
+- Pode conter full snapshots e deltas.
+- Nunca é entregue diretamente ao navegador.
+
+### 6.3 Normalized
+
+- Padroniza chaves, datas, códigos e nullability.
+- Resolve deltas contra uma base full conhecida.
+- Continua separado por fonte para preservar proveniência.
+- Pode ser refeito integralmente a partir de raw.
+
+### 6.4 Reconciliation
+
+- Executa joins, precedência e regras entre fontes.
+- Publica Parquets imutáveis por `run_id`.
+- Inclui resultados, divergências, estatísticas e evidências.
+- Nunca sobrescreve um run anterior.
+
+### 6.5 Serving
+
+- Contém somente JSONs pequenos e orientados às telas.
+- Exclui campos pessoais que a tela não precisa.
+- Declara `run_id`, `generated_at` e schema version.
+- É publicado junto ao mesmo reconciliation run.
+
+## 7. Processadores centrais
+
+O data processor possui três estágios independentes:
+
+1. `NormalizeSource`: source Parquet para normalized Parquet;
+2. `ReconcileCompetencia`: normalized inputs para reconciliation Parquet;
+3. `MaterializeServing`: reconciliation Parquet para serving JSON.
+
+Polars é a primeira opção para transformação determinística. DuckDB pode ser usado
+para joins analíticos e consultas locais sem operar como daemon. O mesmo container
+de processamento deve executar no host local e em ECS Fargate.
+
+## 8. Ports e adapters
+
+O domínio expõe contratos pequenos, sem SQL, expressões DynamoDB ou paths S3:
+
+| Port | Responsabilidade |
+|---|---|
+| `ControlPlanePort` | tenants, memberships, agents, jobs, runs, units, leases, fences, dataset versions/pointers, access requests, idempotência e outbox |
+| `ObjectStorePort` | leitura, escrita, stat e publicação de objetos |
+| `ProcessorExecutorPort` | iniciar e cancelar unidades de processamento |
+| `ServingAccessPort` | resolver versão ativa e autorizar serving |
+| `AuditSinkPort` | registrar eventos de domínio append-only |
+
+Adapters aprovados:
+
+| Perfil | Control plane | Object store | Executor | Audit sink |
+|---|---|---|---|---|
+| local | SQLite | Filesystem | Worker pool | JSONL/Parquet local |
+| aws | DynamoDB | S3 | Step Functions + ECS | S3 Object Lock |
+
+Uma contract test suite deve ser executada contra SQLite e DynamoDB Local. O uso
+de DynamoDB Local é exclusivo de teste e desenvolvimento, não de produção local.
+
+### 8.1 Invariantes do `ControlPlanePort`
+
+Os adapters SQLite e DynamoDB podem ter schemas físicos diferentes, mas devem
+preservar as mesmas invariantes:
+
+- autorização por membership usa lookup direto de `tenant_id + user_id`;
+- registro revogado de agente nunca pode receber ou concluir `Job`;
+- claim de `Job` e `RunUnit` é conditional e incrementa `fencing_token`;
+- retry não cria uma nova identidade lógica para o mesmo trabalho;
+- `DatasetVersion` é imutável;
+- `DatasetPointer` só muda por compare-and-swap contra a versão esperada;
+- uma chave de idempotência com o mesmo request hash retorna o mesmo resultado;
+- a mesma chave com request hash diferente gera conflito;
+- expiração lógica usa `expires_at`; TTL físico nunca decide se uma operação é válida;
+- mutações auditáveis gravam um `OutboxEvent` na mesma transação do estado canônico.
+
+SQLite usa transações (`BEGIN IMMEDIATE` quando houver disputa de claim) e constraints
+únicas. DynamoDB usa `PutItem`/`UpdateItem` condicionais para invariantes de um item e
+`TransactWriteItems` apenas quando a invariância envolver múltiplos itens.
+
+### 8.2 Baseline físico do DynamoDB
+
+O perfil AWS inicia com uma única tabela de control plane por ambiente, modelada por
+access patterns, e não por uma tabela por classe. O layout exato pode evoluir sem
+alterar o domínio, mas o baseline é:
+
+```text
+Tenant
+  PK = TENANT#<tenant_id>
+  SK = META
+
+Membership
+  PK = TENANT#<tenant_id>
+  SK = MEMBER#<user_id>
+  GSI1PK = USER#<user_id>
+  GSI1SK = TENANT#<tenant_id>
+
+Agent
+  PK = TENANT#<tenant_id>
+  SK = AGENT#<agent_id>
+
+Job
+  PK = TENANT#<tenant_id>
+  SK = JOB#<job_id>
+
+Run
+  PK = TENANT#<tenant_id>
+  SK = RUN#<run_id>
+
+RunUnit
+  PK = TENANT#<tenant_id>#RUN#<run_id>
+  SK = UNIT#<unit_id>
+
+DatasetVersion
+  PK = TENANT#<tenant_id>#DATASET#<dataset_name>
+  SK = VERSION#<version_id>
+
+DatasetPointer
+  PK = TENANT#<tenant_id>#DATASET#<dataset_name>
+  SK = POINTER#CURRENT
+
+AccessRequest
+  PK = TENANT#<tenant_id>
+  SK = ACCESS_REQUEST#<request_id>
+
+IdempotencyRecord
+  PK = TENANT#<tenant_id>#IDEMPOTENCY#<scope>
+  SK = KEY#<key>
+
+OutboxEvent
+  PK = TENANT#<tenant_id>#OUTBOX#<shard>
+  SK = <created_at>#<event_id>
+```
+
+GSIs adicionais só são introduzidos para access patterns medidos, por exemplo listar
+tenants de um usuário ou descobrir jobs candidatos por agente/estado. Um resultado
+obtido por GSI é apenas candidato: claim, autorização, revogação e publicação sempre
+revalidam o item na tabela base com condição atômica. Nenhuma propriedade de
+correção depende de leitura strongly consistent em GSI.
+
+O heartbeat do `Agent` atualiza `last_seen_at` e metadados operacionais, mas não usa
+TTL para apagar o registro. Estado `ONLINE/OFFLINE` é derivado do tempo desde o último
+heartbeat; revogação é persistente.
+
+## 9. Estado de jobs, runs e unidades
+
+### 9.1 Job do Edge Agent
+
+`Job` representa trabalho remoto solicitado a um agente, por exemplo extrair uma
+fonte/competência e entregar seu `RawManifest`. O agente obtém jobs pela API; acesso
+direto do Edge Agent ao DynamoDB não faz parte do contrato.
+
+Estados:
+
+```text
+PENDING
+LEASED
+SUCCEEDED
+FAILED_RETRYABLE
+FAILED_FINAL
+CANCEL_REQUESTED
+CANCELED
+```
+
+Cada job possui, no mínimo:
+
+- `job_id` determinístico ou associado a uma idempotency key;
+- `tenant_id`;
+- `agent_id` ou seletor de agente;
+- `source_type`, `file_subtype` e `competencia`;
+- `requested_snapshot_mode`;
+- `attempt`;
+- `fencing_token` monotônico;
+- `lease_owner`;
+- `lease_until`;
+- `result_manifest_id`;
+- `error_code` sanitizado.
+
+Descoberta de jobs pode usar índice eventualmente consistente. O claim sempre é feito
+por chave canônica e condição atômica sobre estado, lease e fence. Quando a validade do
+claim depender do estado atual do `Agent`, o adapter usa a mesma transação para
+`ConditionCheck` do agente e atualização do `Job`, ou uma representação equivalente que
+preserve a mesma invariância.
+
+SQS não é necessário para esse protocolo. Se vier a ser introduzido para wake-up ou
+distribuição entre componentes server-side, uma mensagem duplicada ou fora de ordem
+não pode alterar a correção: o `Job` no control plane continua sendo a fonte de verdade.
+
+### 9.2 Run
+
+Estados:
+
+```text
+PLANNED
+WAITING_INPUTS
+PROCESSING
+PUBLISHING
+PUBLISHED
+PUBLISHED_DEGRADED
+FAILED
+CANCEL_REQUESTED
+CANCELED
+```
+
+### 9.3 Run unit
+
+Estados:
+
+```text
+PENDING
+LEASED
+SUCCEEDED
+FAILED_RETRYABLE
+FAILED_FINAL
+CANCELED
+```
+
+Cada unit possui:
+
+- `run_id`;
+- `unit_id` determinístico;
+- `input_manifest_ids`;
+- `attempt`;
+- `fencing_token` monotônico;
+- `lease_owner`;
+- `lease_until`;
+- `output_manifest_id`;
+- `error_code` sanitizado.
+
+## 10. Fan-out
+
+A unidade de paralelismo é:
+
+```text
+tenant + competencia + source_type + file_subtype ou partition
+```
+
+Não existe fan-out por linha.
+
+No perfil local, SQLite agenda units e um worker pool limitado as executa. No AWS,
+uma Step Functions Standard usa Inline Map com `MaxConcurrency` explícito e inicia
+tasks ECS Fargate. Distributed Map só é habilitado quando uma medição comprovar que
+Inline Map ou o histórico da execução são insuficientes.
+
+A concorrência efetiva é:
+
+```text
+min(units pendentes, limite do deployment, quota da PlanVersion)
+```
+
+Payloads de workflow carregam somente IDs e object keys. Dados permanecem no
+object store.
+
+## 11. Fan-in
+
+O planner cria uma lista explícita de dependências obrigatórias e opcionais. A
+reconciliação começa somente depois que todas as dependências obrigatórias têm
+manifestos válidos e units `SUCCEEDED`.
+
+Falha em fonte obrigatória resulta em `FAILED`. Ausência de fonte opcional pode
+resultar em `PUBLISHED_DEGRADED`, com `missing_sources` visível no manifesto e no
+dashboard. O sistema nunca publica silenciosamente um resultado incompleto como
+completo.
+
+## 12. Leases, fencing e idempotência
+
+Cada claim incrementa `fencing_token` atomicamente. SQLite usa transação imediata;
+DynamoDB usa conditional update. O worker escreve somente em:
+
+```text
+tmp/<tenant>/<run_id>/<unit_id>/<attempt>/
+```
+
+O commit da unit aceita o output apenas se:
+
+- o run não estiver cancelado;
+- o unit continuar `LEASED` pelo mesmo owner;
+- o `fencing_token` recebido ainda for o atual;
+- o output manifest passar validação de schema e hash.
+
+Um worker atrasado pode terminar o cálculo, mas não consegue publicar. Retries
+reusam o mesmo `unit_id` e criam novo `attempt`. Writes são idempotentes por
+`run_id + unit_id + attempt`.
+
+`IdempotencyRecord` contém, no mínimo:
+
+```text
+tenant_id
+scope
+key
+request_hash
+status
+resource_id
+created_at
+expires_at
+```
+
+A primeira operação cria o registro somente se não existir um registro lógico válido.
+Repetição com o mesmo `request_hash` retorna o mesmo `resource_id`/resultado.
+Reutilização da mesma chave com payload diferente é conflito. Se `expires_at <= now`,
+o adapter pode substituir/reclamar o registro por condição atômica mesmo que o item
+ainda exista fisicamente.
+
+No DynamoDB, TTL é configurado apenas para garbage collection. Como a exclusão física
+de itens expirados é assíncrona, nenhuma decisão de claim, idempotência, autorização ou
+lease depende de o item ter desaparecido da tabela.
+
+Para transações DynamoDB, `ClientRequestToken` pode proteger retries imediatos da mesma
+chamada, mas não substitui `IdempotencyRecord`, cuja janela é definida pelo produto.
+
+## 13. Publicação atômica
+
+A atomicidade observável pelo produto não depende de rename atômico no object store.
+Ela depende de objetos finais imutáveis já existentes e de um único compare-and-swap
+no `DatasetPointer`.
+
+O publisher:
+
+1. valida todos os output manifests;
+2. valida invariantes de reconciliação e serving;
+3. promove os objetos para chaves finais imutáveis do `run_id`; no filesystem pode usar
+   rename no mesmo filesystem, enquanto no S3 pode escrever diretamente a chave final
+   ou copiar do prefixo temporário;
+4. verifica os objetos finais e grava o `RunManifest` imutável;
+5. prepara o `DatasetVersion` imutável referente ao novo `run_id`;
+6. em uma transação do control plane, cria o `DatasetVersion`, muda o
+   `DatasetPointer` de `old_version` para `new_version` por compare-and-swap e grava o
+   `OutboxEvent` `reconciliation.published`;
+7. o outbox dispatcher entrega o evento ao `AuditSinkPort` e marca a entrega.
+
+No SQLite, o passo 6 ocorre em uma transação local. No DynamoDB, usa
+`TransactWriteItems` para a versão/pointer/outbox quando esses itens precisarem mudar
+juntos. Se a condição do pointer falhar porque outro publisher venceu, nenhum pointer
+é sobrescrito silenciosamente.
+
+O frontend resolve somente o `DatasetPointer` ativo. Falha antes do commit do passo 6
+deixa a versão anterior ativa. Falha depois do commit não reverte o pointer; o
+`OutboxEvent` pendente garante retry da auditoria. Objetos temporários e objetos finais
+que nunca foram ativados podem ser removidos por lifecycle/retenção após a janela de
+diagnóstico definida.
+
+## 14. Frontend e analytics
+
+O frontend consome serving JSON por meio da API/BFF. No AWS, o bucket continua
+privado e a API emite URL ou cookie assinado de curta duração após autorização.
+
+Athena serve análises ad hoc, investigação de auditoria e consultas que não fazem
+parte da navegação normal. O frontend nunca recebe credenciais AWS para consultar
+Athena ou S3 raw diretamente.
+
+## 15. Segurança e isolamento
+
+### 15.1 Local
+
+- Uma instalação representa exatamente um município.
+- O `tenant_id` vem da configuração do servidor, não do navegador.
+- Data directory e `state/cnesdata.sqlite3` pertencem ao usuário do serviço.
+- A API recusa requests com tenant divergente.
+
+### 15.2 AWS
+
+- Todas as chaves DynamoDB e prefixes S3 incluem `tenant_id`.
+- Membership autenticada é validada por chave canônica antes de resolver o tenant; GSI não autoriza requests.
+- Roles de execução usam least privilege por prefixo e operação.
+- Lake Formation é opcional para acesso analítico compartilhado.
+- Serving, raw e audit usam buckets ou prefixes com policies distintas.
+
+## 16. Logs e auditoria
+
+Logs operacionais são JSON estruturado em stdout. O perfil local pode rotacionar
+arquivos. O perfil AWS envia stdout ao CloudWatch Logs.
+
+Auditoria de domínio é separada de logs operacionais. Eventos incluem:
+
+- manifesto recebido ou rejeitado;
+- full snapshot solicitado;
+- unit claimed, fenced, retried ou failed;
+- run publicado, degradado, cancelado ou invalidado;
+- dataset pointer alterado;
+- acesso de serving concedido ou negado.
+
+No AWS, o audit writer grava S3 versionado com Object Lock. Eventos auditáveis
+críticos são persistidos primeiro como `OutboxEvent` junto da mutação canônica e depois
+entregues ao sink com retry idempotente. DynamoDB Streams pode disparar ou acelerar o
+dispatcher do outbox e capturar mudanças técnicas do control plane, mas não substitui
+os eventos de negócio explícitos.
+
+## 17. Recuperação e falhas
+
+| Falha | Comportamento |
+|---|---|
+| Upload interrompido | Outbox retenta com mesma idempotency key |
+| Delta com gap | Rejeitar e solicitar full snapshot |
+| Worker perde lease | Novo claim incrementa fence; worker antigo não publica |
+| Unit retryable falha | Retry limitado com backoff e jitter |
+| Unit final falha | Run falha ou degrada conforme dependência |
+| Publisher falha antes do pointer swap | `DatasetPointer` anterior permanece ativo |
+| SQLite corrompido | Restaurar backup do control plane; somente estado derivável de datasets/runs pode ser reconstruído de manifestos. Usuários, memberships, agents e decisões de acesso exigem backup/seed próprio |
+| DynamoDB indisponível | Não iniciar claims, conceder acesso novo nem publicar; preservar temporários e retentar sem assumir expiração por TTL |
+| Auditoria indisponível após commit | `OutboxEvent` permanece pendente; dispatcher retenta sem repetir a mutação de domínio |
+| Serving ausente | API retorna indisponibilidade sem cair para versão não autorizada |
+
+## 18. Estratégia de testes
+
+- Contract tests idênticos para SQLite e DynamoDB.
+- Contract tests idênticos para filesystem e S3.
+- Property tests para transições de estado e idempotência.
+- Race tests com dois workers disputando o mesmo unit.
+- Testes que comprovem que fence antigo não publica.
+- Testes de gap, reorder e duplicação de deltas.
+- Golden tests de reconciliação raw para normalized, reconciliation e serving.
+- Shadow runs comparando a saída nova com o Gold PostgreSQL atual.
+- Chaos tests interrompendo worker entre escrita e publicação.
+- Security tests para cross-tenant keys, prefixes e serving access.
+- Testes de idempotência com item expirado ainda fisicamente presente por TTL.
+- Testes em que GSI retorna job/membership stale, comprovando revalidação na chave base.
+- Race test com dois publishers tentando trocar o mesmo `DatasetPointer`.
+- Crash test após pointer commit e antes do audit sink, comprovando replay via outbox.
+- Backup/restore local incluindo usuários, memberships, agents e access decisions.
+
+## 19. Migração
+
+1. Reconciliar a divergência entre `main` e `develop` antes de mudanças funcionais.
+2. Congelar source contracts e manifests existentes como fixtures de compatibilidade.
+3. Introduzir ports e o modelo canônico do control plane sem alterar o comportamento atual.
+4. Implementar filesystem + SQLite e S3 + DynamoDB atrás dos ports, incluindo idempotency e outbox.
+5. Completar normalize, reconcile e materialize com output versionado.
+6. Rodar shadow processing contra o Gold PostgreSQL por competências históricas.
+7. Mudar o frontend para serving JSON e `DatasetPointer`, migrando memberships/access state necessários.
+8. Cortar novos writes em PostgreSQL e MinIO.
+9. Exportar o histórico necessário para Parquet versionado.
+10. Remover migrations, adapters e documentação de PostgreSQL, MinIO e BigQuery.
+11. Remover Keycloak do perfil local e manter OIDC como integração opcional.
+
+O cutover exige equivalência dos principais KPIs, divergências e contagens para as
+fixtures aprovadas. Diferenças devem ser explicadas por mudança de contrato ou regra,
+nunca aceitas apenas por proximidade estatística.
+
+## 20. Critérios de aceitação
+
+- Perfil local inicia sem PostgreSQL, MinIO, Keycloak ou acesso à AWS.
+- Perfil local opera um único tenant e persiste restart em SQLite/filesystem.
+- Perfil AWS usa DynamoDB/S3 sem dependência de PostgreSQL/RDS.
+- Edge Agent não contém reconciliação ou regras de negócio.
+- Gap de delta solicita full snapshot e não corrompe o dataset ativo.
+- Fan-out respeita limites de deployment e plano.
+- Fence antigo não consegue publicar output.
+- Falha de publicação antes do compare-and-swap preserva o `DatasetPointer` anterior.
+- Frontend consome somente serving JSON autorizado.
+- Raw, reconciliation e audit permanecem reprocessáveis e rastreáveis por hash.
+- Claims, autorização e pointer swap não dependem de GSI eventualmente consistente.
+- TTL não participa de correção de lease/idempotência; item expirado ainda presente é tratado corretamente.
+- `Job`, `Run` e `RunUnit` possuem semânticas distintas e contract tests equivalentes em SQLite/DynamoDB.
+- Publicação crítica grava pointer e outbox de forma atômica no control plane.
+- Falha do audit sink após commit não perde o evento publicado.
+
+## 21. Referências externas
+
+- AWS Step Functions Map:
+  <https://docs.aws.amazon.com/step-functions/latest/dg/state-map.html>
+- AWS DynamoDB transactions:
+  <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html>
+- AWS DynamoDB TTL:
+  <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html>
+- AWS DynamoDB read consistency:
+  <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html>
+- AWS DynamoDB data modeling foundations:
+  <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/data-modeling-foundations.html>
+- Amazon SQS at-least-once delivery:
+  <https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues-at-least-once-delivery.html>
+- AWS Athena ACID transactions:
+  <https://docs.aws.amazon.com/athena/latest/ug/acid-transactions.html>
+- AWS S3 Object Lock:
+  <https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html>

--- a/docs/superpowers/specs/2026-08-16-stripe-billing-entitlements-design.md
+++ b/docs/superpowers/specs/2026-08-16-stripe-billing-entitlements-design.md
@@ -1,0 +1,395 @@
+# CnesData — Stripe Billing, Entitlements e Revogação
+
+**Status:** aprovado para planejamento
+
+**Data:** 2026-08-16
+
+**Dependência:**
+[Data Plane Parquet e Orquestração](2026-08-16-parquet-data-plane-orchestration-design.md)
+
+## 1. Objetivo
+
+Adicionar assinatura e cobrança ao perfil SaaS AWS por meio da Stripe, mantendo o
+perfil local open-source sem licença ou validação remota obrigatória.
+
+Stripe é a fonte da verdade financeira. O CnesData mantém uma projeção de
+entitlements no DynamoDB para autorizar operações com baixa latência, aplicar quotas
+e revogar compute ou publicação quando necessário.
+
+## 2. Decisões centrais
+
+| Tema | Decisão |
+|---|---|
+| Perfil local | `BILLING_MODE=disabled`, sem chamadas à Stripe |
+| Perfil AWS | `BILLING_MODE=stripe` |
+| Provedor inicial | Stripe Billing |
+| Checkout | Stripe Checkout hospedado |
+| Autogestão | Stripe Customer Portal |
+| Fonte financeira | Subscription e invoices da Stripe |
+| Autorização runtime | Entitlement projection no DynamoDB |
+| Features booleanas | Stripe Entitlements espelhados localmente |
+| Quotas numéricas | `PlanVersion` interna e imutável |
+| Cache | Curto e local; Redis não é introduzido |
+| Revogação crítica | Leitura consistente + invalidação de fences ativos |
+| Logs operacionais | CloudWatch Logs |
+| Auditoria de domínio | S3 versionado com Object Lock |
+
+## 3. Não objetivos
+
+- Não cobrar nem limitar instalações locais open-source.
+- Não armazenar número de cartão ou outros dados PCI no CnesData.
+- Não consultar a Stripe em cada request.
+- Não codificar quotas em JWT ou claims de longa duração.
+- Não usar CloudFront invalidation como mecanismo de autorização.
+- Não adicionar Redis somente para cache de assinatura.
+- Não suportar múltiplos provedores de pagamento no primeiro release.
+- Não definir preços comerciais nesta especificação.
+
+## 4. Modelo de domínio
+
+### 4.1 Billing account
+
+Um `BillingAccount` representa a organização responsável pelo pagamento. Ele pode
+possuir um ou mais tenants conforme a `PlanVersion`.
+
+Campos mínimos:
+
+```text
+billing_account_id
+stripe_customer_id
+owner_user_id
+status
+created_at
+updated_at
+```
+
+O tenant referencia `billing_account_id`. Isso evita acoplar diretamente município,
+usuário e customer da Stripe.
+
+### 4.2 PlanVersion
+
+`PlanVersion` é imutável depois de publicada:
+
+```text
+plan_version_id
+plan_key
+stripe_product_id
+stripe_price_ids
+features
+max_tenants
+max_agents
+max_runs_per_period
+max_concurrency
+retention_days
+athena_scan_budget_bytes
+effective_from
+```
+
+Mudança de limites cria nova versão. Assinaturas existentes continuam ligadas à
+versão contratada até upgrade, downgrade ou migração explícita.
+
+### 4.3 EntitlementSnapshot
+
+O snapshot runtime contém:
+
+```text
+billing_account_id
+stripe_subscription_id
+subscription_status
+plan_version_id
+features
+quotas
+period_start
+period_end
+grace_until
+valid_until
+entitlement_version
+updated_at
+source_event_id
+```
+
+`entitlement_version` aumenta em toda alteração que possa modificar acesso, quota ou
+fencing. O snapshot é a autoridade runtime; a Stripe continua sendo a autoridade
+financeira usada para reconciliá-lo.
+
+## 5. Mapeamento Stripe
+
+| Stripe | CnesData |
+|---|---|
+| Customer | BillingAccount |
+| Product | Família de plano |
+| Price | Preço e periodicidade de uma PlanVersion |
+| Subscription | Contrato ativo do BillingAccount |
+| Active Entitlement | Feature habilitada |
+| Invoice | Evidência de cobrança e pagamento |
+
+Stripe Entitlements representa features booleanas. Quotas numéricas permanecem na
+`PlanVersion`, porque precisam de semântica e enforcement próprios do CnesData.
+
+## 6. Lifecycle de assinatura
+
+| Estado | Política CnesData |
+|---|---|
+| `trialing` | Acesso conforme plano de trial |
+| `active` | Acesso completo conforme PlanVersion |
+| `cancel_at_period_end=true` | Acesso completo até `period_end` |
+| `past_due` | Grace period configurado na PlanVersion |
+| `incomplete` | Sem provisionamento de compute |
+| `incomplete_expired` | Sem acesso pago |
+| `unpaid` | Read-only; sem novos agents ou runs |
+| `paused` | Read-only; sem novos agents ou runs |
+| `canceled` | Read-only conforme retenção; sem novo compute |
+| `admin_revoked` | Bloqueio imediato, inclusive de publicação em andamento |
+
+Perda de assinatura não apaga datasets automaticamente. Retenção, exportação e
+deleção seguem política explícita e auditável.
+
+## 7. Fluxo de checkout
+
+1. Usuário autenticado cria ou seleciona um BillingAccount.
+2. API valida que o usuário é billing owner.
+3. API cria Checkout Session com idempotency key interna.
+4. Metadata contém somente IDs opacos necessários para correlação.
+5. Usuário conclui pagamento na página hospedada da Stripe.
+6. Redirect de sucesso mostra estado pendente, sem liberar acesso por si só.
+7. Webhook confirmado atualiza Subscription e EntitlementSnapshot.
+8. O frontend observa o novo estado pelo endpoint de billing.
+
+O redirect nunca é usado como prova de pagamento.
+
+## 8. Webhooks
+
+O endpoint usa body raw e valida `Stripe-Signature` com a biblioteca oficial. Eventos
+iniciais:
+
+- `checkout.session.completed`;
+- `customer.subscription.created`;
+- `customer.subscription.updated`;
+- `customer.subscription.deleted`;
+- `customer.subscription.paused`;
+- `customer.subscription.resumed`;
+- `invoice.paid`;
+- `invoice.payment_failed`;
+- `invoice.payment_action_required`;
+- `entitlements.active_entitlement_summary.updated`.
+
+### 8.1 Idempotência
+
+Antes de processar, o handler grava condicionalmente um item por `stripe_event_id`.
+Evento já `PROCESSED` retorna HTTP 200 sem reaplicar efeitos. Evento `PROCESSING`
+vencido pode ser retomado por recovery worker.
+
+### 8.2 Ordem
+
+O handler não presume entrega ordenada. Em eventos capazes de mudar acesso, busca o
+estado atual da Subscription e dos active entitlements na Stripe, recalcula a projeção
+e faz conditional update do snapshot.
+
+### 8.3 Resposta
+
+O endpoint valida, persiste o evento e responde rapidamente. Efeitos secundários são
+processados de forma assíncrona. Falha transitória retorna erro para permitir retry da
+Stripe. Um recovery job consulta eventos não entregues dentro da janela suportada.
+
+## 9. Entitlement gate
+
+O domínio expõe `EntitlementGate` com operações orientadas a casos de uso:
+
+```text
+authorize_create_run
+authorize_register_agent
+authorize_analytics_query
+authorize_serving_access
+authorize_tenant_creation
+```
+
+Processors não conhecem Stripe. Eles recebem um `RunAuthorization` imutável com:
+
+```text
+billing_account_id
+plan_version_id
+entitlement_version
+max_concurrency
+budget_reservation_id
+authorized_at
+```
+
+O publisher revalida entitlement e fence antes de tornar um run ativo.
+
+## 10. Quotas e budgets
+
+Quotas possuem reserva atômica no DynamoDB para impedir oversubscription por requests
+concorrentes. Criar um run executa uma transação que:
+
+1. lê entitlement válido;
+2. verifica quota e budget do período;
+3. cria reservation idempotente;
+4. incrementa uso reservado;
+5. cria o run autorizado.
+
+Conclusão converte reserva em uso consumido. Cancelamento libera a parte não
+consumida. Reconciliação periódica corrige reservations abandonadas.
+
+`max_concurrency` do plano limita fan-out, mas o deployment pode impor limite menor.
+O cliente nunca eleva concorrência acima do menor limite aplicável.
+
+## 11. Revogação e runs em andamento
+
+Revogação normal, como cancelamento ao fim do período, só entra em vigor em
+`period_end`. Revogação imediata executa:
+
+1. atualizar EntitlementSnapshot e incrementar `entitlement_version`;
+2. marcar novos comandos como não autorizados;
+3. localizar runs não terminais do BillingAccount;
+4. definir `CANCEL_REQUESTED` e incrementar seus fencing tokens;
+5. solicitar cancelamento das execuções Step Functions;
+6. impedir que tasks antigas publiquem outputs;
+7. emitir `entitlement.revoked` e `run.cancel_requested` na auditoria.
+
+Workers podem terminar escrita temporária depois da revogação, mas o fence inválido
+impede publicação. Lifecycle remove temporários órfãos.
+
+## 12. Cache e invalidação
+
+Não existe cache distribuído obrigatório.
+
+| Operação | Política |
+|---|---|
+| Criar run | DynamoDB consistent read, sem cache |
+| Registrar agent | DynamoDB consistent read, sem cache |
+| Reservar budget | DynamoDB transaction, sem cache |
+| Publicar run | Revalidação consistente, sem cache |
+| Leitura de UI | Cache local de até 60 segundos |
+| Emitir URL/cookie assinado | Revalidação ou cache de até 60 segundos |
+
+Cache keys incluem `billing_account_id` e `entitlement_version`. Mudança no snapshot
+publica `entitlement.changed` via DynamoDB Streams. Consumidores long-lived removem a
+versão anterior. Lambdas podem simplesmente usar o TTL curto.
+
+URLs e cookies assinados têm duração curta. Cancelamento impede novas emissões; o
+resíduo máximo é a duração da credencial já emitida. CloudFront invalidation não é
+usada para revogar autorização, pois remover conteúdo do cache não invalida uma
+credencial de acesso.
+
+## 13. Serving e conteúdo histórico
+
+Objetos de serving permanecem privados. O BFF resolve tenant, BillingAccount,
+membership e entitlement antes de emitir acesso. Status read-only pode permitir
+consulta e exportação de histórico dentro da retenção, mas nunca iniciar novo compute.
+
+`admin_revoked` bloqueia serving imediatamente, exceto endpoints explícitos de billing,
+suporte e recuperação de conta.
+
+## 14. Logs e auditoria
+
+CloudWatch Logs recebe logs operacionais estruturados. Esses logs não são fonte de
+verdade de billing.
+
+Eventos de domínio append-only incluem:
+
+- billing account criado ou transferido;
+- Checkout Session criada;
+- webhook recebido, duplicado, aplicado ou falho;
+- assinatura ativada, alterada, pausada ou cancelada;
+- entitlement concedido ou revogado;
+- quota reservada, consumida, liberada ou negada;
+- run cancelado por entitlement;
+- serving access negado por assinatura.
+
+O audit writer grava S3 versionado com Object Lock. DynamoDB Streams complementa a
+trilha de mutações, mas eventos explícitos preservam ator, motivo e contexto de negócio.
+
+## 15. Segurança
+
+- Stripe secret key e webhook secret ficam no AWS Secrets Manager.
+- Endpoint exige TLS e valida assinatura sobre body não modificado.
+- Nenhum dado de cartão entra em logs, DynamoDB ou S3.
+- Metadata enviada à Stripe contém IDs opacos, não dados municipais sensíveis.
+- Billing owner e administradores usam autorização separada de tenant viewer.
+- Webhook handler usa role mínima para billing tables e audit events.
+- Checkout e Customer Portal usam URLs de retorno allowlisted.
+- Mudanças administrativas exigem reason code e audit event.
+
+## 16. Falhas e reconciliação
+
+| Falha | Comportamento |
+|---|---|
+| Stripe indisponível durante request | Não criar checkout; retornar erro retryable |
+| Webhook atrasado | Último snapshot vale até `valid_until` |
+| Webhook duplicado | Deduplicar por event ID e retornar 200 |
+| Webhook fora de ordem | Buscar estado atual na Stripe antes de projetar |
+| DynamoDB indisponível | Falhar fechado para novo compute e publicação |
+| Invalidation consumer falha | TTL curto limita staleness; gates críticos não usam cache |
+| Cancelamento de workflow falha | Fence já invalidado impede publicação |
+| Audit sink indisponível | Outbox durável retenta; evento crítico não é descartado |
+
+Um reconciliation job periódico compara Stripe e EntitlementSnapshot para contas
+ativas, corrige drift com conditional write e registra a correção em auditoria.
+
+## 17. Testes
+
+- Unit tests para cada status Stripe e política de acesso.
+- Contract tests do EntitlementGate e quota reservations.
+- Testes de assinatura válida e inválida do webhook.
+- Testes de eventos duplicados, reorder e retry concorrente.
+- Testes com Stripe test clocks para trial, renewal, failure e cancellation.
+- Testes de cancelamento ao fim do período e cancelamento imediato.
+- Race tests de duas reservas consumindo a última unidade de quota.
+- Teste de cache stale provando que gates críticos consultam DynamoDB.
+- Teste end-to-end de revogação invalidando fence de run ativo.
+- Teste provando que perfil local funciona com billing desabilitado e sem secrets.
+
+## 18. Observabilidade
+
+Métricas mínimas:
+
+- webhook latency e failure rate;
+- eventos duplicados e recovery backlog;
+- drift encontrado pelo reconciliation job;
+- entitlement checks denied por motivo;
+- quota reservations ativas e expiradas;
+- runs cancelados por revogação;
+- idade do EntitlementSnapshot;
+- falhas de audit outbox.
+
+Alertas existem para webhook failures persistentes, snapshots stale, drift recorrente
+e audit outbox acumulando.
+
+## 19. Migração e rollout
+
+1. Introduzir BillingAccount, PlanVersion e EntitlementSnapshot sem enforcement.
+2. Integrar Stripe em sandbox e processar webhooks em shadow mode.
+3. Validar deduplicação, reorder e reconciliation com test clocks.
+4. Ativar entitlement checks apenas em logs para tenants internos.
+5. Ativar gates de criação de run e agent registration.
+6. Ativar quotas e budget reservations.
+7. Ativar revogação de publicação e cancelamento de workflows.
+8. Habilitar produção para um plano e expandir após observabilidade estável.
+
+O perfil local mantém `BILLING_MODE=disabled` durante todas as fases.
+
+## 20. Critérios de aceitação
+
+- Instalação local funciona sem Stripe, Secrets Manager ou chamadas externas.
+- Redirect de checkout não libera acesso sem webhook confirmado.
+- Eventos duplicados não duplicam efeitos.
+- Eventos fora de ordem convergem para o estado atual da Stripe.
+- Operações caras fazem leitura consistente e não dependem de cache stale.
+- Cancelamento ao fim do período preserva acesso até `period_end`.
+- Revogação imediata bloqueia novos comandos e impede publicação de runs ativos.
+- Falha ao cancelar Step Functions não permite commit por fence antigo.
+- Perda de assinatura não apaga datasets silenciosamente.
+- Todos os efeitos financeiros e de autorização geram audit events.
+
+## 21. Referências externas
+
+- Stripe subscription webhooks:
+  <https://docs.stripe.com/billing/subscriptions/webhooks>
+- Stripe Entitlements:
+  <https://docs.stripe.com/billing/entitlements>
+- Stripe webhook security:
+  <https://docs.stripe.com/webhooks>
+- Stripe webhook recovery and deduplication:
+  <https://docs.stripe.com/webhooks/process-undelivered-events>
+- Stripe subscription cancellation:
+  <https://docs.stripe.com/billing/subscriptions/cancel>

--- a/docs/superpowers/specs/2026-08-23-cnesdata-redesign-execution-design.md
+++ b/docs/superpowers/specs/2026-08-23-cnesdata-redesign-execution-design.md
@@ -1,0 +1,473 @@
+# CnesData — Redesign Execution and Parallel Worktree Design
+
+**Status:** approved for canonical documentation; awaiting pull-request review
+
+**Date:** 2026-08-23
+
+**Integration base:** `develop`
+
+**Repository:** `VINIClUS/CnesData`
+
+**Source designs:**
+
+- [Data Plane Parquet e Orquestração — V2](2026-08-16-parquet-data-plane-orchestration-design.md)
+- [Stripe Billing, Entitlements e Revogação](2026-08-16-stripe-billing-entitlements-design.md)
+
+## 1. Purpose
+
+Define how the two approved architectural designs will be converted into an
+implementation backlog and executed safely by parallel agents in isolated Git
+worktrees.
+
+This document owns execution order, dependency gates, worktree boundaries,
+integration policy, and rollout sequencing. It does not replace the domain and
+infrastructure decisions in the source designs.
+
+## 2. Repository baseline
+
+At the time this design was approved:
+
+- `develop` was the architectural base required by the source designs;
+- `develop` was 148 commits ahead of and 5 commits behind `main`;
+- there were no open pull requests;
+- the only open issue was unrelated to the redesign;
+- the central API and processor still depended directly on PostgreSQL and MinIO;
+- the target control-plane, dataset, run, entitlement, and audit ports did not exist;
+- the Go Edge Agent already implemented source discovery, delta detection, SHA-256,
+  a durable local outbox, circuit breaking, jittered retry, diagnostics, and mTLS.
+
+The existing Go Edge Agent is evolved in place. It is not rewritten.
+
+## 3. Binding constraints
+
+The following decisions are inherited unchanged from the approved source designs:
+
+- `local` is single-tenant, one installation per municipality;
+- `local` uses SQLite and filesystem storage;
+- `aws` is multi-tenant and uses DynamoDB and S3;
+- PostgreSQL/RDS, MinIO, Keycloak, and BigQuery are absent after cutover;
+- Parquet objects and published dataset versions are immutable;
+- dashboard navigation reads materialized serving JSON, not Athena or raw Parquet;
+- processing is at-least-once with idempotency, leases, and fencing;
+- Edge Agents perform extraction and transport transformations only;
+- normalization, reconciliation, and serving materialization are central concerns;
+- Stripe is enabled only in the AWS SaaS profile;
+- local billing is disabled and has no remote validation;
+- critical authorization and publication do not depend on a stale cache, GSI, or TTL;
+- SIHD, BPA, and SIA may use the legacy path only during migration;
+- the final legacy removal gate requires every retained active source to be migrated.
+
+## 4. Delivery strategy
+
+### 4.1 Chosen approach
+
+Use an incremental, contract-first, CNES-first migration.
+
+The first production-shaped vertical slice is:
+
+```text
+CNES_LOCAL + CNES_NACIONAL
+  -> immutable raw manifests and Parquet
+  -> normalized Parquet per source
+  -> reconciliation Parquet
+  -> materialized serving JSON
+  -> authorized dashboard access
+```
+
+The legacy path may coexist temporarily in `shadow` mode. Runtime compatibility
+with PostgreSQL, MinIO, Keycloak, or BigQuery is removed after source parity and
+cutover acceptance.
+
+### 4.2 Rejected approaches
+
+**Adapter-first without a vertical slice** was rejected because it delays evidence
+that the contracts produce a usable dataset and dashboard response.
+
+**Big-bang rewrite** was rejected because it creates a long-lived integration branch,
+couples unrelated failure domains, and postpones parity testing until the end.
+
+**Rewriting the Edge Agent** was rejected because its existing resilience and source
+capabilities are reusable and independently tested.
+
+## 5. Subprojects
+
+The redesign is split into four implementation plans. Each plan must produce
+independently testable software.
+
+| Plan | Scope | Entry gate | Completion gate |
+|---|---|---|---|
+| Data Plane Foundation and Local Profile | Domain contracts, ports, adapter implementations, orchestration, CNES processing, local auth and serving | Reconciled green baseline | Local CNES vertical slice passes acceptance tests |
+| AWS Runtime Profile | DynamoDB/S3 composition, generic OIDC, Step Functions/ECS execution, audit sink and signed serving access | Stable adapters and orchestration contracts | AWS profile passes integration suites |
+| Billing and Entitlements | Billing domain, Stripe flows, projection, quotas, revocation, cache policy and reconciliation | Stable `RunAuthorization`, fencing, publisher, and AWS control plane | Stripe test-clock and revocation E2E suites pass |
+| Source Migration and Cutover | SIHD/BPA/SIA parity, historical shadow runs, frontend cutover, legacy export and removal | Local CNES vertical slice is stable | No retained source or runtime depends on legacy services |
+
+Production AWS resource provisioning is not inferred in these application plans.
+Infrastructure-as-code requires a dedicated deployment specification before cloud
+resources are created. Application adapters, workflows, IAM requirements, and test
+environments remain in scope.
+
+## 6. Dependency graph
+
+```mermaid
+flowchart TD
+    P0["P0 Baseline"] --> P1["P1 Contracts"]
+    P1 --> P2["P2 Adapters"]
+    P2 --> P3["P3 Raw ingestion"]
+    P3 --> P4["P4 Orchestration"]
+    P4 --> P5["P5 CNES processing"]
+    P5 --> P6["P6 Local product slice"]
+    P4 --> A["AWS runtime lane"]
+    P4 --> B["Billing core lane"]
+    P6 --> S["Source parity lane"]
+    A --> BI["Stripe integration"]
+    B --> BI
+    S --> C["Cutover"]
+    BI --> C
+```
+
+Billing domain work may begin after the orchestration contracts are stable. Stripe
+integration does not begin until the AWS control plane and critical fencing paths are
+available.
+
+## 7. Backlog phases
+
+Logical IDs are stable backlog identifiers and are not GitHub issue numbers.
+
+### Phase 0 — Integration baseline
+
+This phase is serial.
+
+| ID | Deliverable | Depends on | Unlocks |
+|---|---|---|---|
+| `CND-000` | Reconcile `main` into `develop` through a dedicated PR | None | All implementation work |
+| `CND-001` | Run and record the baseline Python, Go, dashboard, and integration test matrix | `CND-000` | Reliable regression attribution |
+| `CND-002` | Freeze existing source contracts, representative raw fixtures, Gold outputs, and dashboard KPIs | `CND-001` | Golden and shadow tests |
+| `CND-003` | Add backlog conventions, issue template, branch naming, and path-ownership policy | `CND-000` | Parallel worktree dispatch |
+
+No feature agent starts before `CND-001` is green or explicitly waived with a recorded
+baseline failure.
+
+### Phase 1 — Canonical contracts and ports
+
+Wave 1 contains two independent worktrees:
+
+| ID | Deliverable | Owned paths |
+|---|---|---|
+| `CND-010` | Control-plane entities, immutable values, state enums, transition rules, and domain errors | `packages/cnes_domain/src/cnes_domain/control_plane/**`; matching tests |
+| `CND-011` | `RawManifest`, delta-chain, output, run, reconciliation, serving, and audit event contracts | `packages/cnes_contracts/src/cnes_contracts/manifests/**`; matching tests |
+
+Wave 2 begins after both are integrated:
+
+| ID | Deliverable | Depends on |
+|---|---|---|
+| `CND-012` | `ControlPlanePort`, `ObjectStorePort`, `ProcessorExecutorPort`, `ServingAccessPort`, and `AuditSinkPort` | `CND-010`, `CND-011` |
+| `CND-013` | Shared adapter contract suites for control plane and object store invariants | `CND-012` |
+| `CND-014` | Profile configuration contract for `local` and `aws`, plus `AUTH_MODE` and `BILLING_MODE` validation | `CND-012` |
+
+Existing SQLAlchemy-bearing protocols are not expanded. New target ports remain free
+of SQL, DynamoDB expressions, S3 paths, and framework-specific request types.
+
+### Phase 2 — Persistence and object-store adapters
+
+Three feature worktrees run concurrently after `CND-013`:
+
+| ID | Deliverable | Worktree boundary |
+|---|---|---|
+| `CND-020` | SQLite control-plane adapter with transactions, constraints, claims, CAS, idempotency, and outbox | SQLite adapter and tests only |
+| `CND-021` | DynamoDB control-plane adapter with base-key revalidation, conditional writes, transactions, and TTL-safe semantics | DynamoDB adapter and tests only |
+| `CND-022` | Filesystem and S3 object-store adapters with identical contract behavior | Object-store adapters and tests only |
+
+The next wave contains:
+
+| ID | Deliverable | Depends on |
+|---|---|---|
+| `CND-023` | Local JSONL/Parquet and AWS S3 Object Lock audit sinks | `CND-012` |
+| `CND-024` | Outbox dispatcher with idempotent delivery and recovery | `CND-020`, `CND-021`, `CND-023` |
+| `CND-025` | Full adapter conformance matrix against SQLite, DynamoDB Local, filesystem, and an S3-compatible test environment | `CND-020` through `CND-024` |
+
+Agents do not edit shared dependency manifests or package exports. A serial integration
+task applies `pyproject.toml`, `uv.lock`, and export changes after feature branches are
+accepted.
+
+### Phase 3 — Raw ingestion and Edge Agent protocol
+
+Wave 1 uses three independent worktrees:
+
+| ID | Deliverable | Boundary |
+|---|---|---|
+| `CND-030` | Raw manifest validator, delta-chain policy, full-resync decisions, and immutable object registration | Python application/domain services |
+| `CND-032` | Go Edge Agent manifest v1, snapshot sequence/hash chain, object layout, and full-resync response handling | `apps/dump_agent_go` |
+| `CND-033` | DATASUS national adapter producing the same raw contract without BigQuery | National ingestion adapter and tests |
+
+Wave 2 adds `CND-031`, the Central API raw-upload and job endpoints wired only
+through the target ports. It depends on `CND-030`. `CND-034` then integrates the
+four deliverables into an end-to-end raw ingestion test. Legacy
+routes may remain available only under the migration mode during this phase.
+
+### Phase 4 — Jobs, runs, fan-out, and atomic publication
+
+Wave 1:
+
+| ID | Deliverable | Depends on |
+|---|---|---|
+| `CND-040` | Edge `Job` lifecycle, agent revocation check, lease renewal, retry, cancellation, and fencing | `CND-020`, `CND-021`, `CND-030` |
+| `CND-041` | `Run` planner, deterministic `RunUnit` IDs, required/optional dependencies, fan-out, fan-in, and degraded publication rules | `CND-010`, `CND-011` |
+| `CND-042` | Local worker-pool and AWS executor adapters behind `ProcessorExecutorPort` | `CND-012`, `CND-041` |
+
+Wave 2:
+
+| ID | Deliverable | Depends on |
+|---|---|---|
+| `CND-043` | Unit claim/commit with attempt paths and stale-fence rejection | `CND-040`, `CND-041` |
+| `CND-044` | Atomic publisher: final immutable objects, `RunManifest`, `DatasetVersion`, pointer CAS, and outbox in one control-plane transaction | `CND-022`, `CND-024`, `CND-043` |
+| `CND-045` | Race and crash suite for dual claims, stale workers, competing publishers, and audit replay | `CND-043`, `CND-044` |
+
+### Phase 5 — CNES processing vertical slice
+
+The two normalizers are independent:
+
+| ID | Deliverable | Depends on |
+|---|---|---|
+| `CND-050` | `NormalizeSource` for `CNES_LOCAL`, including delta reconstruction and provenance | `CND-030`, `CND-043` |
+| `CND-051` | `NormalizeSource` for `CNES_NACIONAL` from the DATASUS raw contract | `CND-033`, `CND-043` |
+
+Dependent tasks:
+
+| ID | Deliverable | Depends on |
+|---|---|---|
+| `CND-052` | `ReconcileCompetencia` with approved precedence, evidence, divergence, and KPI contracts | `CND-050`, `CND-051` |
+| `CND-053` | `MaterializeServing` with versioned, minimal JSON schemas | `CND-052` |
+| `CND-054` | Golden and shadow comparison against frozen PostgreSQL Gold fixtures | `CND-002`, `CND-052`, `CND-053` |
+
+Statistical proximity is not acceptance. Every difference must be explained by an
+approved contract or rule change.
+
+### Phase 6 — Local product slice
+
+After the serving contract is frozen, Wave 1 uses three independent lanes:
+
+| ID | Deliverable | Boundary |
+|---|---|---|
+| `CND-060` | Local bootstrap with SQLite/filesystem and no cloud or legacy-service dependency | Application bootstrap and local configuration |
+| `CND-061` | Local password authentication and optional generic OIDC mapped to server-side membership and fixed tenant | Authentication and membership modules |
+| `CND-062` | Serving BFF and signed/authorized access policy | Central API serving routes |
+
+Wave 2 adds `CND-063`, the dashboard migration to serving JSON and fixed local
+tenant semantics. It depends on `CND-062` and owns `apps/web_dashboard`.
+
+`CND-064` is the local acceptance gate: restart persistence, full/delta ingestion,
+fencing, publication recovery, authorized dashboard access, and backup/restore of
+non-derivable control-plane state.
+
+### Phase 7 — Parallel expansion lanes
+
+After `CND-064`, the following source migrations are independent and may run in
+separate worktrees:
+
+| ID | Deliverable |
+|---|---|
+| `SRC-010` | SIHD raw, normalized, reconciliation, and serving parity |
+| `SRC-011` | BPA raw, normalized, reconciliation, and serving parity |
+| `SRC-012` | SIA raw, normalized, reconciliation, and serving parity |
+
+The AWS runtime lane may begin after Phase 4:
+
+| ID | Deliverable |
+|---|---|
+| `AWS-010` | AWS profile bootstrap using DynamoDB and S3 adapters |
+| `AWS-011` | Generic OIDC tenant resolution and membership authorization |
+| `AWS-012` | Step Functions Standard Inline Map and ECS task integration |
+| `AWS-013` | CloudWatch operational logs, S3 audit delivery, and signed serving access |
+| `AWS-014` | Cross-tenant, stale-GSI, failure, and recovery integration suite |
+
+The billing core lane may also begin after Phase 4:
+
+| ID | Deliverable |
+|---|---|
+| `BIL-010` | `BillingAccount`, immutable `PlanVersion`, `EntitlementSnapshot`, and local disabled mode |
+| `BIL-011` | `EntitlementGate` and immutable `RunAuthorization` |
+| `BIL-012` | DynamoDB entitlement projection, consistent critical gates, and short local cache |
+| `BIL-013` | Atomic quota and budget reservation lifecycle |
+
+Stripe integration follows the AWS and billing-core gates:
+
+| ID | Deliverable | Depends on |
+|---|---|---|
+| `BIL-020` | Hosted Checkout and Customer Portal with billing-owner authorization | `AWS-011`, `BIL-010` |
+| `BIL-021` | Signed webhook inbox, deduplication, reorder-safe projection, retry, and recovery | `AWS-010`, `BIL-012` |
+| `BIL-022` | Immediate revocation, run cancellation request, fence increment, and publication denial | `CND-044`, `BIL-011`, `BIL-021` |
+| `BIL-023` | Stripe reconciliation, audit, metrics, and alerts | `BIL-021`, `BIL-022` |
+| `BIL-024` | Stripe test-clock E2E for trial, renewal, payment failure, period-end cancellation, and immediate revocation | `BIL-020` through `BIL-023` |
+
+### Phase 8 — Migration and cutover
+
+| ID | Deliverable | Depends on |
+|---|---|---|
+| `MIG-010` | Historical shadow runs and per-source equivalence report | `CND-054`, retained `SRC-*` tasks |
+| `MIG-011` | Frontend and serving cutover to active `DatasetPointer` | `CND-064`, `MIG-010` |
+| `MIG-012` | Stop new writes to PostgreSQL and MinIO | `MIG-011` |
+| `MIG-013` | Export required history to immutable Parquet and verify hashes/manifests | `MIG-012` |
+| `MIG-014` | Remove PostgreSQL, MinIO, BigQuery, and Keycloak runtime code, migrations, deployment config, and documentation | `MIG-013` |
+| `MIG-015` | Final local and AWS acceptance matrix | `MIG-014`, `AWS-014`, and `BIL-024` when SaaS billing is released |
+
+Removal is never scheduled in parallel with the code paths it deletes.
+
+## 8. Worktree and agent policy
+
+### 8.1 Concurrency
+
+Use at most three implementation worktrees at once while retaining one controller
+lane for integration, review, and full-suite verification.
+
+An agent receives exactly one independently reviewable task. Related tasks that edit
+the same aggregate or bootstrap file stay in one worktree or run sequentially.
+
+### 8.2 Branch naming
+
+```text
+feat/<logical-id-lowercase>-<short-scope>
+fix/<logical-id-lowercase>-<short-scope>
+test/<logical-id-lowercase>-<short-scope>
+docs/<logical-id-lowercase>-<short-scope>
+```
+
+Examples:
+
+```text
+feat/cnd-020-sqlite-control-plane
+feat/cnd-032-edge-raw-manifest-v1
+feat/bil-021-stripe-webhook-projection
+```
+
+Every branch starts from the latest green `develop` commit containing all declared
+dependencies. Dependent branches are not pre-created from stale integration heads.
+
+### 8.3 Shared-file ownership
+
+The following files and surfaces are integration-owned unless an issue explicitly
+grants ownership:
+
+- root and package `pyproject.toml` files;
+- `uv.lock`, Go module lock changes spanning another task, and frontend lockfiles;
+- package `__init__.py` exports used by multiple tasks;
+- application bootstrap and dependency-injection composition roots;
+- generated OpenAPI and JSON Schema artifacts;
+- root documentation indexes and roadmap;
+- Docker Compose, CI workflows, and deployment-wide configuration.
+
+Feature agents expose new modules through direct imports in their tests. A serial
+integration task updates shared exports, dependency manifests, lockfiles, generated
+contracts, and composition roots after feature review.
+
+### 8.4 Agent task packet
+
+Each dispatched task contains:
+
+- goal and explicit non-goals;
+- source design sections that govern the task;
+- dependency commit SHA;
+- allowed and forbidden paths;
+- consumed and produced interfaces with exact names and types;
+- failing test to write first;
+- targeted test, lint, type, race, and coverage commands;
+- acceptance criteria;
+- required return: root cause or design notes, changed files, verification evidence,
+  and unresolved risks.
+
+## 9. Integration and review gates
+
+Every implementation task follows this sequence:
+
+1. create an isolated worktree from the dependency-complete `develop` head;
+2. run the task-specific baseline test;
+3. write a failing behavior test;
+4. implement the smallest compliant change;
+5. run targeted lint, type, test, race, and coverage checks;
+6. perform specification-compliance review;
+7. perform code-quality review;
+8. open a PR against `develop`;
+9. integrate only after required checks and reviews pass;
+10. run the wave-level suite before dispatching dependents.
+
+Current repository quality constraints remain binding:
+
+- Python package coverage: 100% branch where already enforced;
+- Python app coverage: 90% line where already enforced;
+- Go Edge Agent: race-enabled suite and at least 65% filtered coverage;
+- dashboard: lint, typecheck, unit tests, build, and relevant E2E tests;
+- function body at most 50 lines;
+- cyclomatic complexity at most 10;
+- line width at most 100 characters;
+- file length at most 500 lines;
+- no direct commits to `main`.
+
+Adapter phases additionally require the shared contract suites. Orchestration phases
+require property, race, and crash tests. Migration phases require golden and shadow
+evidence.
+
+## 10. Issue topology
+
+Create four epic issues corresponding to the implementation plans. Atomic issues use
+the logical IDs in this document.
+
+Every issue body includes:
+
+```markdown
+## Goal
+## Non-goals
+## Depends on
+## Unlocks
+## Governing design sections
+## Allowed paths
+## Forbidden shared paths
+## Interfaces consumed
+## Interfaces produced
+## Test-first steps
+## Acceptance criteria
+## Verification commands
+## Worktree and branch
+```
+
+Only Phase 0 and Phase 1 atomic issues are created immediately after plan approval.
+Later atomic issues are materialized when their upstream interfaces are stable, using
+the phase definitions here as the authoritative backlog. This prevents stale file
+paths and signatures from being copied into dozens of premature issues.
+
+## 11. Definition of ready
+
+A task is ready for dispatch only when:
+
+- all `Depends on` tasks are merged into `develop`;
+- consumed interfaces exist at the documented signatures;
+- allowed paths do not overlap another active task;
+- the baseline test command is known and runnable;
+- fixtures or external emulators required by the task are available;
+- the acceptance criteria can be verified without another unmerged branch.
+
+## 12. Definition of done
+
+A task is done only when:
+
+- behavior and negative tests pass;
+- relevant contract, property, race, security, and recovery tests pass;
+- lint, type, coverage, and build gates pass;
+- no forbidden dependency or legacy coupling was introduced;
+- generated artifacts are updated by the integration lane when applicable;
+- the PR documents consumed and produced interfaces;
+- the wave-level suite remains green after integration.
+
+A phase is done only when its final gate is green on integrated `develop`, not when
+individual worktrees pass in isolation.
+
+## 13. Execution handoff
+
+After this design is reviewed, create four detailed implementation plans:
+
+1. Data Plane Foundation and Local Profile;
+2. AWS Runtime Profile;
+3. Billing and Entitlements;
+4. Source Migration and Cutover.
+
+The first executable backlog contains `CND-000` through `CND-014`. Phase 0 begins
+with branch reconciliation and baseline verification; implementation worktrees begin
+only after that gate.


### PR DESCRIPTION
## Summary

- adds the approved Parquet data-plane and orchestration V2 design
- adds the approved Stripe billing, entitlements, and revocation design
- defines the CNES-first implementation sequence for parallel agents and isolated worktrees
- separates Data Plane/Local, AWS Runtime, Billing, and Source Migration/Cutover plans
- reserves logical backlog IDs and dependency gates without creating implementation issues yet

## Repository evidence captured

- `develop` is the required integration base
- `develop` must first be reconciled with `main`
- target control-plane and orchestration ports are not implemented
- the existing Go Edge Agent is evolved rather than rewritten
- SIHD, BPA, and SIA remain legacy only during migration and must reach parity before legacy removal

## Review focus

- task dependencies and phase gates
- worktree path ownership and shared-file integration policy
- CNES_LOCAL + CNES_NACIONAL as the first vertical slice
- timing of AWS and billing lanes
- source-parity requirement before PostgreSQL/MinIO removal
- explicit exclusion of production AWS provisioning until a deployment specification is approved

## Verification

The two source files match the approved attachments byte-for-byte after publication.
The execution design passed placeholder, consistency, scope, and ambiguity review.

No application code or runtime configuration changes are included.