### PR TITLE
fix(ci): establish phase 2 readiness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main, develop]
     paths:
@@ -13,6 +14,7 @@ on:
       - 'docs/contracts/openapi.json'
       - 'docs/contracts/schemas/**'
       - '.github/workflows/ci.yml'
+      - 'scripts/ci_python_gate.sh'
   push:
     branches: [main, develop]
     paths:
@@ -24,6 +26,8 @@ on:
       - '.coveragerc'
       - 'docs/contracts/openapi.json'
       - 'docs/contracts/schemas/**'
+      - '.github/workflows/ci.yml'
+      - 'scripts/ci_python_gate.sh'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -60,59 +64,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          version: "0.9.26"
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e packages/cnes_contracts
-          pip install -e packages/cnes_domain
-          pip install -e packages/cnes_infra
-          pip install -e apps/data_processor
-          pip install -e apps/central_api
-          pip install -e apps/cnes_db_migrator
-          pip install pytest pytest-cov pytest-asyncio pytest-benchmark pytest-httpx hypothesis ruff duckdb psutil
+        run: uv sync --locked --all-packages
 
-      - name: Verify openapi.json up-to-date
-        run: |
-          python scripts/gen_openapi.py --output /tmp/openapi_fresh.json
-          if ! diff -q docs/contracts/openapi.json /tmp/openapi_fresh.json > /dev/null; then
-            echo "::error::openapi.json drift detected"
-            echo "Run: python scripts/gen_openapi.py"
-            diff docs/contracts/openapi.json /tmp/openapi_fresh.json | head -50
-            exit 1
-          fi
-          echo "openapi.json is up-to-date"
-
-      - name: Verify contracts schemas up-to-date
-        run: |
-          python scripts/gen_contracts.py --output /tmp/contracts_fresh/
-          if ! diff -r docs/contracts/schemas/ /tmp/contracts_fresh/ > /tmp/contracts_diff.out 2>&1; then
-            echo "::error::contract schemas drift detected"
-            cat /tmp/contracts_diff.out | head -50
-            exit 1
-          fi
-          echo "contract schemas up-to-date"
-
-      - name: Lint
-        run: ruff check .
-
-      - name: Run migrations
-        run: |
-          cd packages/cnes_infra
-          alembic -c alembic.ini upgrade head
-
-      - name: Test + coverage (core pkgs, branch 100)
-        run: |
-          pytest \
-            packages/cnes_domain packages/cnes_infra \
-            -m "not bigquery and not e2e and not stress and not soak and not spike" \
-            --cov --cov-config=pyproject.toml \
-            --cov-report=term-missing
-
-      - name: Test + coverage (apps, line 90)
-        run: |
-          pytest \
-            apps/ \
-            -m "not integration and not bigquery and not e2e and not stress and not soak and not spike and not windows_only" \
-            --cov --cov-config=.coveragerc \
-            --cov-report=term-missing
+      - name: Run Python gate
+        run: bash scripts/ci_python_gate.sh

--- a/docs/baselines/2026-08-28-phase2-ready.json
+++ b/docs/baselines/2026-08-28-phase2-ready.json
@@ -1,0 +1,42 @@
+{
+  "commit_sha": "aeb7583dcbc7cdf8dea5157f9efbda25e0c78681",
+  "recorded_at": "2026-08-28T22:10:02.251087+00:00",
+  "suites": [
+    {
+      "name": "python-fast",
+      "command": "uv run pytest -m 'not integration and not postgres and not bigquery and not e2e and not stress and not soak and not spike and not windows_only and not chaos_infra' -q",
+      "exit_code": 0,
+      "duration_seconds": 25.792
+    },
+    {
+      "name": "python-packages-coverage",
+      "command": "uv run pytest packages/cnes_domain packages/cnes_infra -m 'not bigquery and not e2e and not stress and not soak and not spike' --cov --cov-config=pyproject.toml --cov-report=term-missing",
+      "exit_code": 0,
+      "duration_seconds": 23.264
+    },
+    {
+      "name": "python-apps-coverage",
+      "command": "uv run pytest apps/ -m 'not integration and not bigquery and not e2e and not stress and not soak and not spike and not windows_only' --cov --cov-config=.coveragerc --cov-report=term-missing",
+      "exit_code": 0,
+      "duration_seconds": 9.546
+    },
+    {
+      "name": "go-race-coverage",
+      "command": "sh -c 'cd apps/dump_agent_go &&\ngo test -race -count=1 -coverprofile=coverage.out ./... &&\ngrep -v -E '\"'\"'internal/apiclient/generated\\.go|cmd/|internal/service/|_windows\\.go:'\"'\"' coverage.out > coverage.filtered.out &&\ntotal=$(go tool cover -func=coverage.filtered.out | tail -1 | awk '\"'\"'{print $3}'\"'\"' | tr -d '\"'\"'%'\"'\"') &&\ngo tool cover -func=coverage.filtered.out | tail -1 &&\nawk -v total=\"$total\" '\"'\"'BEGIN { exit !(total >= 65) }'\"'\"''",
+      "exit_code": 0,
+      "duration_seconds": 19.873
+    },
+    {
+      "name": "dashboard",
+      "command": "sh -c 'cd apps/web_dashboard &&\nbun run codegen &&\nbun run lint &&\nbun run typecheck &&\nbun run test --coverage &&\nbun run build'",
+      "exit_code": 0,
+      "duration_seconds": 34.723
+    },
+    {
+      "name": "python-integration-docker",
+      "command": "sh -c 'docker compose -p cnesdata up -d --wait postgres && uv run pytest packages/ -m \"postgres and not e2e\" -q && uv run pytest apps/ -m \"postgres and not e2e\" -q'",
+      "exit_code": 0,
+      "duration_seconds": 9.908
+    }
+  ]
+}

