### PR TITLE
docs(repo): define CND worktree ownership

### DIFF
--- a/.github/ISSUE_TEMPLATE/cnesdata-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/cnesdata-implementation.yml
@@ -20,7 +20,7 @@ body:
   - type: textarea
     id: allowed_paths
     attributes:
-      label: Paths permitidos
+      label: Caminhos permitidos
       description: Liste os únicos arquivos ou diretórios que esta tarefa pode alterar.
       placeholder: Um path por linha
     validations:
@@ -28,8 +28,8 @@ body:
   - type: textarea
     id: forbidden_shared_paths
     attributes:
-      label: Paths compartilhados proibidos
-      description: Liste superfícies compartilhadas reservadas à controller lane.
+      label: Caminhos compartilhados proibidos
+      description: Liste superfícies compartilhadas reservadas à faixa de controle.
       placeholder: Um path ou superfície por linha
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/cnesdata-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/cnesdata-implementation.yml
@@ -1,0 +1,60 @@
+name: Tarefa de implementação CnesData
+description: Planeje uma tarefa atômica com ownership e verificações explícitas.
+body:
+  - type: input
+    id: logical_id
+    attributes:
+      label: ID lógico
+      description: Informe o identificador estável da tarefa, como CND-003.
+      placeholder: CND-000
+    validations:
+      required: true
+  - type: textarea
+    id: depends_on
+    attributes:
+      label: Dependências
+      description: Liste as tarefas que devem estar integradas ao develop antes do início.
+      placeholder: CND-000
+    validations:
+      required: true
+  - type: textarea
+    id: allowed_paths
+    attributes:
+      label: Paths permitidos
+      description: Liste os únicos arquivos ou diretórios que esta tarefa pode alterar.
+      placeholder: Um path por linha
+    validations:
+      required: true
+  - type: textarea
+    id: forbidden_shared_paths
+    attributes:
+      label: Paths compartilhados proibidos
+      description: Liste superfícies compartilhadas reservadas à controller lane.
+      placeholder: Um path ou superfície por linha
+    validations:
+      required: true
+  - type: textarea
+    id: interfaces_consumed
+    attributes:
+      label: Interfaces consumidas
+      description: Informe nomes e assinaturas exatas das interfaces consumidas.
+      placeholder: Uma interface por linha
+    validations:
+      required: true
+  - type: textarea
+    id: interfaces_produced
+    attributes:
+      label: Interfaces produzidas
+      description: Informe nomes e assinaturas exatas das interfaces produzidas.
+      placeholder: Uma interface por linha
+    validations:
+      required: true
+  - type: textarea
+    id: verification_commands
+    attributes:
+      label: Comandos de verificação
+      description: Liste os comandos de teste, lint, tipos, race e cobertura aplicáveis.
+      placeholder: uv run pytest caminho/do/teste.py -q
+      render: shell
+    validations:
+      required: true

--- a/docs/development/worktree-ownership.md
+++ b/docs/development/worktree-ownership.md
@@ -1,0 +1,77 @@
+# Worktree ownership policy
+
+This policy governs CND task dispatch, branch creation, shared-file ownership, and
+integration order.
+
+## Concurrency
+
+At most three feature worktrees may run at once. One controller lane is retained for
+integration, review, and full-suite verification.
+
+Each worktree owns one independently reviewable task. Tasks that edit the same aggregate or
+bootstrap file stay in one worktree or run sequentially. Parallel tasks must not consume unstable
+interfaces or compete for paths.
+
+## Branch naming and dependencies
+
+Branches must match `^(feat|fix|test|docs)/cnd-[0-9]{3}-[a-z0-9-]+$`.
+
+Valid examples cover every permitted prefix:
+
+- `feat/cnd-020-sqlite-control-plane`
+- `fix/cnd-021-control-plane-retry`
+- `test/cnd-022-control-plane-race`
+- `docs/cnd-003-worktree-ownership`
+
+Every branch starts from the latest green `develop` commit containing all declared dependencies.
+Dependent work never starts from an unmerged branch, and dependent branches are not pre-created
+from stale integration heads.
+
+## Controller-lane ownership
+
+The following surfaces belong to the controller lane unless an issue explicitly grants ownership:
+
+| Surface | Controller-owned scope |
+|---|---|
+| Dependency manifests | Root and package `pyproject.toml` files |
+| Locks | `uv.lock`, Go module lock changes spanning another task, and frontend lockfiles |
+| Shared package exports | Package `__init__.py` exports used by multiple tasks |
+| Composition roots | Application bootstrap and dependency-injection composition roots |
+| Generated contracts | Generated OpenAPI and JSON Schema artifacts |
+| Root planning docs | Root documentation indexes and roadmap |
+| Delivery configuration | Docker Compose, CI workflows, and deployment-wide configuration |
+
+Feature work exposes new modules through direct imports in its tests. A serial integration task
+updates controller-owned surfaces after feature review.
+
+## Controller queue
+
+The fixed integration order is `CND-064` → AWS Task 8 → Billing Task 6 → Source Task 4 →
+Billing Task 13 → Billing Task 17. Each queued task starts only after the previous item is on
+green `develop` and must preserve every previously composed profile.
+
+## Definition of ready
+
+A task is ready for dispatch only when:
+
+- all `Depends on` tasks are merged into `develop`;
+- consumed interfaces exist at the documented signatures;
+- allowed paths do not overlap another active task;
+- the baseline test command is known and runnable;
+- fixtures or external emulators required by the task are available;
+- the acceptance criteria can be verified without another unmerged branch.
+
+## Definition of done
+
+A task is done only when:
+
+- behavior and negative tests pass;
+- relevant contract, property, race, security, and recovery tests pass;
+- lint, type, coverage, and build gates pass;
+- no forbidden dependency or legacy coupling was introduced;
+- generated artifacts are updated by the integration lane when applicable;
+- the PR documents consumed and produced interfaces;
+- the wave-level suite remains green after integration.
+
+A phase is done only when its final gate is green on integrated `develop`, not when
+individual worktrees pass in isolation.

