### PR TITLE
feat(contracts): add versioned data plane manifests

### DIFF
--- a/packages/cnes_contracts/src/cnes_contracts/manifests/outputs.py
+++ b/packages/cnes_contracts/src/cnes_contracts/manifests/outputs.py
@@ -16,7 +16,7 @@ from cnes_contracts.manifests.validation import (
     validate_object_key,
 )
 
-type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
+type JsonValue = bool | int | float | str | list[JsonValue] | dict[str, JsonValue] | None
 
 _SCHEMA_PATTERN = r"^[a-z0-9-]+-v[1-9][0-9]*$"
 _DOCUMENT_PATTERN = r"^[a-z0-9][a-z0-9_-]*$"

--- a/packages/cnes_contracts/src/cnes_contracts/manifests/outputs.py
+++ b/packages/cnes_contracts/src/cnes_contracts/manifests/outputs.py
@@ -1,0 +1,125 @@
+"""Versioned output and serving manifest contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003
+from math import isfinite
+from typing import Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from cnes_contracts.manifests.raw import SourceType  # noqa: TC001
+from cnes_contracts.manifests.validation import (
+    _COMPETENCIA_PATTERN,
+    _HASH_PATTERN,
+    _validate_utc,
+    validate_object_key,
+)
+
+type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
+
+_SCHEMA_PATTERN = r"^[a-z0-9-]+-v[1-9][0-9]*$"
+_DOCUMENT_PATTERN = r"^[a-z0-9][a-z0-9_-]*$"
+
+
+def _is_json_value(value: object) -> bool:
+    if value is None or isinstance(value, bool | int | str):
+        return True
+    if isinstance(value, float):
+        return isfinite(value)
+    if isinstance(value, list):
+        return all(_is_json_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(isinstance(key, str) and _is_json_value(item) for key, item in value.items())
+    return False
+
+
+class OutputManifest(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True, extra="forbid")
+
+    manifest_version: Literal[1]
+    manifest_id: str = Field(min_length=1)
+    tenant_id: str = Field(min_length=1)
+    layer: Literal["normalized", "reconciliation", "serving"]
+    source_type: SourceType | None
+    competencia: str = Field(pattern=_COMPETENCIA_PATTERN)
+    run_id: str = Field(min_length=1)
+    unit_id: str = Field(min_length=1)
+    attempt: int = Field(gt=0)
+    schema_version: str = Field(min_length=1)
+    object_key: str = Field(min_length=1)
+    object_sha256: str = Field(pattern=_HASH_PATTERN)
+    row_count: int = Field(ge=0)
+    created_at: datetime
+
+    @field_validator("created_at")
+    @classmethod
+    def validate_created_at(cls, value: datetime) -> datetime:
+        return _validate_utc(value)
+
+    @model_validator(mode="after")
+    def validate_layer(self) -> Self:
+        if self.layer == "normalized" and self.source_type is None:
+            raise ValueError("source_type_required")
+        if self.layer != "normalized" and self.source_type is not None:
+            raise ValueError("source_type_forbidden")
+        validate_object_key(self)
+        return self
+
+
+class RunManifest(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True, extra="forbid")
+
+    manifest_version: Literal[1]
+    tenant_id: str = Field(min_length=1)
+    dataset_name: str = Field(min_length=1)
+    run_id: str = Field(min_length=1)
+    competencia: str = Field(pattern=_COMPETENCIA_PATTERN)
+    outputs: tuple[OutputManifest, ...]
+    missing_sources: tuple[str, ...]
+    published_at: datetime
+
+    @field_validator("published_at")
+    @classmethod
+    def validate_published_at(cls, value: datetime) -> datetime:
+        return _validate_utc(value)
+
+    @model_validator(mode="after")
+    def validate_outputs(self) -> Self:
+        if not self.outputs:
+            raise ValueError("outputs_required")
+        manifest_ids = {item.manifest_id for item in self.outputs}
+        object_keys = {item.object_key for item in self.outputs}
+        if len(manifest_ids) != len(self.outputs) or len(object_keys) != len(self.outputs):
+            raise ValueError("outputs_unique")
+        expected = (self.tenant_id, self.run_id, self.competencia)
+        if any(
+            (item.tenant_id, item.run_id, item.competencia) != expected for item in self.outputs
+        ):
+            raise ValueError("output_identity")
+        if len(set(self.missing_sources)) != len(self.missing_sources):
+            raise ValueError("missing_sources_unique")
+        return self
+
+
+class ServingDocument(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True, extra="forbid")
+
+    schema_version: str = Field(pattern=_SCHEMA_PATTERN)
+    document_name: str = Field(pattern=_DOCUMENT_PATTERN)
+    tenant_id: str = Field(min_length=1)
+    run_id: str = Field(min_length=1)
+    generated_at: datetime
+    payload: dict[str, JsonValue]
+
+    @field_validator("generated_at")
+    @classmethod
+    def validate_generated_at(cls, value: datetime) -> datetime:
+        return _validate_utc(value)
+
+    @field_validator("payload", mode="before")
+    @classmethod
+    def validate_payload(cls, value: object) -> object:
+        if not isinstance(value, dict) or not _is_json_value(value):
+            raise ValueError("payload_json_required")
+        return value

--- a/packages/cnes_contracts/src/cnes_contracts/manifests/processing.py
+++ b/packages/cnes_contracts/src/cnes_contracts/manifests/processing.py
@@ -1,0 +1,273 @@
+"""Strict processing request and result contracts."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from datetime import datetime  # noqa: TC003
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from cnes_contracts.manifests.outputs import OutputManifest, ServingDocument  # noqa: TC001
+from cnes_contracts.manifests.raw import RawManifest, SnapshotMode, SourceType
+from cnes_contracts.manifests.validation import (
+    _COMPETENCIA_PATTERN,
+    _validate_utc,
+    manifest_sha256,
+)
+
+_STRICT_FROZEN_CONFIG = ConfigDict(frozen=True, strict=True, extra="forbid")
+_SAFE_LEAF = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _ordered_unique(values: tuple[str, ...]) -> tuple[str, ...]:
+    if not values:
+        raise ValueError("target_keys_required")
+    if len(set(values)) != len(values):
+        raise ValueError("target_keys_unique")
+    return tuple(sorted(values))
+
+
+def _validate_target_keys(keys: tuple[str, ...], expected: tuple[str, ...]) -> None:
+    for key in keys:
+        parts = tuple(key.split("/"))
+        if not parts or parts[0] != expected[0]:
+            raise ValueError("target_key_layer")
+        if len(parts) != len(expected) + 1 or parts[:-1] != expected:
+            raise ValueError("target_key_identity")
+        if not _SAFE_LEAF.fullmatch(parts[-1]):
+            raise ValueError("target_key_invalid")
+        if expected[0] == "serving" and not parts[-1].endswith(".json"):
+            raise ValueError("target_key_invalid")
+
+
+def _validate_unique_manifests(manifests: tuple[OutputManifest, ...]) -> None:
+    manifest_ids = {item.manifest_id for item in manifests}
+    object_keys = {item.object_key for item in manifests}
+    if len(manifest_ids) != len(manifests) or len(object_keys) != len(manifests):
+        raise ValueError("manifests_unique")
+
+
+def _output_identity(manifest: OutputManifest) -> tuple[object, ...]:
+    return (
+        manifest.tenant_id,
+        manifest.run_id,
+        manifest.competencia,
+        manifest.unit_id,
+        manifest.attempt,
+        manifest.source_type,
+    )
+
+
+def _validate_output_group(
+    manifests: tuple[OutputManifest, ...], layer: str, *, nonempty: bool = True
+) -> None:
+    if nonempty and not manifests:
+        raise ValueError("manifests_required")
+    if any(item.layer != layer for item in manifests):
+        raise ValueError("manifest_layer")
+    _validate_unique_manifests(manifests)
+    if manifests and any(
+        _output_identity(item) != _output_identity(manifests[0]) for item in manifests
+    ):
+        raise ValueError("manifest_identity")
+
+
+def _validate_raw_chain(chain: tuple[RawManifest, ...]) -> None:
+    first = chain[0]
+    if first.snapshot_mode is not SnapshotMode.FULL:
+        raise ValueError("chain_full_required")
+    for expected_sequence, manifest in enumerate(chain, start=1):
+        if manifest.sequence != expected_sequence:
+            raise ValueError("chain_sequence")
+        if expected_sequence == 1:
+            continue
+        previous = chain[expected_sequence - 2]
+        if manifest.base_snapshot_id != first.snapshot_id:
+            raise ValueError("chain_base")
+        if manifest.previous_manifest_sha256 != manifest_sha256(previous):
+            raise ValueError("chain_hash")
+
+
+def _validate_raw_manifests(manifests: tuple[RawManifest, ...]) -> None:
+    if not manifests:
+        raise ValueError("raw_manifests_required")
+    grouped: dict[str, list[RawManifest]] = defaultdict(list)
+    for manifest in manifests:
+        grouped[manifest.file_subtype].append(manifest)
+    for chain in grouped.values():
+        _validate_raw_chain(tuple(chain))
+
+
+class NormalizeRequest(BaseModel):
+    model_config = _STRICT_FROZEN_CONFIG
+
+    tenant_id: str = Field(min_length=1)
+    run_id: str = Field(min_length=1)
+    unit_id: str = Field(min_length=1)
+    attempt: int = Field(gt=0)
+    source_type: SourceType
+    raw_manifests: tuple[RawManifest, ...]
+    target_keys: tuple[str, ...]
+    normalized_at: datetime
+
+    @field_validator("normalized_at")
+    @classmethod
+    def validate_normalized_at(cls, value: datetime) -> datetime:
+        return _validate_utc(value)
+
+    @field_validator("raw_manifests")
+    @classmethod
+    def order_raw_manifests(cls, values: tuple[RawManifest, ...]) -> tuple[RawManifest, ...]:
+        return tuple(sorted(values, key=lambda item: (item.file_subtype, item.sequence)))
+
+    @field_validator("target_keys")
+    @classmethod
+    def order_target_keys(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        return _ordered_unique(values)
+
+    @model_validator(mode="after")
+    def validate_request(self) -> Self:
+        _validate_raw_manifests(self.raw_manifests)
+        first = self.raw_manifests[0]
+        expected_identity = (self.tenant_id, self.source_type, first.competencia)
+        if any(
+            (item.tenant_id, item.source_type, item.competencia) != expected_identity
+            for item in self.raw_manifests
+        ):
+            raise ValueError("raw_identity")
+        prefix = (
+            "normalized",
+            self.tenant_id,
+            self.source_type.value,
+            first.competencia,
+            self.run_id,
+        )
+        _validate_target_keys(self.target_keys, prefix)
+        return self
+
+
+class NormalizeResult(BaseModel):
+    model_config = _STRICT_FROZEN_CONFIG
+
+    manifests: tuple[OutputManifest, ...]
+
+    @model_validator(mode="after")
+    def validate_manifests(self) -> Self:
+        _validate_output_group(self.manifests, "normalized")
+        return self
+
+
+class ReconcileRequest(BaseModel):
+    model_config = _STRICT_FROZEN_CONFIG
+
+    tenant_id: str = Field(min_length=1)
+    competencia: str = Field(pattern=_COMPETENCIA_PATTERN)
+    run_id: str = Field(min_length=1)
+    unit_id: str = Field(min_length=1)
+    attempt: int = Field(gt=0)
+    normalized_manifests: tuple[OutputManifest, ...]
+    reconciliation_key: str = Field(min_length=1)
+    divergence_key: str = Field(min_length=1)
+    reconciled_at: datetime
+
+    @field_validator("reconciled_at")
+    @classmethod
+    def validate_reconciled_at(cls, value: datetime) -> datetime:
+        return _validate_utc(value)
+
+    @model_validator(mode="after")
+    def validate_request(self) -> Self:
+        if not self.normalized_manifests:
+            raise ValueError("normalized_manifests_required")
+        if any(item.layer != "normalized" for item in self.normalized_manifests):
+            raise ValueError("manifest_layer")
+        _validate_unique_manifests(self.normalized_manifests)
+        expected = (self.tenant_id, self.competencia, self.run_id)
+        if any(
+            (item.tenant_id, item.competencia, item.run_id) != expected
+            for item in self.normalized_manifests
+        ):
+            raise ValueError("manifest_identity")
+        keys = (self.reconciliation_key, self.divergence_key)
+        if len(set(keys)) != len(keys):
+            raise ValueError("target_keys_unique")
+        _validate_target_keys(keys, ("reconciliation", *expected))
+        return self
+
+
+class ReconcileResult(BaseModel):
+    model_config = _STRICT_FROZEN_CONFIG
+
+    reconciliation_manifest: OutputManifest
+    divergence_manifest: OutputManifest
+    kpis: dict[str, int]
+
+    @model_validator(mode="after")
+    def validate_manifests(self) -> Self:
+        manifests = (self.reconciliation_manifest, self.divergence_manifest)
+        _validate_output_group(manifests, "reconciliation")
+        return self
+
+
+class MaterializeRequest(BaseModel):
+    model_config = _STRICT_FROZEN_CONFIG
+
+    tenant_id: str = Field(min_length=1)
+    competencia: str = Field(pattern=_COMPETENCIA_PATTERN)
+    run_id: str = Field(min_length=1)
+    unit_id: str = Field(min_length=1)
+    attempt: int = Field(gt=0)
+    reconciliation_manifest: OutputManifest
+    divergence_manifest: OutputManifest
+    missing_sources: tuple[str, ...]
+    target_keys: tuple[str, ...]
+    generated_at: datetime
+
+    @field_validator("generated_at")
+    @classmethod
+    def validate_generated_at(cls, value: datetime) -> datetime:
+        return _validate_utc(value)
+
+    @field_validator("target_keys")
+    @classmethod
+    def order_target_keys(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        return _ordered_unique(values)
+
+    @model_validator(mode="after")
+    def validate_request(self) -> Self:
+        manifests = (self.reconciliation_manifest, self.divergence_manifest)
+        _validate_output_group(manifests, "reconciliation")
+        expected = (self.tenant_id, self.competencia, self.run_id)
+        if any((item.tenant_id, item.competencia, item.run_id) != expected for item in manifests):
+            raise ValueError("manifest_identity")
+        if len(set(self.missing_sources)) != len(self.missing_sources):
+            raise ValueError("missing_sources_unique")
+        _validate_target_keys(self.target_keys, ("serving", self.tenant_id, self.run_id))
+        return self
+
+
+class MaterializeResult(BaseModel):
+    model_config = _STRICT_FROZEN_CONFIG
+
+    manifests: tuple[OutputManifest, ...]
+    documents: tuple[ServingDocument, ...]
+
+    @model_validator(mode="after")
+    def validate_result(self) -> Self:
+        _validate_output_group(self.manifests, "serving")
+        if len(self.documents) != len(self.manifests):
+            raise ValueError("result_cardinality")
+        names = tuple(item.document_name for item in self.documents)
+        if len(set(names)) != len(names):
+            raise ValueError("documents_unique")
+        if names != tuple(sorted(names)):
+            raise ValueError("result_association")
+        expected_leaves = tuple(f"{name}.json" for name in names)
+        if tuple(item.object_key.rsplit("/", 1)[-1] for item in self.manifests) != expected_leaves:
+            raise ValueError("result_association")
+        tenant_run = (self.manifests[0].tenant_id, self.manifests[0].run_id)
+        if any((item.tenant_id, item.run_id) != tenant_run for item in self.documents):
+            raise ValueError("result_identity")
+        return self

--- a/packages/cnes_contracts/src/cnes_contracts/manifests/raw.py
+++ b/packages/cnes_contracts/src/cnes_contracts/manifests/raw.py
@@ -1,0 +1,72 @@
+"""Versioned raw manifest contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003
+from enum import StrEnum
+from typing import Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from cnes_contracts.manifests.validation import (
+    _COMPETENCIA_PATTERN,
+    _HASH_PATTERN,
+    _validate_utc,
+    validate_object_key,
+)
+
+
+class SourceType(StrEnum):
+    CNES_LOCAL = "CNES_LOCAL"
+    CNES_NACIONAL = "CNES_NACIONAL"
+    SIHD = "SIHD"
+    BPA_MAG = "BPA_MAG"
+    SIA_LOCAL = "SIA_LOCAL"
+
+
+class SnapshotMode(StrEnum):
+    FULL = "FULL"
+    DELTA = "DELTA"
+
+
+class RawManifest(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True, extra="forbid")
+
+    manifest_version: Literal[1]
+    manifest_id: str = Field(min_length=1)
+    tenant_id: str = Field(min_length=1)
+    source_type: SourceType
+    file_subtype: str = Field(min_length=1)
+    competencia: str = Field(pattern=_COMPETENCIA_PATTERN)
+    agent_id: str = Field(min_length=1)
+    agent_version: str = Field(min_length=1)
+    schema_version: str = Field(min_length=1)
+    snapshot_mode: SnapshotMode
+    snapshot_id: str = Field(min_length=1)
+    base_snapshot_id: str | None
+    sequence: int = Field(gt=0)
+    previous_manifest_sha256: str | None = Field(pattern=_HASH_PATTERN)
+    object_sha256: str = Field(pattern=_HASH_PATTERN)
+    row_count: int = Field(ge=0)
+    size_bytes: int = Field(gt=0)
+    object_key: str = Field(min_length=1)
+    created_at: datetime
+
+    @field_validator("created_at")
+    @classmethod
+    def validate_created_at(cls, value: datetime) -> datetime:
+        return _validate_utc(value)
+
+    @model_validator(mode="after")
+    def validate_chain(self) -> Self:
+        if self.snapshot_mode is SnapshotMode.FULL:
+            if self.sequence != 1 or self.base_snapshot_id is not None:
+                raise ValueError("full_chain_invalid")
+            if self.previous_manifest_sha256 is not None:
+                raise ValueError("full_chain_invalid")
+        elif (
+            self.sequence < 2 or not self.base_snapshot_id or self.previous_manifest_sha256 is None
+        ):
+            raise ValueError("delta_chain_required")
+        validate_object_key(self)
+        return self

--- a/packages/cnes_contracts/src/cnes_contracts/manifests/validation.py
+++ b/packages/cnes_contracts/src/cnes_contracts/manifests/validation.py
@@ -1,0 +1,79 @@
+"""Canonical manifest validation helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime  # noqa: TC003
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cnes_contracts.manifests.outputs import OutputManifest
+    from cnes_contracts.manifests.raw import RawManifest
+
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_HASH_PATTERN = r"^[0-9a-f]{64}$"
+_COMPETENCIA_PATTERN = r"^[0-9]{4}-(0[1-9]|1[0-2])$"
+
+
+def _validate_utc(value: datetime) -> datetime:
+    if value.utcoffset() is None or value.utcoffset().total_seconds() != 0:
+        raise ValueError("datetime_utc_required")
+    return value
+
+
+def manifest_sha256(model: RawManifest | OutputManifest) -> str:
+    payload = model.model_dump_json(exclude_none=False, by_alias=False).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _wire_value(value: object) -> str:
+    return str(value.value) if isinstance(value, Enum) else str(value)
+
+
+def _segments(object_key: str) -> tuple[str, ...]:
+    if object_key.startswith("/") or object_key.endswith("/"):
+        raise ValueError("object_key_invalid")
+    parts = tuple(object_key.split("/"))
+    if any(not _SAFE_SEGMENT.fullmatch(part) for part in parts):
+        raise ValueError("object_key_invalid")
+    return parts
+
+
+def _expected_segments(manifest: RawManifest | OutputManifest) -> tuple[str, ...]:
+    layer = _wire_value(getattr(manifest, "layer", "raw"))
+    tenant_id = manifest.tenant_id
+    competencia = manifest.competencia
+    if layer == "raw":
+        return (
+            layer,
+            tenant_id,
+            _wire_value(manifest.source_type),
+            competencia,
+            manifest.snapshot_id,
+        )
+    if layer == "normalized":
+        return (
+            layer,
+            tenant_id,
+            _wire_value(manifest.source_type),
+            competencia,
+            manifest.run_id,
+        )
+    if layer == "reconciliation":
+        return (layer, tenant_id, competencia, manifest.run_id)
+    if layer == "serving":
+        return (layer, tenant_id, manifest.run_id)
+    raise ValueError("object_key_layer")
+
+
+def validate_object_key(manifest: RawManifest | OutputManifest) -> None:
+    parts = _segments(manifest.object_key)
+    expected = _expected_segments(manifest)
+    if len(parts) != len(expected) + 1:
+        raise ValueError("object_key_layout")
+    if parts[:-1] != expected:
+        raise ValueError("object_key_identity")
+    if expected[0] == "serving" and not parts[-1].endswith(".json"):
+        raise ValueError("object_key_invalid")

--- a/packages/cnes_contracts/tests/manifests/test_outputs.py
+++ b/packages/cnes_contracts/tests/manifests/test_outputs.py
@@ -1,0 +1,182 @@
+"""Testes dos manifestos de saída e serving."""
+
+from datetime import UTC, datetime
+from math import inf, nan
+
+import pytest
+from pydantic import ValidationError
+
+from cnes_contracts.manifests.outputs import OutputManifest, RunManifest, ServingDocument
+from cnes_contracts.manifests.raw import SourceType
+
+HASH = "b" * 64
+
+
+def output_values() -> dict[str, object]:
+    return {
+        "manifest_version": 1,
+        "manifest_id": "output-1",
+        "tenant_id": "354130",
+        "layer": "normalized",
+        "source_type": SourceType.CNES_LOCAL,
+        "competencia": "2026-07",
+        "run_id": "run-1",
+        "unit_id": "normalize-cnes",
+        "attempt": 1,
+        "schema_version": "cnes-normalized-v1",
+        "object_key": "normalized/354130/CNES_LOCAL/2026-07/run-1/cnes.parquet",
+        "object_sha256": HASH,
+        "row_count": 10,
+        "created_at": datetime(2026, 7, 2, tzinfo=UTC),
+    }
+
+
+def serving_document(name: str = "overview") -> ServingDocument:
+    return ServingDocument(
+        schema_version="cnes-serving-v1",
+        document_name=name,
+        tenant_id="354130",
+        run_id="run-1",
+        generated_at=datetime(2026, 7, 2, tzinfo=UTC),
+        payload={"total": 10, "items": [None, True, "ok", {"value": 1.5}]},
+    )
+
+
+def run_values(outputs: tuple[OutputManifest, ...]) -> dict[str, object]:
+    return {
+        "manifest_version": 1,
+        "tenant_id": "354130",
+        "dataset_name": "cnes",
+        "run_id": "run-1",
+        "competencia": "2026-07",
+        "outputs": outputs,
+        "missing_sources": (),
+        "published_at": datetime(2026, 7, 2, tzinfo=UTC),
+    }
+
+
+def test_output_normalized_exige_source_type():
+    with pytest.raises(ValidationError, match="source_type_required"):
+        OutputManifest.model_validate({**output_values(), "source_type": None})
+
+
+@pytest.mark.parametrize("layer", ["reconciliation", "serving"])
+def test_output_nao_normalized_rejeita_source_type(layer: str):
+    values = output_values()
+    values.update(
+        layer=layer,
+        source_type=SourceType.CNES_LOCAL,
+        object_key=(
+            "reconciliation/354130/2026-07/run-1/cnes.parquet"
+            if layer == "reconciliation"
+            else "serving/354130/run-1/overview.json"
+        ),
+    )
+
+    with pytest.raises(ValidationError, match="source_type_forbidden"):
+        OutputManifest.model_validate(values)
+
+
+def test_manifesto_de_divergencia_aceita_zero_linhas():
+    values = output_values()
+    values.update(
+        layer="reconciliation",
+        source_type=None,
+        object_key="reconciliation/354130/2026-07/run-1/divergence.parquet",
+        row_count=0,
+    )
+
+    assert OutputManifest.model_validate(values).row_count == 0
+
+
+def test_output_rejeita_hash_timestamp_cardinalidade_e_extra():
+    for changes in (
+        {"object_sha256": "B" * 64},
+        {"created_at": datetime(2026, 7, 2, tzinfo=UTC).replace(tzinfo=None)},
+        {"row_count": -1},
+        {"attempt": 0},
+        {"extra": True},
+    ):
+        with pytest.raises(ValidationError):
+            OutputManifest.model_validate({**output_values(), **changes})
+
+
+def test_run_manifest_valida_identidade_e_duplicatas():
+    output = OutputManifest.model_validate(output_values())
+    assert RunManifest.model_validate(run_values((output,))).outputs == (output,)
+
+    for outputs, message in (
+        ((), "outputs_required"),
+        ((output, output), "outputs_unique"),
+        ((output, output.model_copy(update={"manifest_id": "output-2"})), "outputs_unique"),
+    ):
+        with pytest.raises(ValidationError, match=message):
+            RunManifest.model_validate(run_values(outputs))
+
+
+@pytest.mark.parametrize(
+    ("changes", "object_key"),
+    [
+        ({"tenant_id": "outro"}, "normalized/outro/CNES_LOCAL/2026-07/run-1/cnes.parquet"),
+        ({"run_id": "run-2"}, "normalized/354130/CNES_LOCAL/2026-07/run-2/cnes.parquet"),
+        (
+            {"competencia": "2026-08"},
+            "normalized/354130/CNES_LOCAL/2026-08/run-1/cnes.parquet",
+        ),
+    ],
+)
+def test_run_manifest_rejeita_identidade_output(changes: dict[str, object], object_key: str):
+    member = OutputManifest.model_validate({**output_values(), **changes, "object_key": object_key})
+
+    with pytest.raises(ValidationError, match="output_identity"):
+        RunManifest.model_validate(run_values((member,)))
+
+
+def test_run_manifest_rejeita_missing_sources_repetidas():
+    output = OutputManifest.model_validate(output_values())
+    with pytest.raises(ValidationError, match="missing_sources_unique"):
+        RunManifest(
+            manifest_version=1,
+            tenant_id="354130",
+            dataset_name="cnes",
+            run_id="run-1",
+            competencia="2026-07",
+            outputs=(output,),
+            missing_sources=("SIHD", "SIHD"),
+            published_at=datetime(2026, 7, 2, tzinfo=UTC),
+        )
+
+
+@pytest.mark.parametrize("schema", ["Cnes-v1", "cnes-v0", "cnes", "cnes-v01"])
+def test_serving_document_rejeita_schema_invalido(schema: str):
+    with pytest.raises(ValidationError):
+        serving_document().model_copy(update={"schema_version": schema}).model_validate(
+            {**serving_document().model_dump(), "schema_version": schema}
+        )
+
+
+@pytest.mark.parametrize("name", ["Overview", "../overview", "overview.json", "_overview"])
+def test_serving_document_rejeita_nome_inseguro(name: str):
+    with pytest.raises(ValidationError):
+        ServingDocument.model_validate({**serving_document().model_dump(), "document_name": name})
+
+
+@pytest.mark.parametrize("value", [nan, inf, -inf, (1, 2), datetime(2026, 1, 1, tzinfo=UTC)])
+def test_serving_document_rejeita_payload_nao_json(value: object):
+    with pytest.raises(ValidationError, match="payload_json_required"):
+        ServingDocument.model_validate({**serving_document().model_dump(), "payload": {"x": value}})
+
+
+def test_serving_document_e_estrito_frozen_e_utc():
+    document = serving_document()
+    with pytest.raises(ValidationError):
+        document.run_id = "run-2"
+    with pytest.raises(ValidationError):
+        ServingDocument.model_validate({**document.model_dump(), "extra": True})
+    with pytest.raises(ValidationError, match="datetime_utc_required"):
+        ServingDocument.model_validate(
+            {
+                **document.model_dump(),
+                "generated_at": datetime(2026, 7, 2, tzinfo=UTC).replace(tzinfo=None),
+            }
+        )

--- a/packages/cnes_contracts/tests/manifests/test_processing.py
+++ b/packages/cnes_contracts/tests/manifests/test_processing.py
@@ -1,0 +1,399 @@
+"""Testes dos contratos de processamento."""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from cnes_contracts.manifests.outputs import OutputManifest, ServingDocument
+from cnes_contracts.manifests.processing import (
+    MaterializeRequest,
+    MaterializeResult,
+    NormalizeRequest,
+    NormalizeResult,
+    ReconcileRequest,
+    ReconcileResult,
+)
+from cnes_contracts.manifests.raw import RawManifest, SnapshotMode, SourceType
+from cnes_contracts.manifests.validation import manifest_sha256
+
+HASH = "a" * 64
+NOW = datetime(2026, 7, 2, tzinfo=UTC)
+
+
+def raw_manifest(subtype: str, sequence: int = 1, source: SourceType = SourceType.BPA_MAG):
+    mode = SnapshotMode.FULL if sequence == 1 else SnapshotMode.DELTA
+    return RawManifest(
+        manifest_version=1,
+        manifest_id=f"{subtype}-{sequence}",
+        tenant_id="354130",
+        source_type=source,
+        file_subtype=subtype,
+        competencia="2026-07",
+        agent_id="agent-1",
+        agent_version="1",
+        schema_version="raw-v1",
+        snapshot_mode=mode,
+        snapshot_id=f"{subtype.lower()}-{sequence}",
+        base_snapshot_id=None if sequence == 1 else f"{subtype.lower()}-1",
+        sequence=sequence,
+        previous_manifest_sha256=None if sequence == 1 else HASH,
+        object_sha256=HASH,
+        row_count=1,
+        size_bytes=1,
+        object_key=(f"raw/354130/{source.value}/2026-07/{subtype.lower()}-{sequence}/data.parquet"),
+        created_at=NOW,
+    )
+
+
+def raw_chain(subtype: str, length: int) -> tuple[RawManifest, ...]:
+    chain = [raw_manifest(subtype)]
+    for sequence in range(2, length + 1):
+        chain.append(
+            raw_manifest(subtype, sequence).model_copy(
+                update={"previous_manifest_sha256": manifest_sha256(chain[-1])}
+            )
+        )
+    return tuple(chain)
+
+
+def output_manifest(
+    layer: str = "normalized", name: str = "cnes", unit_id: str = "unit-1"
+) -> OutputManifest:
+    keys = {
+        "normalized": f"normalized/354130/CNES_LOCAL/2026-07/run-1/{name}.parquet",
+        "reconciliation": f"reconciliation/354130/2026-07/run-1/{name}.parquet",
+        "serving": f"serving/354130/run-1/{name}.json",
+    }
+    return OutputManifest.model_validate(
+        {
+            "manifest_version": 1,
+            "manifest_id": f"{layer}-{name}",
+            "tenant_id": "354130",
+            "layer": layer,
+            "source_type": SourceType.CNES_LOCAL if layer == "normalized" else None,
+            "competencia": "2026-07",
+            "run_id": "run-1",
+            "unit_id": unit_id,
+            "attempt": 1,
+            "schema_version": f"{layer}-v1",
+            "object_key": keys[layer],
+            "object_sha256": "b" * 64,
+            "row_count": 1,
+            "created_at": NOW,
+        }
+    )
+
+
+def changed_raw(manifest: RawManifest, **changes: object) -> RawManifest:
+    values = {**manifest.model_dump(), **changes}
+    source = values["source_type"]
+    values["object_key"] = (
+        f"raw/{values['tenant_id']}/{source.value}/{values['competencia']}/"
+        f"{values['snapshot_id']}/data.parquet"
+    )
+    return RawManifest.model_validate(values)
+
+
+def changed_output(manifest: OutputManifest, **changes: object) -> OutputManifest:
+    values = {**manifest.model_dump(), **changes}
+    leaf = manifest.object_key.rsplit("/", 1)[-1]
+    if values["layer"] == "normalized":
+        source = values["source_type"]
+        prefix = (
+            f"normalized/{values['tenant_id']}/{source.value}/"
+            f"{values['competencia']}/{values['run_id']}"
+        )
+    elif values["layer"] == "reconciliation":
+        prefix = f"reconciliation/{values['tenant_id']}/{values['competencia']}/{values['run_id']}"
+    else:
+        prefix = f"serving/{values['tenant_id']}/{values['run_id']}"
+    values["object_key"] = f"{prefix}/{leaf}"
+    return OutputManifest.model_validate(values)
+
+
+def document(name: str) -> ServingDocument:
+    return ServingDocument(
+        schema_version="serving-v1",
+        document_name=name,
+        tenant_id="354130",
+        run_id="run-1",
+        generated_at=NOW,
+        payload={},
+    )
+
+
+def normalize_values() -> dict[str, object]:
+    return {
+        "tenant_id": "354130",
+        "run_id": "run-1",
+        "unit_id": "normalize-bpa",
+        "attempt": 1,
+        "source_type": SourceType.BPA_MAG,
+        "raw_manifests": raw_chain("BPA_C", 2),
+        "target_keys": ("normalized/354130/BPA_MAG/2026-07/run-1/bpa_c.parquet",),
+        "normalized_at": NOW,
+    }
+
+
+def test_normalize_aceita_cadeias_independentes_e_ordena_por_subtipo():
+    request = NormalizeRequest.model_validate(
+        {
+            **normalize_values(),
+            "raw_manifests": (*raw_chain("BPA_I", 1), *raw_chain("BPA_C", 2)),
+            "target_keys": (
+                "normalized/354130/BPA_MAG/2026-07/run-1/bpa_i.parquet",
+                "normalized/354130/BPA_MAG/2026-07/run-1/bpa_c.parquet",
+            ),
+        }
+    )
+
+    assert tuple(item.file_subtype for item in request.raw_manifests) == (
+        "BPA_C",
+        "BPA_C",
+        "BPA_I",
+    )
+    assert request.target_keys == tuple(sorted(request.target_keys))
+
+
+@pytest.mark.parametrize(
+    ("manifests", "message"),
+    [
+        ((), "raw_manifests_required"),
+        ((raw_manifest("BPA_C", 2),), "chain_full_required"),
+        ((raw_manifest("BPA_C"), raw_manifest("BPA_C")), "chain_sequence"),
+        ((raw_manifest("BPA_C"), raw_manifest("BPA_C", 3)), "chain_sequence"),
+    ],
+)
+def test_normalize_rejeita_cadeia_invalida(manifests: tuple[RawManifest, ...], message: str):
+    with pytest.raises(ValidationError, match=message):
+        NormalizeRequest.model_validate({**normalize_values(), "raw_manifests": manifests})
+
+
+def test_normalize_rejeita_hash_anterior_e_base_incorretos():
+    full, delta = raw_chain("BPA_C", 2)
+    for changed, message in (
+        (delta.model_copy(update={"previous_manifest_sha256": "c" * 64}), "chain_hash"),
+        (delta.model_copy(update={"base_snapshot_id": "outro"}), "chain_base"),
+    ):
+        with pytest.raises(ValidationError, match=message):
+            NormalizeRequest.model_validate(
+                {**normalize_values(), "raw_manifests": (full, changed)}
+            )
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        {"tenant_id": "outro"},
+        {"source_type": SourceType.SIA_LOCAL},
+        {"competencia": "2026-08"},
+    ],
+)
+def test_normalize_rejeita_identidade_raw_incorreta(changed: dict[str, object]):
+    manifest = changed_raw(raw_manifest("BPA_C"), **changed)
+    manifests = (manifest, raw_manifest("BPA_I")) if "competencia" in changed else (manifest,)
+    with pytest.raises(ValidationError, match="raw_identity"):
+        NormalizeRequest.model_validate({**normalize_values(), "raw_manifests": manifests})
+
+
+@pytest.mark.parametrize(
+    ("target_keys", "message"),
+    [
+        ((), "target_keys_required"),
+        (("normalized/354130/BPA_MAG/2026-07/run-1/x.parquet",) * 2, "target_keys_unique"),
+        (("reconciliation/354130/2026-07/run-1/x.parquet",), "target_key_layer"),
+        (("normalized/outro/BPA_MAG/2026-07/run-1/x.parquet",), "target_key_identity"),
+        (("normalized/354130/BPA_MAG/2026-07/run-2/x.parquet",), "target_key_identity"),
+        (("normalized/354130/BPA_MAG/2026-07/run-1/.hidden",), "target_key_invalid"),
+    ],
+)
+def test_normalize_rejeita_target_keys_invalidas(target_keys: tuple[str, ...], message: str):
+    with pytest.raises(ValidationError, match=message):
+        NormalizeRequest.model_validate({**normalize_values(), "target_keys": target_keys})
+
+
+def test_normalize_request_e_estrito_frozen_e_utc():
+    request = NormalizeRequest.model_validate(normalize_values())
+    with pytest.raises(ValidationError):
+        request.attempt = 2
+    naive = datetime(2026, 1, 1, tzinfo=UTC).replace(tzinfo=None)
+    for changes in ({"attempt": "1"}, {"extra": True}, {"normalized_at": naive}):
+        with pytest.raises(ValidationError):
+            NormalizeRequest.model_validate({**normalize_values(), **changes})
+
+
+def test_normalize_result_exige_manifests_normalized_coerentes_e_unicos():
+    first = output_manifest()
+    second = output_manifest(name="cnes_extra")
+    assert NormalizeResult(manifests=(first, second)).manifests == (first, second)
+    for manifests, message in (
+        ((), "manifests_required"),
+        ((first, first), "manifests_unique"),
+        ((first, first.model_copy(update={"manifest_id": "outro"})), "manifests_unique"),
+        ((first, changed_output(second, run_id="run-2")), "manifest_identity"),
+        ((output_manifest("reconciliation"),), "manifest_layer"),
+    ):
+        with pytest.raises(ValidationError, match=message):
+            NormalizeResult(manifests=manifests)
+
+
+def reconcile_values() -> dict[str, object]:
+    return {
+        "tenant_id": "354130",
+        "competencia": "2026-07",
+        "run_id": "run-1",
+        "unit_id": "reconcile-cnes",
+        "attempt": 1,
+        "normalized_manifests": (output_manifest(),),
+        "reconciliation_key": "reconciliation/354130/2026-07/run-1/cnes.parquet",
+        "divergence_key": "reconciliation/354130/2026-07/run-1/divergence.parquet",
+        "reconciled_at": NOW,
+    }
+
+
+def test_reconcile_request_valida_inputs_e_targets():
+    assert ReconcileRequest.model_validate(reconcile_values()).run_id == "run-1"
+    for changes, message in (
+        ({"normalized_manifests": ()}, "normalized_manifests_required"),
+        ({"normalized_manifests": (output_manifest("reconciliation"),)}, "manifest_layer"),
+        (
+            {"normalized_manifests": (changed_output(output_manifest(), tenant_id="x"),)},
+            "manifest_identity",
+        ),
+        (
+            {"normalized_manifests": (changed_output(output_manifest(), run_id="x"),)},
+            "manifest_identity",
+        ),
+        (
+            {"normalized_manifests": (changed_output(output_manifest(), competencia="2026-08"),)},
+            "manifest_identity",
+        ),
+        ({"reconciliation_key": "serving/354130/run-1/x.json"}, "target_key_layer"),
+        ({"divergence_key": "reconciliation/other/2026-07/run-1/x.parquet"}, "target_key_identity"),
+        (
+            {"divergence_key": "reconciliation/354130/2026-07/run-1/cnes.parquet"},
+            "target_keys_unique",
+        ),
+    ):
+        with pytest.raises(ValidationError, match=message):
+            ReconcileRequest.model_validate({**reconcile_values(), **changes})
+
+
+def test_reconcile_result_valida_artefatos():
+    reconciliation = output_manifest("reconciliation", "cnes", "reconcile")
+    divergence = output_manifest("reconciliation", "divergence", "reconcile")
+    result = ReconcileResult(
+        reconciliation_manifest=reconciliation,
+        divergence_manifest=divergence,
+        kpis={"total": 1},
+    )
+    assert result.kpis == {"total": 1}
+    for changed, message in (
+        (
+            divergence.model_copy(update={"manifest_id": reconciliation.manifest_id}),
+            "manifests_unique",
+        ),
+        (
+            divergence.model_copy(update={"object_key": reconciliation.object_key}),
+            "manifests_unique",
+        ),
+        (divergence.model_copy(update={"unit_id": "outro"}), "manifest_identity"),
+        (output_manifest(), "manifest_layer"),
+    ):
+        with pytest.raises(ValidationError, match=message):
+            ReconcileResult(
+                reconciliation_manifest=reconciliation,
+                divergence_manifest=changed,
+                kpis={},
+            )
+
+
+def materialize_values() -> dict[str, object]:
+    return {
+        "tenant_id": "354130",
+        "competencia": "2026-07",
+        "run_id": "run-1",
+        "unit_id": "materialize-cnes",
+        "attempt": 1,
+        "reconciliation_manifest": output_manifest("reconciliation", "cnes", "reconcile"),
+        "divergence_manifest": output_manifest("reconciliation", "divergence", "reconcile"),
+        "missing_sources": (),
+        "target_keys": ("serving/354130/run-1/overview.json",),
+        "generated_at": NOW,
+    }
+
+
+def test_materialize_request_valida_inputs_e_targets():
+    assert MaterializeRequest.model_validate(materialize_values()).target_keys
+    other_reconciliation = changed_output(output_manifest("reconciliation", "cnes"), run_id="run-2")
+    other_divergence = changed_output(
+        output_manifest("reconciliation", "divergence"), run_id="run-2"
+    )
+    for changes, message in (
+        ({"reconciliation_manifest": output_manifest()}, "manifest_layer"),
+        (
+            {
+                "divergence_manifest": changed_output(
+                    output_manifest("reconciliation", "divergence"), run_id="x"
+                )
+            },
+            "manifest_identity",
+        ),
+        (
+            {
+                "reconciliation_manifest": other_reconciliation,
+                "divergence_manifest": other_divergence,
+            },
+            "manifest_identity",
+        ),
+        ({"missing_sources": ("SIHD", "SIHD")}, "missing_sources_unique"),
+        ({"target_keys": ()}, "target_keys_required"),
+        ({"target_keys": ("serving/354130/run-1/x.json",) * 2}, "target_keys_unique"),
+        (
+            {"target_keys": ("normalized/354130/CNES_LOCAL/2026-07/run-1/x.parquet",)},
+            "target_key_layer",
+        ),
+        ({"target_keys": ("serving/outro/run-1/x.json",)}, "target_key_identity"),
+        ({"target_keys": ("serving/354130/run-1/x.parquet",)}, "target_key_invalid"),
+    ):
+        with pytest.raises(ValidationError, match=message):
+            MaterializeRequest.model_validate({**materialize_values(), **changes})
+
+
+def test_materialize_result_associa_documentos_ordenados_a_manifests():
+    overview = output_manifest("serving", "overview", "materialize")
+    workforce = output_manifest("serving", "workforce", "materialize")
+    result = MaterializeResult(
+        manifests=(overview, workforce),
+        documents=(document("overview"), document("workforce")),
+    )
+    assert tuple(item.document_name for item in result.documents) == ("overview", "workforce")
+
+    cases = (
+        ((), (), "manifests_required"),
+        ((overview,), (), "result_cardinality"),
+        ((overview, overview), (document("overview"), document("workforce")), "manifests_unique"),
+        ((overview, workforce), (document("overview"), document("overview")), "documents_unique"),
+        (
+            (workforce, overview),
+            (document("overview"), document("workforce")),
+            "result_association",
+        ),
+        (
+            (workforce, overview),
+            (document("workforce"), document("overview")),
+            "result_association",
+        ),
+        ((overview,), (document("workforce"),), "result_association"),
+        ((output_manifest(),), (document("cnes"),), "manifest_layer"),
+        ((changed_output(overview, tenant_id="x"),), (document("overview"),), "result_identity"),
+        (
+            (overview,),
+            (document("overview").model_copy(update={"run_id": "x"}),),
+            "result_identity",
+        ),
+    )
+    for manifests, documents, message in cases:
+        with pytest.raises(ValidationError, match=message):
+            MaterializeResult(manifests=manifests, documents=documents)

--- a/packages/cnes_contracts/tests/manifests/test_raw.py
+++ b/packages/cnes_contracts/tests/manifests/test_raw.py
@@ -1,0 +1,140 @@
+"""Testes dos manifestos raw."""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from cnes_contracts.manifests.raw import RawManifest, SnapshotMode, SourceType
+
+HASH = "a" * 64
+
+
+def raw_values() -> dict[str, object]:
+    return {
+        "manifest_version": 1,
+        "manifest_id": "manifest-1",
+        "tenant_id": "354130",
+        "source_type": SourceType.CNES_LOCAL,
+        "file_subtype": "CNES_VINCULO",
+        "competencia": "2026-07",
+        "agent_id": "agent-1",
+        "agent_version": "1.2.3",
+        "schema_version": "cnes-raw-v1",
+        "snapshot_mode": SnapshotMode.FULL,
+        "snapshot_id": "snapshot-1",
+        "base_snapshot_id": None,
+        "sequence": 1,
+        "previous_manifest_sha256": None,
+        "object_sha256": HASH,
+        "row_count": 10,
+        "size_bytes": 100,
+        "object_key": ("raw/354130/CNES_LOCAL/2026-07/snapshot-1/cnes_vinculo.parquet"),
+        "created_at": datetime(2026, 7, 1, tzinfo=UTC),
+    }
+
+
+def test_manifesto_raw_full_valido_e_imutavel():
+    manifest = RawManifest.model_validate(raw_values())
+
+    assert manifest.sequence == 1
+    with pytest.raises(ValidationError):
+        manifest.sequence = 2
+
+
+def test_manifesto_raw_rejeita_campos_extras_e_tipos_coagidos():
+    with pytest.raises(ValidationError):
+        RawManifest.model_validate({**raw_values(), "unknown": True})
+    with pytest.raises(ValidationError):
+        RawManifest.model_validate({**raw_values(), "row_count": "10"})
+
+
+def test_manifesto_raw_rejeita_versao_diferente():
+    with pytest.raises(ValidationError):
+        RawManifest.model_validate({**raw_values(), "manifest_version": 2})
+
+
+def test_manifesto_raw_aceita_enums_wire_em_json():
+    payload = RawManifest.model_validate(raw_values()).model_dump_json()
+
+    manifest = RawManifest.model_validate_json(payload)
+
+    assert manifest.source_type is SourceType.CNES_LOCAL
+    assert manifest.snapshot_mode is SnapshotMode.FULL
+
+
+@pytest.mark.parametrize("field", ["object_sha256", "previous_manifest_sha256"])
+@pytest.mark.parametrize("value", ["A" * 64, "a" * 63, "g" * 64])
+def test_manifesto_raw_rejeita_hash_invalido(field: str, value: str):
+    values = raw_values()
+    values.update(
+        snapshot_mode=SnapshotMode.DELTA,
+        base_snapshot_id="snapshot-1",
+        sequence=2,
+        previous_manifest_sha256=HASH,
+    )
+    values[field] = value
+
+    with pytest.raises(ValidationError):
+        RawManifest.model_validate(values)
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"sequence": 2}, "full_chain_invalid"),
+        ({"base_snapshot_id": "snapshot-0"}, "full_chain_invalid"),
+        ({"previous_manifest_sha256": HASH}, "full_chain_invalid"),
+        (
+            {
+                "snapshot_mode": SnapshotMode.DELTA,
+                "sequence": 2,
+                "previous_manifest_sha256": HASH,
+            },
+            "delta_chain_required",
+        ),
+        (
+            {
+                "snapshot_mode": SnapshotMode.DELTA,
+                "base_snapshot_id": "snapshot-1",
+                "sequence": 2,
+            },
+            "delta_chain_required",
+        ),
+        (
+            {
+                "snapshot_mode": SnapshotMode.DELTA,
+                "base_snapshot_id": "snapshot-1",
+                "sequence": 1,
+                "previous_manifest_sha256": HASH,
+            },
+            "delta_chain_required",
+        ),
+    ],
+)
+def test_manifesto_raw_valida_cadeia(changes: dict[str, object], message: str):
+    with pytest.raises(ValidationError, match=message):
+        RawManifest.model_validate({**raw_values(), **changes})
+
+
+@pytest.mark.parametrize(("field", "value"), [("size_bytes", 0), ("row_count", -1)])
+def test_manifesto_raw_valida_cardinalidade(field: str, value: int):
+    with pytest.raises(ValidationError):
+        RawManifest.model_validate({**raw_values(), field: value})
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    [
+        datetime(2026, 7, 1, tzinfo=UTC).replace(tzinfo=None),
+        datetime(2026, 7, 1, tzinfo=timezone(timedelta(hours=-3))),
+    ],
+)
+def test_manifesto_raw_exige_timestamp_utc(created_at: datetime):
+    with pytest.raises(ValidationError, match="datetime_utc_required"):
+        RawManifest.model_validate({**raw_values(), "created_at": created_at})
+
+
+def test_manifesto_raw_rejeita_object_key_nao_canonica():
+    with pytest.raises(ValidationError, match="object_key"):
+        RawManifest.model_validate({**raw_values(), "object_key": "raw/outro/arquivo.parquet"})

