### PR TITLE
test(repo): record redesign baseline matrix

### DIFF
--- a/docs/baselines/2026-08-23-develop.json
+++ b/docs/baselines/2026-08-23-develop.json
@@ -1,0 +1,54 @@
+{
+  "commit_sha": "8a2d3a4cbce85e87e31dc4769aab2a7a2b4bf7b2",
+  "recorded_at": "2026-08-26T13:53:23.153595+00:00",
+  "suites": [
+    {
+      "name": "python-fast",
+      "command": "uv run pytest -m 'not integration and not postgres and not bigquery and not e2e and not stress and not soak and not spike and not windows_only' -q",
+      "exit_code": 2,
+      "duration_seconds": 7.495,
+      "waiver": {
+        "failure": "ModuleNotFoundError: No module named 'cnes_infra.storage.repositories.estabelecimento_repo' during collection of tests/perf/{macro,micro,soak,spike,stress}",
+        "expected_exit_code": 2,
+        "approved_by": "VINIClUS",
+        "approved_at": "2026-08-26"
+      }
+    },
+    {
+      "name": "python-packages-coverage",
+      "command": "uv run pytest packages/cnes_domain packages/cnes_infra -m 'not bigquery and not e2e and not stress and not soak and not spike' --cov --cov-config=pyproject.toml --cov-report=term-missing",
+      "exit_code": 0,
+      "duration_seconds": 21.168
+    },
+    {
+      "name": "python-apps-coverage",
+      "command": "uv run pytest apps/ -m 'not integration and not bigquery and not e2e and not stress and not soak and not spike and not windows_only' --cov --cov-config=.coveragerc --cov-report=term-missing",
+      "exit_code": 0,
+      "duration_seconds": 8.558
+    },
+    {
+      "name": "go-race-coverage",
+      "command": "sh -c 'cd apps/dump_agent_go &&\ngo test -race -count=1 -coverprofile=coverage.out ./... &&\ngrep -v -E '\"'\"'internal/apiclient/generated\\.go|cmd/|internal/service/|_windows\\.go:'\"'\"' coverage.out > coverage.filtered.out &&\ntotal=$(go tool cover -func=coverage.filtered.out | tail -1 | awk '\"'\"'{print $3}'\"'\"' | tr -d '\"'\"'%'\"'\"') &&\ngo tool cover -func=coverage.filtered.out | tail -1 &&\nawk -v total=\"$total\" '\"'\"'BEGIN { exit !(total >= 65) }'\"'\"''",
+      "exit_code": 0,
+      "duration_seconds": 18.556
+    },
+    {
+      "name": "dashboard",
+      "command": "sh -c 'cd apps/web_dashboard &&\nbun run codegen &&\nbun run lint &&\nbun run typecheck &&\nbun run test --coverage &&\nbun run build'",
+      "exit_code": 0,
+      "duration_seconds": 33.194
+    },
+    {
+      "name": "python-integration-docker",
+      "command": "sh -c 'docker compose -p cnesdata up -d --wait postgres && uv run pytest -m postgres -q'",
+      "exit_code": 2,
+      "duration_seconds": 4.09,
+      "waiver": {
+        "failure": "ModuleNotFoundError: No module named 'cnes_infra.storage.repositories.estabelecimento_repo' during collection of tests/perf/{macro,micro,soak,spike,stress}",
+        "expected_exit_code": 2,
+        "approved_by": "VINIClUS",
+        "approved_at": "2026-08-26"
+      }
+    }
+  ]
+}

