### PR TITLE
test(infra): strengthen adapter contract invariants

### DIFF
--- a/packages/cnes_infra/tests/contracts/clock.py
+++ b/packages/cnes_infra/tests/contracts/clock.py
@@ -378,8 +378,6 @@ class _HarnessState:
         self.memberships[(membership.tenant_id, membership.user_id)] = membership
 
     def get_membership(self, tenant_id: str, user_id: str) -> Any | None:
-        if self.mutation == "authorization_jobs":
-            return next(iter(self.memberships.values()), None)
         return self.memberships.get((tenant_id, user_id))
 
     def put_agent(self, agent: Any) -> None:

--- a/packages/cnes_infra/tests/contracts/control_plane_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_contract.py
@@ -69,7 +69,6 @@ class ControlPlaneCase:
         except Exception as error:
             raise AssertionError(f"case={self.name}") from error
 
-
 def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     membership = Membership(
         tenant_id=_TENANT, user_id="user-a", role="admin", created_at=clock.now())
@@ -103,10 +102,11 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
     assert adapter.claim_job(_claim_job("job-a", "worker-b", clock)) is None
     clock.advance(timedelta(seconds=30))
     _expect_error(LeaseLost, lambda: adapter.renew_job_lease(_renew_job(clock)))
-    _expect_error(LeaseLost, lambda: adapter.complete_job(complete, _event("expired-complete")))
+    _assert_job_rejected(adapter, LeaseLost, lambda: adapter.complete_job(
+        complete, _event("expired-complete")))
     expired = _fail_job("worker-a", 1, "expired")
-    _assert_job_rejected(
-        adapter, LeaseLost, lambda: adapter.fail_job(expired, _event("expired")))
+    _assert_job_rejected(adapter, LeaseLost,
+                         lambda: adapter.fail_job(expired, _event("expired")))
     discoverable = adapter.list_claimable_jobs(_TENANT, "agent-a", 10)
     assert adapter.get_job(_TENANT, "job-a") in discoverable
     retried = adapter.claim_job(_claim_job("job-a", "worker-b", clock))
@@ -121,12 +121,13 @@ def _case_authorization_jobs(adapter: Any, clock: MutableClock) -> None:
                          lambda: adapter.fail_job(stale_fence, _event("stale-fence")))
     _assert_job_failures(adapter, clock)
 
-
 def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
     records = (
         _raw_record("base-agent-a", "agent-a", 1, _NOW),
         _raw_record("delta-2", "agent-a", 2, _NOW + timedelta(seconds=1)),
         _raw_record("delta-3", "agent-a", 3, _NOW + timedelta(seconds=2)),
+        _raw_record("wrong-base", "agent-a", 4, _NOW + timedelta(seconds=3)).model_copy(
+            update={"base_snapshot_id": "base-agent-b"}),
         _raw_record("base-agent-b", "agent-b", 1, _NOW),
         _raw_record("delta-z", "agent-b", 2, _NOW + timedelta(seconds=2)),
         _raw_record("orphan", "agent-z", 2, _NOW + timedelta(seconds=3)),
@@ -160,14 +161,13 @@ def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:
         _TENANT, "job-agent-b-delta-z")
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 2)
     assert tuple((ref.manifest_id, ref.manifest_key) for ref in chain) == tuple(
-        (record.manifest_id, record.manifest_key) for record in records[3:5])
+        (record.manifest_id, record.manifest_key) for record in records[4:6])
     try:
         short = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1)
     except Conflict:
         pass
     else:
         assert short == ()
