### PR TITLE
docs(deploy): define bounded CnesData production architecture

### DIFF
--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -170,8 +170,9 @@ Cache headers:
 - error responses: not cached when they may hide a fixed deployment.
 
 S3 versioning preserves entrypoint rollback. A lifecycle retains recent
-releases within the CloudFront Free plan's 5 GB origin allowance and removes
-unreferenced noncurrent objects only after the rollback window.
+releases within a voluntary 5 GB operational cap for the web bucket, aligned
+with the CloudFront Free plan's account-wide 5 GB S3 Standard credit, and
+removes unreferenced noncurrent objects only after the rollback window.
 
 SPA routes use a small deterministic CloudFront Function rewrite to
 `/index.html`; it must not rewrite API paths, assets with extensions or known
@@ -230,14 +231,18 @@ issuer preset, but application/domain interfaces remain provider-neutral.
 The deployment creates:
 
 - one User Pool;
-- one public SPA client using Authorization Code + PKCE and no client secret;
+- one public SPA client using Authorization Code + PKCE and no client secret,
+  with `AllowedOAuthScopes` containing
+  `https://api.cnesdata.vinisantana.com/api.access` alongside existing OIDC
+  scopes;
 - one resource server with identifier `https://api.cnesdata.vinisantana.com`
   and one custom `api.access` scope;
 - exact callback/logout URLs for the production domain;
 - email-based development/demo accounts created out of band;
 - no SMS MFA, paid SMS, social IdP or machine-to-machine client.
 
-The SPA requests the custom resource-server scope and passes
+The dashboard requests `https://api.cnesdata.vinisantana.com/api.access`
+alongside existing OIDC scopes and passes
 `resource=https://api.cnesdata.vinisantana.com` in its authorization request.
 The resulting access token contains
 `aud=https://api.cnesdata.vinisantana.com`. Production config sets

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -307,8 +307,8 @@ Required deployment controls:
 - alarms for throttles, system errors and sustained consumption.
 
 API/processor roles receive only required table/index actions. GitHub has no direct
-writes; promotion assumes a release-tagged operator with conditional get/update on
-the separate fence item, never the semaphore item. Demo seed uses another role.
+writes; promotion's operator strongly reads fence/semaphore but updates only the
+separate fence item. Demo seed uses another role; semaphore writes are denied.
 
 ## 10. Data, serving and audit buckets
 
@@ -464,7 +464,7 @@ conditions. The CA private key and API/VPS leaf credentials never enter the
 repository or OpenTofu state; issuance, revocation and recovery are operational.
 
 IAM policies distinguish API, processor, task execution, GitHub plan/apply,
-release-tagged fence operator, demo seed, audit verification and break-glass duties.
+fence/cost-clear operators, demo seed, audit verification and break-glass duties.
 Wildcard permissions require an AWS API that cannot be narrowed and a documented
 condition boundary.
 

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -215,8 +215,8 @@ The container:
 - has a read-only root filesystem, bounded tmpfs and no Linux capabilities;
 - publishes one port to `127.0.0.1` only;
 - has CPU, memory, PID and log-size limits compatible with the KVM 2 host;
-- sets `AWS_CONFIG_FILE` to a read-only config containing a named profile whose
-  `credential_process` invokes IAM Roles Anywhere
+- sets `AWS_CONFIG_FILE` to a read-only config and `AWS_PROFILE` to its named
+  profile, whose `credential_process` invokes IAM Roles Anywhere
   `aws_signing_helper credential-process`;
 - mounts read-only only that config plus the strictly necessary X.509 material
   and helper; the host-owned key is readable only by the fixed runtime UID;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -165,12 +165,11 @@ public configuration such as
 issuer/client ID and release ID. The OpenTofu output maps that exact value to
 the dashboard build variable `VITE_API_BASE_URL`.
 
-Every dashboard API call, including `auth/me` and activation, uses one
-authenticated client bound to
-`https://api.cnesdata.vinisantana.com/api/v1`. Production forbids relative
-`/api` requests. That client sends a bearer token only to the API origin
-`https://api.cnesdata.vinisantana.com` and sends `X-Tenant-Id` only for
-tenant-scoped calls.
+Every dashboard call, including `auth/me` and activation, uses one authenticated
+client bound to `https://api.cnesdata.vinisantana.com/api/v1`. FastAPI mounts
+activation at `/api/v1/activate/confirm`; origin-level `/activate/confirm` is
+removed. Production forbids relative `/api`. The client sends bearer only to
+`https://api.cnesdata.vinisantana.com` and `X-Tenant-Id` only for tenant calls.
 
 Deployment order:
 

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -206,8 +206,13 @@ The container:
 - has a read-only root filesystem, bounded tmpfs and no Linux capabilities;
 - publishes one port to `127.0.0.1` only;
 - has CPU, memory, PID and log-size limits compatible with the KVM 2 host;
-- mounts only public configuration and the CnesData temporary AWS credential
-  directory read-only, so atomic host-side refreshes remain visible;
+- sets `AWS_CONFIG_FILE` to a read-only config containing a named profile whose
+  `credential_process` invokes IAM Roles Anywhere
+  `aws_signing_helper credential-process`;
+- mounts read-only only that config plus the strictly necessary X.509 material
+  and helper, with minimum permissions;
+- accepts neither `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` or
+  `AWS_SESSION_TOKEN` nor shared static credentials;
 - has no Docker socket, host network or access to LimnoPulse volumes/networks;
 - reports liveness separately from readiness;
 - emits redacted JSON stdout and optional loopback metrics.
@@ -309,12 +314,13 @@ bounded recovery window; published raw, reconciliation and serving history is
 not deleted by a deployment workflow.
 
 The first API call remains authenticated and tenant-authorized with
-`X-Tenant-Id`. It returns `200` with `Cache-Control: private, no-store` and a
-minimal envelope containing a signed URL for an exact authorized
-`serving/<tenant>/<run_id>/...` object selected by the active `DatasetPointer`,
-`version_id` and `expires_in=300`. The envelope exposes neither tenant nor
-object key. Raw, normalized, reconciliation, temporary and audit keys are
-never signed to the browser.
+`X-Tenant-Id`. It returns `200` with `Cache-Control: private, no-store` and an
+envelope containing only `url`, `version_id` and `expires_in=300`. There are no
+separate tenant or object-key fields, but the SigV4 URL necessarily contains
+the exact authorized `serving/<tenant>/<run_id>/...` key in its path. The URL is
+bearer-sensitive and must never be logged, persisted, included in telemetry,
+referrer or cache. Raw, normalized, reconciliation, temporary and audit keys
+are never signed to the browser; no other prefix may be signed.
 
 The dashboard then makes a second `fetch` directly to the signed S3 URL with
 credentials omitted and without `Authorization`, `X-Tenant-Id`, cookies or any
@@ -411,8 +417,9 @@ No static AWS access key is accepted by application settings, GitHub or the
 VPS.
 
 - GitHub workflows assume repository/workflow-scoped OIDC roles.
-- The VPS API obtains short-lived credentials through its CnesData Roles
-  Anywhere profile and host-side credential renewer.
+- The VPS API uses its named `AWS_CONFIG_FILE` profile and IAM Roles Anywhere
+  `aws_signing_helper credential-process`. Its output includes `Expiration`,
+  and boto3/botocore refreshes credentials automatically before expiration.
 - Fargate uses task roles.
 - Runtime non-AWS secrets use SSM SecureString under
   `/personal/prod/cnesdata/runtime/` and the approved customer-managed KMS key.

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -386,8 +386,8 @@ verified in the [production operations design](2026-08-29-cnesdata-production-op
   EventBridge Scheduler, under the operations contract;
 - Linux/x86_64, initial size 0.25 vCPU and 0.5-1 GiB memory;
 - included 20 GB ephemeral storage unless measured otherwise;
-- maximum one concurrent unit task, recovery overlap permitted, and two-hour
-  unit-task timeout;
+- maximum one concurrent unit task plus at most one `recover-once` overlap, and
+  two-hour unit-task timeout;
 - maximum 100 task-hours per month;
 - no autoscaling and no Fargate Spot in the first release;
 - public subnets with an ephemeral public IPv4, no inbound security-group rule,

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -16,9 +16,10 @@ profile. The frontend is served through CloudFront from a private S3 origin, the
 FastAPI control-plane/API runs on the personal Hostinger VPS, and data processing
 runs on demand in Step Functions Standard and ECS Fargate.
 
-This specification supplies the production-resource, identity, network,
-delivery, rollback and operations contract intentionally left out of the
-existing AWS Runtime Profile implementation plan.
+This specification supplies the production-resource, identity and network
+contract intentionally left out of the existing AWS Runtime Profile
+implementation plan. The delivery and operations contract is in the related
+[production operations design](2026-08-29-cnesdata-production-operations-design.md).
 
 It does not authorize immediate deployment of the repository's current legacy
 Compose stack. PostgreSQL, MinIO, Keycloak and BigQuery remain implementation
@@ -203,8 +204,14 @@ The container:
 - emits redacted JSON stdout and optional loopback metrics.
 
 Nginx exposes it only through `api.cnesdata.vinisantana.com` on the shared
-Tunnel. It restores the Cloudflare client address only from the local tunnel,
-adds request IDs and applies general plus expensive-job rate limits.
+Tunnel. It restores the Cloudflare client address only from the local tunnel
+and adds request IDs. It forwards `OPTIONS` requests to FastAPI and neither
+terminates preflight requests nor adds CORS headers.
+
+FastAPI is the sole CORS authority. Its CORS policy permits exactly the origin
+`https://cnesdata.vinisantana.com`, methods `GET` and `POST`, and request
+headers `Authorization`, `Content-Type` and `X-Tenant-Id`. It permits no
+credentials and contains no wildcard origin, method or header.
 
 The application remains the authority for:
 
@@ -224,9 +231,18 @@ The deployment creates:
 
 - one User Pool;
 - one public SPA client using Authorization Code + PKCE and no client secret;
+- one resource server with identifier `https://api.cnesdata.vinisantana.com`
+  and one custom `api.access` scope;
 - exact callback/logout URLs for the production domain;
 - email-based development/demo accounts created out of band;
 - no SMS MFA, paid SMS, social IdP or machine-to-machine client.
+
+The SPA requests the custom resource-server scope and passes
+`resource=https://api.cnesdata.vinisantana.com` in its authorization request.
+The resulting access token contains
+`aud=https://api.cnesdata.vinisantana.com`. Production config sets
+`OIDC_AUDIENCE=https://api.cnesdata.vinisantana.com`. The dashboard continues
+to send the `access_token`; the verifier remains provider-neutral.
 
 Tokens establish issuer, audience and subject only. Tenant membership is
 resolved server-side through canonical DynamoDB keys. A tenant claim, header,
@@ -283,6 +299,11 @@ The API may issue a short-lived signed GET only for exact authorized
 `serving/<tenant>/<run_id>/...` objects selected by the active
 `DatasetPointer`. Raw, normalized, reconciliation, temporary and audit keys are
 never signed to the browser. The initial signed URL TTL is 300 seconds.
+
+The data bucket CORS configuration permits exactly
+`https://cnesdata.vinisantana.com`, methods `GET` and `HEAD`, no custom request
+headers, no credentials, and `MaxAgeSeconds=300`. Browser-readable objects are
+limited to signed URLs under `serving/`; no other prefix is browser-readable.
 
 ### 10.2 Audit bucket
 
@@ -403,193 +424,8 @@ There is no destroy workflow. Protected buckets, DynamoDB, KMS references and
 state use lifecycle/policy safeguards. A replacement plan for any protected
 resource fails before an apply artifact is issued.
 
-## 15. CI/CD
+## 15. Operations contract
 
-### 15.1 Continuous integration
-
-Pull requests to `develop` run the existing locked Python/CND/AWS gates plus:
-
-- dashboard lint, typecheck, tests and deterministic production build;
-- API and processor image build tests;
-- OCI vulnerability scan and SBOM generation;
-- OpenTofu format/validate/test and provider-lock verification;
-- policy and cost-manifest checks;
-- release-manifest schema and secret-scan tests.
-
-Untrusted pull-request code runs only on GitHub-hosted runners and receives no
-AWS, Cloudflare or SSH credential.
-
-### 15.2 Release creation
-
-A candidate release is bound to one green `develop` commit and records:
-
-- source SHA and test run IDs;
-- API GHCR digest;
-- processor GHCR and promoted ECR digests;
-- dashboard artifact checksum;
-- Compose/config checksum;
-- OpenTofu/provider lock digest;
-- SBOM checksums and schema version.
-
-Mutable tags may aid discovery but are never deployment authority.
-
-### 15.3 Infrastructure plan/apply
-
-Plan and apply are separate manual workflows. Apply downloads and verifies the
-exact unexpired binary plan; it does not replan. GitHub OIDC supplies temporary
-AWS credentials. The paid Actions spending limit is USD 0.
-
-### 15.4 Application promotion
-
-Production promotion is `workflow_dispatch` only. It verifies that the release
-SHA is contained in `develop`, all required checks succeeded and the cost-freeze
-marker is absent.
-
-Order:
-
-1. promote/verify the processor digest in ECR;
-2. update the inactive API candidate on the VPS;
-3. pass local and tunneled health/authorization smoke tests;
-4. switch Nginx to the candidate;
-5. publish frontend assets and entrypoint;
-6. run the synthetic vertical slice and serving test;
-7. record redacted evidence and retain the previous release.
-
-No production deployment occurs automatically after merge.
-
-## 16. Rollback
-
-- **API:** restore the previous Nginx upstream and already-pulled GHCR digest.
-- **Frontend:** restore the prior versioned entrypoint and invalidate it.
-- **Processor:** register/select the previous task definition/digest for new
-  dispatches; active Standard executions continue with the definition they
-  started unless the runbook determines cancellation is safe.
-- **State machine:** revert only new-execution routing; do not edit an active
-  execution or DynamoDB record manually.
-- **DynamoDB/S3:** application releases never roll data backward or delete
-  published versions. Compatibility changes are expand/contract and additive.
-- **Infrastructure:** failed apply requires diagnosis and a new reviewed plan;
-  protected-resource restore is not an automatic rollback step.
-
-## 17. Rate limiting and abuse containment
-
-- Cloudflare Free rule protects the most sensitive public job/auth surface.
-- Nginx enforces IP-based general and expensive-mutation zones.
-- The API enforces tenant/user/idempotency quotas and maximum 200 jobs,
-  100 task-hours and one concurrent processor task per month/environment.
-- DynamoDB maximum throughput, Step Functions bounded retries and Athena bytes
-  cutoffs contain downstream amplification.
-- Requests beyond product quota fail with `429` or the documented quota error
-  before starting Step Functions or Athena.
-- A USD 15 aggregate budget action freezes new Fargate, Step Functions and
-  Athena starts through automation roles while preserving reads and backups.
-
-## 18. Observability and SLOs
-
-Initial internal targets:
-
-- static frontend availability 99.9%;
-- API availability 99.5%;
-- eligible processing-job success 99%;
-- routine API p95 below two seconds;
-- routine deployment interruption at most 60 seconds.
-
-Grafana Alloy collects VPS/API/Nginx/Tunnel telemetry without Docker-socket
-access. CloudWatch owns DynamoDB, Step Functions, ECS, S3 and Athena alarms.
-Fargate logs retain seven days. High-cardinality tenant, run, object-key and
-user labels are forbidden.
-
-Required alarms include API/tunnel health, DynamoDB throttles/errors, failed or
-timed-out Step Functions executions, ECS task failures, audit/outbox backlog,
-S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
-
-## 19. Backup and recovery
-
-- DynamoDB PITR: 35 days;
-- S3 data/audit: versioning and prefix-specific lifecycle/Object Lock;
-- static entrypoint: versioned rollback;
-- infrastructure state: encrypted/versioned S3 backend;
-- no cross-region replica in phase 1;
-- quarterly recovery exercise reconstructs the API and proves one synthetic
-  dataset pointer/serving object without altering production data;
-- destructive PITR export/restore requires a separately approved runbook run.
-
-## 20. Test and acceptance matrix
-
-### 20.1 Pre-production tests
-
-- all CND adapter and AWS-014 matrices on the exact release SHA;
-- real-AWS DynamoDB transaction/TTL and S3 Object Lock capability checks;
-- OIDC/JWKS rotation, revoked membership and cross-tenant denial;
-- old fence/dispatch rejection and duplicate execution replay;
-- required-source failure and optional-source degraded publication;
-- pointer CAS race, S3 failure before publication and outbox replay;
-- no presigned URL for non-serving prefixes;
-- CDN private-origin, SPA rewrite, CSP and cache rollback;
-- CloudFront Free eligibility plus exact `ACTIVE` distribution/WAF binding;
-- Nginx and application rate-limit behavior;
-- plan policy, cost envelope and protected-resource replacement denial.
-
-### 20.2 Production smoke
-
-- static site returns the expected release ID over TLS;
-- S3 origin is not publicly readable;
-- API is unreachable at the VPS address/ports and healthy through Tunnel;
-- demo user authenticates with PKCE and resolves only the demo tenant;
-- one synthetic run publishes exactly one new immutable version/pointer;
-- serving redirect is short-lived and limited to the expected JSON;
-- logs, traces, state and artifacts contain no secret or synthetic record body;
-- previous API/frontend release can be restored within the documented window.
-
-## 21. Cost contract
-
-CnesData receives a USD 8 monthly operational envelope. Expected initial use is
-approximately USD 2-6 depending on Fargate jobs and stored data.
-
-Cost controls:
-
-- CloudFront Free plan and web origin below 5 GB;
-- one of the account's maximum three CloudFront Free-plan subscriptions, with
-  eligibility and `ACTIVE` status checked before cutover;
-- ECR generally below 2 GB;
-- one Fargate task, zero idle desired count, 100 task-hours maximum;
-- Step Functions Standard and 200 executions maximum;
-- Athena 5 GB/query and 100 GB/month;
-- DynamoDB on-demand maximum throughput;
-- short CloudWatch retention and no Container Insights;
-- no NAT Gateway, load balancer, RDS or multi-region resource;
-- monthly review for the first three months and re-baseline if the project
-  exceeds its envelope or aggregate forecast reaches USD 15.
-
-## 22. Definition of done
-
-- This specification is reviewed and its implementation plan is approved.
-- Required CND and AWS logical gates are green on integrated `develop`.
-- OpenTofu plan contains only approved resources and costs.
-- All production artifacts are immutable and traceable to one source SHA.
-- Static origin, API origin and AWS data resources are not publicly writable.
-- No long-lived AWS or GitHub credential exists on the VPS or in GitHub.
-- Synthetic portfolio data is clearly identified; municipal/local data paths
-  are absent.
-- Deploy, rollback, rate-limit, cost-freeze and recovery drills pass.
-- `cnesdata.vinisantana.com` and `api.cnesdata.vinisantana.com` satisfy their
-  health, TLS and isolation contracts.
-- The deployment makes no claim that DATASUS ingestion or legacy cutover is
-  complete before their governing gates pass.
-
-## 23. References
-
-- Amazon ECS private registry authentication:
-  <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html>
-- AWS Step Functions ECS integration:
-  <https://docs.aws.amazon.com/step-functions/latest/dg/connect-ecs.html>
-- Amazon DynamoDB on-demand maximum throughput:
-  <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode-max-throughput.html>
-- Amazon S3 Object Lock:
-  <https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html>
-- Amazon CloudFront Origin Access Control:
-  <https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html>
-- Amazon CloudFront flat-rate plan quotas:
-  <https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/flat-rate-pricing-plan.html>
-- AWS Pricing Plan Manager API:
-  <https://docs.aws.amazon.com/PricingPlanManager/latest/UserGuide/getting-started-pricingplanmanager-api.html>
+Release, rollback, limits, observability, recovery, acceptance, cost and
+completion requirements are in the
+[production operations design](2026-08-29-cnesdata-production-operations-design.md).

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -342,8 +342,9 @@ are never signed to the browser; no other prefix may be signed.
 
 The dashboard then makes a second `fetch` directly to the signed S3 URL with
 credentials omitted and without `Authorization`, `X-Tenant-Id`, cookies or any
-other custom request header. This production handoff replaces the AWS-014
-`307` route contract before promotion.
+other custom request header. Every `serving/` object has S3 `Cache-Control`
+metadata `private, no-store`, which the second response exposes. This production
+handoff replaces the AWS-014 `307` route contract before promotion.
 
 The data bucket CORS configuration permits exactly
 `https://cnesdata.vinisantana.com`, methods `GET` and `HEAD`, no custom request

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -386,9 +386,11 @@ verified in the [production operations design](2026-08-29-cnesdata-production-op
   EventBridge Scheduler, under the operations contract;
 - Linux/x86_64, initial size 0.25 vCPU and 0.5-1 GiB memory;
 - included 20 GB ephemeral storage unless measured otherwise;
-- maximum one concurrent unit task per environment, bounded recovery overlap,
-  and two-hour unit-task timeout;
-- maximum 100 combined unit and recovery task-hours per month;
+- semaphore-enforced maximum one concurrent unit task per environment;
+  recovery passes may overlap without a global recovery-concurrency ceiling;
+- two-hour unit-task timeout;
+- monitored monthly operating target: 100 task-hours counting every unit and
+  recovery task-hour;
 - no autoscaling and no Fargate Spot in the first release;
 - public subnets with an ephemeral public IPv4, no inbound security-group rule,
   and no NAT Gateway or load balancer;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -217,7 +217,7 @@ The container:
 - has CPU, memory, PID and log-size limits compatible with the KVM 2 host;
 - sets `AWS_CONFIG_FILE` to a read-only config and `AWS_PROFILE` to its named
   profile, whose `credential_process` invokes IAM Roles Anywhere
-  `aws_signing_helper credential-process`;
+  `aws_signing_helper credential-process --session-duration 3600`;
 - mounts read-only only that config plus the strictly necessary X.509 material
   and helper; the host-owned key is readable only by the fixed runtime UID;
 - accepts neither `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` or
@@ -445,8 +445,8 @@ VPS.
 
 - GitHub workflows assume repository/workflow-scoped OIDC roles.
 - The VPS API uses its named `AWS_CONFIG_FILE` profile and IAM Roles Anywhere
-  `aws_signing_helper credential-process`. Its output includes `Expiration`,
-  and boto3/botocore refreshes credentials automatically before expiration.
+  `aws_signing_helper credential-process --session-duration 3600`. Its output
+  includes `Expiration`, and boto3/botocore refreshes lazily on credential use.
 - Fargate uses task roles.
 - Runtime non-AWS secrets use SSM SecureString under
   `/personal/prod/cnesdata/runtime/` and the approved customer-managed KMS key.

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -361,6 +361,7 @@ InfluxDB backup bucket.
 
 The real-AWS acceptance gate proves retention and conflict behavior before any
 release claims WORM compliance. Emulator success alone is insufficient.
+Scheduled `recover-once` passes drain the transactional outbox under the operations contract.
 
 ## 11. Processing plane
 

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -382,7 +382,8 @@ verified in the [production operations design](2026-08-29-cnesdata-production-op
 ### 11.2 Fargate
 
 - one ECS cluster with no continuously running service;
-- tasks launched only by Step Functions;
+- unit tasks launched by Step Functions; separate `recover-once` tasks by
+  EventBridge Scheduler, under the operations contract;
 - Linux/x86_64, initial size 0.25 vCPU and 0.5-1 GiB memory;
 - included 20 GB ephemeral storage unless measured otherwise;
 - maximum one concurrent task and two-hour task timeout;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -1,0 +1,595 @@
+# CnesData Production Deployment Design
+
+**Date:** 2026-08-29  
+**Status:** Draft for repository review; architecture approved in design discussion  
+**Repository:** `VINIClUS/CnesData`  
+**Integration base:** `develop`  
+**Production domains:** `cnesdata.vinisantana.com`,
+`api.cnesdata.vinisantana.com`  
+**Primary AWS region:** `us-east-2`; global edge control plane (ACM,
+CloudFront-scoped WAF and Pricing Plan Manager endpoint): `us-east-1`
+
+## 1. Purpose
+
+Define the first cost-bounded production deployment of the target CnesData AWS
+profile. The frontend is served through CloudFront from a private S3 origin, the
+FastAPI control-plane/API runs on the personal Hostinger VPS, and data processing
+runs on demand in Step Functions Standard and ECS Fargate.
+
+This specification supplies the production-resource, identity, network,
+delivery, rollback and operations contract intentionally left out of the
+existing AWS Runtime Profile implementation plan.
+
+It does not authorize immediate deployment of the repository's current legacy
+Compose stack. PostgreSQL, MinIO, Keycloak and BigQuery remain implementation
+history and migration inputs only; none is provisioned in the target production
+profile.
+
+## 2. Governing designs and precedence
+
+This document composes, rather than replaces:
+
+- `2026-08-16-parquet-data-plane-orchestration-design.md`;
+- `2026-08-23-cnesdata-redesign-execution-design.md`;
+- `2026-08-28-cnesdata-phase2-readiness-and-adapter-hardening-design.md`;
+- `2026-08-23-cnesdata-aws-runtime-profile-implementation-plan.md`;
+- `2026-08-23-cnesdata-source-migration-cutover-implementation-plan.md`.
+
+Domain, manifest, publication, fencing, outbox, serving and tenant-isolation
+contracts in those documents take precedence over deployment convenience.
+
+Where examples in an application plan use `us-east-1`, this production
+deployment supplies `AWS_REGION=us-east-2`. Only ACM certificates and
+CloudFront-scoped WAF resources are created through the `us-east-1` provider;
+the global Pricing Plan Manager API is also invoked at its `us-east-1`
+endpoint.
+
+## 3. Release boundary and readiness gates
+
+### 3.1 Infrastructure may be planned when
+
+- CND-020 through CND-025 are integrated and the exact `develop` SHA passes the
+  Phase 2 gate;
+- the OpenTofu module can validate without application runtime resources;
+- shared state, KMS, GitHub OIDC and budget controls from
+  `personal-infra-live` exist;
+- the expected CnesData monthly base/max cost remains inside the USD 8 product
+  envelope and the aggregate base remains below USD 15.
+
+### 3.2 Runtime may be promoted when
+
+- AWS-010 through AWS-014 and the serial AWS acceptance gate are integrated on
+  a green `develop` SHA;
+- the produced API and processor images pass the existing CND/AWS contract
+  suites;
+- the target composition contains no runtime imports or configuration fallback
+  for PostgreSQL, MinIO, Keycloak or BigQuery;
+- one synthetic CNES vertical slice completes
+  `NORMALIZE -> RECONCILE -> MATERIALIZE` and publishes the expected serving
+  fixture;
+- Cognito/OIDC, tenant membership, signed serving and cross-tenant denial smoke
+  tests pass against real AWS resources;
+- rollback to the previous API digest, task definition and frontend entrypoint
+  has been rehearsed.
+
+### 3.3 Source enablement
+
+The first public deployment is a technical portfolio demo. It contains one
+demo tenant and versioned synthetic fixtures with no person, patient, employee
+or municipal production data.
+
+`CNES_NACIONAL` ingestion is disabled until CND-033 has a ratified official
+DATASUS bulk-distribution contract and the corresponding adapter passes its
+source contract and provenance tests. Enabling it is a separate release flag
+and plan. Local CNES, SIHD, BPA/SIA sources and the municipal Edge Agent are not
+connected to this environment.
+
+The project may not claim completion of the full legacy cutover until MIG-010
+through MIG-015 and their final local/AWS acceptance matrix are complete.
+
+## 4. Target topology
+
+```mermaid
+flowchart TB
+    Browser["Browser"] --> CF["Cloudflare DNS"]
+    CF --> CDN["CloudFront + private web S3"]
+    CF --> Tunnel["Cloudflare Tunnel"]
+    Tunnel --> API["FastAPI on Hostinger VPS"]
+    API --> Data["DynamoDB + private data S3"]
+    API --> SF["Step Functions Standard"]
+    SF --> ECS["Fargate processor"]
+    ECS --> Data
+```
+
+The browser never reaches the VPS for frontend assets. The API has no public
+origin port. Fargate has no load balancer and no idle service.
+
+## 5. Component ownership
+
+| Component | Owner | Responsibility |
+|---|---|---|
+| Web S3, CloudFront, ACM, dedicated WAF | CnesData OpenTofu | Static SPA distribution |
+| CloudFront Free subscription | CnesData release contract | Exact distribution/WAF binding |
+| DynamoDB control plane | CnesData OpenTofu | Canonical multi-tenant state |
+| Data and audit S3 | CnesData OpenTofu | Immutable datasets and audit |
+| Step Functions/ECS/ECR | CnesData OpenTofu | On-demand processing |
+| Cognito | CnesData OpenTofu | Selected generic OIDC issuer |
+| Athena workgroup | CnesData OpenTofu | Manual bounded analytics |
+| Tunnel/API DNS | `personal-infra-live` | Shared edge and routing |
+| VPS baseline/Nginx/deployer | `infra-ansible` via live inventory | Host runtime boundary |
+| Application images/manifests | CnesData CI | Tested immutable release |
+
+No two OpenTofu states manage the same resource. Product outputs expose only
+the CloudFront distribution domain, API loopback contract and required DNS
+validation values to the shared edge change.
+
+## 6. Static frontend
+
+### 6.1 Origin and distribution
+
+- one private S3 web bucket in `us-east-2`;
+- S3 Block Public Access enabled at account and bucket level;
+- CloudFront Origin Access Control with a bucket policy limited to the exact
+  distribution;
+- CloudFront Free flat-rate plan, with no automatic upgrade;
+- one dedicated, CloudFront-scoped AWS WAF web ACL in `us-east-1`, required by
+  that plan and not shared with LimnoPulse;
+- ACM certificate in `us-east-1`, validated through Cloudflare DNS;
+- `cnesdata.vinisantana.com` as a DNS-only Cloudflare CNAME to CloudFront;
+- TLS redirect and a modern security policy;
+- compression enabled;
+- no S3 website endpoint and no public object ACL.
+
+Before DNS cutover, the account-level gate proves Free-plan eligibility and
+available quota. A separate manual, idempotent Pricing Plan Manager API step in
+`us-east-1` binds this exact distribution and WAF to an exact `FREE`
+subscription, then verifies `ACTIVE`. The current AWS provider has no supported
+subscription resource, so this step is outside OpenTofu state but inside the
+signed deployment evidence and subsequent drift checks. Failure stops rollout;
+it never selects pay-as-you-go or a paid tier implicitly.
+
+### 6.2 Release layout and cache policy
+
+The dashboard build is deterministic and contains no secret. It receives only
+public configuration such as API base URL, Cognito issuer/client ID and release
+ID.
+
+Deployment order:
+
+1. upload hashed assets without deleting prior releases;
+2. verify checksums and content types;
+3. upload the new root entrypoint last;
+4. invalidate `/index.html` and other un-hashed entrypoints only;
+5. run unauthenticated load and authenticated contract smoke tests.
+
+Cache headers:
+
+- hashed assets: `public,max-age=31536000,immutable`;
+- `index.html`, manifest and service worker: `no-cache` or a bounded equivalent;
+- error responses: not cached when they may hide a fixed deployment.
+
+S3 versioning preserves entrypoint rollback. A lifecycle retains recent
+releases within the CloudFront Free plan's 5 GB origin allowance and removes
+unreferenced noncurrent objects only after the rollback window.
+
+SPA routes use a small deterministic CloudFront Function rewrite to
+`/index.html`; it must not rewrite API paths, assets with extensions or known
+metadata files.
+
+### 6.3 Security headers
+
+CloudFront applies HSTS after domain validation, `X-Content-Type-Options`, a
+frame policy, `Referrer-Policy`, `Permissions-Policy` and a CSP limited to the
+static origin, Cognito endpoints, the API hostname and required S3 signed-serving
+downloads. CSP starts in report-only during validation and becomes enforcing
+before production acceptance.
+
+## 7. API on the VPS
+
+The API image is built from `apps/central_api` and published privately to GHCR.
+Production pulls use the ephemeral workflow `GITHUB_TOKEN`; no GitHub PAT is
+stored on the host.
+
+The container:
+
+- runs as a fixed non-root UID;
+- has a read-only root filesystem, bounded tmpfs and no Linux capabilities;
+- publishes one port to `127.0.0.1` only;
+- has CPU, memory, PID and log-size limits compatible with the KVM 2 host;
+- mounts only public configuration and the CnesData temporary AWS credential
+  directory read-only, so atomic host-side refreshes remain visible;
+- has no Docker socket, host network or access to LimnoPulse volumes/networks;
+- reports liveness separately from readiness;
+- emits redacted JSON stdout and optional loopback metrics.
+
+Nginx exposes it only through `api.cnesdata.vinisantana.com` on the shared
+Tunnel. It restores the Cloudflare client address only from the local tunnel,
+adds request IDs and applies general plus expensive-job rate limits.
+
+The application remains the authority for:
+
+- membership and tenant authorization;
+- per-user/tenant job quotas;
+- idempotency keys;
+- maximum concurrent and monthly demo jobs;
+- signed-serving allowlists;
+- audit events for denied and accepted mutations.
+
+## 8. Authentication and demo tenancy
+
+Production sets `PROFILE=aws` and `AUTH_MODE=oidc`. Cognito Lite is the selected
+issuer preset, but application/domain interfaces remain provider-neutral.
+
+The deployment creates:
+
+- one User Pool;
+- one public SPA client using Authorization Code + PKCE and no client secret;
+- exact callback/logout URLs for the production domain;
+- email-based development/demo accounts created out of band;
+- no SMS MFA, paid SMS, social IdP or machine-to-machine client.
+
+Tokens establish issuer, audience and subject only. Tenant membership is
+resolved server-side through canonical DynamoDB keys. A tenant claim, header,
+URL parameter, object key or GSI candidate can never grant access without the
+base membership check.
+
+One demo tenant is seeded idempotently. The seed operation records IDs and
+hashes only, can never overwrite an existing non-demo tenant and has no bulk
+delete path.
+
+## 9. DynamoDB
+
+One on-demand control-plane table per environment implements the accepted
+single-table layout.
+
+Required deployment controls:
+
+- `PAY_PER_REQUEST` billing;
+- PITR enabled for 35 days;
+- AWS-owned table encryption or the approved shared KMS key where the access
+  policy remains simple and cost-neutral;
+- TTL enabled only for garbage collection;
+- maximum on-demand throughput initially capped at 100 reads/second and 25
+  writes/second for the table and every GSI;
+- Contributor Insights and global tables disabled;
+- deletion protection and lifecycle protection;
+- alarms for throttles, system errors and sustained consumption.
+
+The API and processor roles receive only their required table/index actions.
+No GitHub role has routine data-plane write access; demo seeding uses a separate
+manual operation role.
+
+## 10. Data, serving and audit buckets
+
+### 10.1 Data bucket
+
+One private versioned data bucket stores canonical prefixes:
+
+```text
+raw/
+normalized/
+reconciliation/
+serving/
+tmp/
+```
+
+It enforces TLS, blocks public access, uses bucket-owner-enforced ownership,
+aborts incomplete multipart uploads and applies retention/lifecycle by prefix.
+Objects are immutable by key and verified by SHA-256. `tmp/` expires after its
+bounded recovery window; published raw, reconciliation and serving history is
+not deleted by a deployment workflow.
+
+The API may issue a short-lived signed GET only for exact authorized
+`serving/<tenant>/<run_id>/...` objects selected by the active
+`DatasetPointer`. Raw, normalized, reconciliation, temporary and audit keys are
+never signed to the browser. The initial signed URL TTL is 300 seconds.
+
+### 10.2 Audit bucket
+
+A separate versioned bucket is created with Object Lock enabled at creation.
+The application contract uses COMPLIANCE retention for its append-only audit
+objects and an initial 365-day retention period, matching the accepted
+`S3ObjectLockAuditSink` behavior. This is distinct from the Governance-mode
+InfluxDB backup bucket.
+
+The real-AWS acceptance gate proves retention and conflict behavior before any
+release claims WORM compliance. Emulator success alone is insufficient.
+
+## 11. Processing plane
+
+### 11.1 Step Functions
+
+- Standard workflows only;
+- Inline Map only; Distributed Map is rejected;
+- exactly the canonical `NORMALIZE`, `RECONCILE`, `MATERIALIZE` wave sequence;
+- IDs-only payloads;
+- bounded retries with jitter and explicit catch/terminal states;
+- execution names derived from canonical dispatch IDs;
+- CloudWatch execution logging without data payloads;
+- maximum 200 demo executions per month, enforced by the application/control
+  plane rather than assumed from billing alerts.
+
+### 11.2 Fargate
+
+- one ECS cluster with no continuously running service;
+- tasks launched only by Step Functions;
+- Linux/x86_64, initial size 0.25 vCPU and 0.5-1 GiB memory;
+- included 20 GB ephemeral storage unless measured otherwise;
+- maximum one concurrent task and two-hour task timeout;
+- maximum 100 task-hours per month;
+- no autoscaling and no Fargate Spot in the first release;
+- public subnets with an ephemeral public IPv4, no inbound security-group rule,
+  and no NAT Gateway or load balancer;
+- free S3 and DynamoDB gateway endpoints where compatible; other required AWS
+  APIs use TLS over the Internet gateway;
+- task execution role limited to ECR pull and CloudWatch logs;
+- task role limited to exact DynamoDB/S3/Step Functions application actions.
+
+The network design deliberately trades an ephemeral public IPv4 during task
+execution for avoiding a NAT Gateway whose fixed monthly cost would exceed the
+entire project budget. The task has no listening service or inbound route.
+
+### 11.3 ECR
+
+Only the Fargate processor requires ECR. CI builds once, identifies the GHCR
+digest and promotes byte-identical content to a private ECR repository in
+`us-east-2`.
+
+Lifecycle policy:
+
+- retain at most five production digests for 30 days;
+- expire untagged images after seven days;
+- keep the currently deployed and immediately previous digest regardless of a
+  routine cleanup calculation;
+- scan on push and block promotion on a reviewed severity policy.
+
+The VPS API continues to use GHCR. ECR is not a general duplicate registry.
+
+## 12. Athena
+
+Athena is an operator-only analytical path, never an API request dependency.
+
+- one workgroup with enforced configuration;
+- 5 GB bytes-scanned cutoff per query;
+- 100 GB logical monthly scan budget, approximately USD 0.50 at USD 5/TB;
+- encrypted, lifecycle-managed result prefix;
+- no scheduled queries, Spark, provisioned capacity or browser credentials;
+- Parquet partition pruning required in runbooks/examples;
+- application roles cannot start Athena queries.
+
+## 13. IAM and secrets
+
+No static AWS access key is accepted by application settings, GitHub or the
+VPS.
+
+- GitHub workflows assume repository/workflow-scoped OIDC roles.
+- The VPS API obtains short-lived credentials through its CnesData Roles
+  Anywhere profile and host-side credential renewer.
+- Fargate uses task roles.
+- Runtime non-AWS secrets use SSM SecureString under
+  `/personal/prod/cnesdata/runtime/` and the approved customer-managed KMS key.
+- Containers receive temporary rendered files from `/run`; no persistent
+  `.env` file is created.
+- Cognito identifiers, bucket names and API URLs are configuration, not secret
+  values.
+
+IAM policies distinguish API, processor, task execution, GitHub plan, GitHub
+apply, demo seed, audit verification and human break-glass duties. Wildcard
+resource permissions require an AWS API that cannot be narrowed further and a
+documented condition boundary.
+
+## 14. OpenTofu design
+
+Product infrastructure lives under an application-owned OpenTofu root and uses
+the private shared S3 backend key `cnesdata/prod/opentofu.tfstate` with native
+locking.
+
+Modules separate:
+
+- static web/CDN/certificate;
+- identity;
+- control plane;
+- data/audit storage;
+- processing/network/ECR;
+- Athena;
+- logging/alarms/IAM.
+
+Every resource carries `Project=cnesdata`, `Environment=prod`,
+`ManagedBy=opentofu`, `Owner=vinisantana`. The plan fails on NAT Gateway, ALB,
+RDS/Aurora, Redshift, OpenSearch, ElastiCache, Global Tables, multi-region
+replication or an unapproved paid plan.
+
+There is no destroy workflow. Protected buckets, DynamoDB, KMS references and
+state use lifecycle/policy safeguards. A replacement plan for any protected
+resource fails before an apply artifact is issued.
+
+## 15. CI/CD
+
+### 15.1 Continuous integration
+
+Pull requests to `develop` run the existing locked Python/CND/AWS gates plus:
+
+- dashboard lint, typecheck, tests and deterministic production build;
+- API and processor image build tests;
+- OCI vulnerability scan and SBOM generation;
+- OpenTofu format/validate/test and provider-lock verification;
+- policy and cost-manifest checks;
+- release-manifest schema and secret-scan tests.
+
+Untrusted pull-request code runs only on GitHub-hosted runners and receives no
+AWS, Cloudflare or SSH credential.
+
+### 15.2 Release creation
+
+A candidate release is bound to one green `develop` commit and records:
+
+- source SHA and test run IDs;
+- API GHCR digest;
+- processor GHCR and promoted ECR digests;
+- dashboard artifact checksum;
+- Compose/config checksum;
+- OpenTofu/provider lock digest;
+- SBOM checksums and schema version.
+
+Mutable tags may aid discovery but are never deployment authority.
+
+### 15.3 Infrastructure plan/apply
+
+Plan and apply are separate manual workflows. Apply downloads and verifies the
+exact unexpired binary plan; it does not replan. GitHub OIDC supplies temporary
+AWS credentials. The paid Actions spending limit is USD 0.
+
+### 15.4 Application promotion
+
+Production promotion is `workflow_dispatch` only. It verifies that the release
+SHA is contained in `develop`, all required checks succeeded and the cost-freeze
+marker is absent.
+
+Order:
+
+1. promote/verify the processor digest in ECR;
+2. update the inactive API candidate on the VPS;
+3. pass local and tunneled health/authorization smoke tests;
+4. switch Nginx to the candidate;
+5. publish frontend assets and entrypoint;
+6. run the synthetic vertical slice and serving test;
+7. record redacted evidence and retain the previous release.
+
+No production deployment occurs automatically after merge.
+
+## 16. Rollback
+
+- **API:** restore the previous Nginx upstream and already-pulled GHCR digest.
+- **Frontend:** restore the prior versioned entrypoint and invalidate it.
+- **Processor:** register/select the previous task definition/digest for new
+  dispatches; active Standard executions continue with the definition they
+  started unless the runbook determines cancellation is safe.
+- **State machine:** revert only new-execution routing; do not edit an active
+  execution or DynamoDB record manually.
+- **DynamoDB/S3:** application releases never roll data backward or delete
+  published versions. Compatibility changes are expand/contract and additive.
+- **Infrastructure:** failed apply requires diagnosis and a new reviewed plan;
+  protected-resource restore is not an automatic rollback step.
+
+## 17. Rate limiting and abuse containment
+
+- Cloudflare Free rule protects the most sensitive public job/auth surface.
+- Nginx enforces IP-based general and expensive-mutation zones.
+- The API enforces tenant/user/idempotency quotas and maximum 200 jobs,
+  100 task-hours and one concurrent processor task per month/environment.
+- DynamoDB maximum throughput, Step Functions bounded retries and Athena bytes
+  cutoffs contain downstream amplification.
+- Requests beyond product quota fail with `429` or the documented quota error
+  before starting Step Functions or Athena.
+- A USD 15 aggregate budget action freezes new Fargate, Step Functions and
+  Athena starts through automation roles while preserving reads and backups.
+
+## 18. Observability and SLOs
+
+Initial internal targets:
+
+- static frontend availability 99.9%;
+- API availability 99.5%;
+- eligible processing-job success 99%;
+- routine API p95 below two seconds;
+- routine deployment interruption at most 60 seconds.
+
+Grafana Alloy collects VPS/API/Nginx/Tunnel telemetry without Docker-socket
+access. CloudWatch owns DynamoDB, Step Functions, ECS, S3 and Athena alarms.
+Fargate logs retain seven days. High-cardinality tenant, run, object-key and
+user labels are forbidden.
+
+Required alarms include API/tunnel health, DynamoDB throttles/errors, failed or
+timed-out Step Functions executions, ECS task failures, audit/outbox backlog,
+S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
+
+## 19. Backup and recovery
+
+- DynamoDB PITR: 35 days;
+- S3 data/audit: versioning and prefix-specific lifecycle/Object Lock;
+- static entrypoint: versioned rollback;
+- infrastructure state: encrypted/versioned S3 backend;
+- no cross-region replica in phase 1;
+- quarterly recovery exercise reconstructs the API and proves one synthetic
+  dataset pointer/serving object without altering production data;
+- destructive PITR export/restore requires a separately approved runbook run.
+
+## 20. Test and acceptance matrix
+
+### 20.1 Pre-production tests
+
+- all CND adapter and AWS-014 matrices on the exact release SHA;
+- real-AWS DynamoDB transaction/TTL and S3 Object Lock capability checks;
+- OIDC/JWKS rotation, revoked membership and cross-tenant denial;
+- old fence/dispatch rejection and duplicate execution replay;
+- required-source failure and optional-source degraded publication;
+- pointer CAS race, S3 failure before publication and outbox replay;
+- no presigned URL for non-serving prefixes;
+- CDN private-origin, SPA rewrite, CSP and cache rollback;
+- CloudFront Free eligibility plus exact `ACTIVE` distribution/WAF binding;
+- Nginx and application rate-limit behavior;
+- plan policy, cost envelope and protected-resource replacement denial.
+
+### 20.2 Production smoke
+
+- static site returns the expected release ID over TLS;
+- S3 origin is not publicly readable;
+- API is unreachable at the VPS address/ports and healthy through Tunnel;
+- demo user authenticates with PKCE and resolves only the demo tenant;
+- one synthetic run publishes exactly one new immutable version/pointer;
+- serving redirect is short-lived and limited to the expected JSON;
+- logs, traces, state and artifacts contain no secret or synthetic record body;
+- previous API/frontend release can be restored within the documented window.
+
+## 21. Cost contract
+
+CnesData receives a USD 8 monthly operational envelope. Expected initial use is
+approximately USD 2-6 depending on Fargate jobs and stored data.
+
+Cost controls:
+
+- CloudFront Free plan and web origin below 5 GB;
+- one of the account's maximum three CloudFront Free-plan subscriptions, with
+  eligibility and `ACTIVE` status checked before cutover;
+- ECR generally below 2 GB;
+- one Fargate task, zero idle desired count, 100 task-hours maximum;
+- Step Functions Standard and 200 executions maximum;
+- Athena 5 GB/query and 100 GB/month;
+- DynamoDB on-demand maximum throughput;
+- short CloudWatch retention and no Container Insights;
+- no NAT Gateway, load balancer, RDS or multi-region resource;
+- monthly review for the first three months and re-baseline if the project
+  exceeds its envelope or aggregate forecast reaches USD 15.
+
+## 22. Definition of done
+
+- This specification is reviewed and its implementation plan is approved.
+- Required CND and AWS logical gates are green on integrated `develop`.
+- OpenTofu plan contains only approved resources and costs.
+- All production artifacts are immutable and traceable to one source SHA.
+- Static origin, API origin and AWS data resources are not publicly writable.
+- No long-lived AWS or GitHub credential exists on the VPS or in GitHub.
+- Synthetic portfolio data is clearly identified; municipal/local data paths
+  are absent.
+- Deploy, rollback, rate-limit, cost-freeze and recovery drills pass.
+- `cnesdata.vinisantana.com` and `api.cnesdata.vinisantana.com` satisfy their
+  health, TLS and isolation contracts.
+- The deployment makes no claim that DATASUS ingestion or legacy cutover is
+  complete before their governing gates pass.
+
+## 23. References
+
+- Amazon ECS private registry authentication:
+  <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html>
+- AWS Step Functions ECS integration:
+  <https://docs.aws.amazon.com/step-functions/latest/dg/connect-ecs.html>
+- Amazon DynamoDB on-demand maximum throughput:
+  <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode-max-throughput.html>
+- Amazon S3 Object Lock:
+  <https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html>
+- Amazon CloudFront Origin Access Control:
+  <https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html>
+- Amazon CloudFront flat-rate plan quotas:
+  <https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/flat-rate-pricing-plan.html>
+- AWS Pricing Plan Manager API:
+  <https://docs.aws.amazon.com/PricingPlanManager/latest/UserGuide/getting-started-pricingplanmanager-api.html>

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -160,14 +160,17 @@ it never selects pay-as-you-go or a paid tier implicitly.
 ### 6.2 Release layout and cache policy
 
 The dashboard build is deterministic and contains no secret. It receives only
-public configuration such as `API_BASE_URL=https://api.cnesdata.vinisantana.com`,
-Cognito issuer/client ID and release ID. The OpenTofu output and dashboard
-configuration use that exact absolute API base URL.
+public configuration such as
+`VITE_API_BASE_URL=https://api.cnesdata.vinisantana.com/api/v1`, Cognito
+issuer/client ID and release ID. The OpenTofu output maps that exact value to
+the dashboard build variable `VITE_API_BASE_URL`.
 
 Every dashboard API call, including `auth/me` and activation, uses one
-authenticated client bound to `https://api.cnesdata.vinisantana.com`. Production
-forbids relative `/api` requests. That client sends a bearer token only to the
-API origin and sends `X-Tenant-Id` only for tenant-scoped calls.
+authenticated client bound to
+`https://api.cnesdata.vinisantana.com/api/v1`. Production forbids relative
+`/api` requests. That client sends a bearer token only to the API origin
+`https://api.cnesdata.vinisantana.com` and sends `X-Tenant-Id` only for
+tenant-scoped calls.
 
 Deployment order:
 

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -373,12 +373,12 @@ release claims WORM compliance. Emulator success alone is insufficient.
 - bounded retries with jitter and explicit catch/terminal states;
 - execution names derived from canonical dispatch IDs;
 - CloudWatch execution logging without data payloads;
-- maximum 200 demo executions per month, enforced by the application/control
-  plane rather than assumed from billing alerts.
+- maximum 200 demo execution attempts monthly, enforced by the control plane.
 
 Step Functions uses a separate execution role assumed by `states.amazonaws.com`;
-its ECS, EventBridge and `iam:PassRole` permission boundary is operationally
-verified in the [production operations design](2026-08-29-cnesdata-production-operations-design.md).
+its ECS, EventBridge, CloudWatch Logs delivery and `iam:PassRole` boundaries,
+including the AWS-required wildcard Logs actions, are verified in the
+[production operations design](2026-08-29-cnesdata-production-operations-design.md).
 
 ### 11.2 Fargate
 

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -386,9 +386,9 @@ verified in the [production operations design](2026-08-29-cnesdata-production-op
   EventBridge Scheduler, under the operations contract;
 - Linux/x86_64, initial size 0.25 vCPU and 0.5-1 GiB memory;
 - included 20 GB ephemeral storage unless measured otherwise;
-- maximum one concurrent unit task plus at most one `recover-once` overlap, and
-  two-hour unit-task timeout;
-- maximum 100 task-hours per month;
+- maximum one concurrent unit task per environment, bounded recovery overlap,
+  and two-hour unit-task timeout;
+- maximum 100 combined unit and recovery task-hours per month;
 - no autoscaling and no Fargate Spot in the first release;
 - public subnets with an ephemeral public IPv4, no inbound security-group rule,
   and no NAT Gateway or load balancer;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -389,7 +389,7 @@ including the AWS-required wildcard Logs actions, are verified in the
 - included 20 GB ephemeral storage unless measured otherwise;
 - semaphore-enforced maximum one concurrent unit task per environment;
   recovery passes may overlap without a global recovery-concurrency ceiling;
-- two-hour unit-task timeout;
+- unit-task hard timeout no later than its non-renewable lease expiry;
 - monitored monthly target: 100 task-hours counting unit, recovery and audit
   dispatcher tasks;
 - no autoscaling and no Fargate Spot in the first release;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -306,9 +306,9 @@ Required deployment controls:
 - deletion protection and lifecycle protection;
 - alarms for throttles, system errors and sustained consumption.
 
-API/processor roles receive only required table/index actions. GitHub roles have no
-direct routine writes; promotion may assume one release-tagged fence operator with
-conditional get/update on the exact gate item. Demo seed uses another manual role.
+API/processor roles receive only required table/index actions. GitHub has no direct
+writes; promotion assumes a release-tagged operator with conditional get/update on
+the separate fence item, never the semaphore item. Demo seed uses another role.
 
 ## 10. Data, serving and audit buckets
 

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -447,6 +447,7 @@ VPS.
 - The VPS API uses its named `AWS_CONFIG_FILE` profile and IAM Roles Anywhere
   `aws_signing_helper credential-process --session-duration 3600`. Its output
   includes `Expiration`, and boto3/botocore refreshes lazily on credential use.
+- API AWS composition omits the audit sink; only the dispatcher initializes it.
 - Fargate uses task roles.
 - Runtime non-AWS secrets use SSM SecureString under
   `/personal/prod/cnesdata/runtime/` and the approved customer-managed KMS key.

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -361,7 +361,7 @@ InfluxDB backup bucket.
 
 The real-AWS acceptance gate proves retention and conflict behavior before any
 release claims WORM compliance. Emulator success alone is insufficient.
-Scheduled `recover-once` passes drain the transactional outbox under the operations contract.
+A dedicated scheduled dispatcher drains the transactional outbox under the operations contract.
 
 ## 11. Processing plane
 
@@ -384,15 +384,15 @@ including the AWS-required wildcard Logs actions, are verified in the
 ### 11.2 Fargate
 
 - one ECS cluster with no continuously running service;
-- unit tasks launched by Step Functions; separate `recover-once` tasks by
-  EventBridge Scheduler, under the operations contract;
+- unit tasks launch by Step Functions; separate recovery/audit-dispatch tasks
+  launch by EventBridge Scheduler under the operations contract;
 - Linux/x86_64, initial size 0.25 vCPU and 0.5-1 GiB memory;
 - included 20 GB ephemeral storage unless measured otherwise;
 - semaphore-enforced maximum one concurrent unit task per environment;
   recovery passes may overlap without a global recovery-concurrency ceiling;
 - two-hour unit-task timeout;
-- monitored monthly operating target: 100 task-hours counting every unit and
-  recovery task-hour;
+- monitored monthly target: 100 task-hours counting unit, recovery and audit
+  dispatcher tasks;
 - no autoscaling and no Fargate Spot in the first release;
 - public subnets with an ephemeral public IPv4, no inbound security-group rule,
   and no NAT Gateway or load balancer;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -375,6 +375,10 @@ release claims WORM compliance. Emulator success alone is insufficient.
 - maximum 200 demo executions per month, enforced by the application/control
   plane rather than assumed from billing alerts.
 
+Step Functions uses a separate execution role assumed by `states.amazonaws.com`;
+its ECS, EventBridge and `iam:PassRole` permission boundary is operationally
+verified in the [production operations design](2026-08-29-cnesdata-production-operations-design.md).
+
 ### 11.2 Fargate
 
 - one ECS cluster with no continuously running service;
@@ -445,6 +449,13 @@ VPS.
   `.env` file is created.
 - Cognito identifiers, bucket names and API URLs are configuration, not secret
   values.
+
+OpenTofu provisions a `us-east-2` Roles Anywhere trust anchor from an external,
+offline CA public PEM and a profile; AWS Private CA is prohibited by the cost
+contract. Its role trusts `rolesanywhere.amazonaws.com` for `sts:AssumeRole`,
+`sts:TagSession` and `sts:SetSourceIdentity` with `SourceArn` and X.509 identity
+conditions. The CA private key and API/VPS leaf credentials never enter the
+repository or OpenTofu state; issuance, revocation and recovery are operational.
 
 IAM policies distinguish API, processor, task execution, GitHub plan, GitHub
 apply, demo seed, audit verification and human break-glass duties. Wildcard

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -219,7 +219,7 @@ The container:
   `credential_process` invokes IAM Roles Anywhere
   `aws_signing_helper credential-process`;
 - mounts read-only only that config plus the strictly necessary X.509 material
-  and helper, with minimum permissions;
+  and helper; the host-owned key is readable only by the fixed runtime UID;
 - accepts neither `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` or
   `AWS_SESSION_TOKEN` nor shared static credentials;
 - has no Docker socket, host network or access to LimnoPulse volumes/networks;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -306,9 +306,9 @@ Required deployment controls:
 - deletion protection and lifecycle protection;
 - alarms for throttles, system errors and sustained consumption.
 
-The API and processor roles receive only their required table/index actions.
-No GitHub role has routine data-plane write access; demo seeding uses a separate
-manual operation role.
+API/processor roles receive only required table/index actions. GitHub roles have no
+direct routine writes; promotion may assume one release-tagged fence operator with
+conditional get/update on the exact gate item. Demo seed uses another manual role.
 
 ## 10. Data, serving and audit buckets
 
@@ -463,10 +463,10 @@ contract. Its role trusts `rolesanywhere.amazonaws.com` for `sts:AssumeRole`,
 conditions. The CA private key and API/VPS leaf credentials never enter the
 repository or OpenTofu state; issuance, revocation and recovery are operational.
 
-IAM policies distinguish API, processor, task execution, GitHub plan, GitHub
-apply, demo seed, audit verification and human break-glass duties. Wildcard
-resource permissions require an AWS API that cannot be narrowed further and a
-documented condition boundary.
+IAM policies distinguish API, processor, task execution, GitHub plan/apply,
+release-tagged fence operator, demo seed, audit verification and break-glass duties.
+Wildcard permissions require an AWS API that cannot be narrowed and a documented
+condition boundary.
 
 ## 14. OpenTofu design
 

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -160,8 +160,14 @@ it never selects pay-as-you-go or a paid tier implicitly.
 ### 6.2 Release layout and cache policy
 
 The dashboard build is deterministic and contains no secret. It receives only
-public configuration such as API base URL, Cognito issuer/client ID and release
-ID.
+public configuration such as `API_BASE_URL=https://api.cnesdata.vinisantana.com`,
+Cognito issuer/client ID and release ID. The OpenTofu output and dashboard
+configuration use that exact absolute API base URL.
+
+Every dashboard API call, including `auth/me` and activation, uses one
+authenticated client bound to `https://api.cnesdata.vinisantana.com`. Production
+forbids relative `/api` requests. That client sends a bearer token only to the
+API origin and sends `X-Tenant-Id` only for tenant-scoped calls.
 
 Deployment order:
 
@@ -250,6 +256,9 @@ The deployment creates:
   scopes;
 - one resource server with identifier `https://api.cnesdata.vinisantana.com`
   and one custom `api.access` scope;
+- one collision-safe AWS-managed prefix domain for the User Pool, generated
+  from the production environment and a unique suffix, with no custom Cognito
+  domain, certificate or DNS resource;
 - exact callback/logout URLs for the production domain;
 - email-based development/demo accounts created out of band;
 - no SMS MFA, paid SMS, social IdP or machine-to-machine client.
@@ -261,6 +270,12 @@ The resulting access token contains
 `aud=https://api.cnesdata.vinisantana.com`. Production config sets
 `OIDC_AUDIENCE=https://api.cnesdata.vinisantana.com`. The dashboard continues
 to send the `access_token`; the verifier remains provider-neutral.
+
+Authorization Code + PKCE requires the AWS-managed prefix domain. Its public
+dashboard configuration and OpenTofu outputs include `COGNITO_DOMAIN` plus the
+absolute `COGNITO_AUTHORIZE_URL`, `COGNITO_TOKEN_URL` and `COGNITO_LOGOUT_URL`
+for `/oauth2/authorize`, `/oauth2/token` and `/logout`. Cognito Lite uses these
+standard endpoints without depending on managed login v2 branding or features.
 
 Tokens establish issuer, audience and subject only. Tenant membership is
 resolved server-side through canonical DynamoDB keys. A tenant claim, header,

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -386,7 +386,8 @@ verified in the [production operations design](2026-08-29-cnesdata-production-op
   EventBridge Scheduler, under the operations contract;
 - Linux/x86_64, initial size 0.25 vCPU and 0.5-1 GiB memory;
 - included 20 GB ephemeral storage unless measured otherwise;
-- maximum one concurrent task and two-hour task timeout;
+- maximum one concurrent unit task, recovery overlap permitted, and two-hour
+  unit-task timeout;
 - maximum 100 task-hours per month;
 - no autoscaling and no Fargate Spot in the first release;
 - public subnets with an ephemeral public IPv4, no inbound security-group rule,

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
@@ -39,6 +39,14 @@ This document composes, rather than replaces:
 Domain, manifest, publication, fencing, outbox, serving and tenant-isolation
 contracts in those documents take precedence over deployment convenience.
 
+The following production AWS-012 override is binding. The generic AWS-012
+fixture/validator with `AssignPublicIp=DISABLED` does not govern this profile.
+Before a SHA can pass AWS-012, `validate_state_machine` must validate
+`AssignPublicIp=ENABLED`, the exact configured public subnet IDs and security
+group, zero security-group ingress, `FARGATE` launch type, maximum concurrency
+of one, and no NAT Gateway or ALB. Implementing this delta is a mandatory gate
+for the production profile.
+
 Where examples in an application plan use `us-east-1`, this production
 deployment supplies `AWS_REGION=us-east-2`. Only ACM certificates and
 CloudFront-scoped WAF resources are created through the `us-east-1` provider;
@@ -300,10 +308,18 @@ Objects are immutable by key and verified by SHA-256. `tmp/` expires after its
 bounded recovery window; published raw, reconciliation and serving history is
 not deleted by a deployment workflow.
 
-The API may issue a short-lived signed GET only for exact authorized
-`serving/<tenant>/<run_id>/...` objects selected by the active
-`DatasetPointer`. Raw, normalized, reconciliation, temporary and audit keys are
-never signed to the browser. The initial signed URL TTL is 300 seconds.
+The first API call remains authenticated and tenant-authorized with
+`X-Tenant-Id`. It returns `200` with `Cache-Control: private, no-store` and a
+minimal envelope containing a signed URL for an exact authorized
+`serving/<tenant>/<run_id>/...` object selected by the active `DatasetPointer`,
+`version_id` and `expires_in=300`. The envelope exposes neither tenant nor
+object key. Raw, normalized, reconciliation, temporary and audit keys are
+never signed to the browser.
+
+The dashboard then makes a second `fetch` directly to the signed S3 URL with
+credentials omitted and without `Authorization`, `X-Tenant-Id`, cookies or any
+other custom request header. This production handoff replaces the AWS-014
+`307` route contract before promotion.
 
 The data bucket CORS configuration permits exactly
 `https://cnesdata.vinisantana.com`, methods `GET` and `HEAD`, no custom request
@@ -350,6 +366,12 @@ release claims WORM compliance. Emulator success alone is insufficient.
   APIs use TLS over the Internet gateway;
 - task execution role limited to ECR pull and CloudWatch logs;
 - task role limited to exact DynamoDB/S3/Step Functions application actions.
+
+For this production profile, `validate_state_machine` accepts
+`AssignPublicIp=ENABLED` only with the exact configured public subnet IDs and
+security group, zero ingress, `FARGATE`, maximum concurrency one, and no NAT
+Gateway or ALB. It rejects `DISABLED`, subnet/security-group drift, inbound
+rules and every incompatible launch or network configuration.
 
 The network design deliberately trades an ephemeral public IPv4 during task
 execution for avoiding a NAT Gateway whose fixed monthly cost would exceed the

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -205,8 +205,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   wraps; poison stays pending/retries without starvation. Alarm/exit is nonzero.
 - Recovery role has control-plane read/write; `states:StartExecution` and
   `states:DescribeStateMachine` on the exact machine, `states:DescribeExecution`
-  and `states:StopExecution` on executions, plus ECS liveness. The Roles Anywhere API
-  role gets start/describe-machine on that machine and describe/stop on its executions.
+  and `states:StopExecution` plus ECS liveness. API gets exact-machine start/describe,
+  execution describe/stop and data-bucket `serving/*` `s3:GetObject` for stat/browser reads.
   Scheduler trusts only `scheduler.amazonaws.com` with exact source account/ARN, runs
   revisions and passes its task/execution roles. Dispatch Scheduler scope is equivalent
   only for dispatch revisions. Both use public subnets, zero-ingress groups,
@@ -401,9 +401,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   ceiling. Every unit, recovery and audit-dispatch task-hour counts toward the
   monitored 100-hour target, not a pre-launch API limit;
 - one synthetic run publishes exactly one new immutable version/pointer;
-- the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
-  with `Cache-Control: private, no-store` and only `url`, `version_id` and
-  `expires_in=300`, with no separate tenant or object-key field;
+- the authenticated tenant-authorized call first completes the serving-key metadata stat;
+  with `X-Tenant-Id` it returns `200`, `Cache-Control: private, no-store` and only
+  `url`, `version_id` and `expires_in=300`, with no tenant or object-key field;
 - the bearer-sensitive SigV4 `url` contains the expected authorized `serving/`
   key, appears in neither logs nor acceptance evidence, is never persisted,
   sent to telemetry, included in a referrer or cached, and no other prefix is

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -198,15 +198,15 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   image, own definition/mode/role and 60-second PID deadline. `run_aws_entrypoint`
   allowlists it; composition builds DynamoDB, S3 audit sink and UTC clock, then calls
   `dispatch_once(control_plane, sink, now, limit=100)`.
-  Recovery failure and budget freeze cannot suppress it. Sink failures stay pending;
-  a persisted cursor advances each batch and wraps, retrying poison without starvation.
-  Alarm/exit is nonzero, replay idempotent, Scheduler retries zero and hours counted.
+  `ControlPlanePort` replaces `pending_outbox(limit)` with table-backed cursor page/read
+  and CAS-advance operations, no hidden persistence. Each evaluated page advances and
+  wraps; poison stays pending/retries without starvation. Alarm/exit is nonzero.
 - Recovery role has control-plane read/write; `states:StartExecution` and
   `states:DescribeStateMachine` on the exact machine, `states:DescribeExecution`
-  and `states:StopExecution` on executions, plus ECS liveness. The Roles Anywhere
-  API role gets only `states:DescribeStateMachine` on that exact machine. Scheduler
-  trusts only `scheduler.amazonaws.com` with exact source account/ARN, runs revisions
-  and passes only its task/execution roles. Dispatch Scheduler scope is equivalent
+  and `states:StopExecution` on executions, plus ECS liveness. The Roles Anywhere API
+  role gets start/describe-machine on that machine and describe/stop on its executions.
+  Scheduler trusts only `scheduler.amazonaws.com` with exact source account/ARN, runs
+  revisions and passes its task/execution roles. Dispatch Scheduler scope is equivalent
   only for dispatch revisions. Both use public subnets, zero-ingress groups,
   public IP, logs and alarms. Recovery/API/takeover ECS liveness reads use the
   configured cluster/family conditions, including required narrow `Resource: *`.
@@ -245,17 +245,17 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - old fence/dispatch rejection and duplicate execution replay;
 - required-source failure and optional-source degraded publication;
 - dispatcher boot tests accept only `dispatch-outbox-once` without unit variables
-  and inject control plane, audit sink and deterministic UTC clock. A pass reads 100,
-  writes COMPLIANCE, marks after success and advances a persisted cursor. Tests prove
-  100 poison events do not starve a second batch, wrap retries and replay is idempotent;
+  and inject control plane, audit sink and UTC clock. Port tests require cursor-aware
+  page/read plus cursor-advance CAS. A pass writes COMPLIANCE and marks after success;
+  100 poison events do not starve a second page; wrap retries and replay is idempotent;
 - no presigned URL for non-serving prefixes;
 - dashboard artifact and browser checks reject a relative `/api` request or an
   API call that bypasses the configured absolute `/api/v1` client;
 - long-lived boto3/botocore clients call AWS without restart: first use invokes
   Roles Anywhere helper, pre-advisory-window calls do not, and first access inside
   the 15-minute window refreshes once. Helper/refresh failure fails closed;
-- VPS boot requires matching AWS config/profile and exact-machine describe permission;
-  invalid values fail. API composition omits audit sink and audit-bucket requests;
+- VPS boot requires matching AWS config/profile, exact-machine start/describe and
+  execution describe/stop; invalid scope fails. API omits audit sink/bucket requests;
 - OpenTofu creates the `us-east-2` trust anchor from external offline public
   CA PEM with the required CA, key-usage and SHA-256 constraints, and the Roles
   Anywhere profile, with AWS Private CA prohibited. The trust policy permits

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -77,21 +77,27 @@ Order:
 4. finalize and sign one post-registration activation manifest with the candidate
    manifest SHA-256, release ID, source SHA, exact revision ARNs, verified
    `ECR_URI@sha256` and phase-A evidence; never re-register those revisions;
-5. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
+5. atomically close the environment deployment fence. The API then rejects all
+   tenant job admissions with `503` and `Retry-After`, recovery starts no new
+   executions, and the workflow waits until no dispatch decision is in flight;
+6. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
    signed activation manifest ARNs only after verifying that binding, then
    switches the still OpenTofu-owned state-machine `TaskDefinition` ARN and
    Scheduler recovery target. No out-of-band mutation or `ignore_changes` is
    allowed;
-6. use `DescribeTaskDefinition`, state-machine and Scheduler evidence to prove
+7. use `DescribeTaskDefinition`, state-machine and Scheduler evidence to prove
    both selected revisions resolve to the exact release digest and verify the
    manifest binding, then verify clean OpenTofu state and no drift;
-7. verify that same signed binding before updating the inactive API candidate
-   and before frontend publication;
-8. pass local and tunneled health/authorization smoke tests;
-9. switch Nginx to the candidate;
+8. verify that same signed binding, update the inactive API candidate and pass
+   local health/authorization smoke tests;
+9. switch Nginx to the candidate and run tunneled health/authorization through
+   the normal production hostname, which now resolves to that candidate;
 10. publish frontend assets and entrypoint;
-11. run the synthetic vertical slice and serving test;
-12. record redacted evidence and retain the previous release.
+11. while the fence rejects tenant jobs, admit only the release-bound synthetic
+    canary, run its vertical slice and serving test, then reopen admissions;
+12. record redacted evidence and retain the previous release. A failure in
+    steps 6-11 keeps the fence closed and immediately restores the prior API,
+    processor and Scheduler routes before reopening admissions.
 
 Retain old revisions and their `ecs:RunTask` grants until all active old Standard
 executions and recovery tasks drain and the rollback-retention period ends. Prune
@@ -120,7 +126,10 @@ No production deployment occurs automatically after merge.
 - Cloudflare Free rule protects the most sensitive public job/auth surface.
 - Nginx enforces IP-based general and expensive-mutation zones.
 - The API enforces tenant/user/idempotency quotas, maximum 200 jobs and the
-  semaphore's one concurrent unit task per environment. The monitored 100-hour
+  semaphore's one concurrent unit task per environment. A separate atomic
+  monthly counter permits at most 200 Step Functions execution attempts across
+  initial and recovery starts; each caller increments it before `StartExecution`
+  or rejects the start when exhausted. The monitored 100-hour
   monthly operating target counts every unit and recovery task-hour; it is not a
   pre-launch API limit.
 - DynamoDB maximum throughput, Step Functions bounded retries and Athena bytes
@@ -226,6 +235,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   only. The semaphore is the cross-run arbiter: losers do not call
   `StartExecution`; dispatch CAS applies only to same-run recovery/idempotency.
   A concurrent request receives the documented quota error or `429`.
+- The deployment fence shares this control plane but is independent of the unit
+  semaphore. It blocks initial and recovery dispatch, except for one
+  release-bound synthetic canary during promotion, until rollback or acceptance
+  explicitly reopens admissions.
 
 ## 7. Test and acceptance matrix
 
@@ -276,6 +289,11 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   binding. API/frontend steps verify the same binding. Tests reject artifact
   mixing, out-of-band mutation and `ignore_changes`, then prove selected exact
   digests, clean state and no drift;
+- promotion tests close the deployment fence before phase B, prove no dispatch
+  decision remains in flight, reject tenant jobs and recovery starts, and allow
+  only the bound canary. Local smoke precedes the Nginx switch; tunneled smoke
+  uses the production hostname after that switch. Any failure restores prior
+  routes before admissions reopen;
 - drain/prune tests retain old revisions and `ecs:RunTask` grants through active
   old Standard/recovery drain and rollback retention, then prune only older
   non-rollback revisions; rollback consumes the prior retained manifest through
@@ -302,6 +320,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   the delayed USD 15 budget action freezes new unit and recovery Fargate, Step
   Functions and Athena starts only after it fires; tests do not claim a
   synchronous spend cap and explicitly allow billing-lag overshoot;
+- execution-quota tests atomically count every initial and recovery
+  `StartExecution` attempt against one 200-attempt monthly maximum and reject
+  both callers when exhausted;
 - recovery role tests scope `states:StartExecution` to the production machine,
   `states:DescribeExecution` to its executions and ECS liveness reads to the
   configured cluster/task family or required narrow `Resource: *` conditions;
@@ -354,6 +375,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   digest, clean state and no drift; API/frontend evidence verifies the same
   binding before switching. Active Standard executions remain on their original
   revision;
+- promotion evidence proves the fence closed before phase B, no dispatch was in
+  flight, local smoke passed before switching, and tunneled smoke reached the
+  candidate through the switched production hostname. Only the bound canary is
+  admitted before acceptance; failure restores prior routes while fenced;
 - the `recover-once` Scheduler run uses the same image/network, emits its log
   and alarm evidence, uses `MaximumRetryAttempts=0`, and cannot start without
   its narrow roles;
@@ -400,7 +425,8 @@ Cost controls:
   recovery passes are individually bounded but have no global concurrency
   ceiling; zero idle desired count; and a monitored 100 combined unit and
   recovery task-hours monthly operating target, including every invocation;
-- Step Functions Standard and 200 executions maximum;
+- Step Functions Standard and 200 execution attempts maximum, atomically shared
+  by initial and recovery starts;
 - Athena 5 GB/query and 100 GB/month;
 - DynamoDB on-demand maximum throughput;
 - short CloudWatch retention and no Container Insights;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -154,7 +154,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - API preflights from another origin or for a disallowed method/header are
   denied by FastAPI;
 - one synthetic run publishes exactly one new immutable version/pointer;
-- a signed `serving/` redirect is followed and returns the expected JSON body;
+- a signed `serving/` redirect has a 300-second TTL; after following it, the
+  browser reads the expected JSON body;
 - logs, traces, state and artifacts contain no secret or synthetic record body;
 - previous API/frontend release can be restored within the documented window.
 

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -193,8 +193,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   session duration plus propagation, issue and install a new leaf, then
   re-enable the profile/trust and test a new session.
 - Step Functions launches unit tasks. Scheduler `recover-once` uses the same image,
-  separate definition/mode, cadence at most half the lease, batch 100 and none of
-  the seven normal variables. Retries are zero; at-least-once passes may overlap.
+  separate mode, cadence at most half the lease and batch 100. Its composition
+  builds only coordinator dependencies: no normal variables or audit sink.
   PID 1 enforces the lease deadline; the semaphore is cross-run, dispatch CAS same-run.
 - Scheduler runs independent `dispatch-outbox-once` every five minutes with the
   same image, own definition/mode/role and five-minute PID deadline.
@@ -306,9 +306,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   non-rollback revisions; rollback consumes the prior retained manifest through
   a reviewed exact OpenTofu plan/apply;
 - recovery validation enforces the separate `recover-once` definition/mode,
-  same image and network shape, Scheduler cadence at most half
-  `AWS_PROCESSOR_LEASE_SECONDS`, `MaximumRetryAttempts=0`, no seven normal
-  processor environment variables, batch 100 and a PID 1 hard wall-clock
+  same image/network, coordinator-only composition without normal variables or
+  audit sink, cadence at most half `AWS_PROCESSOR_LEASE_SECONDS`, batch 100 and
+  `MaximumRetryAttempts=0`. Its PID 1 hard wall-clock
   deadline equal to the lease that logs/alarms, cancels work, exits nonzero and
   stops the ECS task; overlapping, externally retried or at-least-once duplicate
   invocations have no global concurrency ceiling;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -40,8 +40,9 @@ A candidate release is bound to one green `develop` commit. Its candidate
 manifest records:
 
 - source SHA and test run IDs;
+- release ID;
 - API GHCR digest;
-- processor GHCR and promoted ECR digests;
+- processor GHCR digest and expected ECR destination/repository;
 - dashboard artifact checksum;
 - Compose/config checksum;
 - OpenTofu/provider lock digest;
@@ -66,22 +67,26 @@ marker is absent.
 
 Order:
 
-1. promote/verify the processor digest in ECR;
+1. copy/promote and verify the processor digest in the expected ECR repository,
+   yielding its exact `ECR_URI@sha256`;
 2. under a reviewed exact OpenTofu plan/apply, phase A registers immutable unit
-   and `recover-once` revisions pinned to that digest and dual-authorizes old
-   and new `ecs:RunTask` ARNs without changing state-machine/Scheduler routes;
+   and `recover-once` revisions pinned to that exact `ECR_URI@sha256` and
+   dual-authorizes old and new `ecs:RunTask` ARNs without routing changes;
 3. wait for and revalidate IAM propagation, prove both revisions authorized,
    then output their ARNs and phase-A evidence;
-4. finalize and sign one post-registration activation manifest with the exact
-   revision ARNs, digest and phase-A evidence; never re-register those revisions;
+4. finalize and sign one post-registration activation manifest with the candidate
+   manifest SHA-256, release ID, source SHA, exact revision ARNs, verified
+   `ECR_URI@sha256` and phase-A evidence; never re-register those revisions;
 5. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
-   signed activation manifest ARNs and switches the still OpenTofu-owned
-   state-machine `TaskDefinition` ARN and Scheduler recovery target. No
-   out-of-band mutation or `ignore_changes` is allowed;
+   signed activation manifest ARNs only after verifying that binding, then
+   switches the still OpenTofu-owned state-machine `TaskDefinition` ARN and
+   Scheduler recovery target. No out-of-band mutation or `ignore_changes` is
+   allowed;
 6. use `DescribeTaskDefinition`, state-machine and Scheduler evidence to prove
-   both selected revisions resolve to the exact release digest, then verify
-   clean OpenTofu state and no drift;
-7. update the inactive API candidate on the VPS;
+   both selected revisions resolve to the exact release digest and verify the
+   manifest binding, then verify clean OpenTofu state and no drift;
+7. verify that same signed binding before updating the inactive API candidate
+   and before frontend publication;
 8. pass local and tunneled health/authorization smoke tests;
 9. switch Nginx to the candidate;
 10. publish frontend assets and entrypoint;
@@ -206,12 +211,13 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   recovery task, API and any takeover actor use ECS liveness reads only for the
   configured cluster/task family with supported conditions; where ECS requires
   `Resource: *`, those same narrow conditions apply.
-- For `PUBLISHING`, its publisher data-plane permissions are only
-  `s3:GetObject`, `s3:GetObjectVersion` and `s3:PutObject` on the canonical data
-  bucket's `tmp/`, `normalized/`, `reconciliation/` and `serving/` prefixes used
-  by immutable output manifests/final objects. Copy reads the source and writes
-  the destination only. It has no raw/audit/other-prefix access and no
-  `s3:DeleteObject` or `s3:ListBucket` unless separately demonstrated necessary.
+- For `PUBLISHING`, `s3:GetObject`/`s3:GetObjectVersion` read only the canonical
+  data bucket's `tmp/`, `normalized/`, `reconciliation/` and `serving/` prefixes.
+  `s3:PutObject` writes only final `normalized/`, `reconciliation/` and
+  `serving/` objects used by immutable manifests/final objects, never `tmp/`.
+  Copy reads the source and writes the destination only. It has no
+  raw/audit/other-prefix access and no `s3:DeleteObject` or `s3:ListBucket`
+  unless separately demonstrated necessary.
 - One environment-wide control-plane DynamoDB semaphore/lease/fence item gates
   all unit work. Initial API starts and recovery conditionally acquire it before
   `StartExecution`, bind owner to dispatch/execution, renew it and release it
@@ -257,15 +263,19 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   `events:PutRule` and `events:DescribeRule` are scoped to
   `StepFunctionsGetEventsForECSTaskRule`; `iam:PassRole` permits only the task
   and execution roles with `iam:PassedToService=ecs-tasks.amazonaws.com`;
-- candidate-manifest tests reject ECS revision ARNs. Phase-A exact OpenTofu
-  plan/apply registers each revision once, dual-authorizes old/new `ecs:RunTask`
-  ARNs without routing changes, waits for/revalidates IAM propagation and proves
-  both authorized. It outputs phase-A evidence, then one signed activation
-  manifest records the exact revision ARNs/digest;
+- candidate-manifest tests require release ID/source SHA, processor GHCR digest
+  and expected ECR destination/repository while rejecting ECS revision ARNs and
+  a promoted ECR digest. Phase-A exact OpenTofu plan/apply registers each
+  revision once from verified `ECR_URI@sha256`, dual-authorizes old/new
+  `ecs:RunTask` ARNs without routing changes, waits for/revalidates IAM
+  propagation and proves both authorized. One signed activation manifest binds
+  candidate manifest SHA-256, release ID, source SHA, revision ARNs, verified
+  digest and phase-A evidence;
 - phase-B exact OpenTofu plan/apply consumes that signed manifest and switches
-  only the OpenTofu-owned state-machine/Scheduler targets. Tests reject
-  out-of-band mutation and `ignore_changes`, then prove selected exact digests,
-  clean state and no drift;
+  only the OpenTofu-owned state-machine/Scheduler targets after verifying the
+  binding. API/frontend steps verify the same binding. Tests reject artifact
+  mixing, out-of-band mutation and `ignore_changes`, then prove selected exact
+  digests, clean state and no drift;
 - drain/prune tests retain old revisions and `ecs:RunTask` grants through active
   old Standard/recovery drain and rollback retention, then prune only older
   non-rollback revisions; rollback consumes the prior retained manifest through
@@ -298,7 +308,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - a crash during `PUBLISHING` proves the recovery role reads manifest sidecars,
   promotes/verifies source-to-destination copies, writes reconciliation/serving
   manifests and completes pointer CAS without `AccessDenied`. Negative tests
-  deny raw/audit/other prefixes plus delete/list operations;
+  deny `s3:PutObject` on `tmp/`, all raw/audit/other prefixes and delete/list
+  operations;
 - the production AWS-012 override accepts `AssignPublicIp=ENABLED` only with
   exact public subnet IDs, the configured zero-ingress security group,
   `FARGATE`, maximum concurrency one, and no NAT Gateway or ALB; it rejects
@@ -337,10 +348,12 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   roles above, and fails when any scope drifts;
 - phase-A promotion evidence proves propagated old/new `ecs:RunTask`
   authorization without routing changes, then the signed activation manifest
-  records exact ARNs/digest. Phase-B OpenTofu evidence proves the state-machine
-  and Scheduler selected those revisions, exact ECR digest, clean state and no
-  drift before API/frontend switching; active Standard executions remain on
-  their original revision;
+  binds candidate manifest SHA-256, release ID, source SHA, exact ARNs/digest
+  and phase-A evidence. Phase-B OpenTofu evidence verifies that binding and
+  proves the state machine and Scheduler selected those revisions, exact ECR
+  digest, clean state and no drift; API/frontend evidence verifies the same
+  binding before switching. Active Standard executions remain on their original
+  revision;
 - the `recover-once` Scheduler run uses the same image/network, emits its log
   and alarm evidence, uses `MaximumRetryAttempts=0`, and cannot start without
   its narrow roles;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -141,11 +141,11 @@ No production deployment occurs automatically after merge.
   cutoffs contain downstream amplification.
 - Requests beyond product quota fail with `429` or the documented quota error
   before starting Step Functions or Athena.
-- The USD 15 action uses its service-linked role to attach OpenTofu-owned
-  `cnesdata-cost-freeze` to promotion/API, recovery task/Scheduler, Step Functions
-  execution and Athena-operator roles. It denies new compute/query starts; promotion
-  self-reads and aborts. Audit task/Scheduler stay on. Only cost-clear detaches after
-  reviewed spend/forecast recovery; history is retained and billing may lag.
+- At USD 15, OpenTofu creates a dedicated same-account `ExecutionRoleArn` trusted
+  only by `budgets.amazonaws.com` for the exact Budget ARN/source account. It gets
+  `iam:AttachRolePolicy` on named promotion/API, recovery task/Scheduler, Step Functions
+  execution and Athena roles, conditioned to `cnesdata-cost-freeze`. Audit stays on;
+  only cost-clear detaches after reviewed recovery; history remains and billing may lag.
 
 ## 5. Observability and SLOs
 
@@ -324,9 +324,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   semaphore writes are denied. Races prove close-first blocks acquire before drain;
   expired takeover needs liveness proof; losers never start and get `429`/quota;
 - cost tests count billed pull/start/run/stop. Two minutes per 30-minute recovery and
-  audit invocation budget 48+48=96 hours/30 days, leaving 4 for units; excess is alarmed.
-  Freeze tests attach to promotion/API, recovery task/Scheduler and Step Functions/Athena
-  roles; prove self-read/abort, audit task/Scheduler continuity and cost-clear;
+  audit budget 48+48=96 hours/30 days leaves 4 for units; excess is alarmed. Tests assert
+  same-account `ExecutionRoleArn`, exact Budget trust and `iam:AttachRolePolicy` limited
+  by target role/`iam:PolicyARN`; freeze, audit continuity and cost-clear remain proven;
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -80,8 +80,8 @@ Order:
 4. finalize and sign one post-registration activation manifest with the candidate
    manifest SHA-256, release ID, source SHA, exact revision ARNs, verified
    `ECR_URI@sha256` and phase-A evidence; never re-register those revisions. Run
-   the candidate dispatcher via promotion `RunTask` with a canary-role override,
-   scoped only to the OpenTofu-owned canary table/GSI and release bucket prefix;
+   it via promotion `RunTask`, overriding task role, `AWS_CONTROL_PLANE_TABLE` and
+   `AWS_AUDIT_BUCKET` to the OpenTofu-owned canary role/table/bucket only;
 5. atomically close the deployment fence only if the unit semaphore is idle and
    no dispatch decision is in flight. The API then rejects tenant admissions
    with `503`/`Retry-After`, and recovery starts no new executions;
@@ -249,13 +249,11 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - no presigned URL for non-serving prefixes;
 - dashboard artifact and browser checks reject a relative `/api` request or an
   API call that bypasses the configured absolute `/api/v1` client;
-- long-lived boto3/botocore clients complete an AWS call without process or
-  container restart: the initial credential-using call invokes the IAM Roles
-  Anywhere helper; calls before the 15-minute advisory window do not re-invoke
-  it; and the first credential access inside that window invokes one lazy refresh
-  that succeeds. Helper or refresh failure fails closed;
-- VPS config tests require `AWS_CONFIG_FILE` and matching `AWS_PROFILE`; a
-  missing or mismatched profile fails before readiness;
+- long-lived boto3/botocore clients call AWS without restart: first use invokes
+  Roles Anywhere helper, pre-advisory-window calls do not, and first access inside
+  the 15-minute window refreshes once. Helper/refresh failure fails closed;
+- VPS boot requires matching `AWS_CONFIG_FILE`/`AWS_PROFILE`; invalid values fail.
+  API composition omits audit sink and makes no audit-bucket request;
 - OpenTofu creates the `us-east-2` trust anchor from external offline public
   CA PEM with the required CA, key-usage and SHA-256 constraints, and the Roles
   Anywhere profile, with AWS Private CA prohibited. The trust policy permits
@@ -292,9 +290,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   until a diagnosed, reviewed plan converges all routes; mixed routes never reopen;
 - phase C runs only after application and isolated dispatcher canaries pass,
   switches only audit Scheduler by reviewed apply and leaves the old route on failure;
-- canary IAM lets promotion run the exact dispatch revision/pass only its canary
-  role; that role denies production and other releases. Seeded table data expires
-  by TTL, retained objects expire by bucket lifecycle, and phase C removes the role;
+- canary tests permit only exact revision/role/table/bucket overrides and deny
+  production/other releases. Table data expires by TTL, retained objects by
+  lifecycle, and phase C removes the role;
 - promotion tests atomically close the fence before phase B only when the unit
   semaphore is idle and no dispatch is in flight, then reject tenant/recovery
   starts and allow only the bound canary. Local smoke precedes Nginx; tunneled smoke

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -166,7 +166,8 @@ approximately USD 2-6 depending on Fargate jobs and stored data.
 
 Cost controls:
 
-- CloudFront Free plan and web origin below 5 GB;
+- voluntary 5 GB operational cap for the web bucket, aligned with the
+  CloudFront Free plan's account-wide 5 GB S3 Standard credit;
 - one of the account's maximum three CloudFront Free-plan subscriptions, with
   eligibility and `ACTIVE` status checked before cutover;
 - ECR generally below 2 GB;
@@ -199,12 +200,14 @@ Cost controls:
 
 - Amazon Cognito resource-server configuration:
   <https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/create-resource-server.html>
+- Amazon Cognito authorization endpoint resource binding:
+  <https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html>
 - FastAPI CORS:
   <https://fastapi.tiangolo.com/tutorial/cors/>
 - Amazon S3 CORS configuration:
   <https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html>
-- Amazon ECS private registry authentication:
-  <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html>
+- Amazon ECR with Amazon ECS:
+  <https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_on_ECS.html>
 - AWS Step Functions ECS integration:
   <https://docs.aws.amazon.com/step-functions/latest/dg/connect-ecs.html>
 - Amazon DynamoDB on-demand capacity mode:

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -98,9 +98,10 @@ No production deployment occurs automatically after merge.
   cutoffs contain downstream amplification.
 - Requests beyond product quota fail with `429` or the documented quota error
   before starting Step Functions or Athena.
-- A USD 15 aggregate budget action is the hard ceiling: it freezes new unit and
-  recovery Fargate, Step Functions and Athena starts through automation roles
-  while preserving reads and backups.
+- A USD 15 aggregate budget action is a delayed cost-safety backstop. When it
+  fires, it freezes new unit and recovery Fargate, Step Functions and Athena
+  starts through automation roles while preserving reads and backups. Billing
+  data can lag, so spend may exceed USD 15 before the action applies.
 
 ## 5. Observability and SLOs
 
@@ -237,8 +238,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   dispatch CAS covers same-run recovery only;
 - cost-contract tests count every unit and recovery task-hour toward the
   monitored 100-hour monthly operating target, never as a pre-launch API gate;
-  the USD 15 automatic budget action remains the hard freeze for new unit and
-  recovery Fargate, Step Functions and Athena starts;
+  the delayed USD 15 budget action freezes new unit and recovery Fargate, Step
+  Functions and Athena starts only after it fires; tests do not claim a
+  synchronous spend cap and explicitly allow billing-lag overshoot;
 - recovery role tests scope `states:StartExecution` to the production machine,
   `states:DescribeExecution` to its executions and ECS liveness reads to the
   configured cluster/task family or required narrow `Resource: *` conditions;
@@ -365,6 +367,8 @@ Cost controls:
   <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-create-session.html>
 - IAM revoke role sessions:
   <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_revoke-sessions.html>
+- AWS Budgets update-delay considerations:
+  <https://docs.aws.amazon.com/cost-management/latest/userguide/bcm-lite-use-budget.html>
 - AWS SDK process credentials:
   <https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html>
 - FastAPI CORS:

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -1,0 +1,218 @@
+# CnesData Production Operations Design
+
+**Date:** 2026-08-29  
+**Status:** Draft for repository review; architecture approved in design discussion  
+**Repository:** `VINIClUS/CnesData`  
+**Integration base:** `develop`
+
+## 1. Purpose
+
+Define the operational contract for the production deployment architecture in
+[the production deployment design](2026-08-29-cnesdata-production-deployment-design.md).
+This document covers delivery, rollback, abuse containment, observability,
+recovery, acceptance, costs and completion. The linked deployment design owns
+the architecture, resources, identity, network and serving contracts.
+
+## 2. CI/CD
+
+### 2.1 Continuous integration
+
+Pull requests to `develop` run the existing locked Python/CND/AWS gates plus:
+
+- dashboard lint, typecheck, tests and deterministic production build;
+- API and processor image build tests;
+- OCI vulnerability scan and SBOM generation;
+- OpenTofu format/validate/test and provider-lock verification;
+- policy and cost-manifest checks;
+- release-manifest schema and secret-scan tests.
+
+Untrusted pull-request code runs only on GitHub-hosted runners and receives no
+AWS, Cloudflare or SSH credential.
+
+### 2.2 Release creation
+
+A candidate release is bound to one green `develop` commit and records:
+
+- source SHA and test run IDs;
+- API GHCR digest;
+- processor GHCR and promoted ECR digests;
+- dashboard artifact checksum;
+- Compose/config checksum;
+- OpenTofu/provider lock digest;
+- SBOM checksums and schema version.
+
+Mutable tags may aid discovery but are never deployment authority.
+
+### 2.3 Infrastructure plan/apply
+
+Plan and apply are separate manual workflows. Apply downloads and verifies the
+exact unexpired binary plan; it does not replan. GitHub OIDC supplies temporary
+AWS credentials. The paid Actions spending limit is USD 0.
+
+### 2.4 Application promotion
+
+Production promotion is `workflow_dispatch` only. It verifies that the release
+SHA is contained in `develop`, all required checks succeeded and the cost-freeze
+marker is absent.
+
+Order:
+
+1. promote/verify the processor digest in ECR;
+2. update the inactive API candidate on the VPS;
+3. pass local and tunneled health/authorization smoke tests;
+4. switch Nginx to the candidate;
+5. publish frontend assets and entrypoint;
+6. run the synthetic vertical slice and serving test;
+7. record redacted evidence and retain the previous release.
+
+No production deployment occurs automatically after merge.
+
+## 3. Rollback
+
+- **API:** restore the previous Nginx upstream and already-pulled GHCR digest.
+- **Frontend:** restore the prior versioned entrypoint and invalidate it.
+- **Processor:** register/select the previous task definition/digest for new
+  dispatches; active Standard executions continue with the definition they
+  started unless the runbook determines cancellation is safe.
+- **State machine:** revert only new-execution routing; do not edit an active
+  execution or DynamoDB record manually.
+- **DynamoDB/S3:** application releases never roll data backward or delete
+  published versions. Compatibility changes are expand/contract and additive.
+- **Infrastructure:** failed apply requires diagnosis and a new reviewed plan;
+  protected-resource restore is not an automatic rollback step.
+
+## 4. Rate limiting and abuse containment
+
+- Cloudflare Free rule protects the most sensitive public job/auth surface.
+- Nginx enforces IP-based general and expensive-mutation zones.
+- The API enforces tenant/user/idempotency quotas and maximum 200 jobs,
+  100 task-hours and one concurrent processor task per month/environment.
+- DynamoDB maximum throughput, Step Functions bounded retries and Athena bytes
+  cutoffs contain downstream amplification.
+- Requests beyond product quota fail with `429` or the documented quota error
+  before starting Step Functions or Athena.
+- A USD 15 aggregate budget action freezes new Fargate, Step Functions and
+  Athena starts through automation roles while preserving reads and backups.
+
+## 5. Observability and SLOs
+
+Initial internal targets:
+
+- static frontend availability 99.9%;
+- API availability 99.5%;
+- eligible processing-job success 99%;
+- routine API p95 below two seconds;
+- routine deployment interruption at most 60 seconds.
+
+Grafana Alloy collects VPS/API/Nginx/Tunnel telemetry without Docker-socket
+access. CloudWatch owns DynamoDB, Step Functions, ECS, S3 and Athena alarms.
+Fargate logs retain seven days. High-cardinality tenant, run, object-key and
+user labels are forbidden.
+
+Required alarms include API/tunnel health, DynamoDB throttles/errors, failed or
+timed-out Step Functions executions, ECS task failures, audit/outbox backlog,
+S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
+
+## 6. Backup and recovery
+
+- DynamoDB PITR: 35 days;
+- S3 data/audit: versioning and prefix-specific lifecycle/Object Lock;
+- static entrypoint: versioned rollback;
+- infrastructure state: encrypted/versioned S3 backend;
+- no cross-region replica in phase 1;
+- quarterly recovery exercise reconstructs the API and proves one synthetic
+  dataset pointer/serving object without altering production data;
+- destructive PITR export/restore requires a separately approved runbook run.
+
+## 7. Test and acceptance matrix
+
+### 7.1 Pre-production tests
+
+- all CND adapter and AWS-014 matrices on the exact release SHA;
+- real-AWS DynamoDB transaction/TTL and S3 Object Lock capability checks;
+- OIDC/JWKS rotation, revoked membership and cross-tenant denial;
+- old fence/dispatch rejection and duplicate execution replay;
+- required-source failure and optional-source degraded publication;
+- pointer CAS race, S3 failure before publication and outbox replay;
+- no presigned URL for non-serving prefixes;
+- CDN private-origin, SPA rewrite, CSP and cache rollback;
+- CloudFront Free eligibility plus exact `ACTIVE` distribution/WAF binding;
+- Nginx and application rate-limit behavior;
+- plan policy, cost envelope and protected-resource replacement denial.
+
+### 7.2 Production smoke
+
+- static site returns the expected release ID over TLS;
+- S3 origin is not publicly readable;
+- API is unreachable at the VPS address/ports and healthy through Tunnel;
+- demo user authenticates with PKCE and resolves only the demo tenant;
+- a Cognito bearer `access_token` with
+  `aud=https://api.cnesdata.vinisantana.com` is accepted in the real
+  environment;
+- an API preflight from `https://cnesdata.vinisantana.com` for an allowed
+  method/header is accepted by FastAPI;
+- API preflights from another origin or for a disallowed method/header are
+  denied by FastAPI;
+- one synthetic run publishes exactly one new immutable version/pointer;
+- a signed `serving/` redirect is followed and returns the expected JSON body;
+- logs, traces, state and artifacts contain no secret or synthetic record body;
+- previous API/frontend release can be restored within the documented window.
+
+## 8. Cost contract
+
+CnesData receives a USD 8 monthly operational envelope. Expected initial use is
+approximately USD 2-6 depending on Fargate jobs and stored data.
+
+Cost controls:
+
+- CloudFront Free plan and web origin below 5 GB;
+- one of the account's maximum three CloudFront Free-plan subscriptions, with
+  eligibility and `ACTIVE` status checked before cutover;
+- ECR generally below 2 GB;
+- one Fargate task, zero idle desired count, 100 task-hours maximum;
+- Step Functions Standard and 200 executions maximum;
+- Athena 5 GB/query and 100 GB/month;
+- DynamoDB on-demand maximum throughput;
+- short CloudWatch retention and no Container Insights;
+- no NAT Gateway, load balancer, RDS or multi-region resource;
+- monthly review for the first three months and re-baseline if the project
+  exceeds its envelope or aggregate forecast reaches USD 15.
+
+## 9. Definition of done
+
+- This specification is reviewed and its implementation plan is approved.
+- Required CND and AWS logical gates are green on integrated `develop`.
+- OpenTofu plan contains only approved resources and costs.
+- All production artifacts are immutable and traceable to one source SHA.
+- Static origin, API origin and AWS data resources are not publicly writable.
+- No long-lived AWS or GitHub credential exists on the VPS or in GitHub.
+- Synthetic portfolio data is clearly identified; municipal/local data paths
+  are absent.
+- Deploy, rollback, rate-limit, cost-freeze and recovery drills pass.
+- `cnesdata.vinisantana.com` and `api.cnesdata.vinisantana.com` satisfy their
+  health, TLS and isolation contracts.
+- The deployment makes no claim that DATASUS ingestion or legacy cutover is
+  complete before their governing gates pass.
+
+## 10. References
+
+- Amazon Cognito resource-server configuration:
+  <https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/create-resource-server.html>
+- FastAPI CORS:
+  <https://fastapi.tiangolo.com/tutorial/cors/>
+- Amazon S3 CORS configuration:
+  <https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html>
+- Amazon ECS private registry authentication:
+  <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html>
+- AWS Step Functions ECS integration:
+  <https://docs.aws.amazon.com/step-functions/latest/dg/connect-ecs.html>
+- Amazon DynamoDB on-demand capacity mode:
+  <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html>
+- Amazon S3 Object Lock:
+  <https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html>
+- Amazon CloudFront Origin Access Control:
+  <https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateOriginAccessControl.html>
+- Amazon CloudFront flat-rate plan quotas:
+  <https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/flat-rate-pricing-plan.html>
+- AWS Pricing Plan Manager API:
+  <https://docs.aws.amazon.com/pricingplanmanager/latest/APIReference/Welcome.html>

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -128,6 +128,15 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - quarterly recovery exercise reconstructs the API and proves one synthetic
   dataset pointer/serving object without altering production data;
 - destructive PITR export/restore requires a separately approved runbook run.
+- The security owner operates the external, offline CA; AWS Private CA is never
+  enabled. The CA private key and API/VPS leaf credentials never enter the repo
+  or OpenTofu state.
+- The owner issues a unique API/VPS X.509v3 leaf, installs its certificate chain
+  and root-only private key outside the container, and rotates it before expiry
+  with overlap and a refresh test.
+- Revocation imports or updates the CRL at the Roles Anywhere trust anchor; it
+  does not depend on OCSP or CDP. Compromise revokes and rotates the leaf,
+  confirms fail-closed behavior and alerts the security owner.
 
 ## 7. Test and acceptance matrix
 
@@ -145,6 +154,18 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - long-lived boto3/botocore clients cross at least one IAM Roles Anywhere
   `credential_process` expiration/refresh and complete an AWS call without a
   process or container restart; helper or refresh failure fails closed;
+- OpenTofu creates the `us-east-2` trust anchor from external offline public
+  CA PEM and the Roles Anywhere profile, with AWS Private CA prohibited. The
+  trust policy permits `sts:AssumeRole`, `sts:TagSession` and
+  `sts:SetSourceIdentity` only to `rolesanywhere.amazonaws.com`, conditioned on
+  the profile `SourceArn` and API/VPS X.509 identity; no private CA key or leaf
+  appears in repository or state;
+- the separate Step Functions role is trusted only by `states.amazonaws.com`.
+  `ecs:RunTask` is scoped to the task definition; `ecs:DescribeTasks` and
+  `ecs:StopTask` use `Resource: *`; `events:PutTargets`, `events:PutRule` and
+  `events:DescribeRule` are scoped to `StepFunctionsGetEventsForECSTaskRule`;
+  `iam:PassRole` permits only the task and execution roles with
+  `iam:PassedToService=ecs-tasks.amazonaws.com`;
 - the production AWS-012 override accepts `AssignPublicIp=ENABLED` only with
   exact public subnet IDs, the configured zero-ingress security group,
   `FARGATE`, maximum concurrency one, and no NAT Gateway or ALB; it rejects
@@ -164,6 +185,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   exchange and configured logout URL succeed, with no custom Cognito domain or
   managed login v2 dependency;
 - demo user authenticates with PKCE and resolves only the demo tenant;
+- a real API/VPS leaf from the external CA assumes the Roles Anywhere profile;
+  a CRL-revoked leaf is denied, alerts and remains failed closed;
 - a Cognito bearer `access_token` with
   `aud=https://api.cnesdata.vinisantana.com` is accepted in the real
   environment;
@@ -175,6 +198,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   `VITE_API_BASE_URL=https://api.cnesdata.vinisantana.com/api/v1`, never
   relative `/api`; bearer is sent only to the API origin and `X-Tenant-Id` only
   to tenant-scoped calls;
+- a Step Functions execution starts only the approved Fargate task definition,
+  uses only the event rule and pass roles above, and fails when any scope drifts;
 - one synthetic run publishes exactly one new immutable version/pointer;
 - the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
   with `Cache-Control: private, no-store` and only `url`, `version_id` and
@@ -238,6 +263,10 @@ Cost controls:
   <https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-assign-domain.html>
 - IAM Roles Anywhere credential helper:
   <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html>
+- IAM Roles Anywhere getting started:
+  <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html>
+- IAM Roles Anywhere trust model:
+  <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/trust-model.html>
 - AWS SDK process credentials:
   <https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html>
 - FastAPI CORS:

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -73,12 +73,15 @@ Order:
 2. under a reviewed exact OpenTofu plan/apply, phase A registers immutable unit,
    recovery and audit-dispatch revisions pinned to exact `ECR_URI@sha256` and
    dual-authorizes old and new `ecs:RunTask` ARNs without routing changes;
+   it creates the release canary role; persistent canary table/bucket are
+   OpenTofu-owned;
 3. wait for and revalidate IAM propagation, prove all revisions authorized,
    then output their ARNs and phase-A evidence;
 4. finalize and sign one post-registration activation manifest with the candidate
    manifest SHA-256, release ID, source SHA, exact revision ARNs, verified
    `ECR_URI@sha256` and phase-A evidence; never re-register those revisions. Run
-   the candidate dispatcher against an isolated nonproduction table/bucket;
+   the candidate dispatcher via promotion `RunTask` with a canary-role override,
+   scoped only to the OpenTofu-owned canary table/GSI and release bucket prefix;
 5. atomically close the deployment fence only if the unit semaphore is idle and
    no dispatch decision is in flight. The API then rejects tenant admissions
    with `503`/`Retry-After`, and recovery starts no new executions;
@@ -169,24 +172,17 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - quarterly recovery exercise reconstructs the API and proves one synthetic
   dataset pointer/serving object without altering production data;
 - destructive PITR export/restore requires a separately approved runbook run.
-- The security owner operates the external, offline CA; AWS Private CA is never
-  enabled. Its trust-anchor CA has `CA:true`, `Certificate Sign` and `CRL Sign`
-  key usage, and SHA-256 or stronger signatures. The CA private key and API/VPS
-  leaf credentials never enter the repo or OpenTofu state.
-- The owner issues a unique API/VPS X.509v3 leaf with `CA:false`, `Digital
-  Signature` usage and SHA-256 or stronger signatures. Its certificate chain
-  can be readable as needed; its host-owned private key remains outside the
-  container and is bind-mounted read-only for the fixed runtime UID only, with
-  no other user or process able to read it. Rotation occurs before expiry with
-  overlap and a refresh test.
-- Revocation imports or updates the CRL at the Roles Anywhere trust anchor; it
-  does not depend on OCSP or CDP. Compromise revokes and rotates the leaf,
-  confirms fail-closed behavior and alerts the security owner.
-- The Roles Anywhere profile sets `durationSeconds=3600`; its signing helper
-  uses `--session-duration 3600`; and the IAM role sets
-  `MaxSessionDuration=3600`. This bounded lifetime exceeds botocore's default
-  15-minute advisory refresh window. On incident, disable the profile or its
-  trust, import/update the CRL and apply `AWSRevokeOlderSessions` or an explicit
+- The security owner operates the external offline CA; AWS Private CA is disabled.
+  Trust-anchor CA has `CA:true`, certificate/CRL signing usage and SHA-256 or
+  stronger signatures; CA private key/leaf credentials never enter repo/state.
+- The unique API/VPS X.509v3 leaf has `CA:false`, `Digital Signature` and SHA-256
+  or stronger. Its chain may be readable; its host key stays outside the container,
+  read-only to the fixed UID and no other process. Rotate before expiry with overlap.
+- Revocation updates the trust-anchor CRL, never OCSP/CDP; compromise revokes and
+  rotates the leaf, proves fail-closed behavior and alerts the security owner.
+- Roles Anywhere profile/helper/role session limits are all 3600 seconds, beyond
+  botocore's 15-minute advisory refresh window. On incident, disable profile/trust,
+  update CRL and apply `AWSRevokeOlderSessions` or an explicit
   `aws:TokenIssueTime` Deny to the role.
 - Before declaring fail-closed, verify pre-incident credentials are denied by
   DynamoDB, S3 and Step Functions. Retain the deny for at least the maximum
@@ -296,6 +292,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   until a diagnosed, reviewed plan converges all routes; mixed routes never reopen;
 - phase C runs only after application and isolated dispatcher canaries pass,
   switches only audit Scheduler by reviewed apply and leaves the old route on failure;
+- canary IAM lets promotion run the exact dispatch revision/pass only its canary
+  role; that role denies production and other releases. Seeded table data expires
+  by TTL, retained objects expire by bucket lifecycle, and phase C removes the role;
 - promotion tests atomically close the fence before phase B only when the unit
   semaphore is idle and no dispatch is in flight, then reject tenant/recovery
   starts and allow only the bound canary. Local smoke precedes Nginx; tunneled smoke
@@ -312,6 +311,7 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   deadline equal to the lease that logs/alarms, cancels work, exits nonzero and
   stops the ECS task; overlapping, externally retried or at-least-once duplicate
   invocations have no global concurrency ceiling;
+- unit-task tests enforce hard termination no later than the non-renewable lease;
 - profile `durationSeconds=3600`, helper `--session-duration 3600` and role
   `MaxSessionDuration=3600` are asserted;
   the incident drill disables new sessions, updates CRL, revokes old sessions

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -36,18 +36,19 @@ AWS, Cloudflare or SSH credential.
 
 ### 2.2 Release creation
 
-A candidate release is bound to one green `develop` commit. Its finalized
-release manifest records:
+A candidate release is bound to one green `develop` commit. Its candidate
+manifest records:
 
 - source SHA and test run IDs;
 - API GHCR digest;
 - processor GHCR and promoted ECR digests;
-- immutable unit and `recover-once` task-definition revision ARNs, each pinned
-  to the exact promoted ECR digest;
 - dashboard artifact checksum;
 - Compose/config checksum;
 - OpenTofu/provider lock digest;
 - SBOM checksums and schema version.
+
+The candidate manifest contains no ECS task-definition revision ARN. An
+activation manifest is finalized and signed only after phase A below.
 
 Mutable tags may aid discovery but are never deployment authority.
 
@@ -66,16 +67,20 @@ marker is absent.
 Order:
 
 1. promote/verify the processor digest in ECR;
-2. register new immutable unit and `recover-once` revisions pinned to that exact
-   digest without changing the state-machine or Scheduler targets;
-3. extend the Step Functions and Scheduler roles' `ecs:RunTask` grants to authorize
-   both current (old) and candidate (new) revision ARNs; exact-role
-   `iam:PassRole` remains unchanged;
-4. wait for and revalidate IAM propagation, then prove both revisions are
-   authorized;
-5. switch the state-machine `TaskDefinition` ARN and Scheduler recovery target;
+2. under a reviewed exact OpenTofu plan/apply, phase A registers immutable unit
+   and `recover-once` revisions pinned to that digest and dual-authorizes old
+   and new `ecs:RunTask` ARNs without changing state-machine/Scheduler routes;
+3. wait for and revalidate IAM propagation, prove both revisions authorized,
+   then output their ARNs and phase-A evidence;
+4. finalize and sign one post-registration activation manifest with the exact
+   revision ARNs, digest and phase-A evidence; never re-register those revisions;
+5. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
+   signed activation manifest ARNs and switches the still OpenTofu-owned
+   state-machine `TaskDefinition` ARN and Scheduler recovery target. No
+   out-of-band mutation or `ignore_changes` is allowed;
 6. use `DescribeTaskDefinition`, state-machine and Scheduler evidence to prove
-   both selected revisions resolve to the exact release digest;
+   both selected revisions resolve to the exact release digest, then verify
+   clean OpenTofu state and no drift;
 7. update the inactive API candidate on the VPS;
 8. pass local and tunneled health/authorization smoke tests;
 9. switch Nginx to the candidate;
@@ -93,7 +98,8 @@ No production deployment occurs automatically after merge.
 
 - **API:** restore the previous Nginx upstream and already-pulled GHCR digest.
 - **Frontend:** restore the prior versioned entrypoint and invalidate it.
-- **Processor:** rollback assumes the prior routes and grants remain intact;
+- **Processor:** rollback uses the prior retained activation manifest and a
+  reviewed exact OpenTofu plan/apply. Its prior routes and grants remain intact;
   restore both prior immutable unit and `recover-once` revisions, digests and
   state-machine/Scheduler routes for new dispatches. Active Standard executions
   continue with the definition they started unless cancellation is safe.
@@ -188,7 +194,7 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   Every recovery task-hour is counted in the 100-hour monitored monthly
   operating target. The environment semaphore arbitrates cross-run unit starts,
   while dispatch CAS handles only same-run recovery and idempotency.
-- The recovery task role has only control-plane read/write,
+- The recovery task role has control-plane read/write,
   `states:StartExecution` on the exact production state machine and
   `states:DescribeExecution` on its executions, plus minimum liveness
   `ecs:ListTasks`/`ecs:DescribeTasks`. The Scheduler role trusts
@@ -200,6 +206,12 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   recovery task, API and any takeover actor use ECS liveness reads only for the
   configured cluster/task family with supported conditions; where ECS requires
   `Resource: *`, those same narrow conditions apply.
+- For `PUBLISHING`, its publisher data-plane permissions are only
+  `s3:GetObject`, `s3:GetObjectVersion` and `s3:PutObject` on the canonical data
+  bucket's `tmp/`, `normalized/`, `reconciliation/` and `serving/` prefixes used
+  by immutable output manifests/final objects. Copy reads the source and writes
+  the destination only. It has no raw/audit/other-prefix access and no
+  `s3:DeleteObject` or `s3:ListBucket` unless separately demonstrated necessary.
 - One environment-wide control-plane DynamoDB semaphore/lease/fence item gates
   all unit work. Initial API starts and recovery conditionally acquire it before
   `StartExecution`, bind owner to dispatch/execution, renew it and release it
@@ -245,15 +257,19 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   `events:PutRule` and `events:DescribeRule` are scoped to
   `StepFunctionsGetEventsForECSTaskRule`; `iam:PassRole` permits only the task
   and execution roles with `iam:PassedToService=ecs-tasks.amazonaws.com`;
-- release-manifest and promotion tests require immutable unit and `recover-once`
-  revision ARNs pinned to the exact ECR release digest. Before target switching,
-  both current and candidate revisions have authorized `ecs:RunTask` grants;
-  exact `iam:PassRole` is unchanged; IAM propagation is revalidated; and both
-  revisions are proved authorized. After switching, `DescribeTaskDefinition`,
-  state-machine and Scheduler evidence resolves each selection to that digest;
+- candidate-manifest tests reject ECS revision ARNs. Phase-A exact OpenTofu
+  plan/apply registers each revision once, dual-authorizes old/new `ecs:RunTask`
+  ARNs without routing changes, waits for/revalidates IAM propagation and proves
+  both authorized. It outputs phase-A evidence, then one signed activation
+  manifest records the exact revision ARNs/digest;
+- phase-B exact OpenTofu plan/apply consumes that signed manifest and switches
+  only the OpenTofu-owned state-machine/Scheduler targets. Tests reject
+  out-of-band mutation and `ignore_changes`, then prove selected exact digests,
+  clean state and no drift;
 - drain/prune tests retain old revisions and `ecs:RunTask` grants through active
   old Standard/recovery drain and rollback retention, then prune only older
-  non-rollback revisions;
+  non-rollback revisions; rollback consumes the prior retained manifest through
+  a reviewed exact OpenTofu plan/apply;
 - recovery validation enforces the separate `recover-once` definition/mode,
   same image and network shape, Scheduler cadence at most half
   `AWS_PROCESSOR_LEASE_SECONDS`, `MaximumRetryAttempts=0`, no seven normal
@@ -279,6 +295,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - recovery role tests scope `states:StartExecution` to the production machine,
   `states:DescribeExecution` to its executions and ECS liveness reads to the
   configured cluster/task family or required narrow `Resource: *` conditions;
+- a crash during `PUBLISHING` proves the recovery role reads manifest sidecars,
+  promotes/verifies source-to-destination copies, writes reconciliation/serving
+  manifests and completes pointer CAS without `AccessDenied`. Negative tests
+  deny raw/audit/other prefixes plus delete/list operations;
 - the production AWS-012 override accepts `AssignPublicIp=ENABLED` only with
   exact public subnet IDs, the configured zero-ingress security group,
   `FARGATE`, maximum concurrency one, and no NAT Gateway or ALB; it rejects
@@ -315,12 +335,12 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - a Step Functions execution starts only the approved Fargate task definition,
   uses only the exact source account/state-machine trust, event rule and pass
   roles above, and fails when any scope drifts;
-- before target switching, promotion evidence proves propagated `ecs:RunTask`
-  authorization for both old and candidate revisions while exact `iam:PassRole`
-  remains unchanged. After switching, `DescribeTaskDefinition`, state machine
-  and Scheduler prove the selected unit and `recover-once` revisions use the
-  exact release ECR digest; active Standard executions remain on their original
-  revision;
+- phase-A promotion evidence proves propagated old/new `ecs:RunTask`
+  authorization without routing changes, then the signed activation manifest
+  records exact ARNs/digest. Phase-B OpenTofu evidence proves the state-machine
+  and Scheduler selected those revisions, exact ECR digest, clean state and no
+  drift before API/frontend switching; active Standard executions remain on
+  their original revision;
 - the `recover-once` Scheduler run uses the same image/network, emits its log
   and alarm evidence, uses `MaximumRetryAttempts=0`, and cannot start without
   its narrow roles;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -21,7 +21,8 @@ Pull requests to `develop` run the existing locked Python/CND/AWS gates plus:
 
 - dashboard lint, typecheck, tests and deterministic production build;
 - dashboard routing checks require
-  `API_BASE_URL=https://api.cnesdata.vinisantana.com`, one authenticated API
+  `VITE_API_BASE_URL=https://api.cnesdata.vinisantana.com/api/v1`, mapped from
+  the exact OpenTofu output into the dashboard build, one authenticated API
   client for `auth/me` and activation, no production relative `/api` request,
   bearer only to the API origin and `X-Tenant-Id` only for tenant-scoped calls;
 - API and processor image build tests;
@@ -140,7 +141,7 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - pointer CAS race, S3 failure before publication and outbox replay;
 - no presigned URL for non-serving prefixes;
 - dashboard artifact and browser checks reject a relative `/api` request or an
-  API call that bypasses the configured absolute client;
+  API call that bypasses the configured absolute `/api/v1` client;
 - long-lived boto3/botocore clients cross at least one IAM Roles Anywhere
   `credential_process` expiration/refresh and complete an AWS call without a
   process or container restart; helper or refresh failure fails closed;
@@ -171,8 +172,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - API preflights from another origin or for a disallowed method/header are
   denied by FastAPI;
 - browser network evidence proves `auth/me` and activation use the configured
-  absolute API base URL, never relative `/api`; bearer is sent only to the API
-  and `X-Tenant-Id` only to tenant-scoped calls;
+  `VITE_API_BASE_URL=https://api.cnesdata.vinisantana.com/api/v1`, never
+  relative `/api`; bearer is sent only to the API origin and `X-Tenant-Id` only
+  to tenant-scoped calls;
 - one synthetic run publishes exactly one new immutable version/pointer;
 - the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
   with `Cache-Control: private, no-store` and only `url`, `version_id` and

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -36,11 +36,14 @@ AWS, Cloudflare or SSH credential.
 
 ### 2.2 Release creation
 
-A candidate release is bound to one green `develop` commit and records:
+A candidate release is bound to one green `develop` commit. Its finalized
+release manifest records:
 
 - source SHA and test run IDs;
 - API GHCR digest;
 - processor GHCR and promoted ECR digests;
+- immutable unit and `recover-once` task-definition revision ARNs, each pinned
+  to the exact promoted ECR digest;
 - dashboard artifact checksum;
 - Compose/config checksum;
 - OpenTofu/provider lock digest;
@@ -63,12 +66,20 @@ marker is absent.
 Order:
 
 1. promote/verify the processor digest in ECR;
-2. update the inactive API candidate on the VPS;
-3. pass local and tunneled health/authorization smoke tests;
-4. switch Nginx to the candidate;
-5. publish frontend assets and entrypoint;
-6. run the synthetic vertical slice and serving test;
-7. record redacted evidence and retain the previous release.
+2. register new immutable unit and `recover-once` revisions pinned to that exact
+   digest; select the unit revision in the state-machine `TaskDefinition` ARN
+   and the recovery revision in the Scheduler target;
+3. update scoped `ecs:RunTask`/`iam:PassRole` policies when revision ARNs make
+   that necessary, then use `DescribeTaskDefinition`, state-machine and
+   Scheduler evidence to prove both selections resolve to the exact release
+   digest before switching API or frontend. Active Standard executions retain
+   the revision on which they started;
+4. update the inactive API candidate on the VPS;
+5. pass local and tunneled health/authorization smoke tests;
+6. switch Nginx to the candidate;
+7. publish frontend assets and entrypoint;
+8. run the synthetic vertical slice and serving test;
+9. record redacted evidence and retain the previous release.
 
 No production deployment occurs automatically after merge.
 
@@ -76,9 +87,10 @@ No production deployment occurs automatically after merge.
 
 - **API:** restore the previous Nginx upstream and already-pulled GHCR digest.
 - **Frontend:** restore the prior versioned entrypoint and invalidate it.
-- **Processor:** register/select the previous task definition/digest for new
-  dispatches; active Standard executions continue with the definition they
-  started unless the runbook determines cancellation is safe.
+- **Processor:** restore both prior immutable unit and `recover-once` revisions,
+  digests and state-machine/Scheduler routes for new dispatches; active Standard
+  executions continue with the definition they started unless cancellation is
+  safe.
 - **State machine:** revert only new-execution routing; do not edit an active
   execution or DynamoDB record manually.
 - **DynamoDB/S3:** application releases never roll data backward or delete
@@ -145,10 +157,11 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - Revocation imports or updates the CRL at the Roles Anywhere trust anchor; it
   does not depend on OCSP or CDP. Compromise revokes and rotates the leaf,
   confirms fail-closed behavior and alerts the security owner.
-- Roles Anywhere profile/helper `durationSeconds` is 900 seconds and IAM role
-  `MaxSessionDuration` is 3600 seconds. On incident, disable the profile or its
-  trust, import/update the CRL and apply `AWSRevokeOlderSessions` or an explicit
-  `aws:TokenIssueTime` Deny to the role.
+- Roles Anywhere profile/helper `durationSeconds` and IAM role
+  `MaxSessionDuration` are 3600 seconds. This bounded lifetime exceeds
+  botocore's default 15-minute advisory refresh window. On incident, disable the
+  profile or its trust, import/update the CRL and apply `AWSRevokeOlderSessions`
+  or an explicit `aws:TokenIssueTime` Deny to the role.
 - Before declaring fail-closed, verify pre-incident credentials are denied by
   DynamoDB, S3 and Step Functions. Retain the deny for at least the maximum
   session duration plus propagation, issue and install a new leaf, then
@@ -203,7 +216,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   API call that bypasses the configured absolute `/api/v1` client;
 - long-lived boto3/botocore clients cross at least one IAM Roles Anywhere
   `credential_process` expiration/refresh and complete an AWS call without a
-  process or container restart; helper or refresh failure fails closed;
+  process or container restart. The helper is not invoked per request and
+  botocore refreshes near the 3600-second expiry; helper or refresh failure
+  fails closed;
 - VPS config tests require `AWS_CONFIG_FILE` and matching `AWS_PROFILE`; a
   missing or mismatched profile fails before readiness;
 - OpenTofu creates the `us-east-2` trust anchor from external offline public
@@ -221,6 +236,11 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   `events:PutRule` and `events:DescribeRule` are scoped to
   `StepFunctionsGetEventsForECSTaskRule`; `iam:PassRole` permits only the task
   and execution roles with `iam:PassedToService=ecs-tasks.amazonaws.com`;
+- release-manifest and promotion tests require immutable unit and `recover-once`
+  revision ARNs pinned to the exact ECR release digest. `DescribeTaskDefinition`,
+  state-machine and Scheduler evidence must resolve each selected revision to
+  that digest before API/frontend switching, including any revision-scoped
+  `ecs:RunTask`/`iam:PassRole` policy update;
 - recovery validation enforces the separate `recover-once` definition/mode,
   same image and network shape, Scheduler cadence at most half
   `AWS_PROCESSOR_LEASE_SECONDS`, `MaximumRetryAttempts=0`, no seven normal
@@ -228,8 +248,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   deadline equal to the lease that logs/alarms, cancels work, exits nonzero and
   stops the ECS task; overlapping, externally retried or at-least-once duplicate
   invocations have no global concurrency ceiling;
-- profile/helper `durationSeconds` equals 900 and role `MaxSessionDuration`
-  equals 3600 seconds;
+- profile/helper `durationSeconds` and role `MaxSessionDuration` each equal
+  3600 seconds;
   the incident drill disables new sessions, updates CRL, revokes old sessions
   and proves the timed Deny before re-enabling a rotated leaf;
 - semaphore tests require conditional acquisition before initial or recovery
@@ -282,6 +302,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - a Step Functions execution starts only the approved Fargate task definition,
   uses only the exact source account/state-machine trust, event rule and pass
   roles above, and fails when any scope drifts;
+- promotion evidence from `DescribeTaskDefinition`, the state machine and
+  Scheduler proves the selected immutable unit and `recover-once` revisions use
+  the exact release ECR digest before the API/frontend switch; active Standard
+  executions remain on their original revision;
 - the `recover-once` Scheduler run uses the same image/network, emits its log
   and alarm evidence, uses `MaximumRetryAttempts=0`, and cannot start without
   its narrow roles;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -90,16 +90,17 @@ No production deployment occurs automatically after merge.
 
 - Cloudflare Free rule protects the most sensitive public job/auth surface.
 - Nginx enforces IP-based general and expensive-mutation zones.
-- The API enforces tenant/user/idempotency quotas, maximum 200 jobs, 100
-  combined unit and recovery task-hours per month, one concurrent unit task per
-  environment and bounded recovery overlap.
+- The API enforces tenant/user/idempotency quotas, maximum 200 jobs and the
+  semaphore's one concurrent unit task per environment. The monitored 100-hour
+  monthly operating target counts every unit and recovery task-hour; it is not a
+  pre-launch API limit.
 - DynamoDB maximum throughput, Step Functions bounded retries and Athena bytes
   cutoffs contain downstream amplification.
 - Requests beyond product quota fail with `429` or the documented quota error
   before starting Step Functions or Athena.
-- A USD 15 aggregate budget action freezes new unit and recovery Fargate,
-  Step Functions and Athena starts through automation roles while preserving
-  reads and backups.
+- A USD 15 aggregate budget action is the hard ceiling: it freezes new unit and
+  recovery Fargate, Step Functions and Athena starts through automation roles
+  while preserving reads and backups.
 
 ## 5. Observability and SLOs
 
@@ -155,13 +156,17 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   EventBridge Scheduler task using the same processor image but a separate task
   definition and mode, with cadence no greater than half
   `AWS_PROCESSOR_LEASE_SECONDS`; it requires none of the seven normal processor
-  environment variables. Scheduler invocations may overlap, retry and duplicate
-  as required by the governing plan. Each is one bounded pass with
-  `AWS_PROCESSOR_RECOVERY_BATCH_SIZE=100` and a hard timeout equal to
-  `AWS_PROCESSOR_LEASE_SECONDS`; all recovery task-hours count in the 100-hour
-  aggregate and budget freeze. The environment semaphore
-  arbitrates cross-run unit starts, while dispatch CAS handles only same-run
-  recovery and idempotency.
+  environment variables. Scheduler `MaximumRetryAttempts=0`; at-least-once
+  delivery or an external re-invocation can still create overlapping, retried or
+  duplicate passes, with no global recovery-concurrency ceiling. Each is one
+  bounded pass with
+  `AWS_PROCESSOR_RECOVERY_BATCH_SIZE=100`. Its entrypoint/PID 1 enforces a
+  hard wall-clock deadline equal to `AWS_PROCESSOR_LEASE_SECONDS`; at deadline,
+  it emits timeout logs and alarm, cancels work and exits nonzero so the ECS task
+  stops.
+  Every recovery task-hour is counted in the 100-hour monitored monthly
+  operating target. The environment semaphore arbitrates cross-run unit starts,
+  while dispatch CAS handles only same-run recovery and idempotency.
 - The recovery task role has only control-plane read/write,
   `states:StartExecution` on the exact production state machine and
   `states:DescribeExecution` on its executions, plus minimum liveness
@@ -215,10 +220,11 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   and execution roles with `iam:PassedToService=ecs-tasks.amazonaws.com`;
 - recovery validation enforces the separate `recover-once` definition/mode,
   same image and network shape, Scheduler cadence at most half
-  `AWS_PROCESSOR_LEASE_SECONDS`, no seven normal processor environment
-  variables, batch 100/lease-length hard timeout, allowed
-  overlapping/retried/duplicate invocations, least-privilege recovery/Scheduler
-  roles, logs and alarm;
+  `AWS_PROCESSOR_LEASE_SECONDS`, `MaximumRetryAttempts=0`, no seven normal
+  processor environment variables, batch 100 and a PID 1 hard wall-clock
+  deadline equal to the lease that logs/alarms, cancels work, exits nonzero and
+  stops the ECS task; overlapping, externally retried or at-least-once duplicate
+  invocations have no global concurrency ceiling;
 - profile/helper `durationSeconds` equals 900 and role `MaxSessionDuration`
   equals 3600 seconds;
   the incident drill disables new sessions, updates CRL, revokes old sessions
@@ -226,8 +232,13 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - semaphore tests require conditional acquisition before initial or recovery
   `StartExecution`, dispatch/execution ownership, terminal release, no expired
   takeover before Step Functions/ECS proof, no losing cross-run `StartExecution`
-  and `429` or quota on contention. Overlapping/retried/duplicate recovery
-  invocations remain bounded, while dispatch CAS covers same-run recovery only;
+  and `429` or quota on contention. Overlapping, externally retried and
+  at-least-once duplicate recovery passes remain individually bounded, while
+  dispatch CAS covers same-run recovery only;
+- cost-contract tests count every unit and recovery task-hour toward the
+  monitored 100-hour monthly operating target, never as a pre-launch API gate;
+  the USD 15 automatic budget action remains the hard freeze for new unit and
+  recovery Fargate, Step Functions and Athena starts;
 - recovery role tests scope `states:StartExecution` to the production machine,
   `states:DescribeExecution` to its executions and ECS liveness reads to the
   configured cluster/task family or required narrow `Resource: *` conditions;
@@ -268,12 +279,18 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   uses only the exact source account/state-machine trust, event rule and pass
   roles above, and fails when any scope drifts;
 - the `recover-once` Scheduler run uses the same image/network, emits its log
-  and alarm evidence, and cannot start without its narrow roles;
-- two distinct runs plus overlapping/retried/duplicate recovery invocations
-  leave at most one unit Fargate task active; semaphore losers make no
+  and alarm evidence, uses `MaximumRetryAttempts=0`, and cannot start without
+  its narrow roles;
+- a deliberately hung recovery reaches the PID 1 deadline equal to
+  `AWS_PROCESSOR_LEASE_SECONDS`, cancels, exits nonzero and stops in ECS by that
+  deadline, with log and alarm evidence;
+- two distinct runs plus overlapping, externally retried or at-least-once
+  duplicate recovery passes leave at most one unit Fargate task active;
+  semaphore losers make no
   `StartExecution`, while dispatch CAS remains limited to same-run recovery and
-  every recovery pass stays bounded and its recorded task-hours count in the
-  100-hour aggregate and budget freeze;
+  each recovery pass is individually bounded with no global recovery-concurrency
+  ceiling. Every recorded unit and recovery task-hour counts toward the monitored
+  100-hour monthly operating target, not a pre-launch API limit;
 - one synthetic run publishes exactly one new immutable version/pointer;
 - the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
   with `Cache-Control: private, no-store` and only `url`, `version_id` and
@@ -302,9 +319,10 @@ Cost controls:
 - one of the account's maximum three CloudFront Free-plan subscriptions, with
   eligibility and `ACTIVE` status checked before cutover;
 - ECR generally below 2 GB;
-- maximum one concurrent unit Fargate task per environment, bounded recovery
-  overlap, zero idle desired count and 100 combined unit and recovery task-hours
-  maximum per month, including every recovery invocation;
+- semaphore-enforced maximum one concurrent unit Fargate task per environment;
+  recovery passes are individually bounded but have no global concurrency
+  ceiling; zero idle desired count; and a monitored 100 combined unit and
+  recovery task-hours monthly operating target, including every invocation;
 - Step Functions Standard and 200 executions maximum;
 - Athena 5 GB/query and 100 GB/month;
 - DynamoDB on-demand maximum throughput;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -93,8 +93,9 @@ Order:
 9. switch Nginx to the candidate and run tunneled health/authorization through
    the normal production hostname, which now resolves to that candidate;
 10. publish frontend assets and entrypoint;
-11. while the fence rejects tenant jobs, admit only the release-bound synthetic
-    canary, run its vertical slice and serving test, then reopen admissions;
+11. while fenced, admit only the release-bound synthetic canary. The hard fence
+    budget reserves rollback margin, aborting unfinished work early enough to
+    restore prior routes and reopen admissions within 60 seconds of step 5;
 12. record redacted evidence and retain the previous release. A failure in
     steps 6-11 keeps the fence closed and immediately restores the prior API,
     processor and Scheduler routes before reopening admissions.
@@ -270,13 +271,17 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   separately referenced by `credential_process`; no private CA key or leaf
   appears in repository or state;
 - the separate Step Functions role is trusted only by `states.amazonaws.com`
-  with the exact `aws:SourceAccount` and the exact production state-machine
-  `aws:SourceArn`. `ecs:RunTask` is scoped to the current/candidate unit
-  revision ARNs during activation;
+  with exact `aws:SourceAccount` and production state-machine `aws:SourceArn`.
+  `ecs:RunTask` is scoped to current/candidate unit revision ARNs in activation;
   `ecs:DescribeTasks` and `ecs:StopTask` use `Resource: *`; `events:PutTargets`,
   `events:PutRule` and `events:DescribeRule` are scoped to
   `StepFunctionsGetEventsForECSTaskRule`; `iam:PassRole` permits only the task
-  and execution roles with `iam:PassedToService=ecs-tasks.amazonaws.com`;
+  and execution roles with `iam:PassedToService=ecs-tasks.amazonaws.com`. Logs
+  delivery permits `logs:CreateLogDelivery`, `logs:GetLogDelivery`,
+  `logs:UpdateLogDelivery`, `logs:DeleteLogDelivery`, `logs:ListLogDeliveries`,
+  `logs:CreateLogStream`, `logs:PutLogEvents`, `logs:PutResourcePolicy`,
+  `logs:DescribeResourcePolicies` and `logs:DescribeLogGroups`, all with required
+  `Resource: *`. Acceptance observes payload-free logs and denies any omitted action;
 - candidate-manifest tests require release ID/source SHA, processor GHCR digest
   and expected ECR destination/repository while rejecting ECS revision ARNs and
   a promoted ECR digest. Phase-A exact OpenTofu plan/apply registers each
@@ -293,8 +298,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - promotion tests close the deployment fence before phase B, prove no dispatch
   decision remains in flight, reject tenant jobs and recovery starts, and allow
   only the bound canary. Local smoke precedes the Nginx switch; tunneled smoke
-  uses the production hostname after that switch. Any failure restores prior
-  routes before admissions reopen;
+  uses the production hostname after that switch. Any failure or fence-budget
+  cutoff restores prior routes and reopens admissions within 60 seconds;
 - drain/prune tests retain old revisions and `ecs:RunTask` grants through active
   old Standard/recovery drain and rollback retention, then prune only older
   non-rollback revisions; rollback consumes the prior retained manifest through

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -69,10 +69,10 @@ Order:
 
 1. copy/promote and verify the processor digest in the expected ECR repository,
    yielding its exact `ECR_URI@sha256`;
-2. under a reviewed exact OpenTofu plan/apply, phase A registers immutable unit
-   and `recover-once` revisions pinned to that exact `ECR_URI@sha256` and
+2. under a reviewed exact OpenTofu plan/apply, phase A registers immutable unit,
+   recovery and audit-dispatch revisions pinned to exact `ECR_URI@sha256` and
    dual-authorizes old and new `ecs:RunTask` ARNs without routing changes;
-3. wait for and revalidate IAM propagation, prove both revisions authorized,
+3. wait for and revalidate IAM propagation, prove all revisions authorized,
    then output their ARNs and phase-A evidence;
 4. finalize and sign one post-registration activation manifest with the candidate
    manifest SHA-256, release ID, source SHA, exact revision ARNs, verified
@@ -82,11 +82,11 @@ Order:
    with `503`/`Retry-After`, and recovery starts no new executions;
 6. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
    signed activation manifest ARNs only after verifying that binding, then
-   switches the still OpenTofu-owned state-machine `TaskDefinition` ARN and
-   Scheduler recovery target. No out-of-band mutation or `ignore_changes` is
+   switches the OpenTofu-owned state-machine `TaskDefinition` ARN and both
+   Scheduler targets. No out-of-band mutation or `ignore_changes` is
    allowed;
 7. use `DescribeTaskDefinition`, state-machine and Scheduler evidence to prove
-   both selected revisions resolve to the exact release digest and verify the
+   all selected revisions resolve to the exact release digest and verify the
    manifest binding, then verify clean OpenTofu state and no drift;
 8. verify that same signed binding, update the inactive API candidate and pass
    local health/authorization smoke tests;
@@ -100,8 +100,8 @@ Order:
     restores prior routes within the fence budget. A partial apply stays fenced
     until a diagnosed, reviewed plan converges every route; never reopen mixed.
 
-Retain old revisions and `ecs:RunTask` grants until active old Standard/recovery
-work drains and rollback retention ends. Then prune older non-rollback revisions.
+Retain old revisions/grants until active old Standard/scheduled work drains and
+rollback retention ends. Then prune older non-rollback revisions.
 
 No production deployment occurs automatically after merge.
 
@@ -111,8 +111,8 @@ No production deployment occurs automatically after merge.
 - **Frontend:** restore the prior versioned entrypoint and invalidate it.
 - **Processor:** rollback uses the prior retained activation manifest and a
   reviewed exact OpenTofu plan/apply. Its prior routes and grants remain intact;
-  restore both prior immutable unit and `recover-once` revisions, digests and
-  state-machine/Scheduler routes for new dispatches. Active Standard executions
+  restore prior unit, recovery and audit-dispatch revisions/digests plus all
+  state-machine/Scheduler routes. Active Standard executions
   continue with the definition they started unless cancellation is safe.
 - **State machine:** revert only new-execution routing; do not edit an active
   execution or DynamoDB record manually.
@@ -129,17 +129,16 @@ No production deployment occurs automatically after merge.
   semaphore's one concurrent unit task per environment. A separate atomic
   monthly counter permits at most 200 Step Functions execution attempts across
   initial and recovery starts; each caller increments it before `StartExecution`
-  or rejects the start when exhausted. The monitored 100-hour
-  monthly operating target counts every unit and recovery task-hour; it is not a
-  pre-launch API limit.
+  or rejects the start when exhausted. The monitored 100-hour monthly target
+  counts every unit, recovery and audit-dispatch task-hour; it is not a gate.
 - DynamoDB maximum throughput, Step Functions bounded retries and Athena bytes
   cutoffs contain downstream amplification.
 - Requests beyond product quota fail with `429` or the documented quota error
   before starting Step Functions or Athena.
 - A USD 15 aggregate budget action is a delayed cost-safety backstop. When it
-  fires, it freezes new unit and recovery Fargate, Step Functions and Athena
-  starts through automation roles while preserving reads and backups. Billing
-  data can lag, so spend may exceed USD 15 before the action applies.
+  fires, it freezes new unit/recovery Fargate, Step Functions and Athena starts;
+  bounded audit dispatch, reads and backups remain enabled. Billing data can lag,
+  so spend may exceed USD 15 before the action applies.
 
 ## 5. Observability and SLOs
 
@@ -194,29 +193,30 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   session duration plus propagation, issue and install a new leaf, then
   re-enable the profile/trust and test a new session.
 - The normal unit task is launched by Step Functions. `recover-once` is an
-  EventBridge Scheduler task using the same processor image but a separate task
-  definition/mode and cadence at most half `AWS_PROCESSOR_LEASE_SECONDS`; it
-  requires none of the seven normal processor variables. Each bounded pass runs
-  coordinator recovery, then `dispatch_once(limit=100)`. Sink failures remain
-  pending, do not block later events, emit alarm/nonzero exit and retry on the
-  next cadence; same-event replay is idempotent. Scheduler retries are zero, but
-  at-least-once/external invocation can overlap without a global recovery-task
-  ceiling. PID 1 enforces a hard deadline equal to the lease, cancels work and
-  exits nonzero. Every pass counts toward the 100-hour target. The environment
+  EventBridge Scheduler task using the same image but a separate definition/mode,
+  cadence at most half the lease and batch 100; it needs none of the seven normal
+  processor variables. Scheduler retries are zero; at-least-once/external passes
+  may overlap. PID 1 enforces the lease deadline, cancels and exits nonzero. The
   semaphore arbitrates cross-run unit starts; dispatch CAS is same-run only.
+- `dispatch-outbox-once` is an independent Scheduler Fargate task with the same
+  image, its own definition/mode/role, five-minute cadence, batch 100 and
+  five-minute PID 1 deadline. It invokes only `dispatch_once`; recovery failure
+  and the budget freeze cannot suppress it. Sink failures remain pending, do not
+  block later events, alarm/exit nonzero and retry next cadence; replay is
+  idempotent. Scheduler retries are zero. Every task-hour counts toward the target.
 - Recovery role has control-plane read/write; `states:StartExecution` and
   `states:DescribeStateMachine` on the exact production state machine;
   `states:DescribeExecution`/`states:StopExecution` on executions; minimum
   liveness `ecs:ListTasks`/`ecs:DescribeTasks`. The Scheduler role trusts
   `scheduler.amazonaws.com` with exact `aws:SourceAccount` and
-  `aws:SourceArn`, scopes `ecs:RunTask` to recovery revision ARNs and, during
-  activation, both old and candidate revisions; it passes only its task/execution
-  roles. Recovery uses the unit task's public
-  subnets, zero-ingress security group and public IP, with logs and alarm. The
+  `aws:SourceArn`, scopes `ecs:RunTask` to recovery revisions and passes only its
+  task/execution roles. The dispatch Scheduler role has equivalent exact scope
+  only for dispatch revisions. Both use public subnets, zero-ingress security
+  groups, public IP, logs and alarm. The
   recovery task, API and any takeover actor use ECS liveness reads only for the
   configured cluster/task family with supported conditions; where ECS requires
   `Resource: *`, those same narrow conditions apply.
-- Recovery audit IAM allows `s3:GetBucketObjectLockConfiguration` on the bucket;
+- Dispatch audit IAM allows `s3:GetBucketObjectLockConfiguration` on the bucket;
   `s3:GetObject`/`s3:PutObject`/`s3:PutObjectRetention` on `audit/*`; no delete/list/bypass.
 - For `PUBLISHING`, `s3:GetObject`/`s3:GetObjectVersion` read only the canonical
   data bucket's `tmp/`, `normalized/`, `reconciliation/` and `serving/` prefixes.
@@ -320,11 +320,11 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   and `429` or quota on contention. Overlapping, externally retried and
   at-least-once duplicate recovery passes remain individually bounded, while
   dispatch CAS covers same-run recovery only;
-- cost-contract tests count every unit and recovery task-hour toward the
+- cost-contract tests count every unit, recovery and audit-dispatch task-hour in the
   monitored 100-hour monthly operating target, never as a pre-launch API gate;
   the delayed USD 15 budget action freezes new unit and recovery Fargate, Step
-  Functions and Athena starts only after it fires; tests do not claim a
-  synchronous spend cap and explicitly allow billing-lag overshoot;
+  Functions and Athena starts only after it fires, while audit dispatch stays
+  enabled; tests allow billing-lag overshoot and claim no synchronous cap;
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;
@@ -379,7 +379,7 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   authorization without routing changes, then the signed activation manifest
   binds candidate manifest SHA-256, release ID, source SHA, exact ARNs/digest
   and phase-A evidence. Phase-B OpenTofu evidence verifies that binding and
-  proves the state machine and Scheduler selected those revisions, exact ECR
+  proves the state machine and both Schedulers selected those revisions, exact ECR
   digest, clean state and no drift; API/frontend evidence verifies the same
   binding before switching. Active Standard executions remain on their original
   revision;
@@ -387,9 +387,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   flight, local smoke passed before switching, and tunneled smoke reached the
   candidate through the switched production hostname. Only the bound canary is
   admitted before acceptance; failure restores prior routes while fenced;
-- the `recover-once` Scheduler run uses the same image/network, emits its log
-  and alarm evidence, uses `MaximumRetryAttempts=0`, drains one bounded outbox
-  batch to an Object-Locked audit object and cannot start without narrow roles;
+- independent `recover-once` and `dispatch-outbox-once` runs use their exact
+  images/networks/roles and zero Scheduler retries. A forced recovery failure and
+  budget freeze do not stop bounded audit delivery to an Object-Locked object;
 - a deliberately hung recovery reaches the PID 1 deadline equal to
   `AWS_PROCESSOR_LEASE_SECONDS`, cancels, exits nonzero and stops in ECS by that
   deadline, with log and alarm evidence;
@@ -398,8 +398,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   semaphore losers make no
   `StartExecution`, while dispatch CAS remains limited to same-run recovery and
   each recovery pass is individually bounded with no global recovery-concurrency
-  ceiling. Every recorded unit and recovery task-hour counts toward the monitored
-  100-hour monthly operating target, not a pre-launch API limit;
+  ceiling. Every unit, recovery and audit-dispatch task-hour counts toward the
+  monitored 100-hour target, not a pre-launch API limit;
 - one synthetic run publishes exactly one new immutable version/pointer;
 - the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
   with `Cache-Control: private, no-store` and only `url`, `version_id` and
@@ -431,8 +431,8 @@ Cost controls:
 - ECR generally below 2 GB;
 - semaphore-enforced maximum one concurrent unit Fargate task per environment;
   recovery passes are individually bounded but have no global concurrency
-  ceiling; zero idle desired count; and a monitored 100 combined unit and
-  recovery task-hours monthly operating target, including every invocation;
+  ceiling; zero idle desired count; and a monitored 100 combined unit, recovery
+  and audit-dispatch task-hours monthly target, including every invocation;
 - Step Functions Standard and 200 execution attempts maximum, atomically shared
   by initial and recovery starts;
 - Athena 5 GB/query and 100 GB/month;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -142,10 +142,10 @@ No production deployment occurs automatically after merge.
 - Requests beyond product quota fail with `429` or the documented quota error
   before starting Step Functions or Athena.
 - The USD 15 action uses its service-linked role to attach OpenTofu-owned
-  `cnesdata-cost-freeze` to promotion/API/recovery roles. This persistent marker denies
-  new unit/recovery, Step Functions and Athena; promotion may list only its own policies
-  and aborts while attached. Audit remains on. Only the cost-clear operator detaches it
-  after reviewed spend/forecast recovery; history is retained and billing may lag.
+  `cnesdata-cost-freeze` to promotion/API/recovery, Step Functions execution and
+  Athena-operator roles. This marker denies new compute/query starts; promotion lists
+  only its own policies and aborts. Audit stays on. Only cost-clear detaches after
+  reviewed spend/forecast recovery; history is retained and billing may lag.
 
 ## 5. Observability and SLOs
 
@@ -214,9 +214,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   configured cluster/family conditions, including required narrow `Resource: *`.
 - Dispatch audit IAM allows `s3:GetBucketObjectLockConfiguration` on the bucket;
   `s3:GetObject`/`s3:PutObject`/`s3:PutObjectRetention` on `audit/*`; no delete/list/bypass.
-  It allows `dynamodb:Query` on the exact outbox GSI and
-  `dynamodb:GetItem`/`dynamodb:UpdateItem` on the exact control-plane table only;
-  scan, delete, put and access to any other table/index are denied.
+  It permits exact-GSI `Query` and table `GetItem`/`UpdateItem` only with
+  `dynamodb:LeadingKeys` matching outbox/event or cursor namespaces. Scan, delete, put,
+  other indexes/tables and run/fence/semaphore keys are denied.
 - For `PUBLISHING`, `s3:GetObject`/`s3:GetObjectVersion` read only the canonical
   data bucket's `tmp/`, `normalized/`, `reconciliation/` and `serving/` prefixes.
   `s3:PutObject` writes only final `normalized/`, `reconciliation/` and
@@ -325,8 +325,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   expired takeover needs liveness proof; losers never start and get `429`/quota;
 - cost tests count billed pull/start/run/stop. Two minutes per 30-minute recovery and
   audit invocation budget 48+48=96 hours/30 days, leaving 4 of 100 for units. Excess
-  fails acceptance/alarms, not a cap. Freeze tests prove budget attachment, promotion
-  self-read/abort, audit continuity and audited cost-clear-only detachment;
+  fails acceptance/alarms, not a cap. Freeze tests attach to promotion/API/recovery,
+  Step Functions/Athena roles, prove self-read/abort, audit continuity and cost-clear;
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;
@@ -334,8 +334,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   machine, describe/stop-execution to its executions and ECS liveness to the
   configured cluster/task family or required narrow `Resource: *` conditions.
   Cancellation/failed binding proves stop succeeds; another machine is denied;
-- audit IAM tests allow exact outbox-GSI query, table get/update and audit-bucket
-  lock/get/put/retention; deny other tables/indexes, scan, delete, list and bypass;
+- audit IAM tests allow outbox/cursor `LeadingKeys` and audit lock/get/put/retention;
+  deny run/fence/semaphore keys, other tables/indexes, scan/delete/list/bypass;
 - a crash during `PUBLISHING` proves the recovery role reads manifest sidecars,
   promotes/verifies source-to-destination copies, writes reconciliation/serving
   manifests and completes pointer CAS without `AccessDenied`. Negative tests

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -73,15 +73,15 @@ Order:
 2. under a reviewed exact OpenTofu plan/apply, phase A registers immutable unit,
    recovery and audit-dispatch revisions pinned to exact `ECR_URI@sha256` and
    dual-authorizes old and new `ecs:RunTask` ARNs without routing changes;
-   it creates the release canary role; persistent canary table/bucket are
+   it creates release canary roles; persistent canary table/bucket are
    OpenTofu-owned;
 3. wait for and revalidate IAM propagation, prove all revisions authorized,
    then output their ARNs and phase-A evidence;
 4. finalize and sign one post-registration activation manifest with the candidate
    manifest SHA-256, release ID, source SHA, exact revision ARNs, verified
    `ECR_URI@sha256` and phase-A evidence; never re-register those revisions. Run
-   it via promotion `RunTask`, overriding task role, `AWS_CONTROL_PLANE_TABLE` and
-   `AWS_AUDIT_BUCKET` to the OpenTofu-owned canary role/table/bucket only;
+   it via promotion `RunTask`, overriding task/execution roles plus
+   `AWS_CONTROL_PLANE_TABLE`/`AWS_AUDIT_BUCKET` to canary resources only;
    promotion can pass only canary task/execution roles, conditioned by
    `iam:PassedToService=ecs-tasks.amazonaws.com`;
 5. atomically close the deployment fence only if the unit semaphore is idle and
@@ -194,10 +194,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   separate mode, cadence at most half the lease and batch 100. Its composition
   builds only coordinator dependencies: no normal variables or audit sink.
   PID 1 enforces the lease deadline; the semaphore is cross-run, dispatch CAS same-run.
-- Scheduler runs independent `dispatch-outbox-once` every five minutes with the
-  same image, own definition/mode/role and five-minute PID deadline.
-  `run_aws_entrypoint` allowlists it; composition builds only DynamoDB and S3 audit
-  sink and UTC clock, then calls `dispatch_once(control_plane, sink, now, limit=100)`.
+- Scheduler runs independent `dispatch-outbox-once` every 30 minutes with the same
+  image, own definition/mode/role and 60-second PID deadline. `run_aws_entrypoint`
+  allowlists it; composition builds DynamoDB, S3 audit sink and UTC clock, then calls
+  `dispatch_once(control_plane, sink, now, limit=100)`.
   Recovery failure and budget freeze cannot suppress it. Sink failures remain
   pending, do not block later events and retry next cadence; alarm/exit is nonzero,
   replay idempotent, Scheduler retries zero and task-hours counted.
@@ -292,9 +292,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   until a diagnosed, reviewed plan converges all routes; mixed routes never reopen;
 - phase C runs only after application and isolated dispatcher canaries pass,
   switches both Schedulers by reviewed apply and leaves old routes on failure;
-- canary tests permit exact revision/role/table/bucket overrides and `PassRole`
-  only for canary task/execution roles with ECS PassedToService; deny production
-  and other releases. TTL/lifecycle expire data; phase C removes the role;
+- canary tests require exact revision, task/execution-role and table/bucket overrides;
+  `PassRole` is limited to canary task/execution roles with ECS PassedToService;
+  production/other releases are denied; phase C removes roles after lifecycle/TTL;
 - promotion tests atomically close the fence before phase B only when the unit
   semaphore is idle and no dispatch is in flight, then reject tenant/recovery
   starts and allow only the bound canary. Local smoke precedes Nginx; tunneled smoke
@@ -322,11 +322,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   and `429` or quota on contention. Overlapping, externally retried and
   at-least-once duplicate recovery passes remain individually bounded, while
   dispatch CAS covers same-run recovery only;
-- cost-contract tests count every unit, recovery and audit-dispatch task-hour in the
-  monitored 100-hour monthly operating target, never as a pre-launch API gate;
-  the delayed USD 15 budget action freezes new unit and recovery Fargate, Step
-  Functions and Athena starts only after it fires, while audit dispatch stays
-  enabled; tests allow billing-lag overshoot and claim no synchronous cap;
+- cost tests count all task-hours in the 100-hour target; 30-minute cadence and
+  60-second deadline bound audit dispatch to 48 hours per 30 days. USD 15 budget
+  action freezes unit/recovery, Step Functions and Athena, while audit stays
+  enabled; billing-lag overshoot is allowed and no synchronous cap is claimed;
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -198,14 +198,14 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   image, own definition/mode/role and 60-second PID deadline. `run_aws_entrypoint`
   allowlists it; composition builds DynamoDB, S3 audit sink and UTC clock, then calls
   `dispatch_once(control_plane, sink, now, limit=100)`.
-  Recovery failure and budget freeze cannot suppress it. Sink failures remain
-  pending, do not block later events and retry next cadence; alarm/exit is nonzero,
-  replay idempotent, Scheduler retries zero and task-hours counted.
+  Recovery failure and budget freeze cannot suppress it. Sink failures stay pending;
+  a persisted cursor advances each batch and wraps, retrying poison without starvation.
+  Alarm/exit is nonzero, replay idempotent, Scheduler retries zero and hours counted.
 - Recovery role has control-plane read/write; `states:StartExecution` and
   `states:DescribeStateMachine` on the exact machine, `states:DescribeExecution`
-  and `states:StopExecution` on executions, plus `ecs:ListTasks`/`ecs:DescribeTasks`.
-  Its Scheduler role trusts only
-  `scheduler.amazonaws.com` with exact source account/ARN, runs recovery revisions
+  and `states:StopExecution` on executions, plus ECS liveness. The Roles Anywhere
+  API role gets only `states:DescribeStateMachine` on that exact machine. Scheduler
+  trusts only `scheduler.amazonaws.com` with exact source account/ARN, runs revisions
   and passes only its task/execution roles. Dispatch Scheduler scope is equivalent
   only for dispatch revisions. Both use public subnets, zero-ingress groups,
   public IP, logs and alarms. Recovery/API/takeover ECS liveness reads use the
@@ -246,16 +246,16 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - required-source failure and optional-source degraded publication;
 - dispatcher boot tests accept only `dispatch-outbox-once` without unit variables
   and inject control plane, audit sink and deterministic UTC clock. A pass reads 100,
-  writes the COMPLIANCE object, marks after success, retries pending failures and
-  proves same-hash replay idempotent;
+  writes COMPLIANCE, marks after success and advances a persisted cursor. Tests prove
+  100 poison events do not starve a second batch, wrap retries and replay is idempotent;
 - no presigned URL for non-serving prefixes;
 - dashboard artifact and browser checks reject a relative `/api` request or an
   API call that bypasses the configured absolute `/api/v1` client;
 - long-lived boto3/botocore clients call AWS without restart: first use invokes
   Roles Anywhere helper, pre-advisory-window calls do not, and first access inside
   the 15-minute window refreshes once. Helper/refresh failure fails closed;
-- VPS boot requires matching `AWS_CONFIG_FILE`/`AWS_PROFILE`; invalid values fail.
-  API composition omits audit sink and makes no audit-bucket request;
+- VPS boot requires matching AWS config/profile and exact-machine describe permission;
+  invalid values fail. API composition omits audit sink and audit-bucket requests;
 - OpenTofu creates the `us-east-2` trust anchor from external offline public
   CA PEM with the required CA, key-usage and SHA-256 constraints, and the Roles
   Anywhere profile, with AWS Private CA prohibited. The trust policy permits

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -141,11 +141,11 @@ No production deployment occurs automatically after merge.
   cutoffs contain downstream amplification.
 - Requests beyond product quota fail with `429` or the documented quota error
   before starting Step Functions or Athena.
-- At USD 15, OpenTofu creates a dedicated same-account `ExecutionRoleArn` trusted
-  only by `budgets.amazonaws.com` for the exact Budget ARN/source account. It gets
-  `iam:AttachRolePolicy` on named promotion/API, recovery task/Scheduler, Step Functions
-  execution and Athena roles, conditioned to `cnesdata-cost-freeze`. Audit stays on;
-  only cost-clear detaches after reviewed recovery; history remains and billing may lag.
+- At USD 15, OpenTofu creates a same-account `ExecutionRoleArn` trusted only by
+  `budgets.amazonaws.com` for the exact Budget ARN/account. It gets
+  `iam:AttachRolePolicy` on promotion/API/recovery task/Scheduler/Step Functions/Athena with
+  `iam:PolicyARN`=freeze. Promotion gets `iam:ListAttachedRolePolicies` only on itself;
+  freeze aborts; audit stays; reviewed cost-clear detaches; history stays; billing lags.
 
 ## 5. Observability and SLOs
 
@@ -326,7 +326,7 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - cost tests count billed pull/start/run/stop. Two minutes per 30-minute recovery and
   audit budget 48+48=96 hours/30 days leaves 4 for units; excess is alarmed. Tests assert
   same-account `ExecutionRoleArn`, exact Budget trust and `iam:AttachRolePolicy` limited
-  by target role/`iam:PolicyARN`; freeze, audit continuity and cost-clear remain proven;
+  by target role/`iam:PolicyARN`; promotion self-read/abort, audit and cost-clear are proven;
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -210,7 +210,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   while dispatch CAS handles only same-run recovery and idempotency.
 - The recovery task role has control-plane read/write,
   `states:StartExecution` on the exact production state machine and
-  `states:DescribeExecution` on its executions, plus minimum liveness
+  `states:DescribeExecution` and `states:StopExecution` on its executions, plus
+  minimum liveness
   `ecs:ListTasks`/`ecs:DescribeTasks`. The Scheduler role trusts
   `scheduler.amazonaws.com` with exact `aws:SourceAccount` and
   `aws:SourceArn`, scopes `ecs:RunTask` to recovery revision ARNs and, during
@@ -324,8 +325,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;
 - recovery role tests scope `states:StartExecution` to the production machine,
-  `states:DescribeExecution` to its executions and ECS liveness reads to the
-  configured cluster/task family or required narrow `Resource: *` conditions;
+  `states:DescribeExecution`/`states:StopExecution` to its executions and ECS
+  liveness reads to the configured cluster/task family or required narrow
+  `Resource: *` conditions. Cancellation and failed replacement binding prove
+  recovery can stop the execution, while another machine is denied;
 - a crash during `PUBLISHING` proves the recovery role reads manifest sidecars,
   promotes/verifies source-to-destination copies, writes reconciliation/serving
   manifests and completes pointer CAS without `AccessDenied`. Negative tests

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -84,9 +84,9 @@ Order:
    variables to canary-only values. It passes only canary task/execution roles with
    ECS PassedToService. A verifier gets conditioned `GetItem` on the bound key and
    `GetObject`/`GetObjectRetention` on its object; require retention/delivered proof;
-5. atomically close the deployment fence only if the unit semaphore is idle and
-   no dispatch decision is in flight. The API then rejects tenant admissions
-   with `503`/`Retry-After`, and recovery starts no new executions;
+5. promotion assumes the exact release-tagged fence operator and invokes the port
+   close command, atomically only if semaphore is idle and no decision is in flight.
+   The API then rejects admissions with `503`/`Retry-After`; recovery starts none;
 6. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
    signed activation manifest ARNs only after verifying that binding, then
    switches only the OpenTofu-owned state-machine `TaskDefinition` ARN; Schedulers
@@ -222,18 +222,15 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   Copy reads the source and writes the destination only. It has no
   raw/audit/other-prefix access and no `s3:DeleteObject` or `s3:ListBucket`
   unless separately demonstrated necessary.
-- One environment-wide control-plane DynamoDB semaphore/lease/fence item gates
-  all unit work. Initial API starts and recovery conditionally acquire it before
-  `StartExecution`, bind owner to dispatch/execution, renew it and release it
-  terminally. An expired item cannot authorize takeover until
-  `DescribeExecution` and ECS prove no work active; TTL is garbage collection
-  only. The semaphore is the cross-run arbiter: losers do not call
-  `StartExecution`; dispatch CAS applies only to same-run recovery/idempotency.
-  A concurrent request receives the documented quota error or `429`.
-- The deployment fence shares this control plane but is independent of the unit
-  semaphore. It blocks initial and recovery dispatch, except for one
-  release-bound synthetic canary during promotion, until rollback or acceptance
-  explicitly reopens admissions.
+- `ControlPlanePort.mutate_environment_gate(command)` accepts typed acquire, bind,
+  renew, release, close-fence and reopen-fence variants and returns owner/version state.
+  The DynamoDB adapter uses conditional transaction/CAS on one environment gate item.
+  API/recovery use runtime variants; the release-tagged promotion operator may only
+  get and close/reopen that exact item. Expired takeover requires Step Functions/ECS
+  proof; TTL only collects garbage. Losers never call `StartExecution` and receive the
+  quota error or `429`; dispatch CAS remains same-run idempotency only.
+- The independent deployment fence blocks initial/recovery dispatch except the bound
+  synthetic canary. Acceptance or rollback explicitly reopens it through the port.
 
 ## 7. Test and acceptance matrix
 
@@ -318,12 +315,11 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   `MaxSessionDuration=3600` are asserted;
   the incident drill disables new sessions, updates CRL, revokes old sessions
   and proves the timed Deny before re-enabling a rotated leaf;
-- semaphore tests require conditional acquisition before initial or recovery
-  `StartExecution`, dispatch/execution ownership, terminal release, no expired
-  takeover before Step Functions/ECS proof, no losing cross-run `StartExecution`
-  and `429` or quota on contention. Overlapping, externally retried and
-  at-least-once duplicate recovery passes remain individually bounded, while
-  dispatch CAS covers same-run recovery only;
+- gate-port tests cover typed acquire/bind/renew/release/close/reopen and conditional
+  adapter transactions. API/recovery use runtime variants; promotion assumes only the
+  release-tagged operator with exact-item get/close/reopen and no other table access.
+  Expired takeover waits for Step Functions/ECS proof; losers never `StartExecution`
+  and receive `429`/quota. Duplicate recovery stays bounded; dispatch CAS is same-run;
 - cost tests count billed pull/start/run/stop. Two minutes per 30-minute recovery and
   audit invocation budget 48+48=96 hours/30 days, leaving 4 of 100 for units. Excess
   fails acceptance/alarms and is not called a hard cap;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -69,8 +69,8 @@ Order:
 2. register new immutable unit and `recover-once` revisions pinned to that exact
    digest; select the unit revision in the state-machine `TaskDefinition` ARN
    and the recovery revision in the Scheduler target;
-3. update scoped `ecs:RunTask`/`iam:PassRole` policies when revision ARNs make
-   that necessary, then use `DescribeTaskDefinition`, state-machine and
+3. update revision-scoped `ecs:RunTask` and revalidate exact-role
+   `iam:PassRole`, then use `DescribeTaskDefinition`, state-machine and
    Scheduler evidence to prove both selections resolve to the exact release
    digest before switching API or frontend. Active Standard executions retain
    the revision on which they started;
@@ -239,8 +239,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - release-manifest and promotion tests require immutable unit and `recover-once`
   revision ARNs pinned to the exact ECR release digest. `DescribeTaskDefinition`,
   state-machine and Scheduler evidence must resolve each selected revision to
-  that digest before API/frontend switching, including any revision-scoped
-  `ecs:RunTask`/`iam:PassRole` policy update;
+  that digest before API/frontend switching, including revision-scoped
+  `ecs:RunTask` and exact-role `iam:PassRole` validation;
 - recovery validation enforces the separate `recover-once` definition/mode,
   same image and network shape, Scheduler cadence at most half
   `AWS_PROCESSOR_LEASE_SECONDS`, `MaximumRetryAttempts=0`, no seven normal

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -158,7 +158,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   CA PEM and the Roles Anywhere profile, with AWS Private CA prohibited. The
   trust policy permits `sts:AssumeRole`, `sts:TagSession` and
   `sts:SetSourceIdentity` only to `rolesanywhere.amazonaws.com`, conditioned on
-  the profile `SourceArn` and API/VPS X.509 identity; no private CA key or leaf
+  the trust-anchor `SourceArn` and API/VPS X.509 identity; the profile remains
+  separately referenced by `credential_process`; no private CA key or leaf
   appears in repository or state;
 - the separate Step Functions role is trusted only by `states.amazonaws.com`.
   `ecs:RunTask` is scoped to the task definition; `ecs:DescribeTasks` and

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -153,7 +153,7 @@ Initial internal targets:
 - API availability 99.5%;
 - eligible processing-job success 99%;
 - routine API p95 below two seconds;
-- routine deployment interruption at most 60 seconds.
+- routine deployment interruption at most 30 minutes.
 
 Grafana Alloy collects VPS/API/Nginx/Tunnel telemetry without Docker-socket
 access. CloudWatch owns DynamoDB, Step Functions, ECS, S3 and Athena alarms.
@@ -190,8 +190,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   DynamoDB, S3 and Step Functions. Retain the deny for at least the maximum
   session duration plus propagation, issue and install a new leaf, then
   re-enable the profile/trust and test a new session.
-- Step Functions launches unit tasks with production `AWS_PROCESSOR_LEASE_SECONDS=7200`.
-  Hourly `recover-once` uses the same image, separate mode, batch 100 and coordinator
+- Step Functions launches unit tasks with production `AWS_PROCESSOR_LEASE_SECONDS=3600`.
+  `recover-once` runs every 30 minutes with the same image, mode, batch 100 and coordinator
   composition without normal variables/audit sink. PID 1 enforces the lease deadline;
   the semaphore is cross-run and dispatch CAS same-run.
 - Scheduler runs independent `dispatch-outbox-once` every 30 minutes with the same
@@ -299,16 +299,16 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - promotion tests atomically close the fence before phase B only when the unit
   semaphore is idle and no dispatch is in flight, then reject tenant/recovery
   starts and allow only the bound canary. Local smoke precedes Nginx; tunneled smoke
-  uses the production hostname after that switch. Any failure or fence-budget
-  cutoff before phase C restores prior routes and reopens within 60 seconds. Partial
-  phase-B/C applies instead remain fail-closed until reviewed convergence completes;
+  uses the production hostname after that switch. The entire successful fence through
+  both phase-C acceptances is capped at 30 minutes; routine cutoff restores routes
+  within budget. Partial phase-B/C applies remain fail-closed until reviewed convergence;
 - drain/prune tests retain old revisions and `ecs:RunTask` grants through active
   old Standard/recovery drain and rollback retention, then prune only older
   non-rollback revisions; rollback consumes the prior retained manifest through
   a reviewed exact OpenTofu plan/apply;
 - recovery validation enforces the separate `recover-once` definition/mode,
   same image/network, coordinator-only composition without normal variables or
-  audit sink, production lease 7200, hourly cadence, batch 100 and
+  audit sink, production lease 3600, 30-minute cadence, batch 100 and
   `MaximumRetryAttempts=0`. Its PID 1 hard wall-clock
   deadline equal to the lease that logs/alarms, cancels work, exits nonzero and
   stops the ECS task; overlapping, externally retried or at-least-once duplicate
@@ -324,9 +324,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   and `429` or quota on contention. Overlapping, externally retried and
   at-least-once duplicate recovery passes remain individually bounded, while
   dispatch CAS covers same-run recovery only;
-- cost tests count billed pull/start/run/stop. Two minutes per hourly recovery and
-  30-minute audit invocation budget 24+48=72 hours/30 days, leaving 28 of 100 for
-  units. Excess fails acceptance/alarms and is not called a hard cap;
+- cost tests count billed pull/start/run/stop. Two minutes per 30-minute recovery and
+  audit invocation budget 48+48=96 hours/30 days, leaving 4 of 100 for units. Excess
+  fails acceptance/alarms and is not called a hard cap;
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -192,32 +192,31 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   DynamoDB, S3 and Step Functions. Retain the deny for at least the maximum
   session duration plus propagation, issue and install a new leaf, then
   re-enable the profile/trust and test a new session.
-- The normal unit task is launched by Step Functions. `recover-once` is an
-  EventBridge Scheduler task using the same image but a separate definition/mode,
-  cadence at most half the lease and batch 100; it needs none of the seven normal
-  processor variables. Scheduler retries are zero; at-least-once/external passes
-  may overlap. PID 1 enforces the lease deadline, cancels and exits nonzero. The
-  semaphore arbitrates cross-run unit starts; dispatch CAS is same-run only.
+- Step Functions launches unit tasks. Scheduler `recover-once` uses the same image,
+  separate definition/mode, cadence at most half the lease, batch 100 and none of
+  the seven normal variables. Retries are zero; at-least-once passes may overlap.
+  PID 1 enforces the lease deadline; the semaphore is cross-run, dispatch CAS same-run.
 - `dispatch-outbox-once` is an independent Scheduler Fargate task with the same
-  image, its own definition/mode/role, five-minute cadence, batch 100 and
-  five-minute PID 1 deadline. It invokes only `dispatch_once`; recovery failure
-  and the budget freeze cannot suppress it. Sink failures remain pending, do not
-  block later events, alarm/exit nonzero and retry next cadence; replay is
-  idempotent. Scheduler retries are zero. Every task-hour counts toward the target.
+  image and its own definition/mode/role. `run_aws_entrypoint` allowlists that
+  command; its composition builds only the DynamoDB control plane and S3 audit
+  sink, then invokes `dispatch_once(limit=100)`. Cadence/deadline are five minutes.
+  Recovery failure and budget freeze cannot suppress it. Sink failures remain
+  pending, do not block later events and retry next cadence; alarm/exit is nonzero,
+  replay idempotent, Scheduler retries zero and task-hours counted.
 - Recovery role has control-plane read/write; `states:StartExecution` and
-  `states:DescribeStateMachine` on the exact production state machine;
-  `states:DescribeExecution`/`states:StopExecution` on executions; minimum
-  liveness `ecs:ListTasks`/`ecs:DescribeTasks`. The Scheduler role trusts
-  `scheduler.amazonaws.com` with exact `aws:SourceAccount` and
-  `aws:SourceArn`, scopes `ecs:RunTask` to recovery revisions and passes only its
-  task/execution roles. The dispatch Scheduler role has equivalent exact scope
-  only for dispatch revisions. Both use public subnets, zero-ingress security
-  groups, public IP, logs and alarm. The
-  recovery task, API and any takeover actor use ECS liveness reads only for the
-  configured cluster/task family with supported conditions; where ECS requires
-  `Resource: *`, those same narrow conditions apply.
+  `states:DescribeStateMachine` on the exact machine, `states:DescribeExecution`
+  and `states:StopExecution` on executions, plus `ecs:ListTasks`/`ecs:DescribeTasks`.
+  Its Scheduler role trusts only
+  `scheduler.amazonaws.com` with exact source account/ARN, runs recovery revisions
+  and passes only its task/execution roles. Dispatch Scheduler scope is equivalent
+  only for dispatch revisions. Both use public subnets, zero-ingress groups,
+  public IP, logs and alarms. Recovery/API/takeover ECS liveness reads use the
+  configured cluster/family conditions, including required narrow `Resource: *`.
 - Dispatch audit IAM allows `s3:GetBucketObjectLockConfiguration` on the bucket;
   `s3:GetObject`/`s3:PutObject`/`s3:PutObjectRetention` on `audit/*`; no delete/list/bypass.
+  It allows `dynamodb:Query` on the exact outbox GSI and
+  `dynamodb:GetItem`/`dynamodb:UpdateItem` on the exact control-plane table only;
+  scan, delete, put and access to any other table/index are denied.
 - For `PUBLISHING`, `s3:GetObject`/`s3:GetObjectVersion` read only the canonical
   data bucket's `tmp/`, `normalized/`, `reconciliation/` and `serving/` prefixes.
   `s3:PutObject` writes only final `normalized/`, `reconciliation/` and
@@ -247,9 +246,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - OIDC/JWKS rotation, revoked membership and cross-tenant denial;
 - old fence/dispatch rejection and duplicate execution replay;
 - required-source failure and optional-source degraded publication;
-- scheduled outbox dispatch reads at most 100 ordered events, writes the
-  deterministic COMPLIANCE object, marks delivered only after success, retries
-  pending failures next pass and proves same-hash replay idempotent;
+- dispatcher boot tests accept only `dispatch-outbox-once` without unit variables
+  and inject only control plane/audit sink. A pass reads at most 100 ordered events,
+  writes the COMPLIANCE object, marks after success, retries pending failures and
+  proves same-hash replay idempotent;
 - no presigned URL for non-serving prefixes;
 - dashboard artifact and browser checks reject a relative `/api` request or an
   API call that bypasses the configured absolute `/api/v1` client;
@@ -332,8 +332,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   machine, describe/stop-execution to its executions and ECS liveness to the
   configured cluster/task family or required narrow `Resource: *` conditions.
   Cancellation/failed binding proves stop succeeds; another machine is denied;
-- audit IAM tests allow only lock-configuration read plus get/put/put-retention
-  on the exact audit prefix; deny delete, list, bypass and every data-bucket key;
+- audit IAM tests allow exact outbox-GSI query, table get/update and audit-bucket
+  lock/get/put/retention; deny other tables/indexes, scan, delete, list and bypass;
 - a crash during `PUBLISHING` proves the recovery role reads manifest sidecars,
   promotes/verifies source-to-destination copies, writes reconciliation/serving
   manifests and completes pointer CAS without `AccessDenied`. Negative tests

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -141,6 +141,31 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - Revocation imports or updates the CRL at the Roles Anywhere trust anchor; it
   does not depend on OCSP or CDP. Compromise revokes and rotates the leaf,
   confirms fail-closed behavior and alerts the security owner.
+- Roles Anywhere `durationSeconds` on the profile and the IAM role
+  `MaxSessionDuration` are both 900 seconds. On incident, disable the profile
+  or its trust, import/update the CRL and apply `AWSRevokeOlderSessions` or an
+  explicit `aws:TokenIssueTime` Deny to the role.
+- Before declaring fail-closed, verify pre-incident credentials are denied by
+  DynamoDB, S3 and Step Functions. Retain the deny for at least the maximum
+  session duration plus propagation, issue and install a new leaf, then
+  re-enable the profile/trust and test a new session.
+- The normal unit task is launched by Step Functions. `recover-once` is an
+  EventBridge Scheduler task using the same processor image but a separate task
+  definition and mode, with cadence no greater than half
+  `AWS_PROCESSOR_LEASE_SECONDS`; it requires none of the seven normal processor
+  environment variables. Overlap is allowed and resolved by dispatch CAS.
+- The recovery task role has only control-plane read/write and
+  `states:DescribeExecution`. The Scheduler role trusts
+  `scheduler.amazonaws.com` with exact `aws:SourceAccount` and
+  `aws:SourceArn`, scopes `ecs:RunTask` to the recovery task definition and
+  passes only its task/execution roles. Recovery uses the unit task's public
+  subnets, zero-ingress security group and public IP, with logs and alarm.
+- One environment-wide control-plane DynamoDB semaphore/lease/fence item gates
+  all unit work. Initial API starts and recovery conditionally acquire it before
+  `StartExecution`, bind owner to dispatch/execution, renew it and release it
+  terminally. An expired item cannot authorize takeover until
+  `DescribeExecution` and ECS prove no work active; TTL is garbage collection
+  only. A concurrent request receives the documented quota error or `429`.
 
 ## 7. Test and acceptance matrix
 
@@ -173,6 +198,16 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   `events:PutRule` and `events:DescribeRule` are scoped to
   `StepFunctionsGetEventsForECSTaskRule`; `iam:PassRole` permits only the task
   and execution roles with `iam:PassedToService=ecs-tasks.amazonaws.com`;
+- recovery validation enforces the separate `recover-once` definition/mode,
+  same image and network shape, Scheduler cadence at most half
+  `AWS_PROCESSOR_LEASE_SECONDS`, no seven normal processor environment
+  variables, least-privilege recovery/Scheduler roles, logs and alarm;
+- profile `durationSeconds` and role `MaxSessionDuration` equal 900 seconds;
+  the incident drill disables new sessions, updates CRL, revokes old sessions
+  and proves the timed Deny before re-enabling a rotated leaf;
+- semaphore tests require conditional acquisition before initial or recovery
+  `StartExecution`, dispatch/execution ownership, terminal release, no expired
+  takeover before Step Functions/ECS proof and `429` or quota on contention;
 - the production AWS-012 override accepts `AssignPublicIp=ENABLED` only with
   exact public subnet IDs, the configured zero-ingress security group,
   `FARGATE`, maximum concurrency one, and no NAT Gateway or ALB; it rejects
@@ -209,6 +244,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - a Step Functions execution starts only the approved Fargate task definition,
   uses only the exact source account/state-machine trust, event rule and pass
   roles above, and fails when any scope drifts;
+- the `recover-once` Scheduler run uses the same image/network, emits its log
+  and alarm evidence, and cannot start without its narrow roles;
+- two distinct runs plus a recovery race leave at most one unit Fargate task
+  active; dispatch CAS remains the overlap arbiter;
 - one synthetic run publishes exactly one new immutable version/pointer;
 - the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
   with `Cache-Control: private, no-store` and only `url`, `version_id` and
@@ -276,6 +315,10 @@ Cost controls:
   <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html>
 - IAM Roles Anywhere trust model:
   <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/trust-model.html>
+- IAM Roles Anywhere CreateSession:
+  <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/authentication-create-session.html>
+- IAM revoke role sessions:
+  <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_revoke-sessions.html>
 - AWS SDK process credentials:
   <https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html>
 - FastAPI CORS:

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -67,19 +67,25 @@ Order:
 
 1. promote/verify the processor digest in ECR;
 2. register new immutable unit and `recover-once` revisions pinned to that exact
-   digest; select the unit revision in the state-machine `TaskDefinition` ARN
-   and the recovery revision in the Scheduler target;
-3. update revision-scoped `ecs:RunTask` and revalidate exact-role
-   `iam:PassRole`, then use `DescribeTaskDefinition`, state-machine and
-   Scheduler evidence to prove both selections resolve to the exact release
-   digest before switching API or frontend. Active Standard executions retain
-   the revision on which they started;
-4. update the inactive API candidate on the VPS;
-5. pass local and tunneled health/authorization smoke tests;
-6. switch Nginx to the candidate;
-7. publish frontend assets and entrypoint;
-8. run the synthetic vertical slice and serving test;
-9. record redacted evidence and retain the previous release.
+   digest without changing the state-machine or Scheduler targets;
+3. extend the Step Functions and Scheduler roles' `ecs:RunTask` grants to authorize
+   both current (old) and candidate (new) revision ARNs; exact-role
+   `iam:PassRole` remains unchanged;
+4. wait for and revalidate IAM propagation, then prove both revisions are
+   authorized;
+5. switch the state-machine `TaskDefinition` ARN and Scheduler recovery target;
+6. use `DescribeTaskDefinition`, state-machine and Scheduler evidence to prove
+   both selected revisions resolve to the exact release digest;
+7. update the inactive API candidate on the VPS;
+8. pass local and tunneled health/authorization smoke tests;
+9. switch Nginx to the candidate;
+10. publish frontend assets and entrypoint;
+11. run the synthetic vertical slice and serving test;
+12. record redacted evidence and retain the previous release.
+
+Retain old revisions and their `ecs:RunTask` grants until all active old Standard
+executions and recovery tasks drain and the rollback-retention period ends. Prune
+only older non-rollback revisions after that point.
 
 No production deployment occurs automatically after merge.
 
@@ -87,10 +93,10 @@ No production deployment occurs automatically after merge.
 
 - **API:** restore the previous Nginx upstream and already-pulled GHCR digest.
 - **Frontend:** restore the prior versioned entrypoint and invalidate it.
-- **Processor:** restore both prior immutable unit and `recover-once` revisions,
-  digests and state-machine/Scheduler routes for new dispatches; active Standard
-  executions continue with the definition they started unless cancellation is
-  safe.
+- **Processor:** rollback assumes the prior routes and grants remain intact;
+  restore both prior immutable unit and `recover-once` revisions, digests and
+  state-machine/Scheduler routes for new dispatches. Active Standard executions
+  continue with the definition they started unless cancellation is safe.
 - **State machine:** revert only new-execution routing; do not edit an active
   execution or DynamoDB record manually.
 - **DynamoDB/S3:** application releases never roll data backward or delete
@@ -157,11 +163,12 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - Revocation imports or updates the CRL at the Roles Anywhere trust anchor; it
   does not depend on OCSP or CDP. Compromise revokes and rotates the leaf,
   confirms fail-closed behavior and alerts the security owner.
-- Roles Anywhere profile/helper `durationSeconds` and IAM role
-  `MaxSessionDuration` are 3600 seconds. This bounded lifetime exceeds
-  botocore's default 15-minute advisory refresh window. On incident, disable the
-  profile or its trust, import/update the CRL and apply `AWSRevokeOlderSessions`
-  or an explicit `aws:TokenIssueTime` Deny to the role.
+- The Roles Anywhere profile sets `durationSeconds=3600`; its signing helper
+  uses `--session-duration 3600`; and the IAM role sets
+  `MaxSessionDuration=3600`. This bounded lifetime exceeds botocore's default
+  15-minute advisory refresh window. On incident, disable the profile or its
+  trust, import/update the CRL and apply `AWSRevokeOlderSessions` or an explicit
+  `aws:TokenIssueTime` Deny to the role.
 - Before declaring fail-closed, verify pre-incident credentials are denied by
   DynamoDB, S3 and Step Functions. Retain the deny for at least the maximum
   session duration plus propagation, issue and install a new leaf, then
@@ -186,8 +193,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   `states:DescribeExecution` on its executions, plus minimum liveness
   `ecs:ListTasks`/`ecs:DescribeTasks`. The Scheduler role trusts
   `scheduler.amazonaws.com` with exact `aws:SourceAccount` and
-  `aws:SourceArn`, scopes `ecs:RunTask` to the recovery task definition and
-  passes only its task/execution roles. Recovery uses the unit task's public
+  `aws:SourceArn`, scopes `ecs:RunTask` to recovery revision ARNs and, during
+  activation, both old and candidate revisions; it passes only its task/execution
+  roles. Recovery uses the unit task's public
   subnets, zero-ingress security group and public IP, with logs and alarm. The
   recovery task, API and any takeover actor use ECS liveness reads only for the
   configured cluster/task family with supported conditions; where ECS requires
@@ -214,11 +222,11 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - no presigned URL for non-serving prefixes;
 - dashboard artifact and browser checks reject a relative `/api` request or an
   API call that bypasses the configured absolute `/api/v1` client;
-- long-lived boto3/botocore clients cross at least one IAM Roles Anywhere
-  `credential_process` expiration/refresh and complete an AWS call without a
-  process or container restart. The helper is not invoked per request and
-  botocore refreshes near the 3600-second expiry; helper or refresh failure
-  fails closed;
+- long-lived boto3/botocore clients complete an AWS call without process or
+  container restart: the initial credential-using call invokes the IAM Roles
+  Anywhere helper; calls before the 15-minute advisory window do not re-invoke
+  it; and the first credential access inside that window invokes one lazy refresh
+  that succeeds. Helper or refresh failure fails closed;
 - VPS config tests require `AWS_CONFIG_FILE` and matching `AWS_PROFILE`; a
   missing or mismatched profile fails before readiness;
 - OpenTofu creates the `us-east-2` trust anchor from external offline public
@@ -231,16 +239,21 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   appears in repository or state;
 - the separate Step Functions role is trusted only by `states.amazonaws.com`
   with the exact `aws:SourceAccount` and the exact production state-machine
-  `aws:SourceArn`. `ecs:RunTask` is scoped to the task definition;
+  `aws:SourceArn`. `ecs:RunTask` is scoped to the current/candidate unit
+  revision ARNs during activation;
   `ecs:DescribeTasks` and `ecs:StopTask` use `Resource: *`; `events:PutTargets`,
   `events:PutRule` and `events:DescribeRule` are scoped to
   `StepFunctionsGetEventsForECSTaskRule`; `iam:PassRole` permits only the task
   and execution roles with `iam:PassedToService=ecs-tasks.amazonaws.com`;
 - release-manifest and promotion tests require immutable unit and `recover-once`
-  revision ARNs pinned to the exact ECR release digest. `DescribeTaskDefinition`,
-  state-machine and Scheduler evidence must resolve each selected revision to
-  that digest before API/frontend switching, including revision-scoped
-  `ecs:RunTask` and exact-role `iam:PassRole` validation;
+  revision ARNs pinned to the exact ECR release digest. Before target switching,
+  both current and candidate revisions have authorized `ecs:RunTask` grants;
+  exact `iam:PassRole` is unchanged; IAM propagation is revalidated; and both
+  revisions are proved authorized. After switching, `DescribeTaskDefinition`,
+  state-machine and Scheduler evidence resolves each selection to that digest;
+- drain/prune tests retain old revisions and `ecs:RunTask` grants through active
+  old Standard/recovery drain and rollback retention, then prune only older
+  non-rollback revisions;
 - recovery validation enforces the separate `recover-once` definition/mode,
   same image and network shape, Scheduler cadence at most half
   `AWS_PROCESSOR_LEASE_SECONDS`, `MaximumRetryAttempts=0`, no seven normal
@@ -248,8 +261,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   deadline equal to the lease that logs/alarms, cancels work, exits nonzero and
   stops the ECS task; overlapping, externally retried or at-least-once duplicate
   invocations have no global concurrency ceiling;
-- profile/helper `durationSeconds` and role `MaxSessionDuration` each equal
-  3600 seconds;
+- profile `durationSeconds=3600`, helper `--session-duration 3600` and role
+  `MaxSessionDuration=3600` are asserted;
   the incident drill disables new sessions, updates CRL, revokes old sessions
   and proves the timed Deny before re-enabling a rotated leaf;
 - semaphore tests require conditional acquisition before initial or recovery
@@ -302,10 +315,12 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - a Step Functions execution starts only the approved Fargate task definition,
   uses only the exact source account/state-machine trust, event rule and pass
   roles above, and fails when any scope drifts;
-- promotion evidence from `DescribeTaskDefinition`, the state machine and
-  Scheduler proves the selected immutable unit and `recover-once` revisions use
-  the exact release ECR digest before the API/frontend switch; active Standard
-  executions remain on their original revision;
+- before target switching, promotion evidence proves propagated `ecs:RunTask`
+  authorization for both old and candidate revisions while exact `iam:PassRole`
+  remains unchanged. After switching, `DescribeTaskDefinition`, state machine
+  and Scheduler prove the selected unit and `recover-once` revisions use the
+  exact release ECR digest; active Standard executions remain on their original
+  revision;
 - the `recover-once` Scheduler run uses the same image/network, emits its log
   and alarm evidence, uses `MaximumRetryAttempts=0`, and cannot start without
   its narrow roles;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -23,7 +23,8 @@ Pull requests to `develop` run the existing locked Python/CND/AWS gates plus:
 - dashboard routing checks require
   `VITE_API_BASE_URL=https://api.cnesdata.vinisantana.com/api/v1`, mapped from
   the exact OpenTofu output into the dashboard build, one authenticated API
-  client for `auth/me` and activation, no production relative `/api` request,
+  client for `auth/me` and `/api/v1/activate/confirm`, no legacy origin-level
+  activation or production relative `/api` request,
   bearer only to the API origin and `X-Tenant-Id` only for tenant-scoped calls;
 - API and processor image build tests;
 - OCI vulnerability scan and SBOM generation;
@@ -76,29 +77,28 @@ Order:
    then output their ARNs and phase-A evidence;
 4. finalize and sign one post-registration activation manifest with the candidate
    manifest SHA-256, release ID, source SHA, exact revision ARNs, verified
-   `ECR_URI@sha256` and phase-A evidence; never re-register those revisions;
+   `ECR_URI@sha256` and phase-A evidence; never re-register those revisions. Run
+   the candidate dispatcher against an isolated nonproduction table/bucket;
 5. atomically close the deployment fence only if the unit semaphore is idle and
    no dispatch decision is in flight. The API then rejects tenant admissions
    with `503`/`Retry-After`, and recovery starts no new executions;
 6. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
    signed activation manifest ARNs only after verifying that binding, then
-   switches the OpenTofu-owned state-machine `TaskDefinition` ARN and both
-   Scheduler targets. No out-of-band mutation or `ignore_changes` is
-   allowed;
+   switches the OpenTofu-owned state-machine `TaskDefinition` ARN and recovery
+   Scheduler only; audit dispatch stays on its prior validated revision. No
+   out-of-band mutation or `ignore_changes` is allowed;
 7. use `DescribeTaskDefinition`, state-machine and Scheduler evidence to prove
-   all selected revisions resolve to the exact release digest and verify the
-   manifest binding, then verify clean OpenTofu state and no drift;
+   selected unit/recovery revisions match the release while audit dispatch still
+   matches the prior manifest; then verify binding, clean state and no drift;
 8. verify that same signed binding, update the inactive API candidate and pass
    local health/authorization smoke tests;
 9. switch Nginx to the candidate and run tunneled health/authorization through
    the normal production hostname, which now resolves to that candidate;
 10. publish frontend assets and entrypoint;
-11. while fenced, admit only the release-bound synthetic canary. The hard fence
-    budget reserves rollback margin, aborting unfinished work early enough to
-    restore prior routes and reopen admissions within 60 seconds of step 5;
-12. retain the prior release and evidence. After successful phase B, later failure
-    restores prior routes within the fence budget. A partial apply stays fenced
-    until a diagnosed, reviewed plan converges every route; never reopen mixed.
+11. while fenced, run the bound application canary, then reopen within 60 seconds;
+12. after acceptance, reviewed phase C switches only the audit Scheduler and proves
+    binding/digest/no drift. Failure keeps its prior route and deployment incomplete;
+    retain the prior release/evidence.
 
 Retain old revisions/grants until active old Standard/scheduled work drains and
 rollback retention ends. Then prune older non-rollback revisions.
@@ -289,11 +289,13 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   candidate manifest SHA-256, release ID, source SHA, revision ARNs, verified
   digest and phase-A evidence;
 - phase-B exact OpenTofu plan/apply consumes that signed manifest and switches
-  only the OpenTofu-owned state-machine/Scheduler targets after verifying the
-  binding. API/frontend steps verify the same binding. Tests reject artifact
+  only the state-machine/recovery target while audit dispatch remains prior.
+  API/frontend verify the binding. Tests reject artifact
   mixing, out-of-band mutation and `ignore_changes`, then prove selected exact
   digests, clean state and no drift. Fault injection leaves a partial apply fenced
   until a diagnosed, reviewed plan converges all routes; mixed routes never reopen;
+- phase C runs only after application and isolated dispatcher canaries pass,
+  switches only audit Scheduler by reviewed apply and leaves the old route on failure;
 - promotion tests atomically close the fence before phase B only when the unit
   semaphore is idle and no dispatch is in flight, then reject tenant/recovery
   starts and allow only the bound canary. Local smoke precedes Nginx; tunneled smoke
@@ -369,9 +371,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - API preflights from another origin or for a disallowed method/header are
   denied by FastAPI;
 - browser network evidence proves `auth/me` and activation use the configured
-  `VITE_API_BASE_URL=https://api.cnesdata.vinisantana.com/api/v1`, never
-  relative `/api`; bearer is sent only to the API origin and `X-Tenant-Id` only
-  to tenant-scoped calls;
+  base and exact `/api/v1/activate/confirm`; the legacy origin route and relative
+  `/api` are absent. Bearer is API-origin only and tenant header tenant-call only;
 - a Step Functions execution starts only the approved Fargate task definition,
   uses only the exact source account/state-machine trust, event rule and pass
   roles above, and fails when any scope drifts;
@@ -379,10 +380,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   authorization without routing changes, then the signed activation manifest
   binds candidate manifest SHA-256, release ID, source SHA, exact ARNs/digest
   and phase-A evidence. Phase-B OpenTofu evidence verifies that binding and
-  proves the state machine and both Schedulers selected those revisions, exact ECR
-  digest, clean state and no drift; API/frontend evidence verifies the same
-  binding before switching. Active Standard executions remain on their original
-  revision;
+  proves phase B selected unit/recovery while audit remained prior. After both
+  canaries, phase C selects the bound audit revision; each phase proves exact ECR
+  digest, clean state and no drift. Active executions keep original revisions;
 - promotion evidence proves the fence closed before phase B, no dispatch was in
   flight, local smoke passed before switching, and tunneled smoke reached the
   candidate through the switched production hostname. Only the bound canary is

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -80,10 +80,11 @@ Order:
 4. sign one activation manifest with candidate SHA-256, release ID, source SHA,
    exact revisions, ECR digest and phase-A evidence; never re-register them. A seeder
    restricted to `PutItem` on the exact canary table writes one bound pending event.
-   Run the dispatcher through promotion `RunTask`, overriding roles and resource
+   The verifier polls the exact canary GSI until that event is visible, bounded to
+   60 seconds and fail-closed; then run promotion `RunTask`, overriding roles/resource
    variables to canary-only values. It passes only canary task/execution roles with
-   ECS PassedToService. A verifier gets conditioned `GetItem` on the bound key and
-   `GetObject`/`GetObjectRetention` on its object; require retention/delivered proof;
+   ECS PassedToService. Verifier gets exact-GSI `Query`, conditioned `GetItem` and
+   bound `GetObject`/`GetObjectRetention`; require retention/delivered proof;
 5. promotion assumes the release-tagged fence operator and atomically closes the
    separate fence item first. New acquire transactions now fail; wait for the semaphore
    and any in-flight decision to drain. API returns `503`/`Retry-After`; recovery waits;
@@ -290,8 +291,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - phase C follows both canaries; separate reviewed applies accept recovery, then audit,
   while fenced. Faults converge that route; reopening requires both accepted;
 - canary tests seed a release-bound pending event and require exact revision/overrides,
-  its COMPLIANCE object, retention and delivered marker. Seeder `PutItem` is canary-table
-  only. Verifier IAM allows conditioned `GetItem` and bound-object `GetObject` plus
+  then boundedly poll its exact GSI before dispatch; timeout fails closed. They require
+  its COMPLIANCE object, retention and delivered marker. Seeder `PutItem` is table-only.
+  Verifier IAM allows exact-GSI `Query`, conditioned `GetItem`, bound `GetObject` plus
   `GetObjectRetention`; `PassRole` is exact canary/ECS; other releases denied; roles expire;
 - promotion tests atomically close the fence before phase B only when the unit
   semaphore is idle and no dispatch is in flight, then reject tenant/recovery

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -77,9 +77,9 @@ Order:
 4. finalize and sign one post-registration activation manifest with the candidate
    manifest SHA-256, release ID, source SHA, exact revision ARNs, verified
    `ECR_URI@sha256` and phase-A evidence; never re-register those revisions;
-5. atomically close the environment deployment fence. The API then rejects all
-   tenant job admissions with `503` and `Retry-After`, recovery starts no new
-   executions, and the workflow waits until no dispatch decision is in flight;
+5. atomically close the deployment fence only if the unit semaphore is idle and
+   no dispatch decision is in flight. The API then rejects tenant admissions
+   with `503`/`Retry-After`, and recovery starts no new executions;
 6. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
    signed activation manifest ARNs only after verifying that binding, then
    switches the still OpenTofu-owned state-machine `TaskDefinition` ARN and
@@ -96,9 +96,8 @@ Order:
 11. while fenced, admit only the release-bound synthetic canary. The hard fence
     budget reserves rollback margin, aborting unfinished work early enough to
     restore prior routes and reopen admissions within 60 seconds of step 5;
-12. record redacted evidence and retain the previous release. A failure in
-    steps 6-11 keeps the fence closed and immediately restores the prior API,
-    processor and Scheduler routes before reopening admissions.
+12. retain the prior release and record redacted evidence. Failure in steps 6-11
+    restores all prior routes while fenced, then reopens admissions.
 
 Retain old revisions and their `ecs:RunTask` grants until all active old Standard
 executions and recovery tasks drain and the rollback-retention period ends. Prune
@@ -209,9 +208,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   Every recovery task-hour is counted in the 100-hour monitored monthly
   operating target. The environment semaphore arbitrates cross-run unit starts,
   while dispatch CAS handles only same-run recovery and idempotency.
-- The recovery task role has control-plane read/write,
-  `states:StartExecution` on the exact production state machine and
-  `states:DescribeExecution` and `states:StopExecution` on its executions, plus
+- Recovery role has control-plane read/write; `states:StartExecution` and
+  `states:DescribeStateMachine` on the exact production state machine;
+  `states:DescribeExecution`/`states:StopExecution` on its executions, plus
   minimum liveness
   `ecs:ListTasks`/`ecs:DescribeTasks`. The Scheduler role trusts
   `scheduler.amazonaws.com` with exact `aws:SourceAccount` and
@@ -295,9 +294,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   binding. API/frontend steps verify the same binding. Tests reject artifact
   mixing, out-of-band mutation and `ignore_changes`, then prove selected exact
   digests, clean state and no drift;
-- promotion tests close the deployment fence before phase B, prove no dispatch
-  decision remains in flight, reject tenant jobs and recovery starts, and allow
-  only the bound canary. Local smoke precedes the Nginx switch; tunneled smoke
+- promotion tests atomically close the fence before phase B only when the unit
+  semaphore is idle and no dispatch is in flight, then reject tenant/recovery
+  starts and allow only the bound canary. Local smoke precedes Nginx; tunneled smoke
   uses the production hostname after that switch. Any failure or fence-budget
   cutoff restores prior routes and reopens admissions within 60 seconds;
 - drain/prune tests retain old revisions and `ecs:RunTask` grants through active
@@ -329,7 +328,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;
-- recovery role tests scope `states:StartExecution` to the production machine,
+- recovery role tests scope `states:StartExecution`/`states:DescribeStateMachine`
+  to the exact production state machine,
   `states:DescribeExecution`/`states:StopExecution` to its executions and ECS
   liveness reads to the configured cluster/task family or required narrow
   `Resource: *` conditions. Cancellation and failed replacement binding prove

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -204,6 +204,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - long-lived boto3/botocore clients cross at least one IAM Roles Anywhere
   `credential_process` expiration/refresh and complete an AWS call without a
   process or container restart; helper or refresh failure fails closed;
+- VPS config tests require `AWS_CONFIG_FILE` and matching `AWS_PROFILE`; a
+  missing or mismatched profile fails before readiness;
 - OpenTofu creates the `us-east-2` trust anchor from external offline public
   CA PEM with the required CA, key-usage and SHA-256 constraints, and the Roles
   Anywhere profile, with AWS Private CA prohibited. The trust policy permits

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -303,7 +303,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   signed;
 - the dashboard makes a second direct S3 `fetch` with credentials omitted and
   without `Authorization`, `X-Tenant-Id`, cookies or other custom headers; it
-  reads the expected JSON body from the 300-second signed URL;
+  reads the expected JSON body from the 300-second signed URL and asserts the
+  S3 response has `Cache-Control: private, no-store` from object metadata;
 - this production handoff replaces the AWS-014 `307` route contract before
   promotion;
 - logs, traces, state and artifacts contain no secret or synthetic record body;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -96,12 +96,12 @@ Order:
 11. while fenced, admit only the release-bound synthetic canary. The hard fence
     budget reserves rollback margin, aborting unfinished work early enough to
     restore prior routes and reopen admissions within 60 seconds of step 5;
-12. retain the prior release and record redacted evidence. Failure in steps 6-11
-    restores all prior routes while fenced, then reopens admissions.
+12. retain the prior release and evidence. After successful phase B, later failure
+    restores prior routes within the fence budget. A partial apply stays fenced
+    until a diagnosed, reviewed plan converges every route; never reopen mixed.
 
-Retain old revisions and their `ecs:RunTask` grants until all active old Standard
-executions and recovery tasks drain and the rollback-retention period ends. Prune
-only older non-rollback revisions after that point.
+Retain old revisions and `ecs:RunTask` grants until active old Standard/recovery
+work drains and rollback retention ends. Then prune older non-rollback revisions.
 
 No production deployment occurs automatically after merge.
 
@@ -293,7 +293,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   only the OpenTofu-owned state-machine/Scheduler targets after verifying the
   binding. API/frontend steps verify the same binding. Tests reject artifact
   mixing, out-of-band mutation and `ignore_changes`, then prove selected exact
-  digests, clean state and no drift;
+  digests, clean state and no drift. Fault injection leaves a partial apply fenced
+  until a diagnosed, reviewed plan converges all routes; mixed routes never reopen;
 - promotion tests atomically close the fence before phase B only when the unit
   semaphore is idle and no dispatch is in flight, then reject tenant/recovery
   starts and allow only the bound canary. Local smoke precedes Nginx; tunneled smoke
@@ -328,12 +329,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;
-- recovery role tests scope `states:StartExecution`/`states:DescribeStateMachine`
-  to the exact production state machine,
-  `states:DescribeExecution`/`states:StopExecution` to its executions and ECS
-  liveness reads to the configured cluster/task family or required narrow
-  `Resource: *` conditions. Cancellation and failed replacement binding prove
-  recovery can stop the execution, while another machine is denied;
+- recovery-role tests scope start/describe-machine to the exact production
+  machine, describe/stop-execution to its executions and ECS liveness to the
+  configured cluster/task family or required narrow `Resource: *` conditions.
+  Cancellation/failed binding proves stop succeeds; another machine is denied;
 - a crash during `PUBLISHING` proves the recovery role reads manifest sidecars,
   promotes/verifies source-to-destination copies, writes reconciliation/serving
   manifests and completes pointer CAS without `AccessDenied`. Negative tests

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -90,15 +90,16 @@ No production deployment occurs automatically after merge.
 
 - Cloudflare Free rule protects the most sensitive public job/auth surface.
 - Nginx enforces IP-based general and expensive-mutation zones.
-- The API enforces tenant/user/idempotency quotas and maximum 200 jobs,
-  100 total task-hours for unit and recovery work, one unit task and at most one
-  `recover-once` overlap per month/environment.
+- The API enforces tenant/user/idempotency quotas, maximum 200 jobs, 100
+  combined unit and recovery task-hours per month, one concurrent unit task per
+  environment and bounded recovery overlap.
 - DynamoDB maximum throughput, Step Functions bounded retries and Athena bytes
   cutoffs contain downstream amplification.
 - Requests beyond product quota fail with `429` or the documented quota error
   before starting Step Functions or Athena.
-- A USD 15 aggregate budget action freezes new Fargate, Step Functions and
-  Athena starts through automation roles while preserving reads and backups.
+- A USD 15 aggregate budget action freezes new unit and recovery Fargate,
+  Step Functions and Athena starts through automation roles while preserving
+  reads and backups.
 
 ## 5. Observability and SLOs
 
@@ -154,9 +155,12 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   EventBridge Scheduler task using the same processor image but a separate task
   definition and mode, with cadence no greater than half
   `AWS_PROCESSOR_LEASE_SECONDS`; it requires none of the seven normal processor
-  environment variables. Scheduler overlap remains required by the governing
-  plan; the environment semaphore arbitrates cross-run work, while dispatch CAS
-  handles only same-run recovery and idempotency.
+  environment variables. Scheduler invocations may overlap, retry and duplicate
+  as required by the governing plan. Each is a bounded single pass with a
+  configured batch and appropriate hard timeout; all recovery task-hours count in
+  the 100-hour aggregate and budget freeze. The environment semaphore
+  arbitrates cross-run unit starts, while dispatch CAS handles only same-run
+  recovery and idempotency.
 - The recovery task role has only control-plane read/write,
   `states:StartExecution` on the exact production state machine and
   `states:DescribeExecution` on its executions, plus minimum liveness
@@ -211,7 +215,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - recovery validation enforces the separate `recover-once` definition/mode,
   same image and network shape, Scheduler cadence at most half
   `AWS_PROCESSOR_LEASE_SECONDS`, no seven normal processor environment
-  variables, least-privilege recovery/Scheduler roles, logs and alarm;
+  variables, bounded single-pass configured batch/hard timeout, allowed
+  overlapping/retried/duplicate invocations, least-privilege recovery/Scheduler
+  roles, logs and alarm;
 - profile/helper `durationSeconds` equals 900 and role `MaxSessionDuration`
   equals 3600 seconds;
   the incident drill disables new sessions, updates CRL, revokes old sessions
@@ -219,7 +225,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - semaphore tests require conditional acquisition before initial or recovery
   `StartExecution`, dispatch/execution ownership, terminal release, no expired
   takeover before Step Functions/ECS proof, no losing cross-run `StartExecution`
-  and `429` or quota on contention; dispatch CAS covers same-run recovery only;
+  and `429` or quota on contention. Overlapping/retried/duplicate recovery
+  invocations remain bounded, while dispatch CAS covers same-run recovery only;
 - recovery role tests scope `states:StartExecution` to the production machine,
   `states:DescribeExecution` to its executions and ECS liveness reads to the
   configured cluster/task family or required narrow `Resource: *` conditions;
@@ -261,9 +268,11 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   roles above, and fails when any scope drifts;
 - the `recover-once` Scheduler run uses the same image/network, emits its log
   and alarm evidence, and cannot start without its narrow roles;
-- two distinct runs plus a recovery race leave at most one unit Fargate task
-  active and at most one `recover-once` overlap; semaphore losers make no
-  `StartExecution`, while dispatch CAS remains limited to same-run recovery;
+- two distinct runs plus overlapping/retried/duplicate recovery invocations
+  leave at most one unit Fargate task active; semaphore losers make no
+  `StartExecution`, while dispatch CAS remains limited to same-run recovery and
+  every recovery pass stays bounded and its recorded task-hours count in the
+  100-hour aggregate and budget freeze;
 - one synthetic run publishes exactly one new immutable version/pointer;
 - the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
   with `Cache-Control: private, no-store` and only `url`, `version_id` and
@@ -292,8 +301,9 @@ Cost controls:
 - one of the account's maximum three CloudFront Free-plan subscriptions, with
   eligibility and `ACTIVE` status checked before cutover;
 - ECR generally below 2 GB;
-- one unit Fargate task plus at most one `recover-once` overlap, zero idle
-  desired count and 100 total task-hours maximum for both modes;
+- maximum one concurrent unit Fargate task per environment, bounded recovery
+  overlap, zero idle desired count and 100 combined unit and recovery task-hours
+  maximum per month, including every recovery invocation;
 - Step Functions Standard and 200 executions maximum;
 - Athena 5 GB/query and 100 GB/month;
 - DynamoDB on-demand maximum throughput;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -91,7 +91,8 @@ No production deployment occurs automatically after merge.
 - Cloudflare Free rule protects the most sensitive public job/auth surface.
 - Nginx enforces IP-based general and expensive-mutation zones.
 - The API enforces tenant/user/idempotency quotas and maximum 200 jobs,
-  100 task-hours and one concurrent processor task per month/environment.
+  100 total task-hours for unit and recovery work, one unit task and at most one
+  `recover-once` overlap per month/environment.
 - DynamoDB maximum throughput, Step Functions bounded retries and Athena bytes
   cutoffs contain downstream amplification.
 - Requests beyond product quota fail with `429` or the documented quota error
@@ -141,10 +142,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - Revocation imports or updates the CRL at the Roles Anywhere trust anchor; it
   does not depend on OCSP or CDP. Compromise revokes and rotates the leaf,
   confirms fail-closed behavior and alerts the security owner.
-- Roles Anywhere `durationSeconds` on the profile and the IAM role
-  `MaxSessionDuration` are both 900 seconds. On incident, disable the profile
-  or its trust, import/update the CRL and apply `AWSRevokeOlderSessions` or an
-  explicit `aws:TokenIssueTime` Deny to the role.
+- Roles Anywhere profile/helper `durationSeconds` is 900 seconds and IAM role
+  `MaxSessionDuration` is 3600 seconds. On incident, disable the profile or its
+  trust, import/update the CRL and apply `AWSRevokeOlderSessions` or an explicit
+  `aws:TokenIssueTime` Deny to the role.
 - Before declaring fail-closed, verify pre-incident credentials are denied by
   DynamoDB, S3 and Step Functions. Retain the deny for at least the maximum
   session duration plus propagation, issue and install a new leaf, then
@@ -153,19 +154,28 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   EventBridge Scheduler task using the same processor image but a separate task
   definition and mode, with cadence no greater than half
   `AWS_PROCESSOR_LEASE_SECONDS`; it requires none of the seven normal processor
-  environment variables. Overlap is allowed and resolved by dispatch CAS.
-- The recovery task role has only control-plane read/write and
-  `states:DescribeExecution`. The Scheduler role trusts
+  environment variables. Scheduler overlap remains required by the governing
+  plan; the environment semaphore arbitrates cross-run work, while dispatch CAS
+  handles only same-run recovery and idempotency.
+- The recovery task role has only control-plane read/write,
+  `states:StartExecution` on the exact production state machine and
+  `states:DescribeExecution` on its executions, plus minimum liveness
+  `ecs:ListTasks`/`ecs:DescribeTasks`. The Scheduler role trusts
   `scheduler.amazonaws.com` with exact `aws:SourceAccount` and
   `aws:SourceArn`, scopes `ecs:RunTask` to the recovery task definition and
   passes only its task/execution roles. Recovery uses the unit task's public
-  subnets, zero-ingress security group and public IP, with logs and alarm.
+  subnets, zero-ingress security group and public IP, with logs and alarm. The
+  recovery task, API and any takeover actor use ECS liveness reads only for the
+  configured cluster/task family with supported conditions; where ECS requires
+  `Resource: *`, those same narrow conditions apply.
 - One environment-wide control-plane DynamoDB semaphore/lease/fence item gates
   all unit work. Initial API starts and recovery conditionally acquire it before
   `StartExecution`, bind owner to dispatch/execution, renew it and release it
   terminally. An expired item cannot authorize takeover until
   `DescribeExecution` and ECS prove no work active; TTL is garbage collection
-  only. A concurrent request receives the documented quota error or `429`.
+  only. The semaphore is the cross-run arbiter: losers do not call
+  `StartExecution`; dispatch CAS applies only to same-run recovery/idempotency.
+  A concurrent request receives the documented quota error or `429`.
 
 ## 7. Test and acceptance matrix
 
@@ -202,12 +212,17 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   same image and network shape, Scheduler cadence at most half
   `AWS_PROCESSOR_LEASE_SECONDS`, no seven normal processor environment
   variables, least-privilege recovery/Scheduler roles, logs and alarm;
-- profile `durationSeconds` and role `MaxSessionDuration` equal 900 seconds;
+- profile/helper `durationSeconds` equals 900 and role `MaxSessionDuration`
+  equals 3600 seconds;
   the incident drill disables new sessions, updates CRL, revokes old sessions
   and proves the timed Deny before re-enabling a rotated leaf;
 - semaphore tests require conditional acquisition before initial or recovery
   `StartExecution`, dispatch/execution ownership, terminal release, no expired
-  takeover before Step Functions/ECS proof and `429` or quota on contention;
+  takeover before Step Functions/ECS proof, no losing cross-run `StartExecution`
+  and `429` or quota on contention; dispatch CAS covers same-run recovery only;
+- recovery role tests scope `states:StartExecution` to the production machine,
+  `states:DescribeExecution` to its executions and ECS liveness reads to the
+  configured cluster/task family or required narrow `Resource: *` conditions;
 - the production AWS-012 override accepts `AssignPublicIp=ENABLED` only with
   exact public subnet IDs, the configured zero-ingress security group,
   `FARGATE`, maximum concurrency one, and no NAT Gateway or ALB; it rejects
@@ -247,7 +262,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - the `recover-once` Scheduler run uses the same image/network, emits its log
   and alarm evidence, and cannot start without its narrow roles;
 - two distinct runs plus a recovery race leave at most one unit Fargate task
-  active; dispatch CAS remains the overlap arbiter;
+  active and at most one `recover-once` overlap; semaphore losers make no
+  `StartExecution`, while dispatch CAS remains limited to same-run recovery;
 - one synthetic run publishes exactly one new immutable version/pointer;
 - the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
   with `Cache-Control: private, no-store` and only `url`, `version_id` and
@@ -276,7 +292,8 @@ Cost controls:
 - one of the account's maximum three CloudFront Free-plan subscriptions, with
   eligibility and `ACTIVE` status checked before cutover;
 - ECR generally below 2 GB;
-- one Fargate task, zero idle desired count, 100 task-hours maximum;
+- one unit Fargate task plus at most one `recover-once` overlap, zero idle
+  desired count and 100 total task-hours maximum for both modes;
 - Step Functions Standard and 200 executions maximum;
 - Athena 5 GB/query and 100 GB/month;
 - DynamoDB on-demand maximum throughput;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -73,19 +73,17 @@ Order:
 2. under a reviewed exact OpenTofu plan/apply, phase A registers immutable unit,
    recovery and audit-dispatch revisions pinned to exact `ECR_URI@sha256` and
    dual-authorizes old and new `ecs:RunTask` ARNs without routing changes;
-   it creates release canary task/execution/seeder roles plus a persistent canary
+   it creates canary task/execution/seeder/verifier roles plus a persistent canary
    table and bucket owned by OpenTofu;
 3. wait for and revalidate IAM propagation, prove all revisions authorized,
    then output their ARNs and phase-A evidence;
-4. sign one activation manifest with candidate manifest SHA-256, release ID,
-   source SHA, exact revision ARNs, verified
-   `ECR_URI@sha256` and phase-A evidence; never re-register them. Assume a seeder
-   role restricted to `PutItem` on the exact canary table and write one bound pending
-   event. Run the dispatcher via promotion `RunTask`, overriding roles plus
-   `AWS_CONTROL_PLANE_TABLE`/`AWS_AUDIT_BUCKET` to canary resources only;
-   promotion can pass only canary task/execution roles, conditioned by
-   `iam:PassedToService=ecs-tasks.amazonaws.com`. Require its COMPLIANCE object,
-   retention and delivered marker for that event before continuing;
+4. sign one activation manifest with candidate SHA-256, release ID, source SHA,
+   exact revisions, ECR digest and phase-A evidence; never re-register them. A seeder
+   restricted to `PutItem` on the exact canary table writes one bound pending event.
+   Run the dispatcher through promotion `RunTask`, overriding roles and resource
+   variables to canary-only values. It passes only canary task/execution roles with
+   ECS PassedToService. A verifier gets conditioned `GetItem` on the bound key and
+   `GetObject`/`GetObjectRetention` on its object; require retention/delivered proof;
 5. atomically close the deployment fence only if the unit semaphore is idle and
    no dispatch decision is in flight. The API then rejects tenant admissions
    with `503`/`Retry-After`, and recovery starts no new executions;
@@ -192,10 +190,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   DynamoDB, S3 and Step Functions. Retain the deny for at least the maximum
   session duration plus propagation, issue and install a new leaf, then
   re-enable the profile/trust and test a new session.
-- Step Functions launches unit tasks. Scheduler `recover-once` uses the same image,
-  separate mode, cadence at most half the lease and batch 100. Its composition
-  builds only coordinator dependencies: no normal variables or audit sink.
-  PID 1 enforces the lease deadline; the semaphore is cross-run, dispatch CAS same-run.
+- Step Functions launches unit tasks with production `AWS_PROCESSOR_LEASE_SECONDS=7200`.
+  Hourly `recover-once` uses the same image, separate mode, batch 100 and coordinator
+  composition without normal variables/audit sink. PID 1 enforces the lease deadline;
+  the semaphore is cross-run and dispatch CAS same-run.
 - Scheduler runs independent `dispatch-outbox-once` every 30 minutes with the same
   image, own definition/mode/role and 60-second PID deadline. `run_aws_entrypoint`
   allowlists it; composition builds DynamoDB, S3 audit sink and UTC clock, then calls
@@ -296,19 +294,21 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   while fenced. Faults converge that route; reopening requires both accepted;
 - canary tests seed a release-bound pending event and require exact revision/overrides,
   its COMPLIANCE object, retention and delivered marker. Seeder `PutItem` is canary-table
-  only; `PassRole` is canary/ECS only; other releases denied; roles lifecycle-expire;
+  only. Verifier IAM allows conditioned `GetItem` and bound-object `GetObject` plus
+  `GetObjectRetention`; `PassRole` is exact canary/ECS; other releases denied; roles expire;
 - promotion tests atomically close the fence before phase B only when the unit
   semaphore is idle and no dispatch is in flight, then reject tenant/recovery
   starts and allow only the bound canary. Local smoke precedes Nginx; tunneled smoke
   uses the production hostname after that switch. Any failure or fence-budget
-  cutoff restores prior routes and reopens admissions within 60 seconds;
+  cutoff before phase C restores prior routes and reopens within 60 seconds. Partial
+  phase-B/C applies instead remain fail-closed until reviewed convergence completes;
 - drain/prune tests retain old revisions and `ecs:RunTask` grants through active
   old Standard/recovery drain and rollback retention, then prune only older
   non-rollback revisions; rollback consumes the prior retained manifest through
   a reviewed exact OpenTofu plan/apply;
 - recovery validation enforces the separate `recover-once` definition/mode,
   same image/network, coordinator-only composition without normal variables or
-  audit sink, cadence at most half `AWS_PROCESSOR_LEASE_SECONDS`, batch 100 and
+  audit sink, production lease 7200, hourly cadence, batch 100 and
   `MaximumRetryAttempts=0`. Its PID 1 hard wall-clock
   deadline equal to the lease that logs/alarms, cancels work, exits nonzero and
   stops the ECS task; overlapping, externally retried or at-least-once duplicate
@@ -324,9 +324,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   and `429` or quota on contention. Overlapping, externally retried and
   at-least-once duplicate recovery passes remain individually bounded, while
   dispatch CAS covers same-run recovery only;
-- cost tests count billed pull/start/run/stop for every task in the 100-hour target.
-  Audit budgets two billed minutes per 30-minute invocation (48 hours/30 days):
-  60-second PID plus one overhead minute. Excess fails acceptance/alarms, not a cap;
+- cost tests count billed pull/start/run/stop. Two minutes per hourly recovery and
+  30-minute audit invocation budget 24+48=72 hours/30 days, leaving 28 of 100 for
+  units. Excess fails acceptance/alarms and is not called a hard cap;
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -135,6 +135,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - required-source failure and optional-source degraded publication;
 - pointer CAS race, S3 failure before publication and outbox replay;
 - no presigned URL for non-serving prefixes;
+- long-lived boto3/botocore clients cross at least one IAM Roles Anywhere
+  `credential_process` expiration/refresh and complete an AWS call without a
+  process or container restart; helper or refresh failure fails closed;
 - the production AWS-012 override accepts `AssignPublicIp=ENABLED` only with
   exact public subnet IDs, the configured zero-ingress security group,
   `FARGATE`, maximum concurrency one, and no NAT Gateway or ALB; it rejects
@@ -159,8 +162,12 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   denied by FastAPI;
 - one synthetic run publishes exactly one new immutable version/pointer;
 - the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
-  with `Cache-Control: private, no-store` and only the signed URL, `version_id`
-  and `expires_in=300`, without exposing tenant or object key;
+  with `Cache-Control: private, no-store` and only `url`, `version_id` and
+  `expires_in=300`, with no separate tenant or object-key field;
+- the bearer-sensitive SigV4 `url` contains the expected authorized `serving/`
+  key, appears in neither logs nor acceptance evidence, is never persisted,
+  sent to telemetry, included in a referrer or cached, and no other prefix is
+  signed;
 - the dashboard makes a second direct S3 `fetch` with credentials omitted and
   without `Authorization`, `X-Tenant-Id`, cookies or other custom headers; it
   reads the expected JSON body from the 300-second signed URL;
@@ -212,6 +219,10 @@ Cost controls:
   <https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/create-resource-server.html>
 - Amazon Cognito authorization endpoint resource binding:
   <https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html>
+- IAM Roles Anywhere credential helper:
+  <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html>
+- AWS SDK process credentials:
+  <https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html>
 - FastAPI CORS:
   <https://fastapi.tiangolo.com/tutorial/cors/>
 - Amazon S3 CORS configuration:

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -135,6 +135,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - required-source failure and optional-source degraded publication;
 - pointer CAS race, S3 failure before publication and outbox replay;
 - no presigned URL for non-serving prefixes;
+- the production AWS-012 override accepts `AssignPublicIp=ENABLED` only with
+  exact public subnet IDs, the configured zero-ingress security group,
+  `FARGATE`, maximum concurrency one, and no NAT Gateway or ALB; it rejects
+  `DISABLED`, drift, inbound rules and incompatible launch/network config;
 - CDN private-origin, SPA rewrite, CSP and cache rollback;
 - CloudFront Free eligibility plus exact `ACTIVE` distribution/WAF binding;
 - Nginx and application rate-limit behavior;
@@ -154,8 +158,14 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - API preflights from another origin or for a disallowed method/header are
   denied by FastAPI;
 - one synthetic run publishes exactly one new immutable version/pointer;
-- a signed `serving/` redirect has a 300-second TTL; after following it, the
-  browser reads the expected JSON body;
+- the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
+  with `Cache-Control: private, no-store` and only the signed URL, `version_id`
+  and `expires_in=300`, without exposing tenant or object key;
+- the dashboard makes a second direct S3 `fetch` with credentials omitted and
+  without `Authorization`, `X-Tenant-Id`, cookies or other custom headers; it
+  reads the expected JSON body from the 300-second signed URL;
+- this production handoff replaces the AWS-014 `307` route contract before
+  promotion;
 - logs, traces, state and artifacts contain no secret or synthetic record body;
 - previous API/frontend release can be restored within the documented window.
 

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -86,8 +86,8 @@ Order:
    ECS PassedToService. Verifier gets exact-GSI `Query`, conditioned `GetItem` and
    bound `GetObject`/`GetObjectRetention`; require retention/delivered proof;
 5. promotion assumes the release-tagged fence operator and atomically closes the
-   separate fence item first. New acquire transactions now fail; wait for the semaphore
-   and any in-flight decision to drain. API returns `503`/`Retry-After`; recovery waits;
+   separate fence item first. New acquire transactions fail; use strongly consistent
+   gate observation to await semaphore/decision drain. API returns `503`; recovery waits;
 6. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
    signed activation manifest ARNs only after verifying that binding, then
    switches only the OpenTofu-owned state-machine `TaskDefinition` ARN; Schedulers
@@ -141,10 +141,11 @@ No production deployment occurs automatically after merge.
   cutoffs contain downstream amplification.
 - Requests beyond product quota fail with `429` or the documented quota error
   before starting Step Functions or Athena.
-- A USD 15 aggregate budget action is a delayed cost-safety backstop. When it
-  fires, it freezes new unit/recovery Fargate, Step Functions and Athena starts;
-  bounded audit dispatch, reads and backups remain enabled. Billing data can lag,
-  so spend may exceed USD 15 before the action applies.
+- The USD 15 action uses its service-linked role to attach OpenTofu-owned
+  `cnesdata-cost-freeze` to promotion/API/recovery roles. This persistent marker denies
+  new unit/recovery, Step Functions and Athena; promotion may list only its own policies
+  and aborts while attached. Audit remains on. Only the cost-clear operator detaches it
+  after reviewed spend/forecast recovery; history is retained and billing may lag.
 
 ## 5. Observability and SLOs
 
@@ -223,12 +224,12 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   Copy reads the source and writes the destination only. It has no
   raw/audit/other-prefix access and no `s3:DeleteObject` or `s3:ListBucket`
   unless separately demonstrated necessary.
-- `ControlPlanePort.mutate_environment_gate(command)` accepts typed acquire, bind,
-  renew, release, close-fence and reopen-fence variants and returns owner/version state.
+- `ControlPlanePort` exposes strongly consistent `observe_environment_gate()` and typed
+  acquire, bind, renew, release, close-fence and reopen-fence mutation commands.
   Fence and semaphore are separate items. Runtime acquire transactionally requires an
   open fence while updating semaphore; close happens first, then promotion waits drain.
-  API/recovery use runtime variants; the operator can get/close/reopen only the fence
-  item. Expired takeover needs Step Functions/ECS proof; TTL only collects garbage.
+  API/recovery use runtime variants; operator reads fence/semaphore but updates only
+  fence. Expired takeover needs Step Functions/ECS proof; TTL only collects garbage.
   Losers never `StartExecution` and receive quota/`429`; dispatch CAS stays same-run.
 - The fence blocks initial/recovery dispatch except the bound synthetic canary.
   Acceptance or rollback reopens it through the port.
@@ -319,12 +320,13 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   and proves the timed Deny before re-enabling a rotated leaf;
 - gate-port tests cover typed acquire/bind/renew/release/close/reopen and conditional
   adapter transactions. API/recovery use runtime variants; promotion assumes only the
-  release-tagged operator with get/close/reopen on the fence item. Direct semaphore
-  reads/writes are denied. Races prove close-first blocks new acquire before drain;
+  operator with strong reads of fence/semaphore and close/reopen only on fence. Direct
+  semaphore writes are denied. Races prove close-first blocks acquire before drain;
   expired takeover needs liveness proof; losers never start and get `429`/quota;
 - cost tests count billed pull/start/run/stop. Two minutes per 30-minute recovery and
   audit invocation budget 48+48=96 hours/30 days, leaving 4 of 100 for units. Excess
-  fails acceptance/alarms and is not called a hard cap;
+  fails acceptance/alarms, not a cap. Freeze tests prove budget attachment, promotion
+  self-read/abort, audit continuity and audited cost-clear-only detachment;
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -142,9 +142,9 @@ No production deployment occurs automatically after merge.
 - Requests beyond product quota fail with `429` or the documented quota error
   before starting Step Functions or Athena.
 - The USD 15 action uses its service-linked role to attach OpenTofu-owned
-  `cnesdata-cost-freeze` to promotion/API/recovery, Step Functions execution and
-  Athena-operator roles. This marker denies new compute/query starts; promotion lists
-  only its own policies and aborts. Audit stays on. Only cost-clear detaches after
+  `cnesdata-cost-freeze` to promotion/API, recovery task/Scheduler, Step Functions
+  execution and Athena-operator roles. It denies new compute/query starts; promotion
+  self-reads and aborts. Audit task/Scheduler stay on. Only cost-clear detaches after
   reviewed spend/forecast recovery; history is retained and billing may lag.
 
 ## 5. Observability and SLOs
@@ -324,9 +324,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   semaphore writes are denied. Races prove close-first blocks acquire before drain;
   expired takeover needs liveness proof; losers never start and get `429`/quota;
 - cost tests count billed pull/start/run/stop. Two minutes per 30-minute recovery and
-  audit invocation budget 48+48=96 hours/30 days, leaving 4 of 100 for units. Excess
-  fails acceptance/alarms, not a cap. Freeze tests attach to promotion/API/recovery,
-  Step Functions/Athena roles, prove self-read/abort, audit continuity and cost-clear;
+  audit invocation budget 48+48=96 hours/30 days, leaving 4 for units; excess is alarmed.
+  Freeze tests attach to promotion/API, recovery task/Scheduler and Step Functions/Athena
+  roles; prove self-read/abort, audit task/Scheduler continuity and cost-clear;
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -73,25 +73,26 @@ Order:
 2. under a reviewed exact OpenTofu plan/apply, phase A registers immutable unit,
    recovery and audit-dispatch revisions pinned to exact `ECR_URI@sha256` and
    dual-authorizes old and new `ecs:RunTask` ARNs without routing changes;
-   it creates release canary roles; persistent canary table/bucket are
-   OpenTofu-owned;
+   it creates release canary task/execution/seeder roles plus a persistent canary
+   table and bucket owned by OpenTofu;
 3. wait for and revalidate IAM propagation, prove all revisions authorized,
    then output their ARNs and phase-A evidence;
-4. finalize and sign one post-registration activation manifest with the candidate
-   manifest SHA-256, release ID, source SHA, exact revision ARNs, verified
-   `ECR_URI@sha256` and phase-A evidence; never re-register those revisions. Run
-   it via promotion `RunTask`, overriding task/execution roles plus
+4. sign one activation manifest with candidate manifest SHA-256, release ID,
+   source SHA, exact revision ARNs, verified
+   `ECR_URI@sha256` and phase-A evidence; never re-register them. Assume a seeder
+   role restricted to `PutItem` on the exact canary table and write one bound pending
+   event. Run the dispatcher via promotion `RunTask`, overriding roles plus
    `AWS_CONTROL_PLANE_TABLE`/`AWS_AUDIT_BUCKET` to canary resources only;
    promotion can pass only canary task/execution roles, conditioned by
-   `iam:PassedToService=ecs-tasks.amazonaws.com`;
+   `iam:PassedToService=ecs-tasks.amazonaws.com`. Require its COMPLIANCE object,
+   retention and delivered marker for that event before continuing;
 5. atomically close the deployment fence only if the unit semaphore is idle and
    no dispatch decision is in flight. The API then rejects tenant admissions
    with `503`/`Retry-After`, and recovery starts no new executions;
 6. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
    signed activation manifest ARNs only after verifying that binding, then
-   switches only the OpenTofu-owned state-machine `TaskDefinition` ARN; both
-   Schedulers stay on prior validated revisions. No
-   out-of-band mutation or `ignore_changes` is allowed;
+   switches only the OpenTofu-owned state-machine `TaskDefinition` ARN; Schedulers
+   stay on prior revisions. Out-of-band mutation and `ignore_changes` are prohibited;
 7. use `DescribeTaskDefinition`, state-machine and Scheduler evidence to prove
    selected unit revision matches the release while both Schedulers match the
    prior manifest; then verify binding, clean state and no drift;
@@ -100,10 +101,11 @@ Order:
 9. switch Nginx to the candidate and run tunneled health/authorization through
    the normal production hostname, which now resolves to that candidate;
 10. publish frontend assets and entrypoint;
-11. while fenced, run the bound application canary, then reopen within 60 seconds;
-12. after acceptance, reviewed phase C switches recovery and audit Schedulers, then
-    proves binding/digest/no drift. Failure keeps prior routes/deployment incomplete;
-    retain the prior release/evidence.
+11. while fenced, run the bound application canary;
+12. phase C uses separate reviewed applies for recovery and audit, accepting each only
+    after binding/digest/no-drift proof. Partial applies remain fenced while a reviewed
+    plan converges that route to candidate or prior. Reopen only after both accepted;
+    else restore prior routes/evidence and leave deployment incomplete.
 
 Retain old revisions/grants until active old Standard/scheduled work drains and
 rollback retention ends. Then prune older non-rollback revisions.
@@ -290,11 +292,11 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   mixing, out-of-band mutation and `ignore_changes`, then prove selected exact
   digests, clean state and no drift. Fault injection leaves a partial apply fenced
   until a diagnosed, reviewed plan converges all routes; mixed routes never reopen;
-- phase C runs only after application and isolated dispatcher canaries pass,
-  switches both Schedulers by reviewed apply and leaves old routes on failure;
-- canary tests require exact revision, task/execution-role and table/bucket overrides;
-  `PassRole` is limited to canary task/execution roles with ECS PassedToService;
-  production/other releases are denied; phase C removes roles after lifecycle/TTL;
+- phase C follows both canaries; separate reviewed applies accept recovery, then audit,
+  while fenced. Faults converge that route; reopening requires both accepted;
+- canary tests seed a release-bound pending event and require exact revision/overrides,
+  its COMPLIANCE object, retention and delivered marker. Seeder `PutItem` is canary-table
+  only; `PassRole` is canary/ECS only; other releases denied; roles lifecycle-expire;
 - promotion tests atomically close the fence before phase B only when the unit
   semaphore is idle and no dispatch is in flight, then reject tenant/recovery
   starts and allow only the bound canary. Local smoke precedes Nginx; tunneled smoke
@@ -322,10 +324,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   and `429` or quota on contention. Overlapping, externally retried and
   at-least-once duplicate recovery passes remain individually bounded, while
   dispatch CAS covers same-run recovery only;
-- cost tests count all task-hours in the 100-hour target; 30-minute cadence and
-  60-second deadline bound audit dispatch to 48 hours per 30 days. USD 15 budget
-  action freezes unit/recovery, Step Functions and Athena, while audit stays
-  enabled; billing-lag overshoot is allowed and no synchronous cap is claimed;
+- cost tests count billed pull/start/run/stop for every task in the 100-hour target.
+  Audit budgets two billed minutes per 30-minute invocation (48 hours/30 days):
+  60-second PID plus one overhead minute. Excess fails acceptance/alarms, not a cap;
 - execution-quota tests atomically count every initial and recovery
   `StartExecution` attempt against one 200-attempt monthly maximum and reject
   both callers when exhausted;
@@ -380,8 +381,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   binds candidate manifest SHA-256, release ID, source SHA, exact ARNs/digest
   and phase-A evidence. Phase-B OpenTofu evidence verifies that binding and
   proves phase B selected unit while both Schedulers remained prior. After both
-  canaries, phase C selects bound recovery/audit revisions; each phase proves ECR
-  digest, clean state and no drift. Active executions keep original revisions;
+  canaries, separate phase-C applies accept recovery then audit while fenced. Partial
+  applies converge that route; both accepted to reopen. Executions keep revisions;
 - promotion evidence proves the fence closed before phase B, no dispatch was in
   flight, local smoke passed before switching, and tunneled smoke reached the
   candidate through the switched production hostname. Only the bound canary is

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -196,10 +196,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   separate definition/mode, cadence at most half the lease, batch 100 and none of
   the seven normal variables. Retries are zero; at-least-once passes may overlap.
   PID 1 enforces the lease deadline; the semaphore is cross-run, dispatch CAS same-run.
-- `dispatch-outbox-once` is an independent Scheduler Fargate task with the same
-  image and its own definition/mode/role. `run_aws_entrypoint` allowlists that
-  command; its composition builds only the DynamoDB control plane and S3 audit
-  sink, then invokes `dispatch_once(limit=100)`. Cadence/deadline are five minutes.
+- Scheduler runs independent `dispatch-outbox-once` every five minutes with the
+  same image, own definition/mode/role and five-minute PID deadline.
+  `run_aws_entrypoint` allowlists it; composition builds only DynamoDB and S3 audit
+  sink and UTC clock, then calls `dispatch_once(control_plane, sink, now, limit=100)`.
   Recovery failure and budget freeze cannot suppress it. Sink failures remain
   pending, do not block later events and retry next cadence; alarm/exit is nonzero,
   replay idempotent, Scheduler retries zero and task-hours counted.
@@ -247,7 +247,7 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - old fence/dispatch rejection and duplicate execution replay;
 - required-source failure and optional-source degraded publication;
 - dispatcher boot tests accept only `dispatch-outbox-once` without unit variables
-  and inject only control plane/audit sink. A pass reads at most 100 ordered events,
+  and inject control plane, audit sink and deterministic UTC clock. A pass reads 100,
   writes the COMPLIANCE object, marks after success, retries pending failures and
   proves same-hash replay idempotent;
 - no presigned URL for non-serving prefixes;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -82,25 +82,27 @@ Order:
    `ECR_URI@sha256` and phase-A evidence; never re-register those revisions. Run
    it via promotion `RunTask`, overriding task role, `AWS_CONTROL_PLANE_TABLE` and
    `AWS_AUDIT_BUCKET` to the OpenTofu-owned canary role/table/bucket only;
+   promotion can pass only canary task/execution roles, conditioned by
+   `iam:PassedToService=ecs-tasks.amazonaws.com`;
 5. atomically close the deployment fence only if the unit semaphore is idle and
    no dispatch decision is in flight. The API then rejects tenant admissions
    with `503`/`Retry-After`, and recovery starts no new executions;
 6. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
    signed activation manifest ARNs only after verifying that binding, then
-   switches the OpenTofu-owned state-machine `TaskDefinition` ARN and recovery
-   Scheduler only; audit dispatch stays on its prior validated revision. No
+   switches only the OpenTofu-owned state-machine `TaskDefinition` ARN; both
+   Schedulers stay on prior validated revisions. No
    out-of-band mutation or `ignore_changes` is allowed;
 7. use `DescribeTaskDefinition`, state-machine and Scheduler evidence to prove
-   selected unit/recovery revisions match the release while audit dispatch still
-   matches the prior manifest; then verify binding, clean state and no drift;
+   selected unit revision matches the release while both Schedulers match the
+   prior manifest; then verify binding, clean state and no drift;
 8. verify that same signed binding, update the inactive API candidate and pass
    local health/authorization smoke tests;
 9. switch Nginx to the candidate and run tunneled health/authorization through
    the normal production hostname, which now resolves to that candidate;
 10. publish frontend assets and entrypoint;
 11. while fenced, run the bound application canary, then reopen within 60 seconds;
-12. after acceptance, reviewed phase C switches only the audit Scheduler and proves
-    binding/digest/no drift. Failure keeps its prior route and deployment incomplete;
+12. after acceptance, reviewed phase C switches recovery and audit Schedulers, then
+    proves binding/digest/no drift. Failure keeps prior routes/deployment incomplete;
     retain the prior release/evidence.
 
 Retain old revisions/grants until active old Standard/scheduled work drains and
@@ -283,16 +285,16 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   candidate manifest SHA-256, release ID, source SHA, revision ARNs, verified
   digest and phase-A evidence;
 - phase-B exact OpenTofu plan/apply consumes that signed manifest and switches
-  only the state-machine/recovery target while audit dispatch remains prior.
+  only the state-machine target while both Schedulers remain prior.
   API/frontend verify the binding. Tests reject artifact
   mixing, out-of-band mutation and `ignore_changes`, then prove selected exact
   digests, clean state and no drift. Fault injection leaves a partial apply fenced
   until a diagnosed, reviewed plan converges all routes; mixed routes never reopen;
 - phase C runs only after application and isolated dispatcher canaries pass,
-  switches only audit Scheduler by reviewed apply and leaves the old route on failure;
-- canary tests permit only exact revision/role/table/bucket overrides and deny
-  production/other releases. Table data expires by TTL, retained objects by
-  lifecycle, and phase C removes the role;
+  switches both Schedulers by reviewed apply and leaves old routes on failure;
+- canary tests permit exact revision/role/table/bucket overrides and `PassRole`
+  only for canary task/execution roles with ECS PassedToService; deny production
+  and other releases. TTL/lifecycle expire data; phase C removes the role;
 - promotion tests atomically close the fence before phase B only when the unit
   semaphore is idle and no dispatch is in flight, then reject tenant/recovery
   starts and allow only the bound canary. Local smoke precedes Nginx; tunneled smoke
@@ -378,8 +380,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   authorization without routing changes, then the signed activation manifest
   binds candidate manifest SHA-256, release ID, source SHA, exact ARNs/digest
   and phase-A evidence. Phase-B OpenTofu evidence verifies that binding and
-  proves phase B selected unit/recovery while audit remained prior. After both
-  canaries, phase C selects the bound audit revision; each phase proves exact ECR
+  proves phase B selected unit while both Schedulers remained prior. After both
+  canaries, phase C selects bound recovery/audit revisions; each phase proves ECR
   digest, clean state and no drift. Active executions keep original revisions;
 - promotion evidence proves the fence closed before phase B, no dispatch was in
   flight, local smoke passed before switching, and tunneled smoke reached the

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -156,9 +156,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   definition and mode, with cadence no greater than half
   `AWS_PROCESSOR_LEASE_SECONDS`; it requires none of the seven normal processor
   environment variables. Scheduler invocations may overlap, retry and duplicate
-  as required by the governing plan. Each is a bounded single pass with a
-  configured batch and appropriate hard timeout; all recovery task-hours count in
-  the 100-hour aggregate and budget freeze. The environment semaphore
+  as required by the governing plan. Each is one bounded pass with
+  `AWS_PROCESSOR_RECOVERY_BATCH_SIZE=100` and a hard timeout equal to
+  `AWS_PROCESSOR_LEASE_SECONDS`; all recovery task-hours count in the 100-hour
+  aggregate and budget freeze. The environment semaphore
   arbitrates cross-run unit starts, while dispatch CAS handles only same-run
   recovery and idempotency.
 - The recovery task role has only control-plane read/write,
@@ -215,7 +216,7 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - recovery validation enforces the separate `recover-once` definition/mode,
   same image and network shape, Scheduler cadence at most half
   `AWS_PROCESSOR_LEASE_SECONDS`, no seven normal processor environment
-  variables, bounded single-pass configured batch/hard timeout, allowed
+  variables, batch 100/lease-length hard timeout, allowed
   overlapping/retried/duplicate invocations, least-privilege recovery/Scheduler
   roles, logs and alarm;
 - profile/helper `durationSeconds` equals 900 and role `MaxSessionDuration`

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -20,6 +20,10 @@ the architecture, resources, identity, network and serving contracts.
 Pull requests to `develop` run the existing locked Python/CND/AWS gates plus:
 
 - dashboard lint, typecheck, tests and deterministic production build;
+- dashboard routing checks require
+  `API_BASE_URL=https://api.cnesdata.vinisantana.com`, one authenticated API
+  client for `auth/me` and activation, no production relative `/api` request,
+  bearer only to the API origin and `X-Tenant-Id` only for tenant-scoped calls;
 - API and processor image build tests;
 - OCI vulnerability scan and SBOM generation;
 - OpenTofu format/validate/test and provider-lock verification;
@@ -135,6 +139,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - required-source failure and optional-source degraded publication;
 - pointer CAS race, S3 failure before publication and outbox replay;
 - no presigned URL for non-serving prefixes;
+- dashboard artifact and browser checks reject a relative `/api` request or an
+  API call that bypasses the configured absolute client;
 - long-lived boto3/botocore clients cross at least one IAM Roles Anywhere
   `credential_process` expiration/refresh and complete an AWS call without a
   process or container restart; helper or refresh failure fails closed;
@@ -152,6 +158,10 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - static site returns the expected release ID over TLS;
 - S3 origin is not publicly readable;
 - API is unreachable at the VPS address/ports and healthy through Tunnel;
+- the collision-safe AWS-managed Cognito prefix domain serves real
+  `/oauth2/authorize`, `/oauth2/token` and `/logout` endpoints; the PKCE code
+  exchange and configured logout URL succeed, with no custom Cognito domain or
+  managed login v2 dependency;
 - demo user authenticates with PKCE and resolves only the demo tenant;
 - a Cognito bearer `access_token` with
   `aud=https://api.cnesdata.vinisantana.com` is accepted in the real
@@ -160,6 +170,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   method/header is accepted by FastAPI;
 - API preflights from another origin or for a disallowed method/header are
   denied by FastAPI;
+- browser network evidence proves `auth/me` and activation use the configured
+  absolute API base URL, never relative `/api`; bearer is sent only to the API
+  and `X-Tenant-Id` only to tenant-scoped calls;
 - one synthetic run publishes exactly one new immutable version/pointer;
 - the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
   with `Cache-Control: private, no-store` and only `url`, `version_id` and
@@ -219,6 +232,8 @@ Cost controls:
   <https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/create-resource-server.html>
 - Amazon Cognito authorization endpoint resource binding:
   <https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html>
+- Amazon Cognito user pool domain:
+  <https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-assign-domain.html>
 - IAM Roles Anywhere credential helper:
   <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html>
 - AWS SDK process credentials:

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -195,24 +195,19 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   re-enable the profile/trust and test a new session.
 - The normal unit task is launched by Step Functions. `recover-once` is an
   EventBridge Scheduler task using the same processor image but a separate task
-  definition and mode, with cadence no greater than half
-  `AWS_PROCESSOR_LEASE_SECONDS`; it requires none of the seven normal processor
-  environment variables. Scheduler `MaximumRetryAttempts=0`; at-least-once
-  delivery or an external re-invocation can still create overlapping, retried or
-  duplicate passes, with no global recovery-concurrency ceiling. Each is one
-  bounded pass with
-  `AWS_PROCESSOR_RECOVERY_BATCH_SIZE=100`. Its entrypoint/PID 1 enforces a
-  hard wall-clock deadline equal to `AWS_PROCESSOR_LEASE_SECONDS`; at deadline,
-  it emits timeout logs and alarm, cancels work and exits nonzero so the ECS task
-  stops.
-  Every recovery task-hour is counted in the 100-hour monitored monthly
-  operating target. The environment semaphore arbitrates cross-run unit starts,
-  while dispatch CAS handles only same-run recovery and idempotency.
+  definition/mode and cadence at most half `AWS_PROCESSOR_LEASE_SECONDS`; it
+  requires none of the seven normal processor variables. Each bounded pass runs
+  coordinator recovery, then `dispatch_once(limit=100)`. Sink failures remain
+  pending, do not block later events, emit alarm/nonzero exit and retry on the
+  next cadence; same-event replay is idempotent. Scheduler retries are zero, but
+  at-least-once/external invocation can overlap without a global recovery-task
+  ceiling. PID 1 enforces a hard deadline equal to the lease, cancels work and
+  exits nonzero. Every pass counts toward the 100-hour target. The environment
+  semaphore arbitrates cross-run unit starts; dispatch CAS is same-run only.
 - Recovery role has control-plane read/write; `states:StartExecution` and
   `states:DescribeStateMachine` on the exact production state machine;
-  `states:DescribeExecution`/`states:StopExecution` on its executions, plus
-  minimum liveness
-  `ecs:ListTasks`/`ecs:DescribeTasks`. The Scheduler role trusts
+  `states:DescribeExecution`/`states:StopExecution` on executions; minimum
+  liveness `ecs:ListTasks`/`ecs:DescribeTasks`. The Scheduler role trusts
   `scheduler.amazonaws.com` with exact `aws:SourceAccount` and
   `aws:SourceArn`, scopes `ecs:RunTask` to recovery revision ARNs and, during
   activation, both old and candidate revisions; it passes only its task/execution
@@ -221,6 +216,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   recovery task, API and any takeover actor use ECS liveness reads only for the
   configured cluster/task family with supported conditions; where ECS requires
   `Resource: *`, those same narrow conditions apply.
+- Recovery audit IAM allows `s3:GetBucketObjectLockConfiguration` on the bucket;
+  `s3:GetObject`/`s3:PutObject`/`s3:PutObjectRetention` on `audit/*`; no delete/list/bypass.
 - For `PUBLISHING`, `s3:GetObject`/`s3:GetObjectVersion` read only the canonical
   data bucket's `tmp/`, `normalized/`, `reconciliation/` and `serving/` prefixes.
   `s3:PutObject` writes only final `normalized/`, `reconciliation/` and
@@ -250,7 +247,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
 - OIDC/JWKS rotation, revoked membership and cross-tenant denial;
 - old fence/dispatch rejection and duplicate execution replay;
 - required-source failure and optional-source degraded publication;
-- pointer CAS race, S3 failure before publication and outbox replay;
+- scheduled outbox dispatch reads at most 100 ordered events, writes the
+  deterministic COMPLIANCE object, marks delivered only after success, retries
+  pending failures next pass and proves same-hash replay idempotent;
 - no presigned URL for non-serving prefixes;
 - dashboard artifact and browser checks reject a relative `/api` request or an
   API call that bypasses the configured absolute `/api/v1` client;
@@ -333,6 +332,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   machine, describe/stop-execution to its executions and ECS liveness to the
   configured cluster/task family or required narrow `Resource: *` conditions.
   Cancellation/failed binding proves stop succeeds; another machine is denied;
+- audit IAM tests allow only lock-configuration read plus get/put/put-retention
+  on the exact audit prefix; deny delete, list, bypass and every data-bucket key;
 - a crash during `PUBLISHING` proves the recovery role reads manifest sidecars,
   promotes/verifies source-to-destination copies, writes reconciliation/serving
   manifests and completes pointer CAS without `AccessDenied`. Negative tests
@@ -387,8 +388,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   candidate through the switched production hostname. Only the bound canary is
   admitted before acceptance; failure restores prior routes while fenced;
 - the `recover-once` Scheduler run uses the same image/network, emits its log
-  and alarm evidence, uses `MaximumRetryAttempts=0`, and cannot start without
-  its narrow roles;
+  and alarm evidence, uses `MaximumRetryAttempts=0`, drains one bounded outbox
+  batch to an Object-Locked audit object and cannot start without narrow roles;
 - a deliberately hung recovery reaches the PID 1 deadline equal to
   `AWS_PROCESSOR_LEASE_SECONDS`, cancels, exits nonzero and stops in ECS by that
   deadline, with log and alarm evidence;

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -129,11 +129,15 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   dataset pointer/serving object without altering production data;
 - destructive PITR export/restore requires a separately approved runbook run.
 - The security owner operates the external, offline CA; AWS Private CA is never
-  enabled. The CA private key and API/VPS leaf credentials never enter the repo
-  or OpenTofu state.
-- The owner issues a unique API/VPS X.509v3 leaf, installs its certificate chain
-  and root-only private key outside the container, and rotates it before expiry
-  with overlap and a refresh test.
+  enabled. Its trust-anchor CA has `CA:true`, `Certificate Sign` and `CRL Sign`
+  key usage, and SHA-256 or stronger signatures. The CA private key and API/VPS
+  leaf credentials never enter the repo or OpenTofu state.
+- The owner issues a unique API/VPS X.509v3 leaf with `CA:false`, `Digital
+  Signature` usage and SHA-256 or stronger signatures. Its certificate chain
+  can be readable as needed; its host-owned private key remains outside the
+  container and is bind-mounted read-only for the fixed runtime UID only, with
+  no other user or process able to read it. Rotation occurs before expiry with
+  overlap and a refresh test.
 - Revocation imports or updates the CRL at the Roles Anywhere trust anchor; it
   does not depend on OCSP or CDP. Compromise revokes and rotates the leaf,
   confirms fail-closed behavior and alerts the security owner.
@@ -155,18 +159,20 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   `credential_process` expiration/refresh and complete an AWS call without a
   process or container restart; helper or refresh failure fails closed;
 - OpenTofu creates the `us-east-2` trust anchor from external offline public
-  CA PEM and the Roles Anywhere profile, with AWS Private CA prohibited. The
-  trust policy permits `sts:AssumeRole`, `sts:TagSession` and
+  CA PEM with the required CA, key-usage and SHA-256 constraints, and the Roles
+  Anywhere profile, with AWS Private CA prohibited. The trust policy permits
+  `sts:AssumeRole`, `sts:TagSession` and
   `sts:SetSourceIdentity` only to `rolesanywhere.amazonaws.com`, conditioned on
   the trust-anchor `SourceArn` and API/VPS X.509 identity; the profile remains
   separately referenced by `credential_process`; no private CA key or leaf
   appears in repository or state;
-- the separate Step Functions role is trusted only by `states.amazonaws.com`.
-  `ecs:RunTask` is scoped to the task definition; `ecs:DescribeTasks` and
-  `ecs:StopTask` use `Resource: *`; `events:PutTargets`, `events:PutRule` and
-  `events:DescribeRule` are scoped to `StepFunctionsGetEventsForECSTaskRule`;
-  `iam:PassRole` permits only the task and execution roles with
-  `iam:PassedToService=ecs-tasks.amazonaws.com`;
+- the separate Step Functions role is trusted only by `states.amazonaws.com`
+  with the exact `aws:SourceAccount` and the exact production state-machine
+  `aws:SourceArn`. `ecs:RunTask` is scoped to the task definition;
+  `ecs:DescribeTasks` and `ecs:StopTask` use `Resource: *`; `events:PutTargets`,
+  `events:PutRule` and `events:DescribeRule` are scoped to
+  `StepFunctionsGetEventsForECSTaskRule`; `iam:PassRole` permits only the task
+  and execution roles with `iam:PassedToService=ecs-tasks.amazonaws.com`;
 - the production AWS-012 override accepts `AssignPublicIp=ENABLED` only with
   exact public subnet IDs, the configured zero-ingress security group,
   `FARGATE`, maximum concurrency one, and no NAT Gateway or ALB; it rejects
@@ -186,8 +192,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   exchange and configured logout URL succeed, with no custom Cognito domain or
   managed login v2 dependency;
 - demo user authenticates with PKCE and resolves only the demo tenant;
-- a real API/VPS leaf from the external CA assumes the Roles Anywhere profile;
-  a CRL-revoked leaf is denied, alerts and remains failed closed;
+- a real constrained API/VPS leaf from the external CA assumes the Roles
+  Anywhere profile; a CRL-revoked leaf is denied, alerts and remains failed
+  closed;
 - a Cognito bearer `access_token` with
   `aud=https://api.cnesdata.vinisantana.com` is accepted in the real
   environment;
@@ -200,7 +207,8 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   relative `/api`; bearer is sent only to the API origin and `X-Tenant-Id` only
   to tenant-scoped calls;
 - a Step Functions execution starts only the approved Fargate task definition,
-  uses only the event rule and pass roles above, and fails when any scope drifts;
+  uses only the exact source account/state-machine trust, event rule and pass
+  roles above, and fails when any scope drifts;
 - one synthetic run publishes exactly one new immutable version/pointer;
 - the authenticated, tenant-authorized `X-Tenant-Id` API call returns `200`
   with `Cache-Control: private, no-store` and only `url`, `version_id` and

--- a/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+++ b/docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
@@ -84,9 +84,9 @@ Order:
    variables to canary-only values. It passes only canary task/execution roles with
    ECS PassedToService. A verifier gets conditioned `GetItem` on the bound key and
    `GetObject`/`GetObjectRetention` on its object; require retention/delivered proof;
-5. promotion assumes the exact release-tagged fence operator and invokes the port
-   close command, atomically only if semaphore is idle and no decision is in flight.
-   The API then rejects admissions with `503`/`Retry-After`; recovery starts none;
+5. promotion assumes the release-tagged fence operator and atomically closes the
+   separate fence item first. New acquire transactions now fail; wait for the semaphore
+   and any in-flight decision to drain. API returns `503`/`Retry-After`; recovery waits;
 6. under a separate reviewed exact OpenTofu plan/apply, phase B consumes the
    signed activation manifest ARNs only after verifying that binding, then
    switches only the OpenTofu-owned state-machine `TaskDefinition` ARN; Schedulers
@@ -224,13 +224,13 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   unless separately demonstrated necessary.
 - `ControlPlanePort.mutate_environment_gate(command)` accepts typed acquire, bind,
   renew, release, close-fence and reopen-fence variants and returns owner/version state.
-  The DynamoDB adapter uses conditional transaction/CAS on one environment gate item.
-  API/recovery use runtime variants; the release-tagged promotion operator may only
-  get and close/reopen that exact item. Expired takeover requires Step Functions/ECS
-  proof; TTL only collects garbage. Losers never call `StartExecution` and receive the
-  quota error or `429`; dispatch CAS remains same-run idempotency only.
-- The independent deployment fence blocks initial/recovery dispatch except the bound
-  synthetic canary. Acceptance or rollback explicitly reopens it through the port.
+  Fence and semaphore are separate items. Runtime acquire transactionally requires an
+  open fence while updating semaphore; close happens first, then promotion waits drain.
+  API/recovery use runtime variants; the operator can get/close/reopen only the fence
+  item. Expired takeover needs Step Functions/ECS proof; TTL only collects garbage.
+  Losers never `StartExecution` and receive quota/`429`; dispatch CAS stays same-run.
+- The fence blocks initial/recovery dispatch except the bound synthetic canary.
+  Acceptance or rollback reopens it through the port.
 
 ## 7. Test and acceptance matrix
 
@@ -317,9 +317,9 @@ S3 access denial, Athena cutoff, budget thresholds and anomaly detection.
   and proves the timed Deny before re-enabling a rotated leaf;
 - gate-port tests cover typed acquire/bind/renew/release/close/reopen and conditional
   adapter transactions. API/recovery use runtime variants; promotion assumes only the
-  release-tagged operator with exact-item get/close/reopen and no other table access.
-  Expired takeover waits for Step Functions/ECS proof; losers never `StartExecution`
-  and receive `429`/quota. Duplicate recovery stays bounded; dispatch CAS is same-run;
+  release-tagged operator with get/close/reopen on the fence item. Direct semaphore
+  reads/writes are denied. Races prove close-first blocks new acquire before drain;
+  expired takeover needs liveness proof; losers never start and get `429`/quota;
 - cost tests count billed pull/start/run/stop. Two minutes per 30-minute recovery and
   audit invocation budget 48+48=96 hours/30 days, leaving 4 of 100 for units. Excess
   fails acceptance/alarms and is not called a hard cap;


### PR DESCRIPTION
## Summary

Defines the first cost-bounded production deployment for the accepted CnesData redesign:

- private S3 + CloudFront static frontend;
- FastAPI control plane on the personal VPS through Cloudflare Tunnel;
- DynamoDB/S3/Cognito in `us-east-2`;
- Step Functions Standard + on-demand Fargate processing with no NAT or load balancer;
- OIDC/Roles Anywhere/OIDC-for-GitHub identity boundaries;
- manual immutable promotion, rollback, rate limits, observability and recovery;
- USD 8 product envelope with a delayed USD 15 AWS Budgets safety backstop;
- exact CloudFront Free subscription and WAF gate before DNS.

The contract is split between the production deployment design and the linked production
operations design. The deployment design owns architecture, identity, network, storage and
serving. The operations design owns CI/CD, rollback, abuse containment, observability,
recovery, acceptance and costs.

## Release gates

This design explicitly forbids deploying the current legacy PostgreSQL/MinIO/Keycloak/BigQuery
Compose profile. Runtime promotion remains blocked until the governing CND/AWS gates pass.

The initial public environment is synthetic-only. `CNES_NACIONAL` remains disabled until
CND-033 has a ratified official DATASUS contract. Local/municipal sources are absent.

## Safety boundary

Documentation only. No AWS, Cloudflare, Hostinger, DNS, registry or VPS mutation is performed
by this PR. There is no destroy path or automatic production deployment.

## Review focus

- Cognito resource binding, access-token audience and complete SPA OAuth scope;
- Cognito AWS-managed prefix domain for Authorization Code + PKCE on Lite;
- absolute `VITE_API_BASE_URL` and one authenticated dashboard API client;
- exact-origin FastAPI and header-free signed-serving S3 CORS contracts;
- bounded public-subnet AWS-012 override and no-store signed-URL handoff;
- refreshable IAM Roles Anywhere `credential_process` for long-lived boto3 clients;
- external-CA Roles Anywhere trust, certificate lifecycle and revocation boundary;
- least-privilege Step Functions execution role for synchronous Fargate tasks;
- scheduled recovery, cross-run semaphore and individually bounded recovery passes;
- independent bounded audit dispatcher preserved during recovery failure and budget freeze;
- explicit port-level outbox cursor/CAS prevents poison batches from starving newer events;
- dispatcher DynamoDB writes are limited to outbox/cursor key namespaces;
- release-bound outbox seed with COMPLIANCE object, retention and delivered-marker proof;
- bounded exact-GSI visibility poll prevents empty canary dispatch after seeding;
- least-privilege canary verifier for the bound DynamoDB key and S3 object evidence;
- API Roles Anywhere scopes start/describe machine and describe/stop executions exactly;
- release-tagged operator strongly reads gate state but writes only the fence item;
- AWS Budgets marker freezes API/recovery, Step Functions and Athena launch principals;
- typed gate port commands cover atomic acquire/bind/renew/release/close/reopen;
- fenced, independently accepted recovery/audit Scheduler promotion and convergence;
- routine 30-minute fence budget separated from fail-closed partial-apply convergence;
- Fargate billed-duration allowance includes image pull, startup, execution and stop;
- production 3,600-second lease with 30-minute recovery fits the accepted runtime range;
- fenced candidate cutover with production-hostname smoke before admission reopens;
- atomic 200-attempt monthly Step Functions quota shared by initial and recovery starts;
- tenant, signed-serving metadata/browser-read and audit real-environment acceptance;
- Fargate public-subnet/no-inbound tradeoff used to avoid NAT cost;
- two-stage manual plan/apply and digest-only promotion;
- quotas, scoped Budgets role, promotion freeze preflight and recovery acceptance matrix.

## Validation

- deployment design: 500 lines; operations design: 500 lines;
- no line exceeds 100 characters;
- Markdown fences balanced;
- no `TODO`, `TBD` or `FIXME` placeholders;
- `ruff check .`: passed;
- fast pytest selection: 978 passed, 9 skipped, 154 deselected, 1 preexisting failure in
  `tests/chaos/test_central_api_sobrevive_pg_restart.py`;
- independent task review and whole-PR review findings addressed.