--- a/scripts/baseline_matrix.py
+++ b/scripts/baseline_matrix.py
@@ -1,0 +1,185 @@
+"""Executa e registra a matriz de baseline do monorepo."""
+
+import argparse
+import json
+import shlex
+import shutil
+import subprocess
+import time
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+APPROVED_SHA = "8a2d3a4cbce85e87e31dc4769aab2a7a2b4bf7b2"
+WAIVED_SUITES = frozenset({"python-fast", "python-integration-docker"})
+WAIVER = {
+    "failure": (
+        "ModuleNotFoundError: No module named "
+        "'cnes_infra.storage.repositories.estabelecimento_repo' during collection of "
+        "tests/perf/{macro,micro,soak,spike,stress}"
+    ),
+    "expected_exit_code": 2,
+    "approved_by": "VINIClUS",
+    "approved_at": "2026-08-26",
+}
+
+Command = tuple[str, ...]
+Suite = tuple[str, Command]
+
+PYTHON_FAST_MARKERS = (
+    "not integration and not postgres and not bigquery and not e2e and not stress and "
+    "not soak and not spike and not windows_only"
+)
+PYTHON_PACKAGE_MARKERS = "not bigquery and not e2e and not stress and not soak and not spike"
+PYTHON_APP_MARKERS = (
+    "not integration and not bigquery and not e2e and not stress and not soak and not spike "
+    "and not windows_only"
+)
+GO_SCRIPT = """cd apps/dump_agent_go &&
+go test -race -count=1 -coverprofile=coverage.out ./... &&
+grep -v -E 'internal/apiclient/generated\\.go|cmd/|internal/service/|_windows\\.go:' \
+coverage.out > coverage.filtered.out &&
+total=$(go tool cover -func=coverage.filtered.out | tail -1 | awk '{print $3}' | tr -d '%') &&
+go tool cover -func=coverage.filtered.out | tail -1 &&
+awk -v total="$total" 'BEGIN { exit !(total >= 65) }'"""
+DASHBOARD_SCRIPT = """cd apps/web_dashboard &&
+bun run codegen &&
+bun run lint &&
+bun run typecheck &&
+bun run test --coverage &&
+bun run build"""
+INTEGRATION_SCRIPT = (
+    "docker compose -p cnesdata up -d --wait postgres && uv run pytest -m postgres -q"
+)
+
+SUITES: tuple[Suite, ...] = (
+    ("python-fast", ("uv", "run", "pytest", "-m", PYTHON_FAST_MARKERS, "-q")),
+    (
+        "python-packages-coverage",
+        (
+            "uv",
+            "run",
+            "pytest",
+            "packages/cnes_domain",
+            "packages/cnes_infra",
+            "-m",
+            PYTHON_PACKAGE_MARKERS,
+            "--cov",
+            "--cov-config=pyproject.toml",
+            "--cov-report=term-missing",
+        ),
+    ),
+    (
+        "python-apps-coverage",
+        (
+            "uv",
+            "run",
+            "pytest",
+            "apps/",
+            "-m",
+            PYTHON_APP_MARKERS,
+            "--cov",
+            "--cov-config=.coveragerc",
+            "--cov-report=term-missing",
+        ),
+    ),
+    ("go-race-coverage", ("sh", "-c", GO_SCRIPT)),
+    ("dashboard", ("sh", "-c", DASHBOARD_SCRIPT)),
+    ("python-integration-docker", ("sh", "-c", INTEGRATION_SCRIPT)),
+)
+
+
+@dataclass(frozen=True)
+class SuiteResult:
+    name: str
+    command: str
+    exit_code: int
+    duration_seconds: float
+
+
+def run_suite(name: str, command: Sequence[str]) -> SuiteResult:
+    formatted_command = shlex.join(command)
+    started_at = time.perf_counter()
+    print(f"suite_start name={name} command={formatted_command}", flush=True)
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        output = completed.stdout
+        exit_code = completed.returncode
+    except OSError as error:
+        output = f"{type(error).__name__}: {error}"
+        exit_code = 127
+    duration = time.perf_counter() - started_at
+    if output:
+        print(output, end="" if output.endswith("\n") else "\n", flush=True)
+    print(f"suite_end name={name} exit_code={exit_code} duration_seconds={duration:.3f}")
+    return SuiteResult(name, formatted_command, exit_code, round(duration, 3))
+
+
+def run_suites(suites: Sequence[Suite]) -> list[SuiteResult]:
+    return [run_suite(name, command) for name, command in suites]
+
+
+def _waiver_for(result: SuiteResult, commit_sha: str) -> dict[str, object] | None:
+    if (
+        commit_sha == APPROVED_SHA
+        and result.name in WAIVED_SUITES
+        and result.exit_code == WAIVER["expected_exit_code"]
+    ):
+        return dict(WAIVER)
+    return None
+
+
+def write_report(path: Path, results: Sequence[SuiteResult], commit_sha: str) -> None:
+    suites = []
+    for result in results:
+        suite = asdict(result)
+        waiver = _waiver_for(result, commit_sha)
+        if waiver is not None:
+            suite["waiver"] = waiver
+        suites.append(suite)
+    payload = {
+        "commit_sha": commit_sha,
+        "recorded_at": datetime.now(UTC).isoformat(),
+        "suites": suites,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def matrix_exit_code(results: Sequence[SuiteResult], commit_sha: str) -> int:
+    accepted = all(result.exit_code == 0 or _waiver_for(result, commit_sha) for result in results)
+    return 0 if accepted else 1
+
+
+def _commit_sha() -> str:
+    git = shutil.which("git")
+    if git is None:
+        raise FileNotFoundError("executable=git")
+    completed = subprocess.run(
+        (git, "rev-parse", "HEAD"),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    commit_sha = _commit_sha()
+    results = run_suites(SUITES)
+    write_report(args.output, results, commit_sha)
+    return matrix_exit_code(results, commit_sha)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/baseline_matrix_test.py
+++ b/scripts/baseline_matrix_test.py
@@ -1,0 +1,128 @@
+"""Testes da matriz de baseline versionada."""
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from scripts import baseline_matrix
+from scripts.baseline_matrix import SuiteResult
+
+APPROVED_SHA = "8a2d3a4cbce85e87e31dc4769aab2a7a2b4bf7b2"
+
+
+def test_serializa_relatorio_com_timestamp_utc_e_cria_diretorio(tmp_path: Path) -> None:
+    report_path = tmp_path / "nested" / "baseline.json"
+    results = [SuiteResult("python-packages", "uv run pytest packages/", 0, 1.25)]
+
+    baseline_matrix.write_report(report_path, results, APPROVED_SHA)
+
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    recorded_at = datetime.fromisoformat(payload["recorded_at"])
+    assert payload["commit_sha"] == APPROVED_SHA
+    assert recorded_at.utcoffset().total_seconds() == 0
+    assert payload["suites"] == [
+        {
+            "name": "python-packages",
+            "command": "uv run pytest packages/",
+            "exit_code": 0,
+            "duration_seconds": 1.25,
+        }
+    ]
+
+
+def test_executa_comando_exibe_saida_e_mede_duracao(capsys: pytest.CaptureFixture[str]) -> None:
+    result = baseline_matrix.run_suite(
+        "echo",
+        (sys.executable, "-c", "print('baseline-output')"),
+    )
+
+    assert result.name == "echo"
+    assert result.command == f"{sys.executable} -c 'print('\"'\"'baseline-output'\"'\"')'"
+    assert result.exit_code == 0
+    assert result.duration_seconds >= 0
+    assert "baseline-output" in capsys.readouterr().out
+
+
+def test_retorna_127_quando_executavel_nao_existe(capsys: pytest.CaptureFixture[str]) -> None:
+    result = baseline_matrix.run_suite("missing", ("cnesdata-command-that-does-not-exist",))
+
+    assert result.exit_code == 127
+    assert "cnesdata-command-that-does-not-exist" in capsys.readouterr().out
+
+
+def test_executa_suite_seguinte_apos_falha() -> None:
+    suites = (
+        ("failure", (sys.executable, "-c", "raise SystemExit(3)")),
+        ("success", (sys.executable, "-c", "raise SystemExit(0)")),
+    )
+
+    results = baseline_matrix.run_suites(suites)
+
+    assert [result.exit_code for result in results] == [3, 0]
+
+
+@pytest.mark.parametrize("name", ["python-fast", "python-integration-docker"])
+def test_registra_waiver_aprovado_no_sha_e_codigo_exatos(
+    tmp_path: Path,
+    name: str,
+) -> None:
+    report_path = tmp_path / "baseline.json"
+    result = SuiteResult(name, "uv run pytest", 2, 0.5)
+
+    baseline_matrix.write_report(report_path, [result], APPROVED_SHA)
+
+    suite = json.loads(report_path.read_text(encoding="utf-8"))["suites"][0]
+    assert suite["waiver"] == {
+        "failure": (
+            "ModuleNotFoundError: No module named "
+            "'cnes_infra.storage.repositories.estabelecimento_repo' during collection of "
+            "tests/perf/{macro,micro,soak,spike,stress}"
+        ),
+        "expected_exit_code": 2,
+        "approved_by": "VINIClUS",
+        "approved_at": "2026-08-26",
+    }
+
+
+@pytest.mark.parametrize(
+    ("name", "exit_code", "commit_sha"),
+    [
+        ("python-fast", 1, APPROVED_SHA),
+        ("python-fast", 2, "f" * 40),
+        ("python-packages", 2, APPROVED_SHA),
+    ],
+)
+def test_nao_registra_waiver_fora_da_aprovacao(
+    tmp_path: Path,
+    name: str,
+    exit_code: int,
+    commit_sha: str,
+) -> None:
+    report_path = tmp_path / "baseline.json"
+
+    baseline_matrix.write_report(
+        report_path,
+        [SuiteResult(name, "uv run pytest", exit_code, 0.5)],
+        commit_sha,
+    )
+
+    suite = json.loads(report_path.read_text(encoding="utf-8"))["suites"][0]
+    assert "waiver" not in suite
+
+
+def test_status_zero_com_suites_verdes_e_waiver_aprovado() -> None:
+    results = [
+        SuiteResult("python-fast", "uv run pytest", 2, 0.5),
+        SuiteResult("go", "go test ./...", 0, 0.5),
+    ]
+
+    assert baseline_matrix.matrix_exit_code(results, APPROVED_SHA) == 0
+
+
+def test_status_vermelho_sem_waiver_aprovado() -> None:
+    results = [SuiteResult("python-fast", "uv run pytest", 2, 0.5)]
+
+    assert baseline_matrix.matrix_exit_code(results, "f" * 40) == 1


### PR DESCRIPTION
Closes #98

## Escopo

- adiciona runner sequencial stdlib para Python, Go, dashboard e integração Docker
- registra baseline versionada no SHA reconciliado `8a2d3a4cbce85e87e31dc4769aab2a7a2b4bf7b2`
- limita waivers a `python-fast` e `python-integration-docker`, exit 2, SHA e aprovação exatos

## Verificação

- `uv run pytest scripts/baseline_matrix_test.py -q` — 11 passed
- `uv run ruff check .` — passed
- packages — 449 passed, 100% coverage
- apps — 231 passed, 97.55% coverage
- Go race — 83.8% filtered coverage
- dashboard — lint, typecheck, 51 tests with coverage, build
- matrix — exit 0 com somente os dois waivers aprovados