-
 def _case_run_discovery(adapter: Any, clock: MutableClock) -> None:
     deps = (
         RunDependency(source_type="CNES", file_subtype="ST", required=True),
@@ -196,7 +196,6 @@ def _case_run_discovery(adapter: Any, clock: MutableClock) -> None:
     assert tuple(run.run_id for run in adapter.list_recoverable_runs(clock.now(), 2)) == (
         "canceling", "collision")
 
-
 def _case_run_units_atomic(adapter: Any, clock: MutableClock) -> None:
     adapter.put_run(_run("run-a"))
     units = (_unit("unit-a"), _unit("unit-b"))
@@ -205,7 +204,6 @@ def _case_run_units_atomic(adapter: Any, clock: MutableClock) -> None:
     divergent = (units[0], _unit("unit-c"))
     _expect_error(Conflict, lambda: _put_units(adapter, divergent))
     assert adapter.list_run_units(_TENANT, "run-a") == units
-
 def _case_unit_claim(adapter: Any, clock: MutableClock) -> None:
     unit_ids = ("unit-a", "unit-b")
     dispatch = _prepare_unit(adapter, clock, unit_ids)
@@ -213,6 +211,10 @@ def _case_unit_claim(adapter: Any, clock: MutableClock) -> None:
     assert adapter.get_active_run_dispatch(_TENANT, "run-a") == dispatch
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
     assert claimed is not None
+    before_units = adapter.list_run_units(_TENANT, "run-a")
+    stale = _claim_unit_command(_WAVE_B, "worker-a", clock, "unit-b")
+    assert adapter.claim_run_unit(stale) is None
+    assert adapter.list_run_units(_TENANT, "run-a") == before_units
     second_command = _claim_unit_command(dispatch.dispatch_id, "worker-a", clock, "unit-b")
     assert adapter.claim_run_unit(second_command) is not None
     not_dispatched = _claim_unit_command(dispatch.dispatch_id, "worker-a", clock, "unit-z")
@@ -232,7 +234,6 @@ def _case_unit_claim(adapter: Any, clock: MutableClock) -> None:
     assert _claim_unit(adapter, clock, replacement.dispatch_id, "worker-c") is None
     pending = _claim_unit_command(replacement.dispatch_id, "worker-c", clock, "unit-b")
     assert adapter.claim_run_unit(pending) is None
-
 
 def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
     dispatch = _prepare_unit(adapter, clock)
@@ -276,7 +277,6 @@ def _case_unit_fences(adapter: Any, clock: MutableClock) -> None:
         adapter, LeaseLost,
         lambda: adapter.fail_run_unit(expired_fail, _event("expired-fail")))
     _assert_retryable_unit_failure(adapter, clock, fail)
-
 def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
     optional = (RunDependency(source_type="CNES", file_subtype="ST", required=False),)
     adapter.put_run(_run("run-a", dependencies=optional))
@@ -297,7 +297,6 @@ def _case_degraded_unit(adapter: Any, clock: MutableClock) -> None:
     assert adapter.get_run(_TENANT, "run-a").missing_sources == ("CNES/ST",)
     assert adapter.pending_outbox(100).count(event) == 1
 
-
 def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     adapter.put_run(_run("run-a"))
     _put_units(adapter, (_unit("unit-a"), _unit("unit-b"), _unit("unit-c")))
@@ -307,16 +306,21 @@ def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     leased = _claim_unit_command(dispatch.dispatch_id, "worker-b", clock, "unit-b")
     assert adapter.claim_run_unit(leased) is not None
     _assert_committed_unit(adapter, dispatch, claimed)
+    command = FinalizeRunCancellation(
+        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.CANCEL_REQUESTED,
+        canceled_at=clock.now())
+    event = _event("run-canceled")
+    before = (adapter.get_run(_TENANT, "run-a"), adapter.list_run_units(_TENANT, "run-a"),
+              adapter.pending_outbox(100))
+    _expect_error(Conflict, lambda: adapter.finalize_run_cancellation(command, event))
+    assert before == (adapter.get_run(_TENANT, "run-a"),
+                      adapter.list_run_units(_TENANT, "run-a"), adapter.pending_outbox(100))
     requested_event = _event("run-cancel-requested")
     adapter.transition_run(
         TransitionRun(
             tenant_id=_TENANT, run_id="run-a", expected_state=RunState.PROCESSING,
             new_state=RunState.CANCEL_REQUESTED), requested_event)
     assert adapter.pending_outbox(100).count(requested_event) == 1
-    command = FinalizeRunCancellation(
-        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.CANCEL_REQUESTED,
-        canceled_at=clock.now())
-    event = _event("run-canceled")
     result = adapter.finalize_run_cancellation(command, event)
     assert result.state is RunState.CANCELED
     assert adapter.get_run(_TENANT, "run-a") == result
