### PR TITLE
test(infra): define adapter conformance suites

### DIFF
--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -126,6 +126,25 @@ def _assert_active_job_fences(adapter: Any, clock: MutableClock) -> CompleteJob:
     return complete
 
 
+def _assert_job_failures(adapter: Any, clock: MutableClock) -> None:
+    failed_event = _event("failed-retryable")
+    failed = adapter.fail_job(_fail_job("worker-b", 2, "retry"), failed_event)
+    assert (failed.state, failed.lease_owner, failed.lease_until) == (
+        JobState.FAILED_RETRYABLE, None, None
+    )
+    assert adapter.pending_outbox(100).count(failed_event) == 1
+    final_claim = adapter.claim_job(_claim_job("job-a", "worker-c", clock))
+    assert final_claim is not None
+    final_event = _event("failed-final")
+    final_command = _fail_job("worker-c", 3, "permanent").model_copy(
+        update={"retryable": False}
+    )
+    final = adapter.fail_job(final_command, final_event)
+    assert final.state is JobState.FAILED_FINAL
+    assert adapter.get_job(_TENANT, "job-a") == final
+    assert adapter.pending_outbox(100).count(final_event) == 1
+
+
 def _event(event_id: str, now: datetime = _NOW, aggregate_id: str | None = None) -> OutboxEvent:
     return OutboxEvent(
         tenant_id=_TENANT, event_id=event_id, event_type="test.event",

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -34,6 +34,7 @@ _NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
 _TENANT = "354130"
 _HASH_A = "a" * 64
 _WAVE_A = "a" * 16
+_WAVE_B = "b" * 16
 
 
 @dataclass(slots=True)
@@ -100,6 +101,20 @@ def _expect_error(
     raise AssertionError(f"error_not_raised={expected}")
 
 
+def _assert_unit_rejected(
+    adapter: Any,
+    expected: type[Exception] | tuple[type[Exception], ...],
+    action: Callable[[], Any],
+) -> None:
+    before_units = adapter.list_run_units(_TENANT, "run-a")
+    before_run = adapter.get_run(_TENANT, "run-a")
+    before_outbox = adapter.pending_outbox(100)
+    _expect_error(expected, action)
+    assert adapter.list_run_units(_TENANT, "run-a") == before_units
+    assert adapter.get_run(_TENANT, "run-a") == before_run
+    assert adapter.pending_outbox(100) == before_outbox
+
+
 def _assert_active_job_fences(adapter: Any, clock: MutableClock) -> CompleteJob:
     manifest = _raw_record("result", "agent-a", 1, clock.now())
     complete = CompleteJob(
@@ -157,9 +172,7 @@ def _assert_job_failures(adapter: Any, clock: MutableClock) -> None:
     final_claim = adapter.claim_job(_claim_job("job-a", "worker-c", clock))
     assert final_claim is not None
     final_event = _event("failed-final")
-    final_command = _fail_job("worker-c", 3, "permanent").model_copy(
-        update={"retryable": False}
-    )
+    final_command = _fail_job("worker-c", 3, "permanent").model_copy(update={"retryable": False})
     final = adapter.fail_job(final_command, final_event)
     assert final.state is JobState.FAILED_FINAL
     assert adapter.get_job(_TENANT, "job-a") == final
@@ -199,20 +212,13 @@ def _raw_record(
 ) -> RawManifestRecord:
     base = None if sequence == 1 else f"base-{agent_id}"
     return RawManifestRecord(
-        tenant_id=_TENANT,
-        manifest_id=f"manifest-{agent_id}-{snapshot_id}",
+        tenant_id=_TENANT, manifest_id=f"manifest-{agent_id}-{snapshot_id}",
         manifest_key=f"raw/{_TENANT}/CNES/2026-07/{snapshot_id}/manifest.json",
-        agent_id=agent_id,
-        source_type="CNES",
-        file_subtype="ST",
-        competencia="2026-07",
+        agent_id=agent_id, source_type="CNES", file_subtype="ST", competencia="2026-07",
         snapshot_mode="FULL" if sequence == 1 else "DELTA",
-        snapshot_id=snapshot_id,
-        base_snapshot_id=base,
-        sequence=sequence,
+        snapshot_id=snapshot_id, base_snapshot_id=base, sequence=sequence,
         previous_manifest_sha256=None if sequence == 1 else _HASH_A,
-        manifest_sha256=_HASH_A,
-        created_at=created_at,
+        manifest_sha256=_HASH_A, created_at=created_at,
     )
 
 
@@ -322,6 +328,24 @@ def _assert_committed_unit(adapter: Any, dispatch: Any, claimed: Any) -> None:
     )
     assert completed.output_manifests == command.output_manifests
     assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
+    assert adapter.pending_outbox(100).count(event) == 1
+
+
+def _assert_retryable_unit_failure(adapter: Any, clock: MutableClock, base: Any) -> None:
+    dispatch = _reserve(adapter, clock, _WAVE_B)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-b")
+    assert claimed is not None
+    command = base.model_copy(update={
+        "dispatch_id": dispatch.dispatch_id,
+        "owner": "worker-b",
+        "fencing_token": claimed.fencing_token,
+    })
+    event = _event("unit-retryable")
+    failed = adapter.fail_run_unit(command, event)
+    assert (failed.state, failed.lease_owner, failed.lease_until) == (
+        RunUnitState.FAILED_RETRYABLE, None, None
+    )
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == failed
     assert adapter.pending_outbox(100).count(event) == 1
 
 

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -162,6 +162,7 @@ def _assert_job_failures(adapter: Any, clock: MutableClock) -> None:
     assert (failed.state, failed.lease_owner, failed.lease_until) == (
         JobState.FAILED_RETRYABLE, None, None)
     assert adapter.pending_outbox(100).count(failed_event) == 1
+    assert failed in adapter.list_claimable_jobs(_TENANT, "agent-a", 10)
     final_claim = adapter.claim_job(_claim_job("job-a", "worker-c", clock))
     assert final_claim is not None
     final_event = _event("failed-final")

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -292,6 +292,18 @@ def _prepare_unit(
     return _reserve(adapter, clock, unit_ids=unit_ids)
 
 
+def _assert_committed_unit(adapter: Any, dispatch: Any, claimed: Any) -> None:
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    event = _event("unit-completed")
+    completed = adapter.commit_run_unit(command, event)
+    assert (completed.state, completed.lease_owner, completed.lease_until) == (
+        RunUnitState.SUCCEEDED, None, None
+    )
+    assert completed.output_manifests == command.output_manifests
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
+    assert adapter.pending_outbox(100).count(event) == 1
+
+
 class _HarnessState:
     def __init__(self, clock: MutableClock, mutation: str | None = None) -> None:
         self.clock = clock

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -119,11 +119,32 @@ def _assert_active_job_fences(adapter: Any, clock: MutableClock) -> CompleteJob:
         complete.model_copy(update={"owner": "other"}),
         complete.model_copy(update={"fencing_token": 2}),
     )
-    for command in completions:
-        _expect_error((FenceRejected, LeaseLost), lambda command=command: adapter.complete_job(
-            command, _event("invalid-complete")
-        ))
+    for index, command in enumerate(completions):
+        before_job = adapter.get_job(_TENANT, "job-a")
+        before_outbox = adapter.pending_outbox(100)
+        _expect_error(
+            (FenceRejected, LeaseLost),
+            lambda command=command, index=index: adapter.complete_job(
+                command, _event(f"invalid-complete-{index}")
+            ),
+        )
+        assert adapter.get_job(_TENANT, "job-a") == before_job
+        assert adapter.pending_outbox(100) == before_outbox
+        assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 10) == ()
     return complete
+
+
+def _assert_revoked_completion(adapter: Any, complete: CompleteJob) -> None:
+    adapter.put_agent(_agent("agent-a", AgentState.REVOKED))
+    before_job = adapter.get_job(_TENANT, "job-a")
+    before_outbox = adapter.pending_outbox(100)
+    _expect_error((FenceRejected, LeaseLost), lambda: adapter.complete_job(
+        complete, _event("revoked-complete")
+    ))
+    assert adapter.get_job(_TENANT, "job-a") == before_job
+    assert adapter.pending_outbox(100) == before_outbox
+    assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 10) == ()
+    adapter.put_agent(_agent("agent-a"))
 
 
 def _assert_job_failures(adapter: Any, clock: MutableClock) -> None:

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -141,8 +141,10 @@ def _assert_active_job_fences(adapter: Any, clock: MutableClock) -> CompleteJob:
     renewals = (_renew_job(clock).model_copy(update={"owner": "other"}),
                 _renew_job(clock).model_copy(update={"fencing_token": 2}))
     for command in renewals:
+        before = adapter.get_job(_TENANT, "job-a")
         _expect_error((FenceRejected, LeaseLost),
                       lambda command=command: adapter.renew_job_lease(command))
+        assert adapter.get_job(_TENANT, "job-a") == before
     completions = (complete.model_copy(update={"owner": "other"}),
                    complete.model_copy(update={"fencing_token": 2}))
     for index, command in enumerate(completions):
@@ -159,8 +161,8 @@ def _assert_revoked_completion(adapter: Any, complete: CompleteJob) -> None:
 def _assert_job_failures(adapter: Any, clock: MutableClock) -> None:
     failed_event = _event("failed-retryable")
     failed = adapter.fail_job(_fail_job("worker-b", 2, "retry"), failed_event)
-    assert (failed.state, failed.lease_owner, failed.lease_until) == (
-        JobState.FAILED_RETRYABLE, None, None)
+    assert (failed.state, failed.error_code, failed.lease_owner, failed.lease_until) == (
+        JobState.FAILED_RETRYABLE, "retry", None, None)
     assert adapter.pending_outbox(100).count(failed_event) == 1
     assert failed in adapter.list_claimable_jobs(_TENANT, "agent-a", 10)
     final_claim = adapter.claim_job(_claim_job("job-a", "worker-c", clock))
@@ -168,13 +170,13 @@ def _assert_job_failures(adapter: Any, clock: MutableClock) -> None:
     final_event = _event("failed-final")
     final_command = _fail_job("worker-c", 3, "permanent").model_copy(update={"retryable": False})
     final = adapter.fail_job(final_command, final_event)
-    assert final.state is JobState.FAILED_FINAL
+    assert (final.state, final.error_code, final.lease_owner, final.lease_until) == (
+        JobState.FAILED_FINAL, "permanent", None, None)
     assert adapter.get_job(_TENANT, "job-a") == final
     assert adapter.pending_outbox(100).count(final_event) == 1
 
 