--- a/scripts/tests/test_worktree_policy.py
+++ b/scripts/tests/test_worktree_policy.py
@@ -18,6 +18,10 @@ EXPECTED_IDS = {
     "interfaces_produced",
     "verification_commands",
 }
+EXPECTED_LABELS = {
+    "allowed_paths": "Caminhos permitidos",
+    "forbidden_shared_paths": "Caminhos compartilhados proibidos",
+}
 BRANCH_EXAMPLES = (
     "feat/cnd-020-sqlite-control-plane",
     "fix/cnd-021-control-plane-retry",
@@ -90,6 +94,16 @@ def test_define_tipos_dos_campos_e_renderizacao_shell() -> None:
     assert fields["logical_id"]["type"] == "input"
     assert all(fields[field_id]["type"] == "textarea" for field_id in EXPECTED_IDS - {"logical_id"})
     assert fields["verification_commands"]["attributes"]["render"] == "shell"
+
+
+def test_exibe_campos_de_caminhos_em_portugues() -> None:
+    fields = {field["id"]: field for field in _load_issue_form()["body"]}
+    labels = {
+        field_id: fields[field_id]["attributes"]["label"] for field_id in EXPECTED_LABELS
+    }
+
+    assert labels == EXPECTED_LABELS
+    assert "faixa de controle" in fields["forbidden_shared_paths"]["attributes"]["description"]
 
 
 def test_documenta_regex_e_exemplo_valido_para_cada_prefixo() -> None:

--- a/scripts/tests/test_worktree_policy.py
+++ b/scripts/tests/test_worktree_policy.py
@@ -1,0 +1,141 @@
+"""Valida a política executável de worktrees do backlog CND."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+ISSUE_FORM = ROOT / ".github/ISSUE_TEMPLATE/cnesdata-implementation.yml"
+POLICY = ROOT / "docs/development/worktree-ownership.md"
+BRANCH_PATTERN = r"^(feat|fix|test|docs)/cnd-[0-9]{3}-[a-z0-9-]+$"
+EXPECTED_IDS = {
+    "logical_id",
+    "depends_on",
+    "allowed_paths",
+    "forbidden_shared_paths",
+    "interfaces_consumed",
+    "interfaces_produced",
+    "verification_commands",
+}
+BRANCH_EXAMPLES = (
+    "feat/cnd-020-sqlite-control-plane",
+    "fix/cnd-021-control-plane-retry",
+    "test/cnd-022-control-plane-race",
+    "docs/cnd-003-worktree-ownership",
+)
+CONTROLLER_ROWS = (
+    "| Dependency manifests | Root and package `pyproject.toml` files |",
+    (
+        "| Locks | `uv.lock`, Go module lock changes spanning another task, "
+        "and frontend lockfiles |"
+    ),
+    "| Shared package exports | Package `__init__.py` exports used by multiple tasks |",
+    "| Composition roots | Application bootstrap and dependency-injection composition roots |",
+    "| Generated contracts | Generated OpenAPI and JSON Schema artifacts |",
+    "| Root planning docs | Root documentation indexes and roadmap |",
+    "| Delivery configuration | Docker Compose, CI workflows, and deployment-wide configuration |",
+)
+DEFINITION_OF_READY = """A task is ready for dispatch only when:
+
+- all `Depends on` tasks are merged into `develop`;
+- consumed interfaces exist at the documented signatures;
+- allowed paths do not overlap another active task;
+- the baseline test command is known and runnable;
+- fixtures or external emulators required by the task are available;
+- the acceptance criteria can be verified without another unmerged branch."""
+DEFINITION_OF_DONE = """A task is done only when:
+
+- behavior and negative tests pass;
+- relevant contract, property, race, security, and recovery tests pass;
+- lint, type, coverage, and build gates pass;
+- no forbidden dependency or legacy coupling was introduced;
+- generated artifacts are updated by the integration lane when applicable;
+- the PR documents consumed and produced interfaces;
+- the wave-level suite remains green after integration.
+
+A phase is done only when its final gate is green on integrated `develop`, not when
+individual worktrees pass in isolation."""
+
+
+def _load_issue_form() -> dict[str, object]:
+    return yaml.safe_load(ISSUE_FORM.read_text(encoding="utf-8"))
+
+
+def _load_policy() -> str:
+    return POLICY.read_text(encoding="utf-8")
+
+
+def test_define_metadados_minimos_sem_automacoes() -> None:
+    issue_form = _load_issue_form()
+
+    assert set(issue_form) == {"name", "description", "body"}
+    assert issue_form["name"]
+    assert issue_form["description"]
+
+
+def test_exige_sete_campos_com_ids_unicos() -> None:
+    body = _load_issue_form()["body"]
+    ids = [field["id"] for field in body]
+
+    assert len(body) == 7
+    assert len(ids) == len(set(ids))
+    assert set(ids) == EXPECTED_IDS
+    assert all(field["validations"] == {"required": True} for field in body)
+
+
+def test_define_tipos_dos_campos_e_renderizacao_shell() -> None:
+    fields = {field["id"]: field for field in _load_issue_form()["body"]}
+
+    assert fields["logical_id"]["type"] == "input"
+    assert all(fields[field_id]["type"] == "textarea" for field_id in EXPECTED_IDS - {"logical_id"})
+    assert fields["verification_commands"]["attributes"]["render"] == "shell"
+
+
+def test_documenta_regex_e_exemplo_valido_para_cada_prefixo() -> None:
+    policy = _load_policy()
+
+    assert f"`{BRANCH_PATTERN}`" in policy
+    assert {example.split("/", maxsplit=1)[0] for example in BRANCH_EXAMPLES} == {
+        "feat",
+        "fix",
+        "test",
+        "docs",
+    }
+    assert all(re.fullmatch(BRANCH_PATTERN, example) for example in BRANCH_EXAMPLES)
+    assert all(f"`{example}`" in policy for example in BRANCH_EXAMPLES)
+
+
+def test_limita_concorrencia_e_reserva_superficies_para_controller_lane() -> None:
+    policy = _load_policy()
+
+    assert "At most three feature worktrees may run at once." in policy
+    assert "One controller lane is retained" in policy
+    assert all(row in policy for row in CONTROLLER_ROWS)
+    assert "unless an issue explicitly grants ownership" in policy
+
+
+def test_exige_dependencias_integradas_no_ultimo_develop_verde() -> None:
+    policy = _load_policy()
+
+    assert "latest green `develop` commit containing all declared dependencies" in policy
+    assert "Dependent work never starts from an unmerged branch" in policy
+
+
+def test_fixa_fila_da_controller_lane() -> None:
+    policy = _load_policy()
+    normalized_policy = " ".join(policy.split())
+
+    expected_queue = (
+        "`CND-064` → AWS Task 8 → Billing Task 6 → Source Task 4 → "
+        "Billing Task 13 → Billing Task 17"
+    )
+    assert expected_queue in normalized_policy
+    assert "only after the previous item is on green `develop`" in normalized_policy
+
+
+def test_reproduz_definitions_of_ready_e_done_literalmente() -> None:
+    policy = _load_policy()
+
+    assert DEFINITION_OF_READY in policy
+    assert DEFINITION_OF_DONE in policy


### PR DESCRIPTION
## Resumo

- adiciona o issue form CnesData com os sete campos obrigatórios do task packet
- documenta naming, concorrência, ownership e fila da controller lane
- adiciona testes executáveis para a política e as Definitions of Ready/Done

## Verificação

- `uv run pytest scripts/tests/test_worktree_policy.py -q` — 8 passed
- `uv run ruff check scripts/tests/test_worktree_policy.py` — passed
- `uv run ruff check .` — passed
- suíte rápida global — mantém 5 erros preexistentes de coleta em `tests/perf/**` por ausência de `estabelecimento_repo`

Closes #99