--- a/packages/cnes_contracts/tests/manifests/test_validation.py
+++ b/packages/cnes_contracts/tests/manifests/test_validation.py
@@ -1,0 +1,145 @@
+"""Testes das validações comuns de manifestos."""
+
+import hashlib
+from datetime import UTC, datetime
+
+import pytest
+
+from cnes_contracts.manifests.outputs import OutputManifest
+from cnes_contracts.manifests.raw import RawManifest, SnapshotMode, SourceType
+from cnes_contracts.manifests.validation import manifest_sha256, validate_object_key
+
+
+def raw_manifest() -> RawManifest:
+    return RawManifest(
+        manifest_version=1,
+        manifest_id="manifest-1",
+        tenant_id="354130",
+        source_type=SourceType.CNES_LOCAL,
+        file_subtype="CNES_VINCULO",
+        competencia="2026-07",
+        agent_id="agent-1",
+        agent_version="1",
+        schema_version="cnes-raw-v1",
+        snapshot_mode=SnapshotMode.FULL,
+        snapshot_id="snapshot-1",
+        base_snapshot_id=None,
+        sequence=1,
+        previous_manifest_sha256=None,
+        object_sha256="a" * 64,
+        row_count=1,
+        size_bytes=1,
+        object_key="raw/354130/CNES_LOCAL/2026-07/snapshot-1/data.parquet",
+        created_at=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+
+
+def output_manifest(layer: str) -> OutputManifest:
+    source_type = SourceType.CNES_LOCAL if layer == "normalized" else None
+    keys = {
+        "normalized": "normalized/354130/CNES_LOCAL/2026-07/run-1/data.parquet",
+        "reconciliation": "reconciliation/354130/2026-07/run-1/data.parquet",
+        "serving": "serving/354130/run-1/overview.json",
+    }
+    return OutputManifest.model_validate(
+        {
+            "manifest_version": 1,
+            "manifest_id": f"manifest-{layer}",
+            "tenant_id": "354130",
+            "layer": layer,
+            "source_type": source_type,
+            "competencia": "2026-07",
+            "run_id": "run-1",
+            "unit_id": "unit-1",
+            "attempt": 1,
+            "schema_version": "schema-v1",
+            "object_key": keys[layer],
+            "object_sha256": "b" * 64,
+            "row_count": 1,
+            "created_at": datetime(2026, 7, 2, tzinfo=UTC),
+        }
+    )
+
+
+def test_manifest_hash_usa_serializacao_canonica():
+    manifest = raw_manifest()
+
+    expected = hashlib.sha256(
+        manifest.model_dump_json(exclude_none=False, by_alias=False).encode()
+    ).hexdigest()
+
+    assert manifest_sha256(manifest) == expected
+
+
+@pytest.mark.parametrize("layer", ["normalized", "reconciliation", "serving"])
+def test_validate_object_key_aceita_layouts_de_saida(layer: str):
+    validate_object_key(output_manifest(layer))
+
+
+def test_validate_object_key_aceita_layout_raw():
+    validate_object_key(raw_manifest())
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("tenant_id", "outro"),
+        ("source_type", SourceType.SIHD),
+        ("competencia", "2026-08"),
+        ("snapshot_id", "snapshot-2"),
+    ],
+)
+def test_validate_object_key_rejeita_identidade_raw_incorreta(field: str, value: object):
+    with pytest.raises(ValueError, match="object_key_identity"):
+        validate_object_key(raw_manifest().model_copy(update={field: value}))
+
+
+@pytest.mark.parametrize(
+    ("layer", "field", "value"),
+    [
+        ("normalized", "tenant_id", "outro"),
+        ("normalized", "source_type", SourceType.SIHD),
+        ("normalized", "competencia", "2026-08"),
+        ("normalized", "run_id", "run-2"),
+        ("reconciliation", "tenant_id", "outro"),
+        ("reconciliation", "competencia", "2026-08"),
+        ("reconciliation", "run_id", "run-2"),
+        ("serving", "tenant_id", "outro"),
+        ("serving", "run_id", "run-2"),
+    ],
+)
+def test_validate_object_key_rejeita_identidade_output_incorreta(
+    layer: str, field: str, value: object
+):
+    with pytest.raises(ValueError, match="object_key_identity"):
+        validate_object_key(output_manifest(layer).model_copy(update={field: value}))
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "raw/354130/CNES_LOCAL/2026-07/snapshot-1/../secret",
+        "/raw/354130/CNES_LOCAL/2026-07/snapshot-1/data.parquet",
+        "raw//CNES_LOCAL/2026-07/snapshot-1/data.parquet",
+        "raw/354130/CNES_LOCAL/2026-07/snapshot-1/folder/data.parquet",
+        "raw/354130/CNES_LOCAL/2026-07/snapshot-1/.hidden",
+    ],
+)
+def test_validate_object_key_rejeita_traversal_e_leaf_insegura(key: str):
+    manifest = raw_manifest().model_copy(update={"object_key": key})
+    with pytest.raises(ValueError, match="object_key"):
+        validate_object_key(manifest)
+
+
+def test_validate_object_key_rejeita_camada_desconhecida():
+    manifest = output_manifest("normalized").model_copy(update={"layer": "unknown"})
+    with pytest.raises(ValueError, match="object_key_layer"):
+        validate_object_key(manifest)
+
+
+def test_output_serving_rejeita_leaf_sem_extensao_json():
+    manifest = output_manifest("serving")
+    values = {**manifest.model_dump(), "object_key": "serving/354130/run-1/overview.parquet"}
+
+    with pytest.raises(ValueError, match="object_key_invalid"):
+        OutputManifest.model_validate(values)


### PR DESCRIPTION
## Resumo

- adiciona contratos estritos e versionados para manifestos raw, output, run e serving
- valida object keys canônicas, timestamps UTC, hashes e cadeias FULL/DELTA por subtipo
- adiciona requests/results de normalize, reconcile e materialize com identidade e cardinalidade

## Verificação

- `uv run ruff check .`
- `uv run pytest packages/cnes_contracts -q` — 181 passed
- suíte de manifests — 91 passed, 100% branch coverage

Closes #103