--- a/scripts/baseline_matrix.py
+++ b/scripts/baseline_matrix.py
@@ -7,9 +7,11 @@ import shutil
 import subprocess
 import time
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
+from hashlib import sha256
 from pathlib import Path
+from re import compile as compile_pattern
 
 APPROVED_SHA = "8a2d3a4cbce85e87e31dc4769aab2a7a2b4bf7b2"
 WAIVED_SUITES = frozenset({"python-fast", "python-integration-docker"})
@@ -23,13 +25,22 @@ WAIVER = {
     "approved_by": "VINIClUS",
     "approved_at": "2026-08-26",
 }
+WAIVER_FINGERPRINT = "b4b22c61c271c1cf5c4e129644b21a774960901fc3fee3be2bd837f502ae623f"
+COLLECTION_HEADER = compile_pattern(
+    r"(?m)^_*[ \t]*ERROR collecting "
+    r"(?P<path>tests/[\w./-]*test_[\w-]+\.py)(?:[ \t]+_+)?[ \t]*$"
+)
+MISSING_MODULE_LINE = compile_pattern(
+    r"(?m)^E[ \t]+(?P<exception>[A-Za-z_][\w]*): "
+    r"No module named ['\"](?P<module>[^'\"]+)['\"]"
+)
 
 Command = tuple[str, ...]
 Suite = tuple[str, Command]
 
 PYTHON_FAST_MARKERS = (
     "not integration and not postgres and not bigquery and not e2e and not stress and "
-    "not soak and not spike and not windows_only"
+    "not soak and not spike and not windows_only and not chaos_infra"
 )
 PYTHON_PACKAGE_MARKERS = "not bigquery and not e2e and not stress and not soak and not spike"
 PYTHON_APP_MARKERS = (
@@ -50,7 +61,9 @@ bun run typecheck &&
 bun run test --coverage &&
 bun run build"""
 INTEGRATION_SCRIPT = (
-    "docker compose -p cnesdata up -d --wait postgres && uv run pytest -m postgres -q"
+    "docker compose -p cnesdata up -d --wait postgres && "
+    'uv run pytest packages/ -m "postgres and not e2e" -q && '
+    'uv run pytest apps/ -m "postgres and not e2e" -q'
 )
 
 SUITES: tuple[Suite, ...] = (
@@ -96,6 +109,49 @@ class SuiteResult:
     command: str
     exit_code: int
     duration_seconds: float
+    failure_fingerprint: str | None = field(default=None, kw_only=True)
+
+
+def _collection_failures(output: str) -> list[tuple[str, str, str]] | None:
+    headers = list(COLLECTION_HEADER.finditer(output))
+    if not headers:
+        return None
+    failures = []
+    for index, header in enumerate(headers):
+        block_end = headers[index + 1].start() if index + 1 < len(headers) else len(output)
+        signatures = list(MISSING_MODULE_LINE.finditer(output, header.end(), block_end))
+        if len(signatures) != 1:
+            return None
+        signature = signatures[0]
+        failures.append(
+            (
+                header.group("path"),
+                signature.group("exception"),
+                signature.group("module"),
+            )
+        )
+    return failures
+
+
+def _canonical_failure_document(output: str) -> bytes | None:
+    failures = _collection_failures(output)
+    if failures is None:
+        return None
+    signatures = {(exception, module) for _, exception, module in failures}
+    if len(signatures) != 1:
+        return None
+    exception, module = signatures.pop()
+    document = {
+        "exception": exception,
+        "module": module,
+        "affected_paths": sorted({path for path, _, _ in failures}),
+    }
+    return json.dumps(document, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _failure_fingerprint(output: str) -> str | None:
+    document = _canonical_failure_document(output)
+    return sha256(document).hexdigest() if document is not None else None
 
 
 def run_suite(name: str, command: Sequence[str]) -> SuiteResult:
@@ -119,7 +175,13 @@ def run_suite(name: str, command: Sequence[str]) -> SuiteResult:
     if output:
         print(output, end="" if output.endswith("\n") else "\n", flush=True)
     print(f"suite_end name={name} exit_code={exit_code} duration_seconds={duration:.3f}")
-    return SuiteResult(name, formatted_command, exit_code, round(duration, 3))
+    return SuiteResult(
+        name,
+        formatted_command,
+        exit_code,
+        round(duration, 3),
+        failure_fingerprint=_failure_fingerprint(output),
+    )
 
 
 def run_suites(suites: Sequence[Suite]) -> list[SuiteResult]:
@@ -131,6 +193,7 @@ def _waiver_for(result: SuiteResult, commit_sha: str) -> dict[str, object] | Non
         commit_sha == APPROVED_SHA
         and result.name in WAIVED_SUITES
         and result.exit_code == WAIVER["expected_exit_code"]
+        and result.failure_fingerprint == WAIVER_FINGERPRINT
     ):
         return dict(WAIVER)
     return None
@@ -140,6 +203,8 @@ def write_report(path: Path, results: Sequence[SuiteResult], commit_sha: str) ->
     suites = []
     for result in results:
         suite = asdict(result)
+        if result.failure_fingerprint is None:
+            del suite["failure_fingerprint"]
         waiver = _waiver_for(result, commit_sha)
         if waiver is not None:
             suite["waiver"] = waiver

--- a/scripts/baseline_matrix_test.py
+++ b/scripts/baseline_matrix_test.py
@@ -1,6 +1,8 @@
 """Testes da matriz de baseline versionada."""
 
 import json
+import shutil
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -11,6 +13,60 @@ from scripts import baseline_matrix
 from scripts.baseline_matrix import SuiteResult
 
 APPROVED_SHA = "8a2d3a4cbce85e87e31dc4769aab2a7a2b4bf7b2"
+MISSING_MODULE = "cnes_infra.storage.repositories.estabelecimento_repo"
+AFFECTED_PATHS = [
+    "tests/perf/macro/test_data_processor_e2e.py",
+    "tests/perf/micro/test_upsert_bench.py",
+    "tests/perf/soak/test_upsert_soak.py",
+    "tests/perf/spike/test_upsert_spike.py",
+    "tests/perf/stress/test_upsert_stress.py",
+]
+CANONICAL_BYTES = (
+    b'{"affected_paths":["tests/perf/macro/test_data_processor_e2e.py",'
+    b'"tests/perf/micro/test_upsert_bench.py","tests/perf/soak/test_upsert_soak.py",'
+    b'"tests/perf/spike/test_upsert_spike.py","tests/perf/stress/test_upsert_stress.py"],'
+    b'"exception":"ModuleNotFoundError",'
+    b'"module":"cnes_infra.storage.repositories.estabelecimento_repo"}'
+)
+CANONICAL_DIGEST = "b4b22c61c271c1cf5c4e129644b21a774960901fc3fee3be2bd837f502ae623f"
+canonical_failure_document = vars(baseline_matrix)["_canonical_failure_document"]
+failure_fingerprint = vars(baseline_matrix)["_failure_fingerprint"]
+waiver_for = vars(baseline_matrix)["_waiver_for"]
+
+
+def _collection_block(
+    path: str,
+    exception: str = "ModuleNotFoundError",
+    module: str = MISSING_MODULE,
+) -> str:
+    return (
+        f"________ ERROR collecting {path} ________\n"
+        f"ImportError while importing test module '/workspace/{path}'.\n"
+        "Hint: make sure your test modules/packages have valid Python names.\n"
+        "Traceback:\n"
+        "/usr/lib/python3.12/importlib/__init__.py:90: in import_module\n"
+        "    return _bootstrap._gcd_import(name[level:], package, level)\n"
+        f"E   {exception}: No module named '{module}'\n"
+    )
+
+
+def _missing_module_output(
+    module: str = MISSING_MODULE,
+    exception: str = "ModuleNotFoundError",
+    paths: list[str] | None = None,
+) -> str:
+    affected_paths = paths or AFFECTED_PATHS
+    return "\n".join(_collection_block(path, exception, module) for path in affected_paths)
+
+
+def _mixed_failure_output() -> str:
+    blocks = [
+        _collection_block(AFFECTED_PATHS[0], "AssertionError", MISSING_MODULE),
+        _collection_block(AFFECTED_PATHS[1], "ModuleNotFoundError", f"{MISSING_MODULE}.other"),
+        *(_collection_block(path) for path in AFFECTED_PATHS[2:]),
+        f"ModuleNotFoundError: No module named '{MISSING_MODULE}'\n",
+    ]
+    return "\n".join(blocks)
 
 
 def test_serializa_relatorio_com_timestamp_utc_e_cria_diretorio(tmp_path: Path) -> None:
@@ -70,7 +126,13 @@ def test_registra_waiver_aprovado_no_sha_e_codigo_exatos(
     name: str,
 ) -> None:
     report_path = tmp_path / "baseline.json"
-    result = SuiteResult(name, "uv run pytest", 2, 0.5)
+    result = SuiteResult(
+        name,
+        "uv run pytest",
+        2,
+        0.5,
+        failure_fingerprint=CANONICAL_DIGEST,
+    )
 
     baseline_matrix.write_report(report_path, [result], APPROVED_SHA)
 
@@ -115,7 +177,13 @@ def test_nao_registra_waiver_fora_da_aprovacao(
 
 def test_status_zero_com_suites_verdes_e_waiver_aprovado() -> None:
     results = [
-        SuiteResult("python-fast", "uv run pytest", 2, 0.5),
+        SuiteResult(
+            "python-fast",
+            "uv run pytest",
+            2,
+            0.5,
+            failure_fingerprint=CANONICAL_DIGEST,
+        ),
         SuiteResult("go", "go test ./...", 0, 0.5),
     ]
 
@@ -126,3 +194,169 @@ def test_status_vermelho_sem_waiver_aprovado() -> None:
     results = [SuiteResult("python-fast", "uv run pytest", 2, 0.5)]
 
     assert baseline_matrix.matrix_exit_code(results, "f" * 40) == 1
+
+
+def test_aceita_waiver_com_assinatura_normalizada_aprovada() -> None:
+    digest = failure_fingerprint(_missing_module_output())
+    result = SuiteResult(
+        "python-fast",
+        "uv run pytest",
+        2,
+        0.5,
+        failure_fingerprint=digest,
+    )
+
+    assert digest == CANONICAL_DIGEST
+    assert waiver_for(result, APPROVED_SHA) is not None
+
+
+@pytest.mark.parametrize("exit_code", [0, 1, 3])
+def test_rejeita_waiver_com_fingerprint_valido_e_exit_code_diferente(exit_code: int) -> None:
+    result = SuiteResult(
+        "python-fast",
+        "uv run pytest",
+        exit_code,
+        0.5,
+        failure_fingerprint=CANONICAL_DIGEST,
+    )
+
+    assert waiver_for(result, APPROVED_SHA) is None
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        _missing_module_output(exception="AssertionError"),
+        _missing_module_output(module="cnes_infra.storage.repositories.outra"),
+        "",
+    ],
+)
+def test_rejeita_waiver_com_mesmo_codigo_e_falha_diferente(output: str) -> None:
+    result = SuiteResult(
+        "python-fast",
+        "uv run pytest",
+        2,
+        0.5,
+        failure_fingerprint=failure_fingerprint(output),
+    )
+
+    assert waiver_for(result, APPROVED_SHA) is None
+
+
+@pytest.mark.parametrize(
+    ("name", "commit_sha"),
+    [("python-packages", APPROVED_SHA), ("python-fast", "f" * 40)],
+)
+def test_rejeita_waiver_com_suite_ou_sha_nao_aprovados(name: str, commit_sha: str) -> None:
+    result = SuiteResult(
+        name,
+        "uv run pytest",
+        2,
+        0.5,
+        failure_fingerprint=failure_fingerprint(_missing_module_output()),
+    )
+
+    assert waiver_for(result, commit_sha) is None
+
+
+def test_serializa_documento_canonico_da_falha_aprovada() -> None:
+    assert canonical_failure_document(_missing_module_output()) == CANONICAL_BYTES
+
+
+def test_ordem_dos_blocos_nao_altera_fingerprint() -> None:
+    output = _missing_module_output(paths=list(reversed(AFFECTED_PATHS)))
+
+    assert failure_fingerprint(output) == CANONICAL_DIGEST
+
+
+def test_relatorio_expoe_digest_sem_capturar_saida(tmp_path: Path) -> None:
+    report_path = tmp_path / "baseline.json"
+    result = SuiteResult(
+        "python-fast",
+        "uv run pytest",
+        2,
+        0.5,
+        failure_fingerprint=CANONICAL_DIGEST,
+    )
+
+    baseline_matrix.write_report(report_path, [result], APPROVED_SHA)
+
+    suite = json.loads(report_path.read_text(encoding="utf-8"))["suites"][0]
+    assert suite["failure_fingerprint"] == CANONICAL_DIGEST
+    assert "stdout" not in suite
+    assert "stderr" not in suite
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        _missing_module_output(
+            paths=[*AFFECTED_PATHS[:-1], "tests/perf/stress/test_upsert_stresa.py"]
+        ),
+        _missing_module_output(module=f"{MISSING_MODULE[:-1]}a"),
+        _missing_module_output(exception="NoduleNotFoundError"),
+    ],
+)
+def test_alteracao_em_campo_canonico_muda_digest_e_rejeita_waiver(output: str) -> None:
+    digest = failure_fingerprint(output)
+    result = SuiteResult("python-fast", "uv run pytest", 2, 0.5, failure_fingerprint=digest)
+
+    assert digest is not None
+    assert digest != CANONICAL_DIGEST
+    assert waiver_for(result, APPROVED_SHA) is None
+
+
+def test_bloco_relevante_ausente_nao_produz_fingerprint_aprovado() -> None:
+    digest = failure_fingerprint(_missing_module_output(paths=AFFECTED_PATHS[:-1]))
+
+    assert digest != CANONICAL_DIGEST
+
+
+def test_rejeita_assinatura_montada_com_campos_de_blocos_distintos() -> None:
+    assert failure_fingerprint(_mixed_failure_output()) is None
+
+
+def test_rejeita_fingerprint_como_quinto_argumento_posicional() -> None:
+    with pytest.raises(TypeError):
+        SuiteResult("python-fast", "uv run pytest", 2, 0.5, CANONICAL_DIGEST)
+
+
+def test_suite_rapida_nao_seleciona_chaos_infra() -> None:
+    completed = subprocess.run(
+        (
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/chaos/test_central_api_sobrevive_pg_restart.py",
+            "--collect-only",
+            "-m",
+            baseline_matrix.PYTHON_FAST_MARKERS,
+            "-q",
+        ),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 5
+    assert "test_central_api_sobrevive_pg_restart" not in completed.stdout
+
+
+def test_suite_integracao_coleta_packages_apps_sem_e2e() -> None:
+    command = baseline_matrix.INTEGRATION_SCRIPT.removeprefix(
+        "docker compose -p cnesdata up -d --wait postgres && "
+    ).replace("uv run pytest", "uv run pytest --collect-only")
+    shell = shutil.which("sh")
+    assert shell is not None
+    completed = subprocess.run(
+        (shell, "-c", command),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout.count("tests collected") == 2
+    assert "packages/cnes_infra/tests/auth/test_refresh_tokens.py" in completed.stdout
+    assert "apps/central_api/tests/repositories/test_dashboard_repo_overview.py" in completed.stdout
+    assert "apps/central_api/tests/test_smoke.py" not in completed.stdout

--- a/scripts/ci_python_gate.sh
+++ b/scripts/ci_python_gate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+gate_openapi="$(mktemp)"
+gate_contracts="$(mktemp -d)"
+trap 'rm -f "$gate_openapi"; rm -rf "$gate_contracts"' EXIT
+
+uv run python scripts/gen_openapi.py --output "$gate_openapi"
+diff -u docs/contracts/openapi.json "$gate_openapi"
+uv run python scripts/gen_contracts.py --output "$gate_contracts/"
+diff -ru docs/contracts/schemas/ "$gate_contracts/"
+uv run ruff check .
+(
+  cd packages/cnes_infra
+  uv run alembic -c alembic.ini upgrade head
+)
+uv run pytest packages/cnes_domain packages/cnes_infra \
+  -m "not bigquery and not e2e and not stress and not soak and not spike" \
+  --cov --cov-config=pyproject.toml --cov-report=term-missing
+uv run pytest apps/ \
+  -m "not integration and not bigquery and not e2e and not stress and not soak and not spike \
+and not windows_only" \
+  --cov --cov-config=.coveragerc --cov-report=term-missing

--- a/tests/perf/macro/test_data_processor_e2e.py
+++ b/tests/perf/macro/test_data_processor_e2e.py
@@ -3,9 +3,11 @@ import pytest
 from sqlalchemy import text
 
 from cnes_domain.processing.transformer import transformar
-from cnes_infra.storage.repositories.estabelecimento_repo import (
-    EstabelecimentoRepository,
-)
+
+EstabelecimentoRepository = pytest.importorskip(
+    "cnes_infra.storage.repositories.estabelecimento_repo",
+    reason="repositório ausente do develop reconciliado",
+).EstabelecimentoRepository
 
 pytestmark = pytest.mark.perf_macro
 

--- a/tests/perf/micro/test_upsert_bench.py
+++ b/tests/perf/micro/test_upsert_bench.py
@@ -2,9 +2,10 @@
 import pytest
 from sqlalchemy import text
 
-from cnes_infra.storage.repositories.estabelecimento_repo import (
-    EstabelecimentoRepository,
-)
+EstabelecimentoRepository = pytest.importorskip(
+    "cnes_infra.storage.repositories.estabelecimento_repo",
+    reason="repositório ausente do develop reconciliado",
+).EstabelecimentoRepository
 
 pytestmark = pytest.mark.perf_micro
 

--- a/tests/perf/soak/test_upsert_soak.py
+++ b/tests/perf/soak/test_upsert_soak.py
@@ -2,10 +2,12 @@
 import pytest
 from sqlalchemy import text
 
-from cnes_infra.storage.repositories.estabelecimento_repo import (
-    EstabelecimentoRepository,
-)
 from tests.perf.soak._harness import run_soak
+
+EstabelecimentoRepository = pytest.importorskip(
+    "cnes_infra.storage.repositories.estabelecimento_repo",
+    reason="repositório ausente do develop reconciliado",
+).EstabelecimentoRepository
 
 pytestmark = pytest.mark.soak
 

--- a/tests/perf/spike/test_upsert_spike.py
+++ b/tests/perf/spike/test_upsert_spike.py
@@ -2,10 +2,12 @@
 import pytest
 from sqlalchemy import text
 
-from cnes_infra.storage.repositories.estabelecimento_repo import (
-    EstabelecimentoRepository,
-)
 from tests.perf.spike._harness import run_spike
+
+EstabelecimentoRepository = pytest.importorskip(
+    "cnes_infra.storage.repositories.estabelecimento_repo",
+    reason="repositório ausente do develop reconciliado",
+).EstabelecimentoRepository
 
 pytestmark = pytest.mark.spike
 

--- a/tests/perf/stress/test_upsert_stress.py
+++ b/tests/perf/stress/test_upsert_stress.py
@@ -2,8 +2,12 @@
 import pytest
 from sqlalchemy import text
 
-from cnes_infra.storage.repositories.estabelecimento_repo import EstabelecimentoRepository
 from tests.perf.stress._harness import break_point, rampa_sync
+
+EstabelecimentoRepository = pytest.importorskip(
+    "cnes_infra.storage.repositories.estabelecimento_repo",
+    reason="repositório ausente do develop reconciliado",
+).EstabelecimentoRepository
 
 pytestmark = pytest.mark.stress
 


### PR DESCRIPTION
## Resumo

- endurece a waiver histórica com fingerprint canônico por bloco de coleta
- torna os cinco benchmarks legados skips explícitos e reproduzíveis
- unifica CI e verificação local no gate Python lockado
- registra baseline verde vinculado ao commit de implementação

## Verificação

- 31 testes de baseline
- Ruff global
- OpenAPI e schemas sem drift
- Alembic em head
- packages com 100% de cobertura
- apps com 97,55% de cobertura
- matriz com seis suites verdes

Refs #120