### PR TITLE
fix(contracts): enforce normalized manifest order

### DIFF
--- a/packages/cnes_contracts/src/cnes_contracts/manifests/processing.py
+++ b/packages/cnes_contracts/src/cnes_contracts/manifests/processing.py
@@ -156,6 +156,9 @@ class NormalizeResult(BaseModel):
     @model_validator(mode="after")
     def validate_manifests(self) -> Self:
         _validate_output_group(self.manifests, "normalized")
+        object_keys = tuple(item.object_key for item in self.manifests)
+        if object_keys != tuple(sorted(object_keys)):
+            raise ValueError("manifest_order")
         return self
 
 

--- a/packages/cnes_contracts/tests/manifests/test_processing.py
+++ b/packages/cnes_contracts/tests/manifests/test_processing.py
@@ -232,6 +232,7 @@ def test_normalize_result_exige_manifests_normalized_coerentes_e_unicos():
         ((first, first), "manifests_unique"),
         ((first, first.model_copy(update={"manifest_id": "outro"})), "manifests_unique"),
         ((first, changed_output(second, run_id="run-2")), "manifest_identity"),
+        ((second, first), "manifest_order"),
         ((output_manifest("reconciliation"),), "manifest_layer"),
     ):
         with pytest.raises(ValidationError, match=message):


### PR DESCRIPTION
## Resumo

- exige ordenação canônica por `object_key` em `NormalizeResult.manifests`
- adiciona regressão test-first para associação posicional com `NormalizeRequest.target_keys`
- trata o finding procedente do review Codex em #111

## Verificação

- Ruff atual nos manifests: verde
- pacote `cnes_contracts`: 181 passed
- suíte manifests: 91 passed, 100% branch coverage

Closes #103