-def _event(event_id: str, now: datetime = _NOW, aggregate_id: str | None = None,
-           tenant_id: str = _TENANT) -> OutboxEvent:
+def _event(event_id, now=_NOW, aggregate_id=None, tenant_id=_TENANT) -> OutboxEvent:
     return OutboxEvent(
         tenant_id=tenant_id, event_id=event_id, event_type="test.event",
         aggregate_id=aggregate_id or event_id, payload={"event_id": event_id},
@@ -182,9 +184,7 @@ def _event(event_id: str, now: datetime = _NOW, aggregate_id: str | None = None,
     )
 
 
-def _agent(
-    agent_id: str, state: AgentState = AgentState.ACTIVE, tenant_id: str = _TENANT
-) -> Agent:
+def _agent(agent_id, state=AgentState.ACTIVE, tenant_id=_TENANT) -> Agent:
     return Agent(
         tenant_id=tenant_id, agent_id=agent_id, state=state, version="1.0",
         certificate_fingerprint=_HASH_A, last_seen_at=None, created_at=_NOW,

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -12,7 +12,9 @@ from cnes_domain.control_plane.commands import (
     CommitRunUnit,
     CompleteJob,
     FailJob,
+    PutRunUnits,
     RenewJobLease,
+    ReserveRunDispatch,
 )
 from cnes_domain.control_plane.entities import (
     Agent,
@@ -31,6 +33,7 @@ from cnes_domain.control_plane.transitions import transition_run
 _NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
 _TENANT = "354130"
 _HASH_A = "a" * 64
+_WAVE_A = "a" * 16
 
 
 @dataclass(slots=True)
@@ -160,7 +163,9 @@ def _store_record(adapter: Any, record: RawManifestRecord, clock: MutableClock) 
         fencing_token=claimed.fencing_token,
         manifest=record,
     )
-    adapter.complete_job(complete, _event(f"completed-{job.job_id}"))
+    event = _event(f"completed-{job.job_id}")
+    adapter.complete_job(complete, event)
+    assert adapter.pending_outbox(100).count(event) == 1
 
 
 def _run(
@@ -188,6 +193,47 @@ def _unit(unit_id: str, state: RunUnitState = RunUnitState.PENDING) -> RunUnit:
         fencing_token=0, lease_owner=None, lease_until=None, dispatch_id=None,
         output_manifests=(), error_code=None,
     )
+
+
+def _put_units(adapter: Any, units: tuple[Any, ...]) -> tuple[Any, ...]:
+    return adapter.put_run_units(
+        PutRunUnits(
+            tenant_id=_TENANT,
+            run_id="run-a",
+            expected_run_state=RunState.PROCESSING,
+            units=units,
+        )
+    )
+
+
+def _reserve(
+    adapter: Any,
+    clock: MutableClock,
+    wave: str = _WAVE_A,
+    unit_ids: tuple[str, ...] = ("unit-a",),
+) -> Any:
+    return adapter.reserve_run_dispatch(
+        ReserveRunDispatch(
+            tenant_id=_TENANT,
+            run_id="run-a",
+            wave_id=wave,
+            unit_ids=unit_ids,
+            now=clock.now(),
+            lease_seconds=30,
+        )
+    )
+
+
+def _claim_unit(adapter: Any, clock: MutableClock, dispatch_id: str, owner: str) -> Any:
+    return adapter.claim_run_unit(_claim_unit_command(dispatch_id, owner, clock))
+
+
+def _prepare_unit(
+    adapter: Any, clock: MutableClock, unit_ids: tuple[str, ...] = ("unit-a",)
+) -> Any:
+    adapter.put_run(_run("run-a"))
+    _put_units(adapter, (_unit("unit-a"), _unit("unit-b")))
+    return _reserve(adapter, clock, unit_ids=unit_ids)
 
 
 class _HarnessState:

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -10,6 +10,7 @@ from cnes_domain.control_plane.commands import (
     ClaimJob,
     ClaimRunUnit,
     CommitRunUnit,
+    CompleteJob,
     FailJob,
     RenewJobLease,
 )
@@ -18,6 +19,7 @@ from cnes_domain.control_plane.entities import (
     Job,
     ManifestRef,
     OutboxEvent,
+    RawManifestRecord,
     Run,
     RunDependency,
     RunUnit,
@@ -118,6 +120,47 @@ def _job(job_id: str, agent_id: str = "agent-a") -> Job:
         lease_until=None, result_manifest_id=None, result_manifest_key=None,
         error_code=None, created_at=_NOW,
     )
+
+
+def _raw_record(
+    snapshot_id: str,
+    agent_id: str,
+    sequence: int,
+    created_at: datetime,
+) -> RawManifestRecord:
+    base = None if sequence == 1 else f"base-{agent_id}"
+    return RawManifestRecord(
+        tenant_id=_TENANT,
+        manifest_id=f"manifest-{agent_id}-{snapshot_id}",
+        manifest_key=f"raw/{_TENANT}/CNES/2026-07/{snapshot_id}/manifest.json",
+        agent_id=agent_id,
+        source_type="CNES",
+        file_subtype="ST",
+        competencia="2026-07",
+        snapshot_mode="FULL" if sequence == 1 else "DELTA",
+        snapshot_id=snapshot_id,
+        base_snapshot_id=base,
+        sequence=sequence,
+        previous_manifest_sha256=None if sequence == 1 else _HASH_A,
+        manifest_sha256=_HASH_A,
+        created_at=created_at,
+    )
+
+
+def _store_record(adapter: Any, record: RawManifestRecord, clock: MutableClock) -> None:
+    job = _job(f"job-{record.agent_id}-{record.snapshot_id}", record.agent_id)
+    adapter.put_agent(_agent(record.agent_id))
+    adapter.create_job(job, _event(f"created-{job.job_id}"))
+    claimed = adapter.claim_job(_claim_job(job.job_id, "raw-worker", clock))
+    assert claimed is not None
+    complete = CompleteJob(
+        tenant_id=_TENANT,
+        job_id=job.job_id,
+        owner="raw-worker",
+        fencing_token=claimed.fencing_token,
+        manifest=record,
+    )
+    adapter.complete_job(complete, _event(f"completed-{job.job_id}"))
 
 
 def _run(

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -1,0 +1,251 @@
+"""Relógio mutável para suites de contrato."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from itertools import pairwise
+from typing import Any
+
+from cnes_domain.control_plane.commands import (
+    ClaimJob,
+    ClaimRunUnit,
+    CommitRunUnit,
+    FailJob,
+    RenewJobLease,
+)
+from cnes_domain.control_plane.entities import (
+    Agent,
+    Job,
+    ManifestRef,
+    OutboxEvent,
+    Run,
+    RunDependency,
+    RunUnit,
+)
+from cnes_domain.control_plane.enums import AgentState, JobState, RunStage, RunState, RunUnitState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.control_plane.transitions import transition_run
+
+_NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
+_TENANT = "354130"
+_HASH_A = "a" * 64
+
+
+@dataclass(slots=True)
+class MutableClock:
+    """Controla deterministicamente o instante observado pelo adapter."""
+
+    instant: datetime
+
+    def __init__(self, initial: datetime) -> None:
+        self.instant = initial
+
+    def now(self) -> datetime:
+        """Retorna o instante atual."""
+        return self.instant
+
+    def advance(self, delta: timedelta) -> None:
+        """Avança o relógio pelo intervalo informado."""
+        self.instant += delta
+
+
+def _claim_job(job_id: str, owner: str, clock: MutableClock) -> ClaimJob:
+    return ClaimJob(
+        tenant_id=_TENANT, job_id=job_id, owner=owner, now=clock.now(), lease_seconds=30
+    )
+
+
+def _renew_job(clock: MutableClock) -> RenewJobLease:
+    return RenewJobLease(
+        tenant_id=_TENANT, job_id="job-a", owner="worker-a", fencing_token=1,
+        now=clock.now(), lease_seconds=60,
+    )
+
+
+def _fail_job(owner: str, fence: int, error_code: str) -> FailJob:
+    return FailJob(
+        tenant_id=_TENANT, job_id="job-a", owner=owner, fencing_token=fence,
+        error_code=error_code, retryable=True,
+    )
+
+
+def _claim_unit_command(
+    dispatch_id: str, owner: str, clock: MutableClock, unit_id: str = "unit-a"
+) -> ClaimRunUnit:
+    return ClaimRunUnit(
+        tenant_id=_TENANT, run_id="run-a", unit_id=unit_id, dispatch_id=dispatch_id,
+        owner=owner, now=clock.now(), lease_seconds=30,
+    )
+
+
+def _commit_command(dispatch_id: str, owner: str, fence: int) -> CommitRunUnit:
+    return CommitRunUnit(
+        tenant_id=_TENANT, run_id="run-a", unit_id="unit-a", dispatch_id=dispatch_id,
+        owner=owner, fencing_token=fence, output_manifests=(_ref("output"),),
+    )
+
+
+def _expect_error(
+    expected: type[Exception] | tuple[type[Exception], ...], action: Callable[[], Any]
+) -> None:
+    try:
+        action()
+    except expected:
+        return
+    raise AssertionError(f"error_not_raised={expected}")
+
+
+def _event(event_id: str, now: datetime = _NOW, aggregate_id: str | None = None) -> OutboxEvent:
+    return OutboxEvent(
+        tenant_id=_TENANT, event_id=event_id, event_type="test.event",
+        aggregate_id=aggregate_id or event_id, payload={"event_id": event_id},
+        created_at=now, delivered_at=None,
+    )
+
+
+def _agent(agent_id: str, state: AgentState = AgentState.ACTIVE) -> Agent:
+    return Agent(
+        tenant_id=_TENANT, agent_id=agent_id, state=state, version="1.0",
+        certificate_fingerprint=_HASH_A, last_seen_at=None, created_at=_NOW,
+    )
+
+
+def _job(job_id: str, agent_id: str = "agent-a") -> Job:
+    return Job(
+        tenant_id=_TENANT, job_id=job_id, agent_id=agent_id, source_type="CNES",
+        file_subtype="ST", competencia="2026-07", requested_snapshot_mode="FULL",
+        state=JobState.PENDING, attempt=0, fencing_token=0, lease_owner=None,
+        lease_until=None, result_manifest_id=None, result_manifest_key=None,
+        error_code=None, created_at=_NOW,
+    )
+
+
+def _run(
+    run_id: str,
+    state: RunState = RunState.PROCESSING,
+    dependencies: tuple[RunDependency, ...] | None = None,
+) -> Run:
+    deps = dependencies or (RunDependency(source_type="CNES", file_subtype="ST", required=True),)
+    return Run(
+        tenant_id=_TENANT, run_id=run_id, competencia="2026-07", dataset_name="gold",
+        state=state, dependencies=deps, missing_sources=(), created_at=_NOW,
+    )
+
+
+def _ref(name: str) -> ManifestRef:
+    key = f"raw/{_TENANT}/CNES/2026-07/{name}/manifest.json"
+    return ManifestRef(manifest_id=name, manifest_key=key)
+
+
+def _unit(unit_id: str, state: RunUnitState = RunUnitState.PENDING) -> RunUnit:
+    return RunUnit(
+        tenant_id=_TENANT, run_id="run-a", unit_id=unit_id, stage=RunStage.NORMALIZE,
+        source_type="CNES", file_subtype="ST", partition="all", depends_on_unit_ids=(),
+        input_manifests=(_ref(f"input-{unit_id}"),), state=state, attempt=0,
+        fencing_token=0, lease_owner=None, lease_until=None, dispatch_id=None,
+        output_manifests=(), error_code=None,
+    )
+
+
+class _HarnessState:
+    def __init__(self, clock: MutableClock, mutation: str | None = None) -> None:
+        self.clock = clock
+        self.mutation = mutation
+        self.memberships: dict[tuple[str, str], Any] = {}
+        self.agents: dict[tuple[str, str], Any] = {}
+        self.jobs: dict[tuple[str, str], Any] = {}
+        self.raw_records: list[Any] = []
+        self.runs: dict[tuple[str, str], Any] = {}
+        self.units: dict[tuple[str, str, str], Any] = {}
+        self.dispatches: dict[tuple[str, str], Any] = {}
+        self.idempotency: dict[tuple[str, str, str], Any] = {}
+        self.versions: dict[tuple[str, str, str], Any] = {}
+        self.pointers: dict[tuple[str, str, str], Any] = {}
+        self.outbox: dict[str, Any] = {}
+
+    def put_membership(self, membership: Any) -> None:
+        self.memberships[(membership.tenant_id, membership.user_id)] = membership
+
+    def get_membership(self, tenant_id: str, user_id: str) -> Any | None:
+        if self.mutation == "authorization_jobs":
+            return next(iter(self.memberships.values()), None)
+        return self.memberships.get((tenant_id, user_id))
+
+    def put_agent(self, agent: Any) -> None:
+        self.agents[(agent.tenant_id, agent.agent_id)] = agent
+
+    def get_agent(self, tenant_id: str, agent_id: str) -> Any | None:
+        return self.agents.get((tenant_id, agent_id))
+
+    def create_job(self, job: Any, event: Any) -> Any:
+        key = (job.tenant_id, job.job_id)
+        existing = self.jobs.get(key)
+        if existing is not None:
+            if existing != job:
+                raise Conflict("job_conflict")
+            return existing
+        self.jobs[key] = job
+        self.outbox[event.event_id] = event
+        return job
+
+    def get_job(self, tenant_id: str, job_id: str) -> Any | None:
+        return self.jobs.get((tenant_id, job_id))
+
+    def put_run(self, run: Any) -> None:
+        self.runs[(run.tenant_id, run.run_id)] = run
+
+    def get_run(self, tenant_id: str, run_id: str) -> Any | None:
+        return self.runs.get((tenant_id, run_id))
+
+    def transition_run(self, command: Any, event: Any) -> Any:
+        run = self.get_run(command.tenant_id, command.run_id)
+        if run is None or run.state is not command.expected_state:
+            raise Conflict("run_state_conflict")
+        updated = transition_run(run, command.new_state).model_copy(
+            update={"missing_sources": command.missing_sources}
+        )
+        self.put_run(updated)
+        self.outbox[event.event_id] = event
+        return updated
+
+    def list_run_units(self, tenant_id: str, run_id: str) -> tuple[Any, ...]:
+        values = [unit for key, unit in self.units.items() if key[:2] == (tenant_id, run_id)]
+        return tuple(sorted(values, key=lambda item: item.unit_id))
+
+    def get_dataset_version(self, *args: str) -> Any | None:
+        return self.versions.get(tuple(args))
+
+    def pending_outbox(self, limit: int) -> tuple[Any, ...]:
+        values = sorted(self.outbox.values(), key=lambda item: (item.created_at, item.event_id))
+        return tuple(event for event in values if event.delivered_at is None)[:limit]
+
+    def get_active_run_dispatch(self, tenant_id: str, run_id: str) -> Any | None:
+        dispatch = self.dispatches.get((tenant_id, run_id))
+        active = dispatch and dispatch.state.value != "TERMINAL"
+        return dispatch if active and dispatch.lease_until > self.clock.now() else None
+
+    @staticmethod
+    def _select_raw_chain(records: list[Any]) -> list[Any]:
+        candidates = sorted(
+            records,
+            key=lambda item: (item.created_at, item.agent_id, item.snapshot_id),
+            reverse=True,
+        )
+        for head in candidates:
+            base = head.snapshot_id if head.sequence == 1 else head.base_snapshot_id
+            chain = [
+                item
+                for item in records
+                if item.agent_id == head.agent_id
+                and base in (item.snapshot_id, item.base_snapshot_id)
+                and item.sequence <= head.sequence
+            ]
+            chain.sort(key=lambda item: item.sequence)
+            sequences = [item.sequence for item in chain]
+            hashes_match = all(
+                current.previous_manifest_sha256 == previous.manifest_sha256
+                for previous, current in pairwise(chain)
+            )
+            if sequences == list(range(1, head.sequence + 1)) and hashes_match:
+                return chain
+        return []

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -152,6 +152,7 @@ class _HarnessState:
         self.clock = clock
         self.mutation = mutation
         self.memberships: dict[tuple[str, str], Any] = {}
+        self.tenants: dict[str, Any] = {}
         self.agents: dict[tuple[str, str], Any] = {}
         self.jobs: dict[tuple[str, str], Any] = {}
         self.raw_records: list[Any] = []
@@ -161,7 +162,14 @@ class _HarnessState:
         self.idempotency: dict[tuple[str, str, str], Any] = {}
         self.versions: dict[tuple[str, str, str], Any] = {}
         self.pointers: dict[tuple[str, str, str], Any] = {}
+        self.access_requests: dict[tuple[str, str], Any] = {}
         self.outbox: dict[str, Any] = {}
+
+    def put_tenant(self, tenant: Any) -> None:
+        self.tenants[tenant.tenant_id] = tenant
+
+    def get_tenant(self, tenant_id: str) -> Any | None:
+        return self.tenants.get(tenant_id)
 
     def put_membership(self, membership: Any) -> None:
         self.memberships[(membership.tenant_id, membership.user_id)] = membership
@@ -191,6 +199,26 @@ class _HarnessState:
     def get_job(self, tenant_id: str, job_id: str) -> Any | None:
         return self.jobs.get((tenant_id, job_id))
 
+    def latest_succeeded_job(self, *args: str) -> Any | None:
+        tenant_id, agent_id, source_type, file_subtype, competencia = args
+        matches = [
+            job
+            for job in self.jobs.values()
+            if (job.tenant_id, job.agent_id, job.source_type, job.file_subtype, job.competencia)
+            == (tenant_id, agent_id, source_type, file_subtype, competencia)
+            and job.state.value == "SUCCEEDED"
+        ]
+        return max(matches, key=lambda job: (job.created_at, job.job_id), default=None)
+
+    def cancel_job(self, command: Any, event: Any) -> Any:
+        job = self.get_job(command.tenant_id, command.job_id)
+        if job is None:
+            raise Conflict("job_missing")
+        canceled = job.model_copy(update={"state": "CANCEL_REQUESTED"})
+        self.jobs[(job.tenant_id, job.job_id)] = canceled
+        self.outbox[event.event_id] = event
+        return canceled
+
     def put_run(self, run: Any) -> None:
         self.runs[(run.tenant_id, run.run_id)] = run
 
@@ -215,9 +243,27 @@ class _HarnessState:
     def get_dataset_version(self, *args: str) -> Any | None:
         return self.versions.get(tuple(args))
 
+    def get_dataset_pointer(self, tenant_id: str, dataset_name: str) -> Any | None:
+        return self.pointers.get((tenant_id, dataset_name, "current"))
+
+    def put_access_request(self, request: Any, event: Any) -> None:
+        self.access_requests[(request.tenant_id, request.request_id)] = request
+        self.outbox[event.event_id] = event
+
+    def get_access_request(self, tenant_id: str, request_id: str) -> Any | None:
+        return self.access_requests.get((tenant_id, request_id))
+
+    def decide_access_request(self, request: Any, event: Any) -> Any:
+        self.put_access_request(request, event)
+        return request
+
     def pending_outbox(self, limit: int) -> tuple[Any, ...]:
         values = sorted(self.outbox.values(), key=lambda item: (item.created_at, item.event_id))
         return tuple(event for event in values if event.delivered_at is None)[:limit]
+
+    def mark_outbox_delivered(self, event_id: str, delivered_at: datetime) -> None:
+        event = self.outbox[event_id]
+        self.outbox[event_id] = event.model_copy(update={"delivered_at": delivered_at})
 
     def get_active_run_dispatch(self, tenant_id: str, run_id: str) -> Any | None:
         dispatch = self.dispatches.get((tenant_id, run_id))

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -27,7 +27,7 @@ from cnes_domain.control_plane.entities import (
     RunUnit,
 )
 from cnes_domain.control_plane.enums import AgentState, JobState, RunStage, RunState, RunUnitState
-from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
 from cnes_domain.control_plane.transitions import transition_run
 
 _NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
@@ -100,6 +100,32 @@ def _expect_error(
     raise AssertionError(f"error_not_raised={expected}")
 
 
+def _assert_active_job_fences(adapter: Any, clock: MutableClock) -> CompleteJob:
+    manifest = _raw_record("result", "agent-a", 1, clock.now())
+    complete = CompleteJob(
+        tenant_id=_TENANT, job_id="job-a", owner="worker-a", fencing_token=1,
+        manifest=manifest,
+    )
+    renewals = (
+        _renew_job(clock).model_copy(update={"owner": "other"}),
+        _renew_job(clock).model_copy(update={"fencing_token": 2}),
+    )
+    for command in renewals:
+        _expect_error(
+            (FenceRejected, LeaseLost),
+            lambda command=command: adapter.renew_job_lease(command),
+        )
+    completions = (
+        complete.model_copy(update={"owner": "other"}),
+        complete.model_copy(update={"fencing_token": 2}),
+    )
+    for command in completions:
+        _expect_error((FenceRejected, LeaseLost), lambda command=command: adapter.complete_job(
+            command, _event("invalid-complete")
+        ))
+    return complete
+
+
 def _event(event_id: str, now: datetime = _NOW, aggregate_id: str | None = None) -> OutboxEvent:
     return OutboxEvent(
         tenant_id=_TENANT, event_id=event_id, event_type="test.event",
@@ -164,7 +190,18 @@ def _store_record(adapter: Any, record: RawManifestRecord, clock: MutableClock) 
         manifest=record,
     )
     event = _event(f"completed-{job.job_id}")
-    adapter.complete_job(complete, event)
+    completed = adapter.complete_job(complete, event)
+    assert (completed.state, completed.lease_owner, completed.lease_until) == (
+        JobState.SUCCEEDED, None, None
+    )
+    assert (completed.result_manifest_id, completed.result_manifest_key) == (
+        record.manifest_id, record.manifest_key
+    )
+    assert adapter.get_job(record.tenant_id, job.job_id) == completed
+    assert adapter.latest_succeeded_job(
+        record.tenant_id, record.agent_id, record.source_type,
+        record.file_subtype, record.competencia,
+    ) == completed
     assert adapter.pending_outbox(100).count(event) == 1
 
 

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -55,9 +55,7 @@ class MutableClock:
         self.instant += delta
 
 
-def _claim_job(
-    job_id: str, owner: str, clock: MutableClock, tenant_id: str = _TENANT
-) -> ClaimJob:
+def _claim_job(job_id: str, owner: str, clock: MutableClock, tenant_id=_TENANT) -> ClaimJob:
     return ClaimJob(
         tenant_id=tenant_id, job_id=job_id, owner=owner, now=clock.now(), lease_seconds=30
     )
@@ -104,33 +102,34 @@ def _expect_error(
 
 
 def _assert_unit_rejected(
-    adapter: Any,
-    expected: type[Exception] | tuple[type[Exception], ...],
-    action: Callable[[], Any],
-) -> None:
+    adapter: Any, expected: type[Exception] | tuple[type[Exception], ...],
+    action: Callable[[], Any]) -> None:
     before = (
         adapter.list_run_units(_TENANT, "run-a"), adapter.get_run(_TENANT, "run-a"),
-        adapter.pending_outbox(100),
-    )
+        adapter.pending_outbox(100))
     _expect_error(expected, action)
     after = (
         adapter.list_run_units(_TENANT, "run-a"), adapter.get_run(_TENANT, "run-a"),
-        adapter.pending_outbox(100),
-    )
+        adapter.pending_outbox(100))
+    assert after == before
+
+
+def _assert_job_rejected(
+    adapter: Any, expected: type[Exception] | tuple[type[Exception], ...],
+    action: Callable[[], Any]) -> None:
+    before = (
+        adapter.get_job(_TENANT, "job-a"), adapter.pending_outbox(100),
+        adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 10))
+    _expect_error(expected, action)
+    after = (
+        adapter.get_job(_TENANT, "job-a"), adapter.pending_outbox(100),
+        adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 10))
     assert after == before
 
 
 def _assert_completion_rejected(adapter: Any, command: CompleteJob, event: OutboxEvent) -> None:
-    before = (
-        adapter.get_job(_TENANT, "job-a"), adapter.pending_outbox(100),
-        adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 10),
-    )
-    _expect_error((FenceRejected, LeaseLost), lambda: adapter.complete_job(command, event))
-    after = (
-        adapter.get_job(_TENANT, "job-a"), adapter.pending_outbox(100),
-        adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 10),
-    )
-    assert after == before
+    _assert_job_rejected(adapter, (FenceRejected, LeaseLost),
+                         lambda: adapter.complete_job(command, event))
 
 
 def _assert_active_job_fences(adapter: Any, clock: MutableClock) -> CompleteJob:

--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -55,9 +55,11 @@ class MutableClock:
         self.instant += delta
 
 
-def _claim_job(job_id: str, owner: str, clock: MutableClock) -> ClaimJob:
+def _claim_job(
+    job_id: str, owner: str, clock: MutableClock, tenant_id: str = _TENANT
+) -> ClaimJob:
     return ClaimJob(
-        tenant_id=_TENANT, job_id=job_id, owner=owner, now=clock.now(), lease_seconds=30
+        tenant_id=tenant_id, job_id=job_id, owner=owner, now=clock.now(), lease_seconds=30
     )
 
 
@@ -106,59 +108,52 @@ def _assert_unit_rejected(
     expected: type[Exception] | tuple[type[Exception], ...],
     action: Callable[[], Any],
 ) -> None:
-    before_units = adapter.list_run_units(_TENANT, "run-a")
-    before_run = adapter.get_run(_TENANT, "run-a")
-    before_outbox = adapter.pending_outbox(100)
+    before = (
+        adapter.list_run_units(_TENANT, "run-a"), adapter.get_run(_TENANT, "run-a"),
+        adapter.pending_outbox(100),
+    )
     _expect_error(expected, action)
-    assert adapter.list_run_units(_TENANT, "run-a") == before_units
-    assert adapter.get_run(_TENANT, "run-a") == before_run
-    assert adapter.pending_outbox(100) == before_outbox
+    after = (
+        adapter.list_run_units(_TENANT, "run-a"), adapter.get_run(_TENANT, "run-a"),
+        adapter.pending_outbox(100),
+    )
+    assert after == before
+
+
+def _assert_completion_rejected(adapter: Any, command: CompleteJob, event: OutboxEvent) -> None:
+    before = (
+        adapter.get_job(_TENANT, "job-a"), adapter.pending_outbox(100),
+        adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 10),
+    )
+    _expect_error((FenceRejected, LeaseLost), lambda: adapter.complete_job(command, event))
+    after = (
+        adapter.get_job(_TENANT, "job-a"), adapter.pending_outbox(100),
+        adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 10),
+    )
+    assert after == before
 
 
 def _assert_active_job_fences(adapter: Any, clock: MutableClock) -> CompleteJob:
     manifest = _raw_record("result", "agent-a", 1, clock.now())
     complete = CompleteJob(
-        tenant_id=_TENANT, job_id="job-a", owner="worker-a", fencing_token=1,
-        manifest=manifest,
+        tenant_id=_TENANT, job_id="job-a", owner="worker-a",
+        fencing_token=1, manifest=manifest,
     )
-    renewals = (
-        _renew_job(clock).model_copy(update={"owner": "other"}),
-        _renew_job(clock).model_copy(update={"fencing_token": 2}),
-    )
+    renewals = (_renew_job(clock).model_copy(update={"owner": "other"}),
+                _renew_job(clock).model_copy(update={"fencing_token": 2}))
     for command in renewals:
-        _expect_error(
-            (FenceRejected, LeaseLost),
-            lambda command=command: adapter.renew_job_lease(command),
-        )
-    completions = (
-        complete.model_copy(update={"owner": "other"}),
-        complete.model_copy(update={"fencing_token": 2}),
-    )
+        _expect_error((FenceRejected, LeaseLost),
+                      lambda command=command: adapter.renew_job_lease(command))
+    completions = (complete.model_copy(update={"owner": "other"}),
+                   complete.model_copy(update={"fencing_token": 2}))
     for index, command in enumerate(completions):
-        before_job = adapter.get_job(_TENANT, "job-a")
-        before_outbox = adapter.pending_outbox(100)
-        _expect_error(
-            (FenceRejected, LeaseLost),
-            lambda command=command, index=index: adapter.complete_job(
-                command, _event(f"invalid-complete-{index}")
-            ),
-        )
-        assert adapter.get_job(_TENANT, "job-a") == before_job
-        assert adapter.pending_outbox(100) == before_outbox
-        assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 10) == ()
+        _assert_completion_rejected(adapter, command, _event(f"invalid-complete-{index}"))
     return complete
 
 
 def _assert_revoked_completion(adapter: Any, complete: CompleteJob) -> None:
     adapter.put_agent(_agent("agent-a", AgentState.REVOKED))
-    before_job = adapter.get_job(_TENANT, "job-a")
-    before_outbox = adapter.pending_outbox(100)
-    _expect_error((FenceRejected, LeaseLost), lambda: adapter.complete_job(
-        complete, _event("revoked-complete")
-    ))
-    assert adapter.get_job(_TENANT, "job-a") == before_job
-    assert adapter.pending_outbox(100) == before_outbox
-    assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 10) == ()
+    _assert_completion_rejected(adapter, complete, _event("revoked-complete"))
     adapter.put_agent(_agent("agent-a"))
 
 
@@ -166,8 +161,7 @@ def _assert_job_failures(adapter: Any, clock: MutableClock) -> None:
     failed_event = _event("failed-retryable")
     failed = adapter.fail_job(_fail_job("worker-b", 2, "retry"), failed_event)
     assert (failed.state, failed.lease_owner, failed.lease_until) == (
-        JobState.FAILED_RETRYABLE, None, None
-    )
+        JobState.FAILED_RETRYABLE, None, None)
     assert adapter.pending_outbox(100).count(failed_event) == 1
     final_claim = adapter.claim_job(_claim_job("job-a", "worker-c", clock))
     assert final_claim is not None
@@ -179,24 +173,27 @@ def _assert_job_failures(adapter: Any, clock: MutableClock) -> None:
     assert adapter.pending_outbox(100).count(final_event) == 1
 
 
-def _event(event_id: str, now: datetime = _NOW, aggregate_id: str | None = None) -> OutboxEvent:
+def _event(event_id: str, now: datetime = _NOW, aggregate_id: str | None = None,
+           tenant_id: str = _TENANT) -> OutboxEvent:
     return OutboxEvent(
-        tenant_id=_TENANT, event_id=event_id, event_type="test.event",
+        tenant_id=tenant_id, event_id=event_id, event_type="test.event",
         aggregate_id=aggregate_id or event_id, payload={"event_id": event_id},
         created_at=now, delivered_at=None,
     )
 
 
-def _agent(agent_id: str, state: AgentState = AgentState.ACTIVE) -> Agent:
+def _agent(
+    agent_id: str, state: AgentState = AgentState.ACTIVE, tenant_id: str = _TENANT
+) -> Agent:
     return Agent(
-        tenant_id=_TENANT, agent_id=agent_id, state=state, version="1.0",
+        tenant_id=tenant_id, agent_id=agent_id, state=state, version="1.0",
         certificate_fingerprint=_HASH_A, last_seen_at=None, created_at=_NOW,
     )
 
 
-def _job(job_id: str, agent_id: str = "agent-a") -> Job:
+def _job(job_id: str, agent_id: str = "agent-a", tenant_id: str = _TENANT) -> Job:
     return Job(
-        tenant_id=_TENANT, job_id=job_id, agent_id=agent_id, source_type="CNES",
+        tenant_id=tenant_id, job_id=job_id, agent_id=agent_id, source_type="CNES",
         file_subtype="ST", competencia="2026-07", requested_snapshot_mode="FULL",
         state=JobState.PENDING, attempt=0, fencing_token=0, lease_owner=None,
         lease_until=None, result_manifest_id=None, result_manifest_key=None,
@@ -223,31 +220,31 @@ def _raw_record(
 
 
 def _store_record(adapter: Any, record: RawManifestRecord, clock: MutableClock) -> None:
-    job = _job(f"job-{record.agent_id}-{record.snapshot_id}", record.agent_id)
-    adapter.put_agent(_agent(record.agent_id))
-    adapter.create_job(job, _event(f"created-{job.job_id}"))
-    claimed = adapter.claim_job(_claim_job(job.job_id, "raw-worker", clock))
+    job_id = f"job-{record.agent_id}-{record.snapshot_id}"
+    job = _job(job_id, record.agent_id, record.tenant_id).model_copy(update={
+        "source_type": record.source_type, "file_subtype": record.file_subtype,
+        "competencia": record.competencia,
+    })
+    adapter.put_agent(_agent(record.agent_id, tenant_id=record.tenant_id))
+    created = _event(f"created-{job.job_id}", tenant_id=record.tenant_id)
+    adapter.create_job(job, created)
+    claimed = adapter.claim_job(_claim_job(job.job_id, "raw-worker", clock, record.tenant_id))
     assert claimed is not None
     complete = CompleteJob(
-        tenant_id=_TENANT,
-        job_id=job.job_id,
-        owner="raw-worker",
-        fencing_token=claimed.fencing_token,
-        manifest=record,
+        tenant_id=record.tenant_id, job_id=job.job_id, owner="raw-worker",
+        fencing_token=claimed.fencing_token, manifest=record,
     )
-    event = _event(f"completed-{job.job_id}")
+    event = _event(f"completed-{job.job_id}", tenant_id=record.tenant_id)
     completed = adapter.complete_job(complete, event)
     assert (completed.state, completed.lease_owner, completed.lease_until) == (
-        JobState.SUCCEEDED, None, None
-    )
+        JobState.SUCCEEDED, None, None)
     assert (completed.result_manifest_id, completed.result_manifest_key) == (
         record.manifest_id, record.manifest_key
     )
     assert adapter.get_job(record.tenant_id, job.job_id) == completed
-    assert adapter.latest_succeeded_job(
-        record.tenant_id, record.agent_id, record.source_type,
-        record.file_subtype, record.competencia,
-    ) == completed
+    identity = (record.tenant_id, record.agent_id, record.source_type,
+                record.file_subtype, record.competencia)
+    assert adapter.latest_succeeded_job(*identity) == completed
     assert adapter.pending_outbox(100).count(event) == 1
 
 
@@ -278,13 +275,13 @@ def _unit(unit_id: str, state: RunUnitState = RunUnitState.PENDING) -> RunUnit:
     )
 
 
-def _put_units(adapter: Any, units: tuple[Any, ...]) -> tuple[Any, ...]:
+def _put_units(
+    adapter: Any, units: tuple[Any, ...], run_id: str = "run-a"
+) -> tuple[Any, ...]:
     return adapter.put_run_units(
         PutRunUnits(
-            tenant_id=_TENANT,
-            run_id="run-a",
-            expected_run_state=RunState.PROCESSING,
-            units=units,
+            tenant_id=_TENANT, run_id=run_id,
+            expected_run_state=RunState.PROCESSING, units=units,
         )
     )
 
@@ -297,12 +294,8 @@ def _reserve(
 ) -> Any:
     return adapter.reserve_run_dispatch(
         ReserveRunDispatch(
-            tenant_id=_TENANT,
-            run_id="run-a",
-            wave_id=wave,
-            unit_ids=unit_ids,
-            now=clock.now(),
-            lease_seconds=30,
+            tenant_id=_TENANT, run_id="run-a", wave_id=wave, unit_ids=unit_ids,
+            now=clock.now(), lease_seconds=30,
         )
     )
 
@@ -335,18 +328,26 @@ def _assert_retryable_unit_failure(adapter: Any, clock: MutableClock, base: Any)
     dispatch = _reserve(adapter, clock, _WAVE_B)
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-b")
     assert claimed is not None
-    command = base.model_copy(update={
-        "dispatch_id": dispatch.dispatch_id,
-        "owner": "worker-b",
-        "fencing_token": claimed.fencing_token,
-    })
+    command = base.model_copy(update={"dispatch_id": dispatch.dispatch_id,
+                                     "owner": "worker-b",
+                                     "fencing_token": claimed.fencing_token})
     event = _event("unit-retryable")
     failed = adapter.fail_run_unit(command, event)
     assert (failed.state, failed.lease_owner, failed.lease_until) == (
-        RunUnitState.FAILED_RETRYABLE, None, None
-    )
+        RunUnitState.FAILED_RETRYABLE, None, None)
     assert adapter.list_run_units(_TENANT, "run-a")[0] == failed
     assert adapter.pending_outbox(100).count(event) == 1
+    reclaimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-c")
+    assert reclaimed is not None
+    final_command = command.model_copy(update={
+        "owner": "worker-c", "fencing_token": reclaimed.fencing_token,
+        "error_code": "permanent", "retryable": False})
+    final_event = _event("unit-final")
+    final = adapter.fail_run_unit(final_command, final_event)
+    assert (final.state, final.error_code, final.lease_owner, final.lease_until) == (
+        RunUnitState.FAILED_FINAL, "permanent", None, None)
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == final
+    assert adapter.pending_outbox(100).count(final_event) == 1
 
 
 class _HarnessState:

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -14,8 +14,6 @@ from cnes_domain.control_plane.commands import (
     FinishRunDispatch,
     PublicationPermit,
     PublishDataset,
-    PutRunUnits,
-    ReserveRunDispatch,
     TransitionRun,
 )
 from cnes_domain.control_plane.entities import (
@@ -26,6 +24,7 @@ from cnes_domain.control_plane.entities import (
 from cnes_domain.control_plane.enums import (
     AgentState,
     DispatchOutcome,
+    JobState,
     RunState,
     RunUnitState,
 )
@@ -39,14 +38,18 @@ from packages.cnes_infra.tests.contracts.clock import (
     MutableClock,
     _agent,
     _claim_job,
+    _claim_unit,
     _claim_unit_command,
     _commit_command,
     _event,
     _expect_error,
     _fail_job,
     _job,
+    _prepare_unit,
+    _put_units,
     _raw_record,
     _renew_job,
+    _reserve,
     _run,
     _store_record,
     _unit,
@@ -54,7 +57,6 @@ from packages.cnes_infra.tests.contracts.clock import (
 
 _Runner = Callable[[Any, MutableClock], None]
 _HASH_B = "b" * 64
-_WAVE_A = "a" * 16
 _WAVE_B = "b" * 16
 
 
@@ -108,7 +110,9 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     assert adapter.get_membership(_TENANT, "user-a") == membership
     assert adapter.get_membership("other", "user-a") is None
     adapter.put_agent(_agent("agent-a", AgentState.REVOKED))
-    adapter.create_job(_job("job-a"), _event("job-created"))
+    created_event = _event("job-created")
+    adapter.create_job(_job("job-a"), created_event)
+    assert adapter.pending_outbox(100).count(created_event) == 1
     assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
     adapter.put_agent(_agent("agent-a"))
@@ -135,6 +139,12 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     _expect_error(
         FenceRejected, lambda: adapter.fail_job(stale_fence, _event("stale-fence"))
     )
+    failed_event = _event("failed-retryable")
+    failed = adapter.fail_job(_fail_job("worker-b", 2, "retry"), failed_event)
+    assert (failed.state, failed.lease_owner, failed.lease_until) == (
+        JobState.FAILED_RETRYABLE, None, None
+    )
+    assert adapter.pending_outbox(100).count(failed_event) == 1
 
 
 def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
@@ -175,6 +185,8 @@ def _case_run_discovery(adapter: Any, clock: MutableClock) -> None:
     adapter.put_run(_run("published", RunState.PUBLISHED))
     waiting = adapter.list_waiting_runs_for_dependency(_TENANT, "CNES", "ST", "2026-07", 10)
     assert tuple(run.run_id for run in waiting) == ("waiting-a", "waiting-b")
+    limited = adapter.list_waiting_runs_for_dependency(_TENANT, "CNES", "ST", "2026-07", 1)
+    assert tuple(run.run_id for run in limited) == ("waiting-a",)
     assert run_dependency_key(_TENANT, "CNES", "ST", "2026-07") != run_dependency_key(
         _TENANT, "CNES_ST", "X", "2026-07"
     )
@@ -187,16 +199,8 @@ def _case_run_discovery(adapter: Any, clock: MutableClock) -> None:
         "waiting-a",
         "waiting-b",
     )
-
-
-def _put_units(adapter: Any, units: tuple[Any, ...]) -> tuple[Any, ...]:
-    return adapter.put_run_units(
-        PutRunUnits(
-            tenant_id=_TENANT,
-            run_id="run-a",
-            expected_run_state=RunState.PROCESSING,
-            units=units,
-        )
+    assert tuple(run.run_id for run in adapter.list_recoverable_runs(clock.now(), 2)) == (
+        "canceling", "collision"
     )
 
 
@@ -210,47 +214,26 @@ def _case_run_units_atomic(adapter: Any, clock: MutableClock) -> None:
     assert adapter.list_run_units(_TENANT, "run-a") == units
 
 
-def _reserve(adapter: Any, clock: MutableClock, wave: str = _WAVE_A) -> Any:
-    return adapter.reserve_run_dispatch(
-        ReserveRunDispatch(
-            tenant_id=_TENANT,
-            run_id="run-a",
-            wave_id=wave,
-            unit_ids=("unit-a",),
-            now=clock.now(),
-            lease_seconds=30,
-        )
-    )
-
-
-def _claim_unit(adapter: Any, clock: MutableClock, dispatch_id: str, owner: str) -> Any:
-    return adapter.claim_run_unit(_claim_unit_command(dispatch_id, owner, clock))
-
-
-def _prepare_unit(adapter: Any, clock: MutableClock) -> Any:
-    adapter.put_run(_run("run-a"))
-    _put_units(adapter, (_unit("unit-a"), _unit("unit-b")))
-    return _reserve(adapter, clock)
-
-
 def _case_unit_claim(adapter: Any, clock: MutableClock) -> None:
-    dispatch = _prepare_unit(adapter, clock)
+    unit_ids = ("unit-a", "unit-b")
+    dispatch = _prepare_unit(adapter, clock, unit_ids)
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
     assert claimed is not None
-    not_dispatched = _claim_unit_command(dispatch.dispatch_id, "worker-a", clock, "unit-b")
+    not_dispatched = _claim_unit_command(dispatch.dispatch_id, "worker-a", clock, "unit-z")
     assert adapter.claim_run_unit(not_dispatched) is None
     assert (claimed.attempt, claimed.fencing_token) == (1, 1)
     assert claimed.dispatch_id == dispatch.dispatch_id
     assert _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-b") is None
     clock.advance(timedelta(seconds=31))
-    replacement = _reserve(adapter, clock)
+    replacement = _reserve(adapter, clock, unit_ids=unit_ids)
     retried = _claim_unit(adapter, clock, replacement.dispatch_id, "worker-b")
     assert retried is not None
     assert retried.unit_id == "unit-a"
     assert (retried.attempt, retried.fencing_token) == (2, 2)
     adapter.put_run(_run("run-a", RunState.PUBLISHING))
-    clock.advance(timedelta(seconds=31))
     assert _claim_unit(adapter, clock, replacement.dispatch_id, "worker-c") is None
+    pending = _claim_unit_command(replacement.dispatch_id, "worker-c", clock, "unit-b")
+    assert adapter.claim_run_unit(pending) is None
 
 
 def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
@@ -282,19 +265,21 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
         _expect_error((FenceRejected, LeaseLost), lambda command=command: adapter.fail_run_unit(
             command, _event("invalid-fail")
         ))
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    parent_commit = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    parent_fail = fail.model_copy(update={"dispatch_id": dispatch.dispatch_id})
+    _expect_error((FenceRejected, LeaseLost), lambda: adapter.commit_run_unit(
+        parent_commit, _event("invalid-parent-commit")
+    ))
+    _expect_error((FenceRejected, LeaseLost), lambda: adapter.fail_run_unit(
+        parent_fail, _event("invalid-parent-fail")
+    ))
+    adapter.put_run(_run("run-a"))
     clock.advance(timedelta(seconds=31))
     expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
     _expect_error(LeaseLost, lambda: adapter.commit_run_unit(expired, _event("expired-unit")))
     expired_fail = fail.model_copy(update={"dispatch_id": dispatch.dispatch_id})
     _expect_error(LeaseLost, lambda: adapter.fail_run_unit(expired_fail, _event("expired-fail")))
-    adapter.put_run(_run("run-a", RunState.PUBLISHING))
-    _expect_error(
-        (FenceRejected, LeaseLost),
-        lambda: adapter.commit_run_unit(
-            _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
-            _event("invalid-parent"),
-        ),
-    )
 
 
 def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
@@ -376,11 +361,16 @@ def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
         tenant_id=_TENANT, run_id="run-a", dispatch_id=_WAVE_B,
         outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now()
     )))
-    finished = adapter.finish_run_dispatch(FinishRunDispatch(
+    finish = FinishRunDispatch(
         tenant_id=_TENANT, run_id="run-a", dispatch_id=dispatch.dispatch_id,
         outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now()
-    ))
+    )
+    finished = adapter.finish_run_dispatch(finish)
     assert finished.terminal_outcome is DispatchOutcome.SUCCEEDED
+    assert adapter.finish_run_dispatch(finish) == finished
+    _expect_error(Conflict, lambda: adapter.finish_run_dispatch(
+        finish.model_copy(update={"outcome": DispatchOutcome.FAILED})
+    ))
     assert _reserve(adapter, clock, _WAVE_B).generation == 2
 
 

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -38,6 +38,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _assert_active_job_fences,
     _assert_committed_unit,
     _assert_job_failures,
+    _assert_revoked_completion,
     _claim_job,
     _claim_unit,
     _claim_unit_command,
@@ -104,6 +105,7 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     assert renewed.lease_until == clock.now() + timedelta(seconds=60)
     assert adapter.get_job(_TENANT, "job-a") == renewed
     complete = _assert_active_job_fences(adapter, clock)
+    _assert_revoked_completion(adapter, complete)
     clock.advance(timedelta(seconds=31))
     assert adapter.claim_job(_claim_job("job-a", "worker-b", clock)) is None
     clock.advance(timedelta(seconds=30))
@@ -303,6 +305,8 @@ def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
     failed = adapter.fail_run_unit(command, event)
     assert failed.state is RunUnitState.SUCCEEDED_DEGRADED
     assert failed.output_manifests == ()
+    assert (failed.lease_owner, failed.lease_until) == (None, None)
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == failed
     assert adapter.get_run(_TENANT, "run-a").missing_sources == ("CNES/ST",)
     assert adapter.pending_outbox(100).count(event) == 1
 
@@ -334,6 +338,7 @@ def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     event = _event("run-canceled")
     result = adapter.finalize_run_cancellation(command, event)
     assert result.state is RunState.CANCELED
+    assert adapter.get_run(_TENANT, "run-a") == result
     states = {unit.unit_id: unit.state for unit in adapter.list_run_units(_TENANT, "run-a")}
     assert states == {"unit-a": RunUnitState.SUCCEEDED, "unit-b": RunUnitState.CANCELED}
     assert adapter.finalize_run_cancellation(command, event) == result

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -32,6 +32,7 @@ from cnes_domain.control_plane.enums import (
 )
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
 from cnes_domain.control_plane.ids import run_dependency_key
+from cnes_domain.ports.control_plane import ControlPlanePort
 from packages.cnes_infra.tests.contracts.clock import (
     _HASH_A,
     _NOW,
@@ -66,6 +67,7 @@ class ControlPlaneCase:
     def run(self, adapter: Any, clock: MutableClock) -> None:
         """Executa o caso e identifica qualquer falha pelo nome."""
         try:
+            assert isinstance(adapter, ControlPlanePort)
             self._runner(adapter, clock)
         except Exception as error:
             raise AssertionError(f"case={self.name}") from error

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -1,5 +1,3 @@
-"""Casos reutilizáveis de conformidade do plano de controle."""
-
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -63,16 +61,14 @@ from packages.cnes_infra.tests.contracts.clock import (
     _unit,
 )
 
-_Runner = Callable[[Any, MutableClock], None]
 _HASH_B = "b" * 64
 
 
 @dataclass(frozen=True, slots=True)
 class ControlPlaneCase:
     """Executa uma invariável contra um adapter de plano de controle."""
-
     name: str
-    _runner: _Runner = field(repr=False, compare=False)
+    _runner: Callable[[Any, MutableClock], None] = field(repr=False, compare=False)
 
     def run(self, adapter: Any, clock: MutableClock) -> None:
         """Executa o caso e identifica qualquer falha pelo nome."""
@@ -96,11 +92,13 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
     adapter.put_agent(_agent("agent-a"))
-    second_event = _event("job-b-created")
-    adapter.create_job(_job("job-b"), second_event)
-    assert adapter.pending_outbox(100).count(second_event) == 1
-    claimable = adapter.list_claimable_jobs(_TENANT, "agent-a", 1)
-    assert tuple(job.job_id for job in claimable) == ("job-a",)
+    adapter.create_job(_job("job-b"), _event("job-b-created"))
+    for tenant_id, agent_id in ((_TENANT, "agent-z"), ("other", "agent-a")):
+        adapter.put_agent(_agent(agent_id, tenant_id=tenant_id))
+        job = _job("job-0", agent_id, tenant_id)
+        adapter.create_job(job, _event(f"{tenant_id}-job-created", tenant_id=tenant_id))
+    claimable = adapter.list_claimable_jobs(_TENANT, "agent-a", 10)
+    assert tuple(job.job_id for job in claimable) == ("job-a", "job-b")
     claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
     assert claimed is not None
     assert (claimed.attempt, claimed.fencing_token) == (1, 1)
@@ -157,6 +155,9 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
         key = f"raw/{item.tenant_id}/{item.source_type}/{item.competencia}"
         item = item.model_copy(update={"manifest_key": f"{key}/{snapshot_id}/manifest.json"})
         _store_record(adapter, item, clock)
+    identity = (_TENANT, "agent-b", "CNES", "ST", "2026-07")
+    assert adapter.latest_succeeded_job(*identity) == adapter.get_job(
+        _TENANT, "job-agent-b-delta-z")
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 2)
     assert tuple((ref.manifest_id, ref.manifest_key) for ref in chain) == tuple(
         (record.manifest_id, record.manifest_key) for record in records[3:5])
@@ -166,7 +167,6 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
         pass
     else:
         assert short == ()
-
 
 def _case_run_discovery(adapter: Any, clock: MutableClock) -> None:
     deps = (
@@ -205,7 +205,6 @@ def _case_run_units_atomic(adapter: Any, clock: MutableClock) -> None:
     divergent = (units[0], _unit("unit-c"))
     _expect_error(Conflict, lambda: _put_units(adapter, divergent))
     assert adapter.list_run_units(_TENANT, "run-a") == units
-
 
 def _case_unit_claim(adapter: Any, clock: MutableClock) -> None:
     unit_ids = ("unit-a", "unit-b")
@@ -278,7 +277,6 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
         lambda: adapter.fail_run_unit(expired_fail, _event("expired-fail")))
     _assert_retryable_unit_failure(adapter, clock, fail)
 
-
 def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
     optional = (RunDependency(source_type="CNES", file_subtype="ST", required=False),)
     adapter.put_run(_run("run-a", dependencies=optional))
@@ -313,8 +311,7 @@ def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     adapter.transition_run(
         TransitionRun(
             tenant_id=_TENANT, run_id="run-a", expected_state=RunState.PROCESSING,
-            new_state=RunState.CANCEL_REQUESTED), requested_event,
-    )
+            new_state=RunState.CANCEL_REQUESTED), requested_event)
     assert adapter.pending_outbox(100).count(requested_event) == 1
     command = FinalizeRunCancellation(
         tenant_id=_TENANT, run_id="run-a", expected_state=RunState.CANCEL_REQUESTED,
@@ -325,13 +322,11 @@ def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     assert adapter.get_run(_TENANT, "run-a") == result
     states = {unit.unit_id: (unit.state, unit.lease_owner, unit.lease_until)
               for unit in adapter.list_run_units(_TENANT, "run-a")}
-    assert states == {
-        "unit-a": (RunUnitState.SUCCEEDED, None, None),
-        "unit-b": (RunUnitState.CANCELED, None, None),
-        "unit-c": (RunUnitState.CANCELED, None, None)}
+    assert states["unit-a"] == (RunUnitState.SUCCEEDED, None, None)
+    assert states["unit-b"] == states["unit-c"] == (RunUnitState.CANCELED, None, None)
+    assert set(states) == {"unit-a", "unit-b", "unit-c"}
     assert adapter.finalize_run_cancellation(command, event) == result
     assert adapter.pending_outbox(10).count(event) == 1
-
 
 def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
     dispatch = _prepare_unit(adapter, clock)
@@ -348,9 +343,11 @@ def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
     assert adapter.bind_run_dispatch(bind) == started
     _expect_error(Conflict, lambda: adapter.bind_run_dispatch(
         bind.model_copy(update={"execution_ref": "x"})))
+    before_finish = adapter.get_active_run_dispatch(_TENANT, "run-a")
     _expect_error(Conflict, lambda: adapter.finish_run_dispatch(FinishRunDispatch(
         tenant_id=_TENANT, run_id="run-a", dispatch_id=_WAVE_B,
         outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now())))
+    assert adapter.get_active_run_dispatch(_TENANT, "run-a") == before_finish
     finish = FinishRunDispatch(
         tenant_id=_TENANT, run_id="run-a", dispatch_id=dispatch.dispatch_id,
         outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now())
@@ -415,12 +412,17 @@ def _case_idempotency(adapter: Any, clock: MutableClock) -> None:
         resource_id="resource-a", now=clock.now(),
         expires_at=clock.now() + timedelta(minutes=5))
     created = adapter.begin_idempotency(first)
+    other_tenant = first.model_copy(update={"tenant_id": "other", "resource_id": "other"})
+    other_scope = first.model_copy(update={"scope": "runs", "resource_id": "scoped"})
+    assert adapter.begin_idempotency(other_tenant).created
+    assert adapter.begin_idempotency(other_scope).created
     replay = adapter.begin_idempotency(first.model_copy(update={"resource_id": "resource-b"}))
     assert created.created
     assert not replay.created
     assert replay.record.resource_id == "resource-a"
     _expect_error(Conflict, lambda: adapter.begin_idempotency(
         first.model_copy(update={"request_hash": _HASH_B})))
+    assert adapter.begin_idempotency(first) == replay
     clock.advance(timedelta(minutes=6))
     replaced = adapter.begin_idempotency(first.model_copy(update={
         "request_hash": _HASH_B, "resource_id": "resource-b", "now": clock.now(),
@@ -430,14 +432,12 @@ def _case_idempotency(adapter: Any, clock: MutableClock) -> None:
 
 
 def _publish(run_id: str, event_id: str, expected: str | None, degraded: bool) -> PublishDataset:
-    state = RunState.PUBLISHED_DEGRADED if degraded else RunState.PUBLISHED
-    version = DatasetVersion(
-        tenant_id=_TENANT, dataset_name="gold", version_id=run_id, run_id=run_id,
-        run_manifest_key=f"reconciliation/{_TENANT}/2026-07/{run_id}/run-manifest.json",
-        created_at=_NOW)
     return PublishDataset(
-        version=version, pointer_name="current", expected_version_id=expected,
-        final_state=state,
+        version=DatasetVersion(
+            tenant_id=_TENANT, dataset_name="gold", version_id=run_id, run_id=run_id,
+            run_manifest_key=f"reconciliation/{_TENANT}/2026-07/{run_id}/run-manifest.json",
+            created_at=_NOW), pointer_name="current", expected_version_id=expected,
+        final_state=RunState.PUBLISHED_DEGRADED if degraded else RunState.PUBLISHED,
         missing_sources=("CNES/ST",) if degraded else (),
         publication_permit=PublicationPermit(
             tenant_id=_TENANT, run_id=run_id, policy_version=1, fencing_token=1),

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -8,7 +8,6 @@ from typing import Any
 from cnes_domain.control_plane.commands import (
     BeginIdempotency,
     BindRunDispatch,
-    CompleteJob,
     FailRunUnit,
     FinalizeRunCancellation,
     FinishRunDispatch,
@@ -37,6 +36,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _TENANT,
     MutableClock,
     _agent,
+    _assert_active_job_fences,
     _claim_job,
     _claim_unit,
     _claim_unit_command,
@@ -74,32 +74,6 @@ class ControlPlaneCase:
             self._runner(adapter, clock)
         except Exception as error:
             raise AssertionError(f"case={self.name}") from error
-
-
-def _assert_active_job_fences(adapter: Any, clock: MutableClock) -> CompleteJob:
-    manifest = _raw_record("result", "agent-a", 1, clock.now())
-    complete = CompleteJob(
-        tenant_id=_TENANT, job_id="job-a", owner="worker-a", fencing_token=1,
-        manifest=manifest,
-    )
-    renewals = (
-        _renew_job(clock).model_copy(update={"owner": "other"}),
-        _renew_job(clock).model_copy(update={"fencing_token": 2}),
-    )
-    for command in renewals:
-        _expect_error(
-            (FenceRejected, LeaseLost),
-            lambda command=command: adapter.renew_job_lease(command),
-        )
-    completions = (
-        complete.model_copy(update={"owner": "other"}),
-        complete.model_copy(update={"fencing_token": 2}),
-    )
-    for command in completions:
-        _expect_error((FenceRejected, LeaseLost), lambda command=command: adapter.complete_job(
-            command, _event("invalid-complete")
-        ))
-    return complete
 
 
 def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
@@ -236,6 +210,24 @@ def _case_unit_claim(adapter: Any, clock: MutableClock) -> None:
     assert adapter.claim_run_unit(pending) is None
 
 
+def _assert_retryable_unit_failure(adapter: Any, clock: MutableClock, base: FailRunUnit) -> None:
+    dispatch = _reserve(adapter, clock, _WAVE_B)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-b")
+    assert claimed is not None
+    command = base.model_copy(update={
+        "dispatch_id": dispatch.dispatch_id,
+        "owner": "worker-b",
+        "fencing_token": claimed.fencing_token,
+    })
+    event = _event("unit-retryable")
+    failed = adapter.fail_run_unit(command, event)
+    assert (failed.state, failed.lease_owner, failed.lease_until) == (
+        RunUnitState.FAILED_RETRYABLE, None, None
+    )
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == failed
+    assert adapter.pending_outbox(100).count(event) == 1
+
+
 def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
     dispatch = _prepare_unit(adapter, clock)
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
@@ -280,6 +272,7 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
     _expect_error(LeaseLost, lambda: adapter.commit_run_unit(expired, _event("expired-unit")))
     expired_fail = fail.model_copy(update={"dispatch_id": dispatch.dispatch_id})
     _expect_error(LeaseLost, lambda: adapter.fail_run_unit(expired_fail, _event("expired-fail")))
+    _assert_retryable_unit_failure(adapter, clock, fail)
 
 
 def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
@@ -299,10 +292,12 @@ def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
         error_code="optional_failed",
         retryable=False,
     )
-    failed = adapter.fail_run_unit(command, _event("unit-degraded"))
+    event = _event("unit-degraded")
+    failed = adapter.fail_run_unit(command, event)
     assert failed.state is RunUnitState.SUCCEEDED_DEGRADED
     assert failed.output_manifests == ()
     assert adapter.get_run(_TENANT, "run-a").missing_sources == ("CNES/ST",)
+    assert adapter.pending_outbox(100).count(event) == 1
 
 
 def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
@@ -311,10 +306,13 @@ def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     dispatch = _reserve(adapter, clock)
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
     assert claimed is not None
+    completed_event = _event("unit-completed")
     adapter.commit_run_unit(
         _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
-        _event("unit-completed"),
+        completed_event,
     )
+    assert adapter.pending_outbox(100).count(completed_event) == 1
+    requested_event = _event("run-cancel-requested")
     adapter.transition_run(
         TransitionRun(
             tenant_id=_TENANT,
@@ -322,8 +320,9 @@ def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
             expected_state=RunState.PROCESSING,
             new_state=RunState.CANCEL_REQUESTED,
         ),
-        _event("run-cancel-requested"),
+        requested_event,
     )
+    assert adapter.pending_outbox(100).count(requested_event) == 1
     command = FinalizeRunCancellation(
         tenant_id=_TENANT,
         run_id="run-a",
@@ -447,6 +446,7 @@ def _case_publication(adapter: Any, clock: MutableClock) -> None:
     first = _publish("run-a", "published-a", None, False)
     pointer = adapter.publish_dataset(first)
     assert pointer.version_id == "run-a"
+    assert adapter.get_dataset_pointer(_TENANT, "gold") == pointer
     assert adapter.get_run(_TENANT, "run-a").state is RunState.PUBLISHED
     assert adapter.publish_dataset(first) == pointer
     assert adapter.pending_outbox(10).count(first.event) == 1
@@ -464,7 +464,11 @@ def _case_publication(adapter: Any, clock: MutableClock) -> None:
     assert adapter.get_run(_TENANT, "run-b").state is RunState.PUBLISHING
     assert conflict.event not in adapter.pending_outbox(10)
     success = conflict.model_copy(update={"expected_version_id": "run-a"})
-    adapter.publish_dataset(success)
+    degraded_pointer = adapter.publish_dataset(success)
+    assert degraded_pointer.version_id == "run-b"
+    assert adapter.get_dataset_pointer(_TENANT, "gold") == degraded_pointer
+    assert adapter.get_dataset_version(_TENANT, "gold", "run-b") == success.version
+    assert adapter.pending_outbox(100).count(success.event) == 1
     run = adapter.get_run(_TENANT, "run-b")
     assert run.state is RunState.PUBLISHED_DEGRADED
     assert run.missing_sources == ("CNES/ST",)

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
+from functools import partial
 from typing import Any
 
 from cnes_domain.control_plane.commands import (
@@ -33,12 +34,15 @@ from packages.cnes_infra.tests.contracts.clock import (
     _HASH_A,
     _NOW,
     _TENANT,
+    _WAVE_B,
     MutableClock,
     _agent,
     _assert_active_job_fences,
     _assert_committed_unit,
     _assert_job_failures,
+    _assert_retryable_unit_failure,
     _assert_revoked_completion,
+    _assert_unit_rejected,
     _claim_job,
     _claim_unit,
     _claim_unit_command,
@@ -59,7 +63,6 @@ from packages.cnes_infra.tests.contracts.clock import (
 
 _Runner = Callable[[Any, MutableClock], None]
 _HASH_B = "b" * 64
-_WAVE_B = "b" * 16
 
 
 @dataclass(frozen=True, slots=True)
@@ -138,9 +141,8 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
     for record in records:
         _store_record(adapter, record, clock)
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 2)
-    assert tuple(ref.manifest_id for ref in chain) == (
-        "manifest-agent-b-base-agent-b",
-        "manifest-agent-b-delta-z",
+    assert tuple((ref.manifest_id, ref.manifest_key) for ref in chain) == tuple(
+        (record.manifest_id, record.manifest_key) for record in records[3:5]
     )
     try:
         short = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1)
@@ -196,17 +198,19 @@ def _case_run_units_atomic(adapter: Any, clock: MutableClock) -> None:
 def _case_unit_claim(adapter: Any, clock: MutableClock) -> None:
     unit_ids = ("unit-a", "unit-b")
     dispatch = _prepare_unit(adapter, clock, unit_ids)
+    assert dispatch.unit_ids == unit_ids
+    assert adapter.get_active_run_dispatch(_TENANT, "run-a") == dispatch
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
     assert claimed is not None
+    second_command = _claim_unit_command(dispatch.dispatch_id, "worker-a", clock, "unit-b")
+    assert adapter.claim_run_unit(second_command) is not None
     not_dispatched = _claim_unit_command(dispatch.dispatch_id, "worker-a", clock, "unit-z")
     assert adapter.claim_run_unit(not_dispatched) is None
     assert (claimed.attempt, claimed.fencing_token) == (1, 1)
     assert claimed.dispatch_id == dispatch.dispatch_id
     assert _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-b") is None
     clock.advance(timedelta(seconds=31))
-    expired_pending = _claim_unit_command(
-        dispatch.dispatch_id, "worker-b", clock, "unit-b"
-    )
+    expired_pending = _claim_unit_command(dispatch.dispatch_id, "worker-b", clock, "unit-b")
     assert adapter.claim_run_unit(expired_pending) is None
     replacement = _reserve(adapter, clock, unit_ids=unit_ids)
     retried = _claim_unit(adapter, clock, replacement.dispatch_id, "worker-b")
@@ -219,24 +223,6 @@ def _case_unit_claim(adapter: Any, clock: MutableClock) -> None:
     assert adapter.claim_run_unit(pending) is None
 
 
-def _assert_retryable_unit_failure(adapter: Any, clock: MutableClock, base: FailRunUnit) -> None:
-    dispatch = _reserve(adapter, clock, _WAVE_B)
-    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-b")
-    assert claimed is not None
-    command = base.model_copy(update={
-        "dispatch_id": dispatch.dispatch_id,
-        "owner": "worker-b",
-        "fencing_token": claimed.fencing_token,
-    })
-    event = _event("unit-retryable")
-    failed = adapter.fail_run_unit(command, event)
-    assert (failed.state, failed.lease_owner, failed.lease_until) == (
-        RunUnitState.FAILED_RETRYABLE, None, None
-    )
-    assert adapter.list_run_units(_TENANT, "run-a")[0] == failed
-    assert adapter.pending_outbox(100).count(event) == 1
-
-
 def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
     dispatch = _prepare_unit(adapter, clock)
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
@@ -247,9 +233,9 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
         _commit_command(_WAVE_B, "worker-a", claimed.fencing_token),
     )
     for command in invalid:
-        _expect_error((FenceRejected, LeaseLost), lambda command=command: adapter.commit_run_unit(
-            command, _event(f"invalid-{command.owner}-{command.fencing_token}")
-        ))
+        event = _event(f"invalid-{command.owner}-{command.fencing_token}")
+        action = partial(adapter.commit_run_unit, command, event)
+        _assert_unit_rejected(adapter, (FenceRejected, LeaseLost), action)
     fail = FailRunUnit(
         tenant_id=_TENANT, run_id="run-a", unit_id="unit-a", dispatch_id=_WAVE_B,
         owner="worker-a", fencing_token=claimed.fencing_token, error_code="stale",
@@ -263,24 +249,28 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
         fail,
     )
     for command in invalid_failures:
-        _expect_error((FenceRejected, LeaseLost), lambda command=command: adapter.fail_run_unit(
-            command, _event("invalid-fail")
-        ))
+        action = partial(adapter.fail_run_unit, command, _event("invalid-fail"))
+        _assert_unit_rejected(adapter, (FenceRejected, LeaseLost), action)
     adapter.put_run(_run("run-a", RunState.PUBLISHING))
     parent_commit = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
     parent_fail = fail.model_copy(update={"dispatch_id": dispatch.dispatch_id})
-    _expect_error((FenceRejected, LeaseLost), lambda: adapter.commit_run_unit(
+    _assert_unit_rejected(adapter, (FenceRejected, LeaseLost), lambda: adapter.commit_run_unit(
         parent_commit, _event("invalid-parent-commit")
     ))
-    _expect_error((FenceRejected, LeaseLost), lambda: adapter.fail_run_unit(
+    _assert_unit_rejected(adapter, (FenceRejected, LeaseLost), lambda: adapter.fail_run_unit(
         parent_fail, _event("invalid-parent-fail")
     ))
     adapter.put_run(_run("run-a"))
     clock.advance(timedelta(seconds=31))
     expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
-    _expect_error(LeaseLost, lambda: adapter.commit_run_unit(expired, _event("expired-unit")))
+    _assert_unit_rejected(
+        adapter, LeaseLost, lambda: adapter.commit_run_unit(expired, _event("expired-unit"))
+    )
     expired_fail = fail.model_copy(update={"dispatch_id": dispatch.dispatch_id})
-    _expect_error(LeaseLost, lambda: adapter.fail_run_unit(expired_fail, _event("expired-fail")))
+    _assert_unit_rejected(
+        adapter, LeaseLost,
+        lambda: adapter.fail_run_unit(expired_fail, _event("expired-fail")),
+    )
     _assert_retryable_unit_failure(adapter, clock, fail)
 
 
@@ -292,14 +282,9 @@ def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
     assert claimed is not None
     command = FailRunUnit(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        unit_id="unit-a",
-        dispatch_id=dispatch.dispatch_id,
-        owner="worker-a",
-        fencing_token=claimed.fencing_token,
-        error_code="optional_failed",
-        retryable=False,
+        tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
+        dispatch_id=dispatch.dispatch_id, owner="worker-a",
+        fencing_token=claimed.fencing_token, error_code="optional_failed", retryable=False,
     )
     event = _event("unit-degraded")
     failed = adapter.fail_run_unit(command, event)
@@ -401,6 +386,18 @@ def _case_dispatch_expiry(adapter: Any, clock: MutableClock) -> None:
         )
     )
     clock.advance(timedelta(seconds=2))
+    commit = _commit_command(renewed.dispatch_id, "worker-b", claimed.fencing_token)
+    fail = FailRunUnit(
+        tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
+        dispatch_id=renewed.dispatch_id, owner="worker-b",
+        fencing_token=claimed.fencing_token, error_code="dispatch-expired", retryable=True,
+    )
+    _assert_unit_rejected(adapter, LeaseLost, lambda: adapter.commit_run_unit(
+        commit, _event("expired-dispatch-commit")
+    ))
+    _assert_unit_rejected(adapter, LeaseLost, lambda: adapter.fail_run_unit(
+        fail, _event("expired-dispatch-fail")
+    ))
     _expect_error(Conflict, lambda: _reserve(adapter, clock, "c" * 16))
 
 

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -14,6 +14,7 @@ from cnes_domain.control_plane.commands import (
     FinishRunDispatch,
     PublicationPermit,
     PublishDataset,
+    ReserveRunDispatch,
     TransitionRun,
 )
 from cnes_domain.control_plane.entities import (
@@ -83,8 +84,7 @@ class ControlPlaneCase:
 
 def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     membership = Membership(
-        tenant_id=_TENANT, user_id="user-a", role="admin", created_at=clock.now()
-    )
+        tenant_id=_TENANT, user_id="user-a", role="admin", created_at=clock.now())
     adapter.put_membership(membership)
     assert adapter.get_membership(_TENANT, "user-a") == membership
     assert adapter.get_membership("other", "user-a") is None
@@ -123,9 +123,8 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     stale = _fail_job("worker-a", 1, "stale")
     _expect_error((FenceRejected, LeaseLost), lambda: adapter.fail_job(stale, _event("stale")))
     stale_fence = stale.model_copy(update={"owner": "worker-b"})
-    _expect_error(
-        FenceRejected, lambda: adapter.fail_job(stale_fence, _event("stale-fence"))
-    )
+    _expect_error(FenceRejected,
+                  lambda: adapter.fail_job(stale_fence, _event("stale-fence")))
     _assert_job_failures(adapter, clock)
 
 
@@ -140,6 +139,19 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
     )
     for record in records:
         _store_record(adapter, record, clock)
+    identities = ({"tenant_id": "other"}, {"source_type": "SIHD"},
+                  {"file_subtype": "PF"}, {"competencia": "2026-06"})
+    for index, identity in enumerate(identities):
+        snapshot_id = f"foreign-{index}"
+        update = {
+            "agent_id": snapshot_id, "snapshot_id": snapshot_id,
+            "manifest_id": f"manifest-{snapshot_id}",
+            "created_at": _NOW + timedelta(minutes=index + 1), **identity,
+        }
+        item = records[0].model_copy(update=update)
+        key = f"raw/{item.tenant_id}/{item.source_type}/{item.competencia}"
+        item = item.model_copy(update={"manifest_key": f"{key}/{snapshot_id}/manifest.json"})
+        _store_record(adapter, item, clock)
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 2)
     assert tuple((ref.manifest_id, ref.manifest_key) for ref in chain) == tuple(
         (record.manifest_id, record.manifest_key) for record in records[3:5]
@@ -164,6 +176,11 @@ def _case_run_discovery(adapter: Any, clock: MutableClock) -> None:
     adapter.put_run(_run("publishing", RunState.PUBLISHING))
     adapter.put_run(_run("canceling", RunState.CANCEL_REQUESTED))
     adapter.put_run(_run("published", RunState.PUBLISHED))
+    future = {"created_at": clock.now() + timedelta(days=1)}
+    foreign = _run("foreign-tenant", RunState.WAITING_INPUTS)
+    adapter.put_run(foreign.model_copy(update={"tenant_id": "other", **future}))
+    foreign = _run("foreign-period", RunState.WAITING_INPUTS)
+    adapter.put_run(foreign.model_copy(update={"competencia": "2026-06", **future}))
     waiting = adapter.list_waiting_runs_for_dependency(_TENANT, "CNES", "ST", "2026-07", 10)
     assert tuple(run.run_id for run in waiting) == ("waiting-a", "waiting-b")
     limited = adapter.list_waiting_runs_for_dependency(_TENANT, "CNES", "ST", "2026-07", 1)
@@ -171,15 +188,9 @@ def _case_run_discovery(adapter: Any, clock: MutableClock) -> None:
     assert run_dependency_key(_TENANT, "CNES", "ST", "2026-07") != run_dependency_key(
         _TENANT, "CNES_ST", "X", "2026-07"
     )
-    recoverable = adapter.list_recoverable_runs(clock.now(), 10)
+    recoverable = adapter.list_recoverable_runs(clock.now(), 6)
     assert tuple(run.run_id for run in recoverable) == (
-        "canceling",
-        "collision",
-        "processing",
-        "publishing",
-        "waiting-a",
-        "waiting-b",
-    )
+        "canceling", "collision", "processing", "publishing", "waiting-a", "waiting-b")
     assert tuple(run.run_id for run in adapter.list_recoverable_runs(clock.now(), 2)) == (
         "canceling", "collision"
     )
@@ -306,18 +317,12 @@ def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     requested_event = _event("run-cancel-requested")
     adapter.transition_run(
         TransitionRun(
-            tenant_id=_TENANT,
-            run_id="run-a",
-            expected_state=RunState.PROCESSING,
-            new_state=RunState.CANCEL_REQUESTED,
-        ),
-        requested_event,
+            tenant_id=_TENANT, run_id="run-a", expected_state=RunState.PROCESSING,
+            new_state=RunState.CANCEL_REQUESTED), requested_event,
     )
     assert adapter.pending_outbox(100).count(requested_event) == 1
     command = FinalizeRunCancellation(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        expected_state=RunState.CANCEL_REQUESTED,
+        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.CANCEL_REQUESTED,
         canceled_at=clock.now(),
     )
     event = _event("run-canceled")
@@ -335,19 +340,17 @@ def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
     assert _reserve(adapter, clock) == dispatch
     _expect_error(Conflict, lambda: _reserve(adapter, clock, _WAVE_B))
     bind = BindRunDispatch(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        dispatch_id=dispatch.dispatch_id,
-        execution_ref="exec-a",
-        now=clock.now(),
-        lease_seconds=30,
+        tenant_id=_TENANT, run_id="run-a", dispatch_id=dispatch.dispatch_id,
+        execution_ref="exec-a", now=clock.now(), lease_seconds=30,
     )
+    clock.advance(timedelta(seconds=10))
+    bind = bind.model_copy(update={"now": clock.now()})
     started = adapter.bind_run_dispatch(bind)
+    assert started.lease_until == clock.now() + timedelta(seconds=30)
+    assert adapter.get_active_run_dispatch(_TENANT, "run-a") == started
     assert adapter.bind_run_dispatch(bind) == started
-    _expect_error(
-        Conflict,
-        lambda: adapter.bind_run_dispatch(bind.model_copy(update={"execution_ref": "x"})),
-    )
+    _expect_error(Conflict, lambda: adapter.bind_run_dispatch(
+        bind.model_copy(update={"execution_ref": "x"})))
     _expect_error(Conflict, lambda: adapter.finish_run_dispatch(FinishRunDispatch(
         tenant_id=_TENANT, run_id="run-a", dispatch_id=_WAVE_B,
         outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now()
@@ -362,6 +365,17 @@ def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
     _expect_error(Conflict, lambda: adapter.finish_run_dispatch(
         finish.model_copy(update={"outcome": DispatchOutcome.FAILED})
     ))
+    adapter.put_run(_run("run-b"))
+    other_unit = _unit("unit-a").model_copy(update={"run_id": "run-b"})
+    _put_units(adapter, (other_unit,), "run-b")
+    other_command = ReserveRunDispatch(
+        tenant_id=_TENANT, run_id="run-b", wave_id=_WAVE_B, unit_ids=("unit-a",),
+        now=clock.now(), lease_seconds=30,
+    )
+    other = adapter.reserve_run_dispatch(other_command)
+    assert other.generation == 1
+    assert other.dispatch_id != dispatch.dispatch_id
+    assert adapter.reserve_run_dispatch(other_command) == other
     assert _reserve(adapter, clock, _WAVE_B).generation == 2
 
 
@@ -375,16 +389,9 @@ def _case_dispatch_expiry(adapter: Any, clock: MutableClock) -> None:
     assert renewed.generation == 2
     claimed = _claim_unit(adapter, clock, renewed.dispatch_id, "worker-b")
     assert claimed is not None
-    adapter.bind_run_dispatch(
-        BindRunDispatch(
-            tenant_id=_TENANT,
-            run_id="run-a",
-            dispatch_id=renewed.dispatch_id,
-            execution_ref="short-dispatch",
-            now=clock.now(),
-            lease_seconds=1,
-        )
-    )
+    adapter.bind_run_dispatch(BindRunDispatch(
+        tenant_id=_TENANT, run_id="run-a", dispatch_id=renewed.dispatch_id,
+        execution_ref="short-dispatch", now=clock.now(), lease_seconds=1))
     clock.advance(timedelta(seconds=2))
     commit = _commit_command(renewed.dispatch_id, "worker-b", claimed.fencing_token)
     fail = FailRunUnit(
@@ -393,11 +400,9 @@ def _case_dispatch_expiry(adapter: Any, clock: MutableClock) -> None:
         fencing_token=claimed.fencing_token, error_code="dispatch-expired", retryable=True,
     )
     _assert_unit_rejected(adapter, LeaseLost, lambda: adapter.commit_run_unit(
-        commit, _event("expired-dispatch-commit")
-    ))
+        commit, _event("expired-dispatch-commit")))
     _assert_unit_rejected(adapter, LeaseLost, lambda: adapter.fail_run_unit(
-        fail, _event("expired-dispatch-fail")
-    ))
+        fail, _event("expired-dispatch-fail")))
     _expect_error(Conflict, lambda: _reserve(adapter, clock, "c" * 16))
 
 
@@ -433,8 +438,7 @@ def _publish(run_id: str, event_id: str, expected: str | None, degraded: bool) -
         created_at=_NOW,
     )
     return PublishDataset(
-        version=version,
-        pointer_name="current",
+        version=version, pointer_name="current",
         expected_version_id=expected,
         final_state=state,
         missing_sources=("CNES/ST",) if degraded else (),

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -15,17 +15,8 @@ from cnes_domain.control_plane.commands import (
     ReserveRunDispatch,
     TransitionRun,
 )
-from cnes_domain.control_plane.entities import (
-    DatasetVersion,
-    Membership,
-    RunDependency,
-)
-from cnes_domain.control_plane.enums import (
-    AgentState,
-    DispatchOutcome,
-    RunState,
-    RunUnitState,
-)
+from cnes_domain.control_plane.entities import DatasetVersion, Membership, RunDependency
+from cnes_domain.control_plane.enums import AgentState, DispatchOutcome, RunState, RunUnitState
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
 from cnes_domain.control_plane.ids import run_dependency_key
 from cnes_domain.ports.control_plane import ControlPlanePort
@@ -116,6 +107,8 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     expired = _fail_job("worker-a", 1, "expired")
     _assert_job_rejected(
         adapter, LeaseLost, lambda: adapter.fail_job(expired, _event("expired")))
+    discoverable = adapter.list_claimable_jobs(_TENANT, "agent-a", 10)
+    assert adapter.get_job(_TENANT, "job-a") in discoverable
     retried = adapter.claim_job(_claim_job("job-a", "worker-b", clock))
     assert retried is not None
     assert retried.job_id == "job-a"
@@ -142,8 +135,8 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
             update={"previous_manifest_sha256": _HASH_B}),)
     for record in records:
         _store_record(adapter, record, clock)
-    identities = ({"tenant_id": "other"}, {"source_type": "SIHD"},
-                  {"file_subtype": "PF"}, {"competencia": "2026-06"})
+    identities = ({"tenant_id": "other"}, {"source_type": "SIHD"}, {"file_subtype": "PF"},
+                  {"competencia": "2026-06"})
     for index, identity in enumerate(identities):
         snapshot_id = f"foreign-{index}"
         update = {
@@ -155,6 +148,13 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
         key = f"raw/{item.tenant_id}/{item.source_type}/{item.competencia}"
         item = item.model_copy(update={"manifest_key": f"{key}/{snapshot_id}/manifest.json"})
         _store_record(adapter, item, clock)
+    failed = _job("job-agent-b-failed", "agent-b").model_copy(
+        update={"created_at": _NOW + timedelta(minutes=10)})
+    adapter.create_job(failed, _event("failed-created"))
+    failed_claim = adapter.claim_job(_claim_job(failed.job_id, "failed-worker", clock))
+    failed_command = _fail_job("failed-worker", failed_claim.fencing_token, "failed").model_copy(
+        update={"job_id": failed.job_id, "retryable": False})
+    adapter.fail_job(failed_command, _event("failed-final"))
     identity = (_TENANT, "agent-b", "CNES", "ST", "2026-07")
     assert adapter.latest_succeeded_job(*identity) == adapter.get_job(
         _TENANT, "job-agent-b-delta-z")

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -36,6 +36,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     MutableClock,
     _agent,
     _assert_active_job_fences,
+    _assert_committed_unit,
     _assert_job_failures,
     _claim_job,
     _claim_unit,
@@ -312,12 +313,7 @@ def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     dispatch = _reserve(adapter, clock)
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
     assert claimed is not None
-    completed_event = _event("unit-completed")
-    adapter.commit_run_unit(
-        _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
-        completed_event,
-    )
-    assert adapter.pending_outbox(100).count(completed_event) == 1
+    _assert_committed_unit(adapter, dispatch, claimed)
     requested_event = _event("run-cancel-requested")
     adapter.transition_run(
         TransitionRun(

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any
 
 from cnes_domain.control_plane.commands import (
@@ -21,7 +21,6 @@ from cnes_domain.control_plane.commands import (
 from cnes_domain.control_plane.entities import (
     DatasetVersion,
     Membership,
-    RawManifestRecord,
     RunDependency,
 )
 from cnes_domain.control_plane.enums import (
@@ -46,8 +45,10 @@ from packages.cnes_infra.tests.contracts.clock import (
     _expect_error,
     _fail_job,
     _job,
+    _raw_record,
     _renew_job,
     _run,
+    _store_record,
     _unit,
 )
 
@@ -73,6 +74,32 @@ class ControlPlaneCase:
             raise AssertionError(f"case={self.name}") from error
 
 
+def _assert_active_job_fences(adapter: Any, clock: MutableClock) -> CompleteJob:
+    manifest = _raw_record("result", "agent-a", 1, clock.now())
+    complete = CompleteJob(
+        tenant_id=_TENANT, job_id="job-a", owner="worker-a", fencing_token=1,
+        manifest=manifest,
+    )
+    renewals = (
+        _renew_job(clock).model_copy(update={"owner": "other"}),
+        _renew_job(clock).model_copy(update={"fencing_token": 2}),
+    )
+    for command in renewals:
+        _expect_error(
+            (FenceRejected, LeaseLost),
+            lambda command=command: adapter.renew_job_lease(command),
+        )
+    completions = (
+        complete.model_copy(update={"owner": "other"}),
+        complete.model_copy(update={"fencing_token": 2}),
+    )
+    for command in completions:
+        _expect_error((FenceRejected, LeaseLost), lambda command=command: adapter.complete_job(
+            command, _event("invalid-complete")
+        ))
+    return complete
+
+
 def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     membership = Membership(
         tenant_id=_TENANT, user_id="user-a", role="admin", created_at=clock.now()
@@ -91,8 +118,11 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     assert claimed.lease_until == clock.now() + timedelta(seconds=30)
     renewed = adapter.renew_job_lease(_renew_job(clock))
     assert renewed.lease_until == clock.now() + timedelta(seconds=60)
+    complete = _assert_active_job_fences(adapter, clock)
     assert adapter.claim_job(_claim_job("job-a", "worker-b", clock)) is None
     clock.advance(timedelta(seconds=61))
+    _expect_error(LeaseLost, lambda: adapter.renew_job_lease(_renew_job(clock)))
+    _expect_error(LeaseLost, lambda: adapter.complete_job(complete, _event("expired-complete")))
     expired = _fail_job("worker-a", 1, "expired")
     _expect_error(LeaseLost, lambda: adapter.fail_job(expired, _event("expired")))
     retried = adapter.claim_job(_claim_job("job-a", "worker-b", clock))
@@ -105,47 +135,6 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     _expect_error(
         FenceRejected, lambda: adapter.fail_job(stale_fence, _event("stale-fence"))
     )
-
-
-def _raw_record(
-    snapshot_id: str,
-    agent_id: str,
-    sequence: int,
-    created_at: datetime,
-) -> RawManifestRecord:
-    base = None if sequence == 1 else f"base-{agent_id}"
-    return RawManifestRecord(
-        tenant_id=_TENANT,
-        manifest_id=f"manifest-{agent_id}-{snapshot_id}",
-        manifest_key=f"raw/{_TENANT}/CNES/2026-07/{snapshot_id}/manifest.json",
-        agent_id=agent_id,
-        source_type="CNES",
-        file_subtype="ST",
-        competencia="2026-07",
-        snapshot_mode="FULL" if sequence == 1 else "DELTA",
-        snapshot_id=snapshot_id,
-        base_snapshot_id=base,
-        sequence=sequence,
-        previous_manifest_sha256=None if sequence == 1 else _HASH_A,
-        manifest_sha256=_HASH_A,
-        created_at=created_at,
-    )
-
-
-def _store_record(adapter: Any, record: RawManifestRecord, clock: MutableClock) -> None:
-    job = _job(f"job-{record.agent_id}-{record.snapshot_id}", record.agent_id)
-    adapter.put_agent(_agent(record.agent_id))
-    adapter.create_job(job, _event(f"created-{job.job_id}"))
-    claimed = adapter.claim_job(_claim_job(job.job_id, "raw-worker", clock))
-    assert claimed is not None
-    complete = CompleteJob(
-        tenant_id=_TENANT,
-        job_id=job.job_id,
-        owner="raw-worker",
-        fencing_token=claimed.fencing_token,
-        manifest=record,
-    )
-    adapter.complete_job(complete, _event(f"completed-{job.job_id}"))
 
 
 def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
@@ -277,18 +266,27 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
         _expect_error((FenceRejected, LeaseLost), lambda command=command: adapter.commit_run_unit(
             command, _event(f"invalid-{command.owner}-{command.fencing_token}")
         ))
-    stale_fail = FailRunUnit(
+    fail = FailRunUnit(
         tenant_id=_TENANT, run_id="run-a", unit_id="unit-a", dispatch_id=_WAVE_B,
         owner="worker-a", fencing_token=claimed.fencing_token, error_code="stale",
         retryable=True,
     )
-    _expect_error(
-        (FenceRejected, LeaseLost),
-        lambda: adapter.fail_run_unit(stale_fail, _event("invalid-fail")),
+    invalid_failures = (
+        fail.model_copy(update={"dispatch_id": dispatch.dispatch_id, "owner": "other"}),
+        fail.model_copy(update={
+            "dispatch_id": dispatch.dispatch_id, "fencing_token": claimed.fencing_token + 1
+        }),
+        fail,
     )
+    for command in invalid_failures:
+        _expect_error((FenceRejected, LeaseLost), lambda command=command: adapter.fail_run_unit(
+            command, _event("invalid-fail")
+        ))
     clock.advance(timedelta(seconds=31))
     expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
     _expect_error(LeaseLost, lambda: adapter.commit_run_unit(expired, _event("expired-unit")))
+    expired_fail = fail.model_copy(update={"dispatch_id": dispatch.dispatch_id})
+    _expect_error(LeaseLost, lambda: adapter.fail_run_unit(expired_fail, _event("expired-fail")))
     adapter.put_run(_run("run-a", RunState.PUBLISHING))
     _expect_error(
         (FenceRejected, LeaseLost),

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -23,7 +23,6 @@ from cnes_domain.control_plane.entities import (
 from cnes_domain.control_plane.enums import (
     AgentState,
     DispatchOutcome,
-    JobState,
     RunState,
     RunUnitState,
 )
@@ -37,6 +36,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     MutableClock,
     _agent,
     _assert_active_job_fences,
+    _assert_job_failures,
     _claim_job,
     _claim_unit,
     _claim_unit_command,
@@ -90,15 +90,22 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
     adapter.put_agent(_agent("agent-a"))
+    second_event = _event("job-b-created")
+    adapter.create_job(_job("job-b"), second_event)
+    assert adapter.pending_outbox(100).count(second_event) == 1
+    claimable = adapter.list_claimable_jobs(_TENANT, "agent-a", 1)
+    assert tuple(job.job_id for job in claimable) == ("job-a",)
     claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
     assert claimed is not None
     assert (claimed.attempt, claimed.fencing_token) == (1, 1)
     assert claimed.lease_until == clock.now() + timedelta(seconds=30)
     renewed = adapter.renew_job_lease(_renew_job(clock))
     assert renewed.lease_until == clock.now() + timedelta(seconds=60)
+    assert adapter.get_job(_TENANT, "job-a") == renewed
     complete = _assert_active_job_fences(adapter, clock)
+    clock.advance(timedelta(seconds=31))
     assert adapter.claim_job(_claim_job("job-a", "worker-b", clock)) is None
-    clock.advance(timedelta(seconds=61))
+    clock.advance(timedelta(seconds=30))
     _expect_error(LeaseLost, lambda: adapter.renew_job_lease(_renew_job(clock)))
     _expect_error(LeaseLost, lambda: adapter.complete_job(complete, _event("expired-complete")))
     expired = _fail_job("worker-a", 1, "expired")
@@ -113,12 +120,7 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     _expect_error(
         FenceRejected, lambda: adapter.fail_job(stale_fence, _event("stale-fence"))
     )
-    failed_event = _event("failed-retryable")
-    failed = adapter.fail_job(_fail_job("worker-b", 2, "retry"), failed_event)
-    assert (failed.state, failed.lease_owner, failed.lease_until) == (
-        JobState.FAILED_RETRYABLE, None, None
-    )
-    assert adapter.pending_outbox(100).count(failed_event) == 1
+    _assert_job_failures(adapter, clock)
 
 
 def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
@@ -199,6 +201,10 @@ def _case_unit_claim(adapter: Any, clock: MutableClock) -> None:
     assert claimed.dispatch_id == dispatch.dispatch_id
     assert _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-b") is None
     clock.advance(timedelta(seconds=31))
+    expired_pending = _claim_unit_command(
+        dispatch.dispatch_id, "worker-b", clock, "unit-b"
+    )
+    assert adapter.claim_run_unit(expired_pending) is None
     replacement = _reserve(adapter, clock, unit_ids=unit_ids)
     retried = _claim_unit(adapter, clock, replacement.dispatch_id, "worker-b")
     assert retried is not None

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -138,7 +138,10 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
         _raw_record("delta-3", "agent-a", 3, _NOW + timedelta(seconds=2)),
         _raw_record("base-agent-b", "agent-b", 1, _NOW),
         _raw_record("delta-z", "agent-b", 2, _NOW + timedelta(seconds=2)),
-        _raw_record("orphan", "agent-z", 2, _NOW + timedelta(seconds=3)),)
+        _raw_record("orphan", "agent-z", 2, _NOW + timedelta(seconds=3)),
+        _raw_record("base-agent-y", "agent-y", 1, _NOW - timedelta(seconds=1)),
+        _raw_record("broken", "agent-y", 2, _NOW + timedelta(seconds=5)).model_copy(
+            update={"previous_manifest_sha256": _HASH_B}),)
     for record in records:
         _store_record(adapter, record, clock)
     identities = ({"tenant_id": "other"}, {"source_type": "SIHD"},
@@ -268,13 +271,11 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
     clock.advance(timedelta(seconds=31))
     expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
     _assert_unit_rejected(
-        adapter, LeaseLost, lambda: adapter.commit_run_unit(expired, _event("expired-unit"))
-    )
+        adapter, LeaseLost, lambda: adapter.commit_run_unit(expired, _event("expired-unit")))
     expired_fail = fail.model_copy(update={"dispatch_id": dispatch.dispatch_id})
     _assert_unit_rejected(
         adapter, LeaseLost,
-        lambda: adapter.fail_run_unit(expired_fail, _event("expired-fail")),
-    )
+        lambda: adapter.fail_run_unit(expired_fail, _event("expired-fail")))
     _assert_retryable_unit_failure(adapter, clock, fail)
 
 
@@ -398,8 +399,7 @@ def _case_dispatch_expiry(adapter: Any, clock: MutableClock) -> None:
     fail = FailRunUnit(
         tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
         dispatch_id=renewed.dispatch_id, owner="worker-b",
-        fencing_token=claimed.fencing_token, error_code="dispatch-expired", retryable=True,
-    )
+        fencing_token=claimed.fencing_token, error_code="dispatch-expired", retryable=True)
     _assert_unit_rejected(adapter, LeaseLost, lambda: adapter.commit_run_unit(
         commit, _event("expired-dispatch-commit")))
     _assert_unit_rejected(adapter, LeaseLost, lambda: adapter.fail_run_unit(

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -41,6 +41,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _assert_active_job_fences,
     _assert_committed_unit,
     _assert_job_failures,
+    _assert_job_rejected,
     _assert_retryable_unit_failure,
     _assert_revoked_completion,
     _assert_unit_rejected,
@@ -115,16 +116,18 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     _expect_error(LeaseLost, lambda: adapter.renew_job_lease(_renew_job(clock)))
     _expect_error(LeaseLost, lambda: adapter.complete_job(complete, _event("expired-complete")))
     expired = _fail_job("worker-a", 1, "expired")
-    _expect_error(LeaseLost, lambda: adapter.fail_job(expired, _event("expired")))
+    _assert_job_rejected(
+        adapter, LeaseLost, lambda: adapter.fail_job(expired, _event("expired")))
     retried = adapter.claim_job(_claim_job("job-a", "worker-b", clock))
     assert retried is not None
     assert retried.job_id == "job-a"
     assert (retried.attempt, retried.fencing_token) == (2, 2)
     stale = _fail_job("worker-a", 1, "stale")
-    _expect_error((FenceRejected, LeaseLost), lambda: adapter.fail_job(stale, _event("stale")))
+    _assert_job_rejected(adapter, (FenceRejected, LeaseLost),
+                         lambda: adapter.fail_job(stale, _event("stale")))
     stale_fence = stale.model_copy(update={"owner": "worker-b"})
-    _expect_error(FenceRejected,
-                  lambda: adapter.fail_job(stale_fence, _event("stale-fence")))
+    _assert_job_rejected(adapter, FenceRejected,
+                         lambda: adapter.fail_job(stale_fence, _event("stale-fence")))
     _assert_job_failures(adapter, clock)
 
 
@@ -135,8 +138,7 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
         _raw_record("delta-3", "agent-a", 3, _NOW + timedelta(seconds=2)),
         _raw_record("base-agent-b", "agent-b", 1, _NOW),
         _raw_record("delta-z", "agent-b", 2, _NOW + timedelta(seconds=2)),
-        _raw_record("orphan", "agent-z", 2, _NOW + timedelta(seconds=3)),
-    )
+        _raw_record("orphan", "agent-z", 2, _NOW + timedelta(seconds=3)),)
     for record in records:
         _store_record(adapter, record, clock)
     identities = ({"tenant_id": "other"}, {"source_type": "SIHD"},
@@ -154,8 +156,7 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
         _store_record(adapter, item, clock)
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 2)
     assert tuple((ref.manifest_id, ref.manifest_key) for ref in chain) == tuple(
-        (record.manifest_id, record.manifest_key) for record in records[3:5]
-    )
+        (record.manifest_id, record.manifest_key) for record in records[3:5])
     try:
         short = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1)
     except Conflict:
@@ -167,8 +168,7 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
 def _case_run_discovery(adapter: Any, clock: MutableClock) -> None:
     deps = (
         RunDependency(source_type="CNES", file_subtype="ST", required=True),
-        RunDependency(source_type="CNES_ST", file_subtype="X", required=True),
-    )
+        RunDependency(source_type="CNES_ST", file_subtype="X", required=True),)
     adapter.put_run(_run("waiting-a", RunState.WAITING_INPUTS, deps))
     adapter.put_run(_run("waiting-b", RunState.WAITING_INPUTS))
     adapter.put_run(_run("collision", RunState.WAITING_INPUTS, (deps[1],)))
@@ -186,14 +186,12 @@ def _case_run_discovery(adapter: Any, clock: MutableClock) -> None:
     limited = adapter.list_waiting_runs_for_dependency(_TENANT, "CNES", "ST", "2026-07", 1)
     assert tuple(run.run_id for run in limited) == ("waiting-a",)
     assert run_dependency_key(_TENANT, "CNES", "ST", "2026-07") != run_dependency_key(
-        _TENANT, "CNES_ST", "X", "2026-07"
-    )
+        _TENANT, "CNES_ST", "X", "2026-07")
     recoverable = adapter.list_recoverable_runs(clock.now(), 6)
     assert tuple(run.run_id for run in recoverable) == (
         "canceling", "collision", "processing", "publishing", "waiting-a", "waiting-b")
     assert tuple(run.run_id for run in adapter.list_recoverable_runs(clock.now(), 2)) == (
-        "canceling", "collision"
-    )
+        "canceling", "collision")
 
 
 def _case_run_units_atomic(adapter: Any, clock: MutableClock) -> None:
@@ -241,8 +239,7 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
     invalid = (
         _commit_command(dispatch.dispatch_id, "other", claimed.fencing_token),
         _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token + 1),
-        _commit_command(_WAVE_B, "worker-a", claimed.fencing_token),
-    )
+        _commit_command(_WAVE_B, "worker-a", claimed.fencing_token),)
     for command in invalid:
         event = _event(f"invalid-{command.owner}-{command.fencing_token}")
         action = partial(adapter.commit_run_unit, command, event)
@@ -250,15 +247,13 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
     fail = FailRunUnit(
         tenant_id=_TENANT, run_id="run-a", unit_id="unit-a", dispatch_id=_WAVE_B,
         owner="worker-a", fencing_token=claimed.fencing_token, error_code="stale",
-        retryable=True,
-    )
+        retryable=True)
     invalid_failures = (
         fail.model_copy(update={"dispatch_id": dispatch.dispatch_id, "owner": "other"}),
         fail.model_copy(update={
             "dispatch_id": dispatch.dispatch_id, "fencing_token": claimed.fencing_token + 1
         }),
-        fail,
-    )
+        fail,)
     for command in invalid_failures:
         action = partial(adapter.fail_run_unit, command, _event("invalid-fail"))
         _assert_unit_rejected(adapter, (FenceRejected, LeaseLost), action)
@@ -266,11 +261,9 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
     parent_commit = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
     parent_fail = fail.model_copy(update={"dispatch_id": dispatch.dispatch_id})
     _assert_unit_rejected(adapter, (FenceRejected, LeaseLost), lambda: adapter.commit_run_unit(
-        parent_commit, _event("invalid-parent-commit")
-    ))
+        parent_commit, _event("invalid-parent-commit")))
     _assert_unit_rejected(adapter, (FenceRejected, LeaseLost), lambda: adapter.fail_run_unit(
-        parent_fail, _event("invalid-parent-fail")
-    ))
+        parent_fail, _event("invalid-parent-fail")))
     adapter.put_run(_run("run-a"))
     clock.advance(timedelta(seconds=31))
     expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
@@ -295,8 +288,7 @@ def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
     command = FailRunUnit(
         tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
         dispatch_id=dispatch.dispatch_id, owner="worker-a",
-        fencing_token=claimed.fencing_token, error_code="optional_failed", retryable=False,
-    )
+        fencing_token=claimed.fencing_token, error_code="optional_failed", retryable=False)
     event = _event("unit-degraded")
     failed = adapter.fail_run_unit(command, event)
     assert failed.state is RunUnitState.SUCCEEDED_DEGRADED
@@ -391,10 +383,17 @@ def _case_dispatch_expiry(adapter: Any, clock: MutableClock) -> None:
     assert renewed.generation == 2
     claimed = _claim_unit(adapter, clock, renewed.dispatch_id, "worker-b")
     assert claimed is not None
-    adapter.bind_run_dispatch(BindRunDispatch(
+    short_bind = BindRunDispatch(
         tenant_id=_TENANT, run_id="run-a", dispatch_id=renewed.dispatch_id,
-        execution_ref="short-dispatch", now=clock.now(), lease_seconds=1))
+        execution_ref="short-dispatch", now=clock.now(), lease_seconds=1)
+    adapter.bind_run_dispatch(short_bind)
     clock.advance(timedelta(seconds=2))
+    expired_bind = short_bind.model_copy(update={"now": clock.now()})
+    _expect_error(Conflict, lambda: adapter.bind_run_dispatch(expired_bind))
+    expired_finish = FinishRunDispatch(
+        tenant_id=_TENANT, run_id="run-a", dispatch_id=renewed.dispatch_id,
+        outcome=DispatchOutcome.FAILED, finished_at=clock.now())
+    _expect_error(Conflict, lambda: adapter.finish_run_dispatch(expired_finish))
     commit = _commit_command(renewed.dispatch_id, "worker-b", claimed.fencing_token)
     fail = FailRunUnit(
         tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
@@ -405,14 +404,16 @@ def _case_dispatch_expiry(adapter: Any, clock: MutableClock) -> None:
         commit, _event("expired-dispatch-commit")))
     _assert_unit_rejected(adapter, LeaseLost, lambda: adapter.fail_run_unit(
         fail, _event("expired-dispatch-fail")))
+    before = adapter.get_active_run_dispatch(_TENANT, "run-a")
     _expect_error(Conflict, lambda: _reserve(adapter, clock, "c" * 16))
+    assert adapter.get_active_run_dispatch(_TENANT, "run-a") == before
 
 
 def _case_idempotency(adapter: Any, clock: MutableClock) -> None:
     first = BeginIdempotency(
         tenant_id=_TENANT, scope="jobs", key="key-a", request_hash=_HASH_A,
-        resource_id="resource-a", now=clock.now(), expires_at=clock.now() + timedelta(minutes=5)
-    )
+        resource_id="resource-a", now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5))
     created = adapter.begin_idempotency(first)
     replay = adapter.begin_idempotency(first.model_copy(update={"resource_id": "resource-b"}))
     assert created.created
@@ -496,5 +497,4 @@ def control_plane_cases() -> tuple[ControlPlaneCase, ...]:
         ControlPlaneCase("dispatch", _case_dispatch),
         ControlPlaneCase("dispatch_expiry", _case_dispatch_expiry),
         ControlPlaneCase("idempotency", _case_idempotency),
-        ControlPlaneCase("publication", _case_publication),
-    )
+        ControlPlaneCase("publication", _case_publication),)

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -1,0 +1,498 @@
+"""Casos reutilizáveis de conformidade do plano de controle."""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any
+
+from cnes_domain.control_plane.commands import (
+    BeginIdempotency,
+    BindRunDispatch,
+    CompleteJob,
+    FailRunUnit,
+    FinalizeRunCancellation,
+    FinishRunDispatch,
+    PublicationPermit,
+    PublishDataset,
+    PutRunUnits,
+    ReserveRunDispatch,
+    TransitionRun,
+)
+from cnes_domain.control_plane.entities import (
+    DatasetVersion,
+    Membership,
+    RawManifestRecord,
+    RunDependency,
+)
+from cnes_domain.control_plane.enums import (
+    AgentState,
+    DispatchOutcome,
+    RunState,
+    RunUnitState,
+)
+from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
+from cnes_domain.control_plane.ids import run_dependency_key
+from packages.cnes_infra.tests.contracts.clock import (
+    _HASH_A,
+    _NOW,
+    _TENANT,
+    MutableClock,
+    _agent,
+    _claim_job,
+    _claim_unit_command,
+    _commit_command,
+    _event,
+    _expect_error,
+    _fail_job,
+    _job,
+    _renew_job,
+    _run,
+    _unit,
+)
+
+_Runner = Callable[[Any, MutableClock], None]
+_HASH_B = "b" * 64
+_WAVE_A = "a" * 16
+_WAVE_B = "b" * 16
+
+
+@dataclass(frozen=True, slots=True)
+class ControlPlaneCase:
+    """Executa uma invariável contra um adapter de plano de controle."""
+
+    name: str
+    _runner: _Runner = field(repr=False, compare=False)
+
+    def run(self, adapter: Any, clock: MutableClock) -> None:
+        """Executa o caso e identifica qualquer falha pelo nome."""
+        try:
+            self._runner(adapter, clock)
+        except Exception as error:
+            raise AssertionError(f"case={self.name}") from error
+
+
+def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
+    membership = Membership(
+        tenant_id=_TENANT, user_id="user-a", role="admin", created_at=clock.now()
+    )
+    adapter.put_membership(membership)
+    assert adapter.get_membership(_TENANT, "user-a") == membership
+    assert adapter.get_membership("other", "user-a") is None
+    adapter.put_agent(_agent("agent-a", AgentState.REVOKED))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
+    assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
+    adapter.put_agent(_agent("agent-a"))
+    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    assert claimed is not None
+    assert (claimed.attempt, claimed.fencing_token) == (1, 1)
+    assert claimed.lease_until == clock.now() + timedelta(seconds=30)
+    renewed = adapter.renew_job_lease(_renew_job(clock))
+    assert renewed.lease_until == clock.now() + timedelta(seconds=60)
+    assert adapter.claim_job(_claim_job("job-a", "worker-b", clock)) is None
+    clock.advance(timedelta(seconds=61))
+    expired = _fail_job("worker-a", 1, "expired")
+    _expect_error(LeaseLost, lambda: adapter.fail_job(expired, _event("expired")))
+    retried = adapter.claim_job(_claim_job("job-a", "worker-b", clock))
+    assert retried is not None
+    assert retried.job_id == "job-a"
+    assert (retried.attempt, retried.fencing_token) == (2, 2)
+    stale = _fail_job("worker-a", 1, "stale")
+    _expect_error((FenceRejected, LeaseLost), lambda: adapter.fail_job(stale, _event("stale")))
+    stale_fence = stale.model_copy(update={"owner": "worker-b"})
+    _expect_error(
+        FenceRejected, lambda: adapter.fail_job(stale_fence, _event("stale-fence"))
+    )
+
+
+def _raw_record(
+    snapshot_id: str,
+    agent_id: str,
+    sequence: int,
+    created_at: datetime,
+) -> RawManifestRecord:
+    base = None if sequence == 1 else f"base-{agent_id}"
+    return RawManifestRecord(
+        tenant_id=_TENANT,
+        manifest_id=f"manifest-{agent_id}-{snapshot_id}",
+        manifest_key=f"raw/{_TENANT}/CNES/2026-07/{snapshot_id}/manifest.json",
+        agent_id=agent_id,
+        source_type="CNES",
+        file_subtype="ST",
+        competencia="2026-07",
+        snapshot_mode="FULL" if sequence == 1 else "DELTA",
+        snapshot_id=snapshot_id,
+        base_snapshot_id=base,
+        sequence=sequence,
+        previous_manifest_sha256=None if sequence == 1 else _HASH_A,
+        manifest_sha256=_HASH_A,
+        created_at=created_at,
+    )
+
+
+def _store_record(adapter: Any, record: RawManifestRecord, clock: MutableClock) -> None:
+    job = _job(f"job-{record.agent_id}-{record.snapshot_id}", record.agent_id)
+    adapter.put_agent(_agent(record.agent_id))
+    adapter.create_job(job, _event(f"created-{job.job_id}"))
+    claimed = adapter.claim_job(_claim_job(job.job_id, "raw-worker", clock))
+    assert claimed is not None
+    complete = CompleteJob(
+        tenant_id=_TENANT,
+        job_id=job.job_id,
+        owner="raw-worker",
+        fencing_token=claimed.fencing_token,
+        manifest=record,
+    )
+    adapter.complete_job(complete, _event(f"completed-{job.job_id}"))
+
+
+def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
+    records = (
+        _raw_record("base-agent-a", "agent-a", 1, _NOW),
+        _raw_record("delta-2", "agent-a", 2, _NOW + timedelta(seconds=1)),
+        _raw_record("delta-3", "agent-a", 3, _NOW + timedelta(seconds=2)),
+        _raw_record("base-agent-b", "agent-b", 1, _NOW),
+        _raw_record("delta-z", "agent-b", 2, _NOW + timedelta(seconds=2)),
+        _raw_record("orphan", "agent-z", 2, _NOW + timedelta(seconds=3)),
+    )
+    for record in records:
+        _store_record(adapter, record, clock)
+    chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 2)
+    assert tuple(ref.manifest_id for ref in chain) == (
+        "manifest-agent-b-base-agent-b",
+        "manifest-agent-b-delta-z",
+    )
+    try:
+        short = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1)
+    except Conflict:
+        pass
+    else:
+        assert short == ()
+
+
+def _case_run_discovery(adapter: Any, clock: MutableClock) -> None:
+    deps = (
+        RunDependency(source_type="CNES", file_subtype="ST", required=True),
+        RunDependency(source_type="CNES_ST", file_subtype="X", required=True),
+    )
+    adapter.put_run(_run("waiting-a", RunState.WAITING_INPUTS, deps))
+    adapter.put_run(_run("waiting-b", RunState.WAITING_INPUTS))
+    adapter.put_run(_run("collision", RunState.WAITING_INPUTS, (deps[1],)))
+    adapter.put_run(_run("processing", RunState.PROCESSING))
+    adapter.put_run(_run("publishing", RunState.PUBLISHING))
+    adapter.put_run(_run("canceling", RunState.CANCEL_REQUESTED))
+    adapter.put_run(_run("published", RunState.PUBLISHED))
+    waiting = adapter.list_waiting_runs_for_dependency(_TENANT, "CNES", "ST", "2026-07", 10)
+    assert tuple(run.run_id for run in waiting) == ("waiting-a", "waiting-b")
+    assert run_dependency_key(_TENANT, "CNES", "ST", "2026-07") != run_dependency_key(
+        _TENANT, "CNES_ST", "X", "2026-07"
+    )
+    recoverable = adapter.list_recoverable_runs(clock.now(), 10)
+    assert tuple(run.run_id for run in recoverable) == (
+        "canceling",
+        "collision",
+        "processing",
+        "publishing",
+        "waiting-a",
+        "waiting-b",
+    )
+
+
+def _put_units(adapter: Any, units: tuple[Any, ...]) -> tuple[Any, ...]:
+    return adapter.put_run_units(
+        PutRunUnits(
+            tenant_id=_TENANT,
+            run_id="run-a",
+            expected_run_state=RunState.PROCESSING,
+            units=units,
+        )
+    )
+
+
+def _case_run_units_atomic(adapter: Any, clock: MutableClock) -> None:
+    adapter.put_run(_run("run-a"))
+    units = (_unit("unit-a"), _unit("unit-b"))
+    assert _put_units(adapter, units) == units
+    assert _put_units(adapter, units) == units
+    divergent = (units[0], _unit("unit-c"))
+    _expect_error(Conflict, lambda: _put_units(adapter, divergent))
+    assert adapter.list_run_units(_TENANT, "run-a") == units
+
+
+def _reserve(adapter: Any, clock: MutableClock, wave: str = _WAVE_A) -> Any:
+    return adapter.reserve_run_dispatch(
+        ReserveRunDispatch(
+            tenant_id=_TENANT,
+            run_id="run-a",
+            wave_id=wave,
+            unit_ids=("unit-a",),
+            now=clock.now(),
+            lease_seconds=30,
+        )
+    )
+
+
+def _claim_unit(adapter: Any, clock: MutableClock, dispatch_id: str, owner: str) -> Any:
+    return adapter.claim_run_unit(_claim_unit_command(dispatch_id, owner, clock))
+
+
+def _prepare_unit(adapter: Any, clock: MutableClock) -> Any:
+    adapter.put_run(_run("run-a"))
+    _put_units(adapter, (_unit("unit-a"), _unit("unit-b")))
+    return _reserve(adapter, clock)
+
+
+def _case_unit_claim(adapter: Any, clock: MutableClock) -> None:
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    assert claimed is not None
+    not_dispatched = _claim_unit_command(dispatch.dispatch_id, "worker-a", clock, "unit-b")
+    assert adapter.claim_run_unit(not_dispatched) is None
+    assert (claimed.attempt, claimed.fencing_token) == (1, 1)
+    assert claimed.dispatch_id == dispatch.dispatch_id
+    assert _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-b") is None
+    clock.advance(timedelta(seconds=31))
+    replacement = _reserve(adapter, clock)
+    retried = _claim_unit(adapter, clock, replacement.dispatch_id, "worker-b")
+    assert retried is not None
+    assert retried.unit_id == "unit-a"
+    assert (retried.attempt, retried.fencing_token) == (2, 2)
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    clock.advance(timedelta(seconds=31))
+    assert _claim_unit(adapter, clock, replacement.dispatch_id, "worker-c") is None
+
+
+def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    assert claimed is not None
+    invalid = (
+        _commit_command(dispatch.dispatch_id, "other", claimed.fencing_token),
+        _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token + 1),
+        _commit_command(_WAVE_B, "worker-a", claimed.fencing_token),
+    )
+    for command in invalid:
+        _expect_error((FenceRejected, LeaseLost), lambda command=command: adapter.commit_run_unit(
+            command, _event(f"invalid-{command.owner}-{command.fencing_token}")
+        ))
+    stale_fail = FailRunUnit(
+        tenant_id=_TENANT, run_id="run-a", unit_id="unit-a", dispatch_id=_WAVE_B,
+        owner="worker-a", fencing_token=claimed.fencing_token, error_code="stale",
+        retryable=True,
+    )
+    _expect_error(
+        (FenceRejected, LeaseLost),
+        lambda: adapter.fail_run_unit(stale_fail, _event("invalid-fail")),
+    )
+    clock.advance(timedelta(seconds=31))
+    expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    _expect_error(LeaseLost, lambda: adapter.commit_run_unit(expired, _event("expired-unit")))
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    _expect_error(
+        (FenceRejected, LeaseLost),
+        lambda: adapter.commit_run_unit(
+            _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
+            _event("invalid-parent"),
+        ),
+    )
+
+
+def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
+    optional = (RunDependency(source_type="CNES", file_subtype="ST", required=False),)
+    adapter.put_run(_run("run-a", dependencies=optional))
+    _put_units(adapter, (_unit("unit-a"),))
+    dispatch = _reserve(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    assert claimed is not None
+    command = FailRunUnit(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        unit_id="unit-a",
+        dispatch_id=dispatch.dispatch_id,
+        owner="worker-a",
+        fencing_token=claimed.fencing_token,
+        error_code="optional_failed",
+        retryable=False,
+    )
+    failed = adapter.fail_run_unit(command, _event("unit-degraded"))
+    assert failed.state is RunUnitState.SUCCEEDED_DEGRADED
+    assert failed.output_manifests == ()
+    assert adapter.get_run(_TENANT, "run-a").missing_sources == ("CNES/ST",)
+
+
+def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
+    adapter.put_run(_run("run-a"))
+    _put_units(adapter, (_unit("unit-a"), _unit("unit-b")))
+    dispatch = _reserve(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    assert claimed is not None
+    adapter.commit_run_unit(
+        _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
+        _event("unit-completed"),
+    )
+    adapter.transition_run(
+        TransitionRun(
+            tenant_id=_TENANT,
+            run_id="run-a",
+            expected_state=RunState.PROCESSING,
+            new_state=RunState.CANCEL_REQUESTED,
+        ),
+        _event("run-cancel-requested"),
+    )
+    command = FinalizeRunCancellation(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        expected_state=RunState.CANCEL_REQUESTED,
+        canceled_at=clock.now(),
+    )
+    event = _event("run-canceled")
+    result = adapter.finalize_run_cancellation(command, event)
+    assert result.state is RunState.CANCELED
+    states = {unit.unit_id: unit.state for unit in adapter.list_run_units(_TENANT, "run-a")}
+    assert states == {"unit-a": RunUnitState.SUCCEEDED, "unit-b": RunUnitState.CANCELED}
+    assert adapter.finalize_run_cancellation(command, event) == result
+    assert adapter.pending_outbox(10).count(event) == 1
+
+
+def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
+    dispatch = _prepare_unit(adapter, clock)
+    assert _reserve(adapter, clock) == dispatch
+    _expect_error(Conflict, lambda: _reserve(adapter, clock, _WAVE_B))
+    bind = BindRunDispatch(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        dispatch_id=dispatch.dispatch_id,
+        execution_ref="exec-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    started = adapter.bind_run_dispatch(bind)
+    assert adapter.bind_run_dispatch(bind) == started
+    _expect_error(
+        Conflict,
+        lambda: adapter.bind_run_dispatch(bind.model_copy(update={"execution_ref": "x"})),
+    )
+    _expect_error(Conflict, lambda: adapter.finish_run_dispatch(FinishRunDispatch(
+        tenant_id=_TENANT, run_id="run-a", dispatch_id=_WAVE_B,
+        outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now()
+    )))
+    finished = adapter.finish_run_dispatch(FinishRunDispatch(
+        tenant_id=_TENANT, run_id="run-a", dispatch_id=dispatch.dispatch_id,
+        outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now()
+    ))
+    assert finished.terminal_outcome is DispatchOutcome.SUCCEEDED
+    assert _reserve(adapter, clock, _WAVE_B).generation == 2
+
+
+def _case_dispatch_expiry(adapter: Any, clock: MutableClock) -> None:
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    assert claimed is not None
+    clock.advance(timedelta(seconds=31))
+    assert adapter.get_active_run_dispatch(_TENANT, "run-a") is None
+    renewed = _reserve(adapter, clock, _WAVE_B)
+    assert renewed.generation == 2
+    claimed = _claim_unit(adapter, clock, renewed.dispatch_id, "worker-b")
+    assert claimed is not None
+    adapter.bind_run_dispatch(
+        BindRunDispatch(
+            tenant_id=_TENANT,
+            run_id="run-a",
+            dispatch_id=renewed.dispatch_id,
+            execution_ref="short-dispatch",
+            now=clock.now(),
+            lease_seconds=1,
+        )
+    )
+    clock.advance(timedelta(seconds=2))
+    _expect_error(Conflict, lambda: _reserve(adapter, clock, "c" * 16))
+
+
+def _case_idempotency(adapter: Any, clock: MutableClock) -> None:
+    first = BeginIdempotency(
+        tenant_id=_TENANT, scope="jobs", key="key-a", request_hash=_HASH_A,
+        resource_id="resource-a", now=clock.now(), expires_at=clock.now() + timedelta(minutes=5)
+    )
+    created = adapter.begin_idempotency(first)
+    replay = adapter.begin_idempotency(first.model_copy(update={"resource_id": "resource-b"}))
+    assert created.created
+    assert not replay.created
+    assert replay.record.resource_id == "resource-a"
+    _expect_error(Conflict, lambda: adapter.begin_idempotency(
+        first.model_copy(update={"request_hash": _HASH_B})
+    ))
+    clock.advance(timedelta(minutes=6))
+    replaced = adapter.begin_idempotency(first.model_copy(update={
+        "request_hash": _HASH_B,
+        "resource_id": "resource-b",
+        "now": clock.now(),
+        "expires_at": clock.now() + timedelta(minutes=5),
+    }))
+    assert replaced.created
+    assert replaced.record.resource_id == "resource-b"
+
+
+def _publish(run_id: str, event_id: str, expected: str | None, degraded: bool) -> PublishDataset:
+    state = RunState.PUBLISHED_DEGRADED if degraded else RunState.PUBLISHED
+    version = DatasetVersion(
+        tenant_id=_TENANT, dataset_name="gold", version_id=run_id, run_id=run_id,
+        run_manifest_key=f"reconciliation/{_TENANT}/2026-07/{run_id}/run-manifest.json",
+        created_at=_NOW,
+    )
+    return PublishDataset(
+        version=version,
+        pointer_name="current",
+        expected_version_id=expected,
+        final_state=state,
+        missing_sources=("CNES/ST",) if degraded else (),
+        publication_permit=PublicationPermit(
+            tenant_id=_TENANT, run_id=run_id, policy_version=1, fencing_token=1
+        ),
+        event=_event(event_id, aggregate_id=run_id),
+    )
+
+
+def _case_publication(adapter: Any, clock: MutableClock) -> None:
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    first = _publish("run-a", "published-a", None, False)
+    pointer = adapter.publish_dataset(first)
+    assert pointer.version_id == "run-a"
+    assert adapter.get_run(_TENANT, "run-a").state is RunState.PUBLISHED
+    assert adapter.publish_dataset(first) == pointer
+    assert adapter.pending_outbox(10).count(first.event) == 1
+    changed = first.model_copy(update={
+        "version": first.version.model_copy(update={
+            "run_manifest_key": f"reconciliation/{_TENANT}/2026-06/run-a/run-manifest.json"
+        })
+    })
+    _expect_error(Conflict, lambda: adapter.publish_dataset(changed))
+    assert adapter.get_dataset_version(_TENANT, "gold", "run-a") == first.version
+    adapter.put_run(_run("run-b", RunState.PUBLISHING))
+    conflict = _publish("run-b", "published-b", "stale", True)
+    _expect_error(Conflict, lambda: adapter.publish_dataset(conflict))
+    assert adapter.get_dataset_version(_TENANT, "gold", "run-b") is None
+    assert adapter.get_run(_TENANT, "run-b").state is RunState.PUBLISHING
+    assert conflict.event not in adapter.pending_outbox(10)
+    success = conflict.model_copy(update={"expected_version_id": "run-a"})
+    adapter.publish_dataset(success)
+    run = adapter.get_run(_TENANT, "run-b")
+    assert run.state is RunState.PUBLISHED_DEGRADED
+    assert run.missing_sources == ("CNES/ST",)
+
+
+def control_plane_cases() -> tuple[ControlPlaneCase, ...]:
+    """Retorna o catálogo estável de invariáveis do plano de controle."""
+    return (
+        ControlPlaneCase("authorization_jobs", _case_authorization_jobs),
+        ControlPlaneCase("raw_chains", _case_raw_chains),
+        ControlPlaneCase("run_discovery", _case_run_discovery),
+        ControlPlaneCase("run_units_atomic", _case_run_units_atomic),
+        ControlPlaneCase("unit_claim", _case_unit_claim),
+        ControlPlaneCase("unit_fences", _case_unit_fences),
+        ControlPlaneCase("degraded_unit", _case_degraded_unit),
+        ControlPlaneCase("cancellation", _case_cancellation),
+        ControlPlaneCase("dispatch", _case_dispatch),
+        ControlPlaneCase("dispatch_expiry", _case_dispatch_expiry),
+        ControlPlaneCase("idempotency", _case_idempotency),
+        ControlPlaneCase("publication", _case_publication),
+    )

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -145,8 +145,8 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
         snapshot_id = f"foreign-{index}"
         update = {
             "agent_id": snapshot_id, "snapshot_id": snapshot_id,
-            "manifest_id": f"manifest-{snapshot_id}",
-            "created_at": _NOW + timedelta(minutes=index + 1), **identity,
+            "manifest_id": f"manifest-{snapshot_id}", **identity,
+            "created_at": _NOW + timedelta(minutes=index + 1),
         }
         item = records[0].model_copy(update=update)
         key = f"raw/{item.tenant_id}/{item.source_type}/{item.competencia}"
@@ -309,10 +309,12 @@ def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
 
 def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     adapter.put_run(_run("run-a"))
-    _put_units(adapter, (_unit("unit-a"), _unit("unit-b")))
-    dispatch = _reserve(adapter, clock)
+    _put_units(adapter, (_unit("unit-a"), _unit("unit-b"), _unit("unit-c")))
+    dispatch = _reserve(adapter, clock, unit_ids=("unit-a", "unit-b"))
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
     assert claimed is not None
+    leased = _claim_unit_command(dispatch.dispatch_id, "worker-b", clock, "unit-b")
+    assert adapter.claim_run_unit(leased) is not None
     _assert_committed_unit(adapter, dispatch, claimed)
     requested_event = _event("run-cancel-requested")
     adapter.transition_run(
@@ -323,14 +325,17 @@ def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     assert adapter.pending_outbox(100).count(requested_event) == 1
     command = FinalizeRunCancellation(
         tenant_id=_TENANT, run_id="run-a", expected_state=RunState.CANCEL_REQUESTED,
-        canceled_at=clock.now(),
-    )
+        canceled_at=clock.now())
     event = _event("run-canceled")
     result = adapter.finalize_run_cancellation(command, event)
     assert result.state is RunState.CANCELED
     assert adapter.get_run(_TENANT, "run-a") == result
-    states = {unit.unit_id: unit.state for unit in adapter.list_run_units(_TENANT, "run-a")}
-    assert states == {"unit-a": RunUnitState.SUCCEEDED, "unit-b": RunUnitState.CANCELED}
+    states = {unit.unit_id: (unit.state, unit.lease_owner, unit.lease_until)
+              for unit in adapter.list_run_units(_TENANT, "run-a")}
+    assert states == {
+        "unit-a": (RunUnitState.SUCCEEDED, None, None),
+        "unit-b": (RunUnitState.CANCELED, None, None),
+        "unit-c": (RunUnitState.CANCELED, None, None)}
     assert adapter.finalize_run_cancellation(command, event) == result
     assert adapter.pending_outbox(10).count(event) == 1
 
@@ -341,8 +346,7 @@ def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
     _expect_error(Conflict, lambda: _reserve(adapter, clock, _WAVE_B))
     bind = BindRunDispatch(
         tenant_id=_TENANT, run_id="run-a", dispatch_id=dispatch.dispatch_id,
-        execution_ref="exec-a", now=clock.now(), lease_seconds=30,
-    )
+        execution_ref="exec-a", now=clock.now(), lease_seconds=30)
     clock.advance(timedelta(seconds=10))
     bind = bind.model_copy(update={"now": clock.now()})
     started = adapter.bind_run_dispatch(bind)
@@ -353,14 +357,13 @@ def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
         bind.model_copy(update={"execution_ref": "x"})))
     _expect_error(Conflict, lambda: adapter.finish_run_dispatch(FinishRunDispatch(
         tenant_id=_TENANT, run_id="run-a", dispatch_id=_WAVE_B,
-        outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now()
-    )))
+        outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now())))
     finish = FinishRunDispatch(
         tenant_id=_TENANT, run_id="run-a", dispatch_id=dispatch.dispatch_id,
-        outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now()
-    )
+        outcome=DispatchOutcome.SUCCEEDED, finished_at=clock.now())
     finished = adapter.finish_run_dispatch(finish)
     assert finished.terminal_outcome is DispatchOutcome.SUCCEEDED
+    assert adapter.get_active_run_dispatch(_TENANT, "run-a") is None
     assert adapter.finish_run_dispatch(finish) == finished
     _expect_error(Conflict, lambda: adapter.finish_run_dispatch(
         finish.model_copy(update={"outcome": DispatchOutcome.FAILED})
@@ -370,8 +373,7 @@ def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
     _put_units(adapter, (other_unit,), "run-b")
     other_command = ReserveRunDispatch(
         tenant_id=_TENANT, run_id="run-b", wave_id=_WAVE_B, unit_ids=("unit-a",),
-        now=clock.now(), lease_seconds=30,
-    )
+        now=clock.now(), lease_seconds=30)
     other = adapter.reserve_run_dispatch(other_command)
     assert other.generation == 1
     assert other.dispatch_id != dispatch.dispatch_id
@@ -417,15 +419,11 @@ def _case_idempotency(adapter: Any, clock: MutableClock) -> None:
     assert not replay.created
     assert replay.record.resource_id == "resource-a"
     _expect_error(Conflict, lambda: adapter.begin_idempotency(
-        first.model_copy(update={"request_hash": _HASH_B})
-    ))
+        first.model_copy(update={"request_hash": _HASH_B})))
     clock.advance(timedelta(minutes=6))
     replaced = adapter.begin_idempotency(first.model_copy(update={
-        "request_hash": _HASH_B,
-        "resource_id": "resource-b",
-        "now": clock.now(),
-        "expires_at": clock.now() + timedelta(minutes=5),
-    }))
+        "request_hash": _HASH_B, "resource_id": "resource-b", "now": clock.now(),
+        "expires_at": clock.now() + timedelta(minutes=5)}))
     assert replaced.created
     assert replaced.record.resource_id == "resource-b"
 
@@ -435,18 +433,14 @@ def _publish(run_id: str, event_id: str, expected: str | None, degraded: bool) -
     version = DatasetVersion(
         tenant_id=_TENANT, dataset_name="gold", version_id=run_id, run_id=run_id,
         run_manifest_key=f"reconciliation/{_TENANT}/2026-07/{run_id}/run-manifest.json",
-        created_at=_NOW,
-    )
+        created_at=_NOW)
     return PublishDataset(
-        version=version, pointer_name="current",
-        expected_version_id=expected,
+        version=version, pointer_name="current", expected_version_id=expected,
         final_state=state,
         missing_sources=("CNES/ST",) if degraded else (),
         publication_permit=PublicationPermit(
-            tenant_id=_TENANT, run_id=run_id, policy_version=1, fencing_token=1
-        ),
-        event=_event(event_id, aggregate_id=run_id),
-    )
+            tenant_id=_TENANT, run_id=run_id, policy_version=1, fencing_token=1),
+        event=_event(event_id, aggregate_id=run_id))
 
 
 def _case_publication(adapter: Any, clock: MutableClock) -> None:
@@ -458,11 +452,17 @@ def _case_publication(adapter: Any, clock: MutableClock) -> None:
     assert adapter.get_run(_TENANT, "run-a").state is RunState.PUBLISHED
     assert adapter.publish_dataset(first) == pointer
     assert adapter.pending_outbox(10).count(first.event) == 1
-    changed = first.model_copy(update={
-        "version": first.version.model_copy(update={
-            "run_manifest_key": f"reconciliation/{_TENANT}/2026-06/run-a/run-manifest.json"
-        })
-    })
+    adapter.put_run(_run("run-c"))
+    invalid_parent = _publish("run-c", "published-c", "run-a", False)
+    before = (adapter.get_dataset_pointer(_TENANT, "gold"),
+              adapter.get_run(_TENANT, "run-c"), adapter.pending_outbox(100))
+    _expect_error(Conflict, lambda: adapter.publish_dataset(invalid_parent))
+    after = (adapter.get_dataset_pointer(_TENANT, "gold"),
+             adapter.get_run(_TENANT, "run-c"), adapter.pending_outbox(100))
+    assert after == before
+    assert adapter.get_dataset_version(_TENANT, "gold", "run-c") is None
+    changed = first.model_copy(update={"version": first.version.model_copy(update={
+        "run_manifest_key": f"reconciliation/{_TENANT}/2026-06/run-a/run-manifest.json"})})
     _expect_error(Conflict, lambda: adapter.publish_dataset(changed))
     assert adapter.get_dataset_version(_TENANT, "gold", "run-a") == first.version
     adapter.put_run(_run("run-b", RunState.PUBLISHING))

--- a/packages/cnes_infra/tests/contracts/object_store_contract.py
+++ b/packages/cnes_infra/tests/contracts/object_store_contract.py
@@ -70,7 +70,7 @@ def _case_immutability(adapter: Any, clock: MutableClock) -> None:
 
 
 def _case_safe_keys(adapter: Any, clock: MutableClock) -> None:
-    invalid_keys = ("", "/absolute", "a/../b", "a/./b", "a//b", "a\\b")
+    invalid_keys = ("", "/absolute", "valid/../key", "a/./b", "a//b", "a\\b")
     adapter.put("valid/key", BytesIO(b"x"), _digest(b"x"))
     for key in invalid_keys:
         _expect_rejection(lambda key=key: adapter.put(key, BytesIO(b"x"), _digest(b"x")))

--- a/packages/cnes_infra/tests/contracts/object_store_contract.py
+++ b/packages/cnes_infra/tests/contracts/object_store_contract.py
@@ -71,6 +71,7 @@ def _case_immutability(adapter: Any, clock: MutableClock) -> None:
 
 def _case_safe_keys(adapter: Any, clock: MutableClock) -> None:
     invalid_keys = ("", "/absolute", "a/../b", "a/./b", "a//b", "a\\b")
+    adapter.put("valid/key", BytesIO(b"x"), _digest(b"x"))
     for key in invalid_keys:
         _expect_rejection(lambda key=key: adapter.put(key, BytesIO(b"x"), _digest(b"x")))
         _expect_rejection(lambda key=key: _open(adapter, key))

--- a/packages/cnes_infra/tests/contracts/object_store_contract.py
+++ b/packages/cnes_infra/tests/contracts/object_store_contract.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from typing import Any
 
 from cnes_domain.control_plane.errors import Conflict
-from cnes_domain.ports.object_store import ObjectStat
+from cnes_domain.ports.object_store import ObjectStat, ObjectStorePort
 from packages.cnes_infra.tests.contracts.clock import MutableClock
 
 _Runner = Callable[[Any, MutableClock], None]
@@ -25,6 +25,7 @@ class ObjectStoreCase:
     def run(self, adapter: Any, clock: MutableClock) -> None:
         """Executa o caso e identifica qualquer falha pelo nome."""
         try:
+            assert isinstance(adapter, ObjectStorePort)
             self._runner(adapter, clock)
         except Exception as error:
             raise AssertionError(f"case={self.name}") from error
@@ -98,6 +99,13 @@ def _case_promote(adapter: Any, clock: MutableClock) -> None:
         assert stream.read() == body
 
 
+def _case_delete(adapter: Any, clock: MutableClock) -> None:
+    body = b"temporary"
+    adapter.put(_KEY, BytesIO(body), _digest(body))
+    adapter.delete(_KEY)
+    assert adapter.stat(_KEY) is None
+
+
 def object_store_cases() -> tuple[ObjectStoreCase, ...]:
     """Retorna o catálogo estável de invariáveis do armazenamento."""
     return (
@@ -105,6 +113,7 @@ def object_store_cases() -> tuple[ObjectStoreCase, ...]:
         ObjectStoreCase("immutability", _case_immutability),
         ObjectStoreCase("safe_keys", _case_safe_keys),
         ObjectStoreCase("promote", _case_promote),
+        ObjectStoreCase("delete", _case_delete),
     )
 
 
@@ -157,6 +166,8 @@ class _MemoryObjectStore:
 
     def delete(self, key: str) -> None:
         self._validate_key(key)
+        if self.mutation == "delete":
+            return
         self.objects.pop(key, None)
 
     def promote(self, source_key: str, destination_key: str, expected_sha256: str) -> ObjectStat:

--- a/packages/cnes_infra/tests/contracts/object_store_contract.py
+++ b/packages/cnes_infra/tests/contracts/object_store_contract.py
@@ -1,0 +1,176 @@
+"""Casos reutilizáveis de conformidade do armazenamento de objetos."""
+
+from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from hashlib import sha256
+from io import BytesIO
+from typing import Any
+
+from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.ports.object_store import ObjectStat
+from packages.cnes_infra.tests.contracts.clock import MutableClock
+
+_Runner = Callable[[Any, MutableClock], None]
+_KEY = "raw/354130/CNES/2026-07/snapshot/data.parquet"
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectStoreCase:
+    """Executa uma invariável contra um adapter de objetos."""
+
+    name: str
+    _runner: _Runner = field(repr=False, compare=False)
+
+    def run(self, adapter: Any, clock: MutableClock) -> None:
+        """Executa o caso e identifica qualquer falha pelo nome."""
+        try:
+            self._runner(adapter, clock)
+        except Exception as error:
+            raise AssertionError(f"case={self.name}") from error
+
+
+def _digest(body: bytes) -> str:
+    return sha256(body).hexdigest()
+
+
+def _expect_rejection(action: Callable[[], Any]) -> None:
+    try:
+        action()
+    except Exception:
+        return
+    raise AssertionError("rejection_required")
+
+
+def _open(adapter: Any, key: str) -> None:
+    with adapter.open(key):
+        pass
+
+
+def _case_roundtrip(adapter: Any, clock: MutableClock) -> None:
+    body = b"cnes-contract\x00\xff"
+    expected_hash = _digest(body)
+    stat = adapter.put(_KEY, BytesIO(body), expected_hash)
+    assert (stat.key, stat.size_bytes, stat.sha256) == (_KEY, len(body), expected_hash)
+    with adapter.open(_KEY) as stream:
+        assert stream.read() == body
+    assert adapter.stat(_KEY) == stat
+    assert adapter.put(_KEY, BytesIO(body), expected_hash) == stat
+
+
+def _case_immutability(adapter: Any, clock: MutableClock) -> None:
+    original = b"original"
+    adapter.put(_KEY, BytesIO(original), _digest(original))
+    _expect_rejection(lambda: adapter.put(_KEY, BytesIO(b"changed"), _digest(b"changed")))
+    _expect_rejection(lambda: adapter.put("raw/hash-error", BytesIO(original), _digest(b"wrong")))
+    with adapter.open(_KEY) as stream:
+        assert stream.read() == original
+    assert adapter.stat("raw/hash-error") is None
+
+
+def _case_safe_keys(adapter: Any, clock: MutableClock) -> None:
+    invalid_keys = ("", "/absolute", "a/../b", "a/./b", "a//b", "a\\b")
+    for key in invalid_keys:
+        _expect_rejection(lambda key=key: adapter.put(key, BytesIO(b"x"), _digest(b"x")))
+        _expect_rejection(lambda key=key: _open(adapter, key))
+        _expect_rejection(lambda key=key: adapter.stat(key))
+        _expect_rejection(lambda key=key: adapter.delete(key))
+        _expect_rejection(lambda key=key: adapter.promote(key, "valid/key", _digest(b"x")))
+        _expect_rejection(lambda key=key: adapter.promote("valid/key", key, _digest(b"x")))
+
+
+def _case_promote(adapter: Any, clock: MutableClock) -> None:
+    source = "staging/upload"
+    destination = "raw/promoted"
+    body = b"promoted-content"
+    expected_hash = _digest(body)
+    adapter.put(source, BytesIO(body), expected_hash)
+    promoted = adapter.promote(source, destination, expected_hash)
+    assert promoted.key == destination
+    assert adapter.stat(source) is not None
+    assert adapter.promote(source, destination, expected_hash) == promoted
+    conflict = b"conflicting"
+    adapter.put("staging/conflict", BytesIO(conflict), _digest(conflict))
+    _expect_rejection(lambda: adapter.promote("staging/conflict", destination, _digest(conflict)))
+    _expect_rejection(lambda: adapter.promote(source, "raw/bad-hash", _digest(b"wrong")))
+    assert adapter.stat("raw/bad-hash") is None
+    with adapter.open(destination) as stream:
+        assert stream.read() == body
+
+
+def object_store_cases() -> tuple[ObjectStoreCase, ...]:
+    """Retorna o catálogo estável de invariáveis do armazenamento."""
+    return (
+        ObjectStoreCase("roundtrip", _case_roundtrip),
+        ObjectStoreCase("immutability", _case_immutability),
+        ObjectStoreCase("safe_keys", _case_safe_keys),
+        ObjectStoreCase("promote", _case_promote),
+    )
+
+
+class _MemoryObjectStore:
+    def __init__(self, mutation: str | None = None) -> None:
+        self.mutation = mutation
+        self.objects: dict[str, bytes] = {}
+
+    def _validate_key(self, key: str) -> None:
+        if self.mutation == "safe_keys" and key == "":
+            return
+        invalid = not key or key.startswith("/") or "\\" in key or "//" in key
+        if invalid or any(part in {"", ".", ".."} for part in key.split("/")):
+            raise ValueError("invalid_key")
+
+    @staticmethod
+    def _stat(key: str, body: bytes) -> ObjectStat:
+        return ObjectStat(key=key, size_bytes=len(body), sha256=sha256(body).hexdigest())
+
+    def put(self, key: str, body: Any, expected_sha256: str) -> ObjectStat:
+        self._validate_key(key)
+        content = body.read()
+        digest = sha256(content).hexdigest()
+        if digest != expected_sha256:
+            if self.mutation == "immutability":
+                self.objects[key] = content
+            raise ValueError("hash_mismatch")
+        current = self.objects.get(key)
+        if current is not None and current != content:
+            if self.mutation == "immutability":
+                self.objects[key] = content
+            raise Conflict("immutable_object")
+        self.objects[key] = content
+        stat = self._stat(key, content)
+        if self.mutation == "roundtrip":
+            return ObjectStat(key=key, size_bytes=0, sha256=stat.sha256)
+        return stat
+
+    @contextmanager
+    def open(self, key: str):
+        self._validate_key(key)
+        if key not in self.objects:
+            raise FileNotFoundError(key)
+        yield BytesIO(self.objects[key])
+
+    def stat(self, key: str) -> ObjectStat | None:
+        self._validate_key(key)
+        body = self.objects.get(key)
+        return None if body is None else self._stat(key, body)
+
+    def delete(self, key: str) -> None:
+        self._validate_key(key)
+        self.objects.pop(key, None)
+
+    def promote(self, source_key: str, destination_key: str, expected_sha256: str) -> ObjectStat:
+        self._validate_key(source_key)
+        self._validate_key(destination_key)
+        source = self.objects.get(source_key)
+        if source is None or sha256(source).hexdigest() != expected_sha256:
+            if self.mutation == "promote":
+                self.objects[destination_key] = source or b""
+            raise ValueError("source_hash_mismatch")
+        current = self.objects.get(destination_key)
+        if current is not None and current != source:
+            if self.mutation == "promote":
+                self.objects[destination_key] = source
+            raise Conflict("immutable_destination")
+        self.objects[destination_key] = source
+        return self._stat(destination_key, source)

--- a/packages/cnes_infra/tests/contracts/object_store_contract.py
+++ b/packages/cnes_infra/tests/contracts/object_store_contract.py
@@ -85,13 +85,15 @@ def _case_promote(adapter: Any, clock: MutableClock) -> None:
     destination = "raw/promoted"
     body = b"promoted-content"
     expected_hash = _digest(body)
-    adapter.put(source, BytesIO(body), expected_hash)
+    source_stat = adapter.put(source, BytesIO(body), expected_hash)
     promoted = adapter.promote(source, destination, expected_hash)
     assert (promoted.key, promoted.size_bytes, promoted.sha256) == (
         destination, len(body), expected_hash
     )
     assert adapter.stat(destination) == promoted
-    assert adapter.stat(source) is not None
+    assert adapter.stat(source) == source_stat
+    with adapter.open(source) as stream:
+        assert stream.read() == body
     assert adapter.promote(source, destination, expected_hash) == promoted
     conflict = b"conflicting"
     adapter.put("staging/conflict", BytesIO(conflict), _digest(conflict))

--- a/packages/cnes_infra/tests/contracts/object_store_contract.py
+++ b/packages/cnes_infra/tests/contracts/object_store_contract.py
@@ -87,7 +87,10 @@ def _case_promote(adapter: Any, clock: MutableClock) -> None:
     expected_hash = _digest(body)
     adapter.put(source, BytesIO(body), expected_hash)
     promoted = adapter.promote(source, destination, expected_hash)
-    assert promoted.key == destination
+    assert (promoted.key, promoted.size_bytes, promoted.sha256) == (
+        destination, len(body), expected_hash
+    )
+    assert adapter.stat(destination) == promoted
     assert adapter.stat(source) is not None
     assert adapter.promote(source, destination, expected_hash) == promoted
     conflict = b"conflicting"

--- a/packages/cnes_infra/tests/contracts/test_contract_harness.py
+++ b/packages/cnes_infra/tests/contracts/test_contract_harness.py
@@ -231,6 +231,8 @@ class FakeControlPlane(_HarnessState):
                 raise LeaseLost("parent_not_processing")
             if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
                 raise LeaseLost("dispatch_mismatch")
+            if dispatch.lease_until <= self.clock.now():
+                raise LeaseLost("dispatch_expired")
             if unit is None or unit.lease_owner != command.owner:
                 raise LeaseLost("owner_mismatch")
             if unit.fencing_token != command.fencing_token:
@@ -481,9 +483,7 @@ def test_mutacao_do_object_store_e_detectada(case: ObjectStoreCase, clock: Mutab
     ("catalog", "case_type"),
     [(control_plane_cases(), ControlPlaneCase), (object_store_cases(), ObjectStoreCase)],
 )
-def test_catalogo_e_estavel_e_congelado(
-    catalog: tuple[Any, ...], case_type: type[Any]
-) -> None:
+def test_catalogo_e_estavel_e_congelado(catalog, case_type) -> None:
     assert catalog == tuple(catalog)
     assert len({case.name for case in catalog}) == len(catalog)
     assert all(isinstance(case, case_type) for case in catalog)

--- a/packages/cnes_infra/tests/contracts/test_contract_harness.py
+++ b/packages/cnes_infra/tests/contracts/test_contract_harness.py
@@ -1,0 +1,499 @@
+"""Autocertificação das suites compartilhadas de contrato."""
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from cnes_domain.control_plane.commands import IdempotencyOutcome
+from cnes_domain.control_plane.entities import DatasetPointer, IdempotencyRecord, RunDispatch
+from cnes_domain.control_plane.enums import (
+    AgentState,
+    DispatchState,
+    JobState,
+    RunState,
+    RunUnitState,
+)
+from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
+from cnes_domain.control_plane.transitions import transition_run, transition_run_unit
+from packages.cnes_infra.tests.contracts.clock import MutableClock, _HarnessState
+from packages.cnes_infra.tests.contracts.control_plane_contract import (
+    ControlPlaneCase,
+    control_plane_cases,
+)
+from packages.cnes_infra.tests.contracts.object_store_contract import (
+    ObjectStoreCase,
+    _MemoryObjectStore,
+    object_store_cases,
+)
+
+_NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
+
+
+class FakeControlPlane(_HarnessState):
+    def list_claimable_jobs(self, tenant_id: str, agent_id: str, limit: int) -> tuple[Any, ...]:
+        agent = self.get_agent(tenant_id, agent_id)
+        if agent is None or agent.state is AgentState.REVOKED:
+            return ()
+        values = [
+            job
+            for job in self.jobs.values()
+            if job.tenant_id == tenant_id
+            and job.agent_id == agent_id
+            and self._job_claimable(job)
+        ]
+        return tuple(sorted(values, key=lambda item: (item.created_at, item.job_id))[:limit])
+
+    def _job_claimable(self, job: Any) -> bool:
+        retryable = job.state in {JobState.PENDING, JobState.FAILED_RETRYABLE}
+        expired = job.state is JobState.LEASED and job.lease_until <= self.clock.now()
+        return retryable or expired
+
+    def claim_job(self, command: Any) -> Any | None:
+        job = self.get_job(command.tenant_id, command.job_id)
+        agent = None if job is None else self.get_agent(command.tenant_id, job.agent_id)
+        if job is None or agent is None or agent.state is AgentState.REVOKED:
+            return None
+        if not self._job_claimable(job):
+            return None
+        claimed = job.model_copy(
+            update={
+                "state": JobState.LEASED,
+                "attempt": job.attempt + 1,
+                "fencing_token": job.fencing_token + 1,
+                "lease_owner": command.owner,
+                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+            }
+        )
+        self.jobs[(job.tenant_id, job.job_id)] = claimed
+        return claimed
+
+    def _validate_job_fence(self, command: Any) -> Any:
+        job = self.get_job(command.tenant_id, command.job_id)
+        if job is None or job.state is not JobState.LEASED:
+            raise LeaseLost("job_not_leased")
+        if job.lease_owner != command.owner:
+            raise LeaseLost("owner_mismatch")
+        if job.fencing_token != command.fencing_token:
+            raise FenceRejected("fence_mismatch")
+        if job.lease_until <= self.clock.now():
+            raise LeaseLost("lease_expired")
+        return job
+
+    def renew_job_lease(self, command: Any) -> Any:
+        job = self._validate_job_fence(command)
+        renewed = job.model_copy(
+            update={"lease_until": command.now + timedelta(seconds=command.lease_seconds)}
+        )
+        self.jobs[(job.tenant_id, job.job_id)] = renewed
+        return renewed
+
+    def fail_job(self, command: Any, event: Any) -> Any:
+        job = self._validate_job_fence(command)
+        state = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
+        failed = job.model_copy(
+            update={
+                "state": state,
+                "lease_owner": None,
+                "lease_until": None,
+                "error_code": command.error_code,
+            }
+        )
+        self.jobs[(job.tenant_id, job.job_id)] = failed
+        self.outbox[event.event_id] = event
+        return failed
+
+    def complete_job(self, command: Any, event: Any) -> Any:
+        job = self._validate_job_fence(command)
+        manifest = command.manifest
+        completed = job.model_copy(
+            update={
+                "state": JobState.SUCCEEDED,
+                "lease_owner": None,
+                "lease_until": None,
+                "result_manifest_id": manifest.manifest_id,
+                "result_manifest_key": manifest.manifest_key,
+            }
+        )
+        self.jobs[(job.tenant_id, job.job_id)] = completed
+        self.raw_records.append(manifest)
+        self.outbox[event.event_id] = event
+        return completed
+
+    def list_raw_manifest_chain(self, *args: Any) -> tuple[Any, ...]:
+        tenant_id, source_type, file_subtype, competencia, limit = args
+        identity = (tenant_id, source_type, file_subtype, competencia)
+        records = [
+            item
+            for item in self.raw_records
+            if (item.tenant_id, item.source_type, item.file_subtype, item.competencia) == identity
+        ]
+        if not records:
+            return ()
+        if self.mutation == "raw_chains":
+            selected = sorted(records, key=lambda item: item.created_at)
+        else:
+            selected = self._select_raw_chain(records)
+        bounded = selected if len(selected) <= limit else []
+        return tuple(self._manifest_ref(item) for item in bounded)
+
+    @staticmethod
+    def _manifest_ref(record: Any) -> Any:
+        from cnes_domain.control_plane.entities import ManifestRef
+
+        return ManifestRef(manifest_id=record.manifest_id, manifest_key=record.manifest_key)
+
+    def list_waiting_runs_for_dependency(self, *args: Any) -> tuple[Any, ...]:
+        tenant_id, source_type, file_subtype, competencia, limit = args
+        values = [
+            run
+            for run in self.runs.values()
+            if run.tenant_id == tenant_id
+            and run.competencia == competencia
+            and run.state is RunState.WAITING_INPUTS
+            and any(
+                (dep.source_type, dep.file_subtype) == (source_type, file_subtype)
+                for dep in run.dependencies
+            )
+        ]
+        if self.mutation == "run_discovery":
+            values = list(self.runs.values())
+        return tuple(sorted(values, key=lambda item: (item.created_at, item.run_id))[:limit])
+
+    def list_recoverable_runs(self, now: datetime, limit: int = 100) -> tuple[Any, ...]:
+        states = {
+            RunState.WAITING_INPUTS,
+            RunState.PROCESSING,
+            RunState.PUBLISHING,
+            RunState.CANCEL_REQUESTED,
+        }
+        values = [run for run in self.runs.values() if run.state in states]
+        return tuple(sorted(values, key=lambda item: (item.created_at, item.run_id))[:limit])
+
+    def put_run_units(self, command: Any) -> tuple[Any, ...]:
+        run = self.get_run(command.tenant_id, command.run_id)
+        if run is None or run.state is not command.expected_run_state:
+            raise Conflict("run_state_conflict")
+        existing = self.list_run_units(command.tenant_id, command.run_id)
+        if existing:
+            if existing != command.units:
+                if self.mutation == "run_units_atomic":
+                    self._write_units(command.units)
+                raise Conflict("units_conflict")
+            return existing
+        self._write_units(command.units)
+        return command.units
+
+    def _write_units(self, units: tuple[Any, ...]) -> None:
+        for unit in units:
+            self.units[(unit.tenant_id, unit.run_id, unit.unit_id)] = unit
+
+    def claim_run_unit(self, command: Any) -> Any | None:
+        key = (command.tenant_id, command.run_id, command.unit_id)
+        unit = self.units.get(key)
+        run = self.get_run(command.tenant_id, command.run_id)
+        dispatch = self.dispatches.get((command.tenant_id, command.run_id))
+        valid_parent = run is not None and run.state is RunState.PROCESSING
+        valid_dispatch = (
+            dispatch is not None
+            and dispatch.dispatch_id == command.dispatch_id
+            and dispatch.state is not DispatchState.TERMINAL
+            and command.unit_id in dispatch.unit_ids
+        )
+        if self.mutation == "unit_claim":
+            valid_parent = True
+        if unit is None or not valid_parent or not valid_dispatch:
+            return None
+        claimable = unit.state in {RunUnitState.PENDING, RunUnitState.FAILED_RETRYABLE}
+        claimable |= unit.state is RunUnitState.LEASED and unit.lease_until <= command.now
+        if not claimable:
+            return None
+        claimed = unit.model_copy(
+            update={
+                "state": RunUnitState.LEASED,
+                "attempt": unit.attempt + 1,
+                "fencing_token": unit.fencing_token + 1,
+                "lease_owner": command.owner,
+                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+                "dispatch_id": command.dispatch_id,
+            }
+        )
+        self.units[key] = claimed
+        return claimed
+
+    def _validate_unit_fence(self, command: Any) -> tuple[Any, Any]:
+        unit = self.units.get((command.tenant_id, command.run_id, command.unit_id))
+        run = self.get_run(command.tenant_id, command.run_id)
+        dispatch = self.dispatches.get((command.tenant_id, command.run_id))
+        if self.mutation != "unit_fences":
+            if run is None or run.state is not RunState.PROCESSING:
+                raise LeaseLost("parent_not_processing")
+            if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
+                raise LeaseLost("dispatch_mismatch")
+            if unit is None or unit.lease_owner != command.owner:
+                raise LeaseLost("owner_mismatch")
+            if unit.fencing_token != command.fencing_token:
+                raise FenceRejected("fence_mismatch")
+            if unit.lease_until <= self.clock.now():
+                raise LeaseLost("lease_expired")
+        if unit is None:
+            raise LeaseLost("unit_missing")
+        return unit, run
+
+    def commit_run_unit(self, command: Any, event: Any) -> Any:
+        unit, run = self._validate_unit_fence(command)
+        completed = transition_run_unit(unit, RunUnitState.SUCCEEDED, run).model_copy(
+            update={
+                "lease_owner": None,
+                "lease_until": None,
+                "output_manifests": command.output_manifests,
+            }
+        )
+        self.units[(unit.tenant_id, unit.run_id, unit.unit_id)] = completed
+        self.outbox[event.event_id] = event
+        return completed
+
+    def fail_run_unit(self, command: Any, event: Any) -> Any:
+        unit, run = self._validate_unit_fence(command)
+        optional = any(
+            (dep.source_type, dep.file_subtype) == (unit.source_type, unit.file_subtype)
+            and not dep.required
+            for dep in run.dependencies
+        )
+        if command.retryable:
+            state = RunUnitState.FAILED_RETRYABLE
+        elif optional and self.mutation != "degraded_unit":
+            state = RunUnitState.SUCCEEDED_DEGRADED
+        else:
+            state = RunUnitState.FAILED_FINAL
+        failed = unit.model_copy(
+            update={"error_code": command.error_code, "lease_owner": None, "lease_until": None}
+        )
+        failed = transition_run_unit(failed, state, run)
+        self.units[(unit.tenant_id, unit.run_id, unit.unit_id)] = failed
+        if state is RunUnitState.SUCCEEDED_DEGRADED:
+            source = f"{unit.source_type}/{unit.file_subtype}"
+            self.put_run(run.model_copy(update={"missing_sources": (*run.missing_sources, source)}))
+        self.outbox[event.event_id] = event
+        return failed
+
+    def finalize_run_cancellation(self, command: Any, event: Any) -> Any:
+        run = self.get_run(command.tenant_id, command.run_id)
+        if run is not None and run.state is RunState.CANCELED:
+            return run
+        if run is None or run.state is not RunState.CANCEL_REQUESTED:
+            raise Conflict("run_not_canceling")
+        terminal_states = {
+            RunUnitState.SUCCEEDED,
+            RunUnitState.SUCCEEDED_DEGRADED,
+            RunUnitState.FAILED_FINAL,
+            RunUnitState.CANCELED,
+        }
+        for key, unit in tuple(self.units.items()):
+            if key[:2] != (command.tenant_id, command.run_id):
+                continue
+            if unit.state not in terminal_states or self.mutation == "cancellation":
+                self.units[key] = unit.model_copy(
+                    update={
+                        "state": RunUnitState.CANCELED,
+                        "lease_owner": None,
+                        "lease_until": None,
+                    }
+                )
+        canceled = transition_run(run, RunState.CANCELED)
+        self.put_run(canceled)
+        self.outbox.setdefault(event.event_id, event)
+        return canceled
+
+    def reserve_run_dispatch(self, command: Any) -> Any:
+        key = (command.tenant_id, command.run_id)
+        active = self.dispatches.get(key)
+        replay = active and active.wave_id == command.wave_id and active.lease_until > command.now
+        if replay and self.mutation != "dispatch":
+            return active
+        live = active and active.state is not DispatchState.TERMINAL
+        if live and (
+            active.lease_until > command.now or self._has_live_unit_lease(active, command.now)
+        ):
+            raise Conflict("dispatch_live")
+        generation = 1 if active is None else active.generation + 1
+        dispatch = RunDispatch(
+            tenant_id=command.tenant_id,
+            run_id=command.run_id,
+            wave_id=command.wave_id,
+            dispatch_id=f"{generation:016x}",
+            generation=generation,
+            unit_ids=command.unit_ids,
+            state=DispatchState.RESERVED,
+            lease_until=command.now + timedelta(seconds=command.lease_seconds),
+        )
+        self.dispatches[key] = dispatch
+        return dispatch
+
+    def _has_live_unit_lease(self, dispatch: Any, now: datetime) -> bool:
+        if self.mutation == "dispatch_expiry":
+            return False
+        return any(
+            unit.dispatch_id == dispatch.dispatch_id
+            and unit.state is RunUnitState.LEASED
+            and unit.lease_until > now
+            for unit in self.units.values()
+        )
+
+    def bind_run_dispatch(self, command: Any) -> Any:
+        key = (command.tenant_id, command.run_id)
+        dispatch = self.dispatches.get(key)
+        if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
+            raise Conflict("dispatch_stale")
+        if dispatch.state is DispatchState.STARTED:
+            if dispatch.execution_ref != command.execution_ref:
+                raise Conflict("execution_conflict")
+            return dispatch
+        if dispatch.state is not DispatchState.RESERVED:
+            raise Conflict("dispatch_terminal")
+        started = dispatch.model_copy(
+            update={
+                "state": DispatchState.STARTED,
+                "execution_ref": command.execution_ref,
+                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+            }
+        )
+        self.dispatches[key] = started
+        return started
+
+    def finish_run_dispatch(self, command: Any) -> Any:
+        key = (command.tenant_id, command.run_id)
+        dispatch = self.dispatches.get(key)
+        if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
+            raise Conflict("dispatch_stale")
+        if dispatch.state is DispatchState.TERMINAL:
+            if dispatch.terminal_outcome != command.outcome:
+                raise Conflict("outcome_conflict")
+            return dispatch
+        finished = dispatch.model_copy(
+            update={"state": DispatchState.TERMINAL, "terminal_outcome": command.outcome}
+        )
+        self.dispatches[key] = finished
+        return finished
+
+    def begin_idempotency(self, command: Any) -> Any:
+        key = (command.tenant_id, command.scope, command.key)
+        current = self.idempotency.get(key)
+        if current and current.expires_at > command.now:
+            if current.request_hash != command.request_hash:
+                raise Conflict("idempotency_hash_conflict")
+            if self.mutation == "idempotency":
+                current = current.model_copy(update={"resource_id": command.resource_id})
+            return IdempotencyOutcome(record=current, created=False)
+        record = IdempotencyRecord(
+            tenant_id=command.tenant_id,
+            scope=command.scope,
+            key=command.key,
+            request_hash=command.request_hash,
+            status="CREATED",
+            resource_id=command.resource_id,
+            created_at=command.now,
+            expires_at=command.expires_at,
+        )
+        self.idempotency[key] = record
+        return IdempotencyOutcome(record=record, created=True)
+
+    def publish_dataset(self, command: Any) -> Any:
+        version_key = (
+            command.version.tenant_id,
+            command.version.dataset_name,
+            command.version.version_id,
+        )
+        pointer_key = (
+            command.version.tenant_id,
+            command.version.dataset_name,
+            command.pointer_name,
+        )
+        current_version = self.versions.get(version_key)
+        pointer = self.pointers.get(pointer_key)
+        if current_version is not None:
+            if current_version != command.version:
+                raise Conflict("version_immutable")
+            if pointer and pointer.version_id == command.version.version_id:
+                return pointer
+        actual = None if pointer is None else pointer.version_id
+        if actual != command.expected_version_id:
+            if self.mutation == "publication":
+                self.versions[version_key] = command.version
+            raise Conflict("pointer_cas")
+        run = self.get_run(command.version.tenant_id, command.version.run_id)
+        if run is None or run.state is not RunState.PUBLISHING:
+            raise Conflict("run_not_publishing")
+        updated = run.model_copy(
+            update={"state": command.final_state, "missing_sources": command.missing_sources}
+        )
+        result = DatasetPointer(
+            tenant_id=command.version.tenant_id,
+            dataset_name=command.version.dataset_name,
+            pointer_name=command.pointer_name,
+            version_id=command.version.version_id,
+            updated_at=self.clock.now(),
+        )
+        self.versions[version_key] = command.version
+        self.pointers[pointer_key] = result
+        self.put_run(updated)
+        self.outbox.setdefault(command.event.event_id, command.event)
+        return result
+
+@pytest.fixture
+def clock() -> MutableClock:
+    return MutableClock(_NOW)
+
+
+@pytest.fixture
+def fake_control_plane(clock: MutableClock) -> FakeControlPlane:
+    return FakeControlPlane(clock)
+
+
+@pytest.fixture
+def fake_object_store() -> _MemoryObjectStore:
+    return _MemoryObjectStore()
+
+@pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
+def test_fake_control_plane_expoe_todas_as_invariantes(
+    case: ControlPlaneCase, fake_control_plane: FakeControlPlane, clock: MutableClock
+) -> None:
+    case.run(fake_control_plane, clock)
+
+
+@pytest.mark.parametrize("case", object_store_cases(), ids=lambda case: case.name)
+def test_fake_object_store_expoe_todas_as_invariantes(
+    case: ObjectStoreCase, fake_object_store: _MemoryObjectStore, clock: MutableClock
+) -> None:
+    case.run(fake_object_store, clock)
+
+
+@pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
+def test_mutacao_do_control_plane_e_detectada_pelo_caso(
+    case: ControlPlaneCase, clock: MutableClock
+) -> None:
+    with pytest.raises(AssertionError, match=f"case={case.name}"):
+        case.run(FakeControlPlane(clock, case.name), clock)
+
+
+@pytest.mark.parametrize("case", object_store_cases(), ids=lambda case: case.name)
+def test_mutacao_do_object_store_e_detectada_pelo_caso(
+    case: ObjectStoreCase, clock: MutableClock
+) -> None:
+    with pytest.raises(AssertionError, match=f"case={case.name}"):
+        case.run(_MemoryObjectStore(case.name), clock)
+
+
+@pytest.mark.parametrize(
+    ("catalog", "case_type"),
+    [(control_plane_cases(), ControlPlaneCase), (object_store_cases(), ObjectStoreCase)],
+)
+def test_catalogo_tem_ordem_estavel_nomes_unicos_e_casos_congelados(
+    catalog: tuple[Any, ...], case_type: type[Any]
+) -> None:
+    assert catalog == tuple(catalog)
+    assert len({case.name for case in catalog}) == len(catalog)
+    assert all(isinstance(case, case_type) for case in catalog)
+    with pytest.raises(FrozenInstanceError):
+        catalog[0].name = "alterado"

--- a/packages/cnes_infra/tests/contracts/test_contract_harness.py
+++ b/packages/cnes_infra/tests/contracts/test_contract_harness.py
@@ -1,5 +1,6 @@
 from dataclasses import FrozenInstanceError
 from datetime import UTC, datetime, timedelta
+from hashlib import sha256
 from typing import Any
 
 import pytest
@@ -315,16 +316,17 @@ class FakeControlPlane(_HarnessState):
         if replay and self.mutation != "dispatch":
             return active
         live = active and active.state is not DispatchState.TERMINAL
-        if live and (
-            active.lease_until > command.now or self._has_live_unit_lease(active, command.now)
-        ):
+        lease_live = active is not None and active.lease_until > command.now
+        if live and (lease_live or self._has_live_unit_lease(active, command.now)):
             raise Conflict("dispatch_live")
         generation = 1 if active is None else active.generation + 1
+        identity = "\x1f".join((command.tenant_id, command.run_id, command.wave_id,
+                                str(generation), *command.unit_ids))
         dispatch = RunDispatch(
             tenant_id=command.tenant_id,
             run_id=command.run_id,
             wave_id=command.wave_id,
-            dispatch_id=f"{generation:016x}",
+            dispatch_id=sha256(identity.encode()).hexdigest()[:16],
             generation=generation,
             unit_ids=command.unit_ids,
             state=DispatchState.RESERVED,
@@ -402,16 +404,10 @@ class FakeControlPlane(_HarnessState):
         return IdempotencyOutcome(record=record, created=True)
 
     def publish_dataset(self, command: Any) -> Any:
-        version_key = (
-            command.version.tenant_id,
-            command.version.dataset_name,
-            command.version.version_id,
-        )
-        pointer_key = (
-            command.version.tenant_id,
-            command.version.dataset_name,
-            command.pointer_name,
-        )
+        version_key = (command.version.tenant_id, command.version.dataset_name,
+                       command.version.version_id)
+        pointer_key = (command.version.tenant_id, command.version.dataset_name,
+                       command.pointer_name)
         current_version = self.versions.get(version_key)
         pointer = self.pointers.get(pointer_key)
         if current_version is not None:

--- a/packages/cnes_infra/tests/contracts/test_contract_harness.py
+++ b/packages/cnes_infra/tests/contracts/test_contract_harness.py
@@ -456,31 +456,23 @@ def fake_object_store() -> _MemoryObjectStore:
     return _MemoryObjectStore()
 
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
-def test_fake_control_plane_expoe_todas_as_invariantes(
-    case: ControlPlaneCase, fake_control_plane: FakeControlPlane, clock: MutableClock
-) -> None:
+def test_fake_control_plane_conforme(case, fake_control_plane, clock):
     case.run(fake_control_plane, clock)
 
 
 @pytest.mark.parametrize("case", object_store_cases(), ids=lambda case: case.name)
-def test_fake_object_store_expoe_todas_as_invariantes(
-    case: ObjectStoreCase, fake_object_store: _MemoryObjectStore, clock: MutableClock
-) -> None:
+def test_fake_object_store_conforme(case, fake_object_store, clock):
     case.run(fake_object_store, clock)
 
 
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
-def test_mutacao_do_control_plane_e_detectada_pelo_caso(
-    case: ControlPlaneCase, clock: MutableClock
-) -> None:
+def test_mutacao_do_control_plane_e_detectada(case: ControlPlaneCase, clock: MutableClock) -> None:
     with pytest.raises(AssertionError, match=f"case={case.name}"):
         case.run(FakeControlPlane(clock, case.name), clock)
 
 
 @pytest.mark.parametrize("case", object_store_cases(), ids=lambda case: case.name)
-def test_mutacao_do_object_store_e_detectada_pelo_caso(
-    case: ObjectStoreCase, clock: MutableClock
-) -> None:
+def test_mutacao_do_object_store_e_detectada(case: ObjectStoreCase, clock: MutableClock) -> None:
     with pytest.raises(AssertionError, match=f"case={case.name}"):
         case.run(_MemoryObjectStore(case.name), clock)
 
@@ -489,7 +481,7 @@ def test_mutacao_do_object_store_e_detectada_pelo_caso(
     ("catalog", "case_type"),
     [(control_plane_cases(), ControlPlaneCase), (object_store_cases(), ObjectStoreCase)],
 )
-def test_catalogo_tem_ordem_estavel_nomes_unicos_e_casos_congelados(
+def test_catalogo_e_estavel_e_congelado(
     catalog: tuple[Any, ...], case_type: type[Any]
 ) -> None:
     assert catalog == tuple(catalog)
@@ -497,3 +489,12 @@ def test_catalogo_tem_ordem_estavel_nomes_unicos_e_casos_congelados(
     assert all(isinstance(case, case_type) for case in catalog)
     with pytest.raises(FrozenInstanceError):
         catalog[0].name = "alterado"
+
+
+def test_rejeita_adapter_parcial(clock: MutableClock, fake_control_plane: FakeControlPlane) -> None:
+    class Parcial:
+        def __getattr__(self, name: str) -> Any:
+            return getattr(fake_control_plane, name)
+
+    with pytest.raises(AssertionError, match="case=authorization_jobs"):
+        control_plane_cases()[0].run(Parcial(), clock)

--- a/packages/cnes_infra/tests/contracts/test_contract_harness.py
+++ b/packages/cnes_infra/tests/contracts/test_contract_harness.py
@@ -1,5 +1,3 @@
-"""Autocertificação das suites compartilhadas de contrato."""
-
 from dataclasses import FrozenInstanceError
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -71,7 +69,9 @@ class FakeControlPlane(_HarnessState):
 
     def _validate_job_fence(self, command: Any) -> Any:
         job = self.get_job(command.tenant_id, command.job_id)
-        if job is None or job.state is not JobState.LEASED:
+        agent = None if job is None else self.get_agent(command.tenant_id, job.agent_id)
+        invalid = job is None or job.state is not JobState.LEASED
+        if invalid or agent is None or agent.state is AgentState.REVOKED:
             raise LeaseLost("job_not_leased")
         if job.lease_owner != command.owner:
             raise LeaseLost("owner_mismatch")

--- a/packages/cnes_infra/tests/contracts/test_contract_harness.py
+++ b/packages/cnes_infra/tests/contracts/test_contract_harness.py
@@ -350,6 +350,8 @@ class FakeControlPlane(_HarnessState):
         dispatch = self.dispatches.get(key)
         if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
             raise Conflict("dispatch_stale")
+        if dispatch.lease_until <= command.now:
+            raise Conflict("dispatch_expired")
         if dispatch.state is DispatchState.STARTED:
             if dispatch.execution_ref != command.execution_ref:
                 raise Conflict("execution_conflict")
@@ -371,6 +373,8 @@ class FakeControlPlane(_HarnessState):
         dispatch = self.dispatches.get(key)
         if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
             raise Conflict("dispatch_stale")
+        if dispatch.lease_until <= command.finished_at:
+            raise Conflict("dispatch_expired")
         if dispatch.state is DispatchState.TERMINAL:
             if dispatch.terminal_outcome != command.outcome:
                 raise Conflict("outcome_conflict")

--- a/packages/cnes_infra/tests/contracts/test_contract_harness.py
+++ b/packages/cnes_infra/tests/contracts/test_contract_harness.py
@@ -198,7 +198,7 @@ class FakeControlPlane(_HarnessState):
         valid_dispatch = (
             dispatch is not None
             and dispatch.dispatch_id == command.dispatch_id
-            and dispatch.state is not DispatchState.TERMINAL
+            and dispatch.state is not DispatchState.TERMINAL and dispatch.lease_until > command.now
             and command.unit_id in dispatch.unit_ids
         )
         if self.mutation == "unit_claim":


### PR DESCRIPTION
## Resumo

- adiciona MutableClock e catálogos executáveis para ControlPlanePort e ObjectStorePort
- cobre leases, fences, raw chains, units, dispatch, cancelamento, idempotência, publicação e outbox
- autocertifica cada contrato com fake correto e uma mutação deliberada por caso

## Verificação

- uv run ruff check packages/cnes_infra/tests/contracts
- 34 passed no harness
- 583 passed, 4 skipped em cnes_domain + contracts
- uv run ruff check .
- 948 passed, 8 skipped na suíte rápida sem tests/perf e chaos_infra

O comando global documentado coleta cinco testes perf que importam um módulo ausente no develop e o chaos_infra de restart do Postgres expirou; ambos são preexistentes e fora deste diff.

Closes #105