@@ -327,7 +331,6 @@ def _case_cancellation(adapter: Any, clock: MutableClock) -> None:
     assert set(states) == {"unit-a", "unit-b", "unit-c"}
     assert adapter.finalize_run_cancellation(command, event) == result
     assert adapter.pending_outbox(10).count(event) == 1
-
 def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
     dispatch = _prepare_unit(adapter, clock)
     assert _reserve(adapter, clock) == dispatch
@@ -358,6 +361,7 @@ def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
     _expect_error(Conflict, lambda: adapter.finish_run_dispatch(
         finish.model_copy(update={"outcome": DispatchOutcome.FAILED})
     ))
+    assert adapter.finish_run_dispatch(finish) == finished
     adapter.put_run(_run("run-b"))
     other_unit = _unit("unit-a").model_copy(update={"run_id": "run-b"})
     _put_units(adapter, (other_unit,), "run-b")
@@ -369,7 +373,6 @@ def _case_dispatch(adapter: Any, clock: MutableClock) -> None:
     assert other.dispatch_id != dispatch.dispatch_id
     assert adapter.reserve_run_dispatch(other_command) == other
     assert _reserve(adapter, clock, _WAVE_B).generation == 2
-
 
 def _case_dispatch_expiry(adapter: Any, clock: MutableClock) -> None:
     dispatch = _prepare_unit(adapter, clock)
@@ -405,7 +408,6 @@ def _case_dispatch_expiry(adapter: Any, clock: MutableClock) -> None:
     _expect_error(Conflict, lambda: _reserve(adapter, clock, "c" * 16))
     assert adapter.get_active_run_dispatch(_TENANT, "run-a") == before
 
-
 def _case_idempotency(adapter: Any, clock: MutableClock) -> None:
     first = BeginIdempotency(
         tenant_id=_TENANT, scope="jobs", key="key-a", request_hash=_HASH_A,
@@ -430,7 +432,6 @@ def _case_idempotency(adapter: Any, clock: MutableClock) -> None:
     assert replaced.created
     assert replaced.record.resource_id == "resource-b"
 
-
 def _publish(run_id: str, event_id: str, expected: str | None, degraded: bool) -> PublishDataset:
     return PublishDataset(
         version=DatasetVersion(
@@ -442,7 +443,6 @@ def _publish(run_id: str, event_id: str, expected: str | None, degraded: bool) -
         publication_permit=PublicationPermit(
             tenant_id=_TENANT, run_id=run_id, policy_version=1, fencing_token=1),
         event=_event(event_id, aggregate_id=run_id))
-
 
 def _case_publication(adapter: Any, clock: MutableClock) -> None:
     adapter.put_run(_run("run-a", RunState.PUBLISHING))

--- a/packages/cnes_infra/tests/contracts/test_contract_harness.py
+++ b/packages/cnes_infra/tests/contracts/test_contract_harness.py
@@ -308,11 +308,12 @@ class FakeControlPlane(_HarnessState):
                         "lease_until": None,
                     }
                 )
+        if wrong_state:
+            raise Conflict("run_not_canceling")
         canceled = transition_run(run, RunState.CANCELED)
         self.put_run(canceled)
         self.outbox.setdefault(event.event_id, event)
         return canceled
-
     def reserve_run_dispatch(self, command: Any) -> Any:
         key = (command.tenant_id, command.run_id)
         active = self.dispatches.get(key)
@@ -369,7 +370,6 @@ class FakeControlPlane(_HarnessState):
         )
         self.dispatches[key] = started
         return started
-
     def finish_run_dispatch(self, command: Any) -> Any:
         key = (command.tenant_id, command.run_id)
         dispatch = self.dispatches.get(key)

--- a/packages/cnes_infra/tests/contracts/test_contract_harness.py
+++ b/packages/cnes_infra/tests/contracts/test_contract_harness.py
@@ -106,6 +106,10 @@ class FakeControlPlane(_HarnessState):
         return failed
 
     def complete_job(self, command: Any, event: Any) -> Any:
+        current = self.get_job(command.tenant_id, command.job_id)
+        if self.mutation == "authorization_jobs" and current.lease_until <= self.clock.now():
+            self.raw_records.append(command.manifest)
+            self.outbox[event.event_id] = event
         job = self._validate_job_fence(command)
         manifest = command.manifest
         completed = job.model_copy(
@@ -133,7 +137,9 @@ class FakeControlPlane(_HarnessState):
         if not records:
             return ()
         if self.mutation == "raw_chains":
-            selected = sorted(records, key=lambda item: item.created_at)
+            records = [item.model_copy(update={"base_snapshot_id": f"base-{item.agent_id}"})
+                       if item.sequence > 1 else item for item in records]
+            selected = self._select_raw_chain(records)
         else:
             selected = self._select_raw_chain(records)
         bounded = selected if len(selected) <= limit else []
@@ -171,7 +177,6 @@ class FakeControlPlane(_HarnessState):
         }
         values = [run for run in self.runs.values() if run.state in states]
         return tuple(sorted(values, key=lambda item: (item.created_at, item.run_id))[:limit])
-
     def put_run_units(self, command: Any) -> tuple[Any, ...]:
         run = self.get_run(command.tenant_id, command.run_id)
         if run is None or run.state is not command.expected_run_state:
@@ -185,25 +190,26 @@ class FakeControlPlane(_HarnessState):
             return existing
         self._write_units(command.units)
         return command.units
-
     def _write_units(self, units: tuple[Any, ...]) -> None:
         for unit in units:
             self.units[(unit.tenant_id, unit.run_id, unit.unit_id)] = unit
-
     def claim_run_unit(self, command: Any) -> Any | None:
         key = (command.tenant_id, command.run_id, command.unit_id)
         unit = self.units.get(key)
         run = self.get_run(command.tenant_id, command.run_id)
         dispatch = self.dispatches.get((command.tenant_id, command.run_id))
         valid_parent = run is not None and run.state is RunState.PROCESSING
+        stale = dispatch is not None and dispatch.dispatch_id != command.dispatch_id
+        if self.mutation == "unit_claim" and unit is not None and stale:
+            self.units[key] = unit.model_copy(update={"attempt": 1, "fencing_token": 1,
+                                                     "dispatch_id": command.dispatch_id})
+            return None
         valid_dispatch = (
             dispatch is not None
             and dispatch.dispatch_id == command.dispatch_id
             and dispatch.state is not DispatchState.TERMINAL and dispatch.lease_until > command.now
             and command.unit_id in dispatch.unit_ids
         )
-        if self.mutation == "unit_claim":
-            valid_parent = True
         if unit is None or not valid_parent or not valid_dispatch:
             return None
         claimable = unit.state in {RunUnitState.PENDING, RunUnitState.FAILED_RETRYABLE}
@@ -222,7 +228,6 @@ class FakeControlPlane(_HarnessState):
         )
         self.units[key] = claimed
         return claimed
-
     def _validate_unit_fence(self, command: Any) -> tuple[Any, Any]:
         unit = self.units.get((command.tenant_id, command.run_id, command.unit_id))
         run = self.get_run(command.tenant_id, command.run_id)
@@ -256,7 +261,6 @@ class FakeControlPlane(_HarnessState):
         self.units[(unit.tenant_id, unit.run_id, unit.unit_id)] = completed
         self.outbox[event.event_id] = event
         return completed
-
     def fail_run_unit(self, command: Any, event: Any) -> Any:
         unit, run = self._validate_unit_fence(command)
         optional = any(
@@ -280,12 +284,12 @@ class FakeControlPlane(_HarnessState):
             self.put_run(run.model_copy(update={"missing_sources": (*run.missing_sources, source)}))
         self.outbox[event.event_id] = event
         return failed
-
     def finalize_run_cancellation(self, command: Any, event: Any) -> Any:
         run = self.get_run(command.tenant_id, command.run_id)
         if run is not None and run.state is RunState.CANCELED:
             return run
-        if run is None or run.state is not RunState.CANCEL_REQUESTED:
+        wrong_state = run is not None and run.state is not RunState.CANCEL_REQUESTED
+        if run is None or (wrong_state and self.mutation != "cancellation"):
             raise Conflict("run_not_canceling")
         terminal_states = {
             RunUnitState.SUCCEEDED,
@@ -296,7 +300,7 @@ class FakeControlPlane(_HarnessState):
         for key, unit in tuple(self.units.items()):
             if key[:2] != (command.tenant_id, command.run_id):
                 continue
-            if unit.state not in terminal_states or self.mutation == "cancellation":
+            if unit.state not in terminal_states:
                 self.units[key] = unit.model_copy(
                     update={
                         "state": RunUnitState.CANCELED,
@@ -313,7 +317,7 @@ class FakeControlPlane(_HarnessState):
         key = (command.tenant_id, command.run_id)
         active = self.dispatches.get(key)
         replay = active and active.wave_id == command.wave_id and active.lease_until > command.now
-        if replay and self.mutation != "dispatch":
+        if replay:
             return active
         live = active and active.state is not DispatchState.TERMINAL
         lease_live = active is not None and active.lease_until > command.now
@@ -334,7 +338,6 @@ class FakeControlPlane(_HarnessState):
         )
         self.dispatches[key] = dispatch
         return dispatch
-
     def _has_live_unit_lease(self, dispatch: Any, now: datetime) -> bool:
         if self.mutation == "dispatch_expiry":
             return False
@@ -344,7 +347,6 @@ class FakeControlPlane(_HarnessState):
             and unit.lease_until > now
             for unit in self.units.values()
         )
-
     def bind_run_dispatch(self, command: Any) -> Any:
         key = (command.tenant_id, command.run_id)
         dispatch = self.dispatches.get(key)
@@ -377,6 +379,9 @@ class FakeControlPlane(_HarnessState):
             raise Conflict("dispatch_expired")
         if dispatch.state is DispatchState.TERMINAL:
             if dispatch.terminal_outcome != command.outcome:
+                if self.mutation == "dispatch":
+                    self.dispatches[key] = dispatch.model_copy(
+                        update={"terminal_outcome": command.outcome})
                 raise Conflict("outcome_conflict")
             return dispatch
         finished = dispatch.model_copy(
@@ -442,7 +447,6 @@ class FakeControlPlane(_HarnessState):
         self.put_run(updated)
         self.outbox.setdefault(command.event.event_id, command.event)
         return result
-
 @pytest.fixture
 def clock() -> MutableClock:
     return MutableClock(_NOW)
@@ -452,20 +456,16 @@ def clock() -> MutableClock:
 def fake_control_plane(clock: MutableClock) -> FakeControlPlane:
     return FakeControlPlane(clock)
 
-
 @pytest.fixture
 def fake_object_store() -> _MemoryObjectStore:
     return _MemoryObjectStore()
-
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
 def test_fake_control_plane_conforme(case, fake_control_plane, clock):
     case.run(fake_control_plane, clock)
 
-
 @pytest.mark.parametrize("case", object_store_cases(), ids=lambda case: case.name)
 def test_fake_object_store_conforme(case, fake_object_store, clock):
     case.run(fake_object_store, clock)
-
 
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
 def test_mutacao_do_control_plane_e_detectada(case: ControlPlaneCase, clock: MutableClock) -> None:


### PR DESCRIPTION
## Summary

- makes expired job completion rejection side-effect free
- rejects stale dispatch claims atomically and premature cancellation finalization
- preserves terminal dispatch outcomes after conflicting replay
- rejects raw delta chains linked to the wrong base snapshot
- retargets deliberate mutations to prove each reviewed invariant

Follow-up to #116 and #105.

## Verification

- `uv run ruff check .`
- `uv run pytest packages/cnes_infra/tests/contracts/test_contract_harness.py -q` — 37 passed
- `uv run pytest packages/cnes_domain packages/cnes_infra/tests/contracts -q` — 586 passed, 4 skipped
- fast global suite collection remains blocked by pre-existing imports of removed `estabelecimento_repo` in five perf tests