### PR TITLE
docs(plan): add CnesData production implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-08-31-cnesdata-production-delivery-and-operations-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-31-cnesdata-production-delivery-and-operations-implementation-plan.md
@@ -1,0 +1,538 @@
+# CnesData Production Delivery and Operations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create credential-free CI, immutable candidate/activation evidence, manual OpenTofu plan/apply, phased processor routing, health-guarded API/static promotion, canary/audit verification, rollback/drain and production acceptance for CnesData.
+
+**Architecture:** A candidate manifest binds one green develop commit to tested artifacts but contains no ECS revisions. Phase A promotes the processor bytes to ECR, registers immutable unit/recovery/audit revisions and dual-authorizes them without routing changes; it then signs an activation manifest. Phase B switches only unit routing while the environment fence is closed. After unit/API/frontend canaries, separate Phase C applies switch recovery then audit. Only complete accepted routing reopens the fence.
+
+**Tech Stack:** GitHub Actions hosted runners, GHCR, ECR, OpenTofu binary plans, GitHub OIDC through personal-infra-live reusable gates, Python release/deployment tooling, S3/CloudFront, Nginx shared dispatcher, ECS/Fargate, Step Functions, EventBridge Scheduler, Cognito PKCE, Playwright, pytest, OPA/Conftest, Syft, Trivy.
+
+**Spec:** docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md with resource contracts from docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md
+
+## Global Constraints
+
+- Start only after runtime amendments and infrastructure Tasks 1-12 are merged and green on develop.
+- Infrastructure may be planned after CND-020…025; application promotion additionally requires AWS-010…014 and the serial AWS gate.
+- Untrusted pull requests use GitHub-hosted runners with no AWS, Cloudflare, SSH, id-token or production secret.
+- Candidate release is one green develop SHA. Mutable tags are never authority.
+- Candidate manifest contains processor GHCR digest and expected ECR repository but no ECR promoted digest or ECS revision ARN.
+- Activation manifest is signed only after Phase A and binds candidate SHA-256, release/source IDs, verified ECR_URI@sha256, exact unit/recovery/audit revisions and Phase A evidence.
+- Plan/apply are separate workflow_dispatch operations; apply verifies one unexpired binary plan and never replans.
+- Promotion is manual. Merge never deploys.
+- Phase A registers revisions once and dual-authorizes old/new RunTask without routing changes.
+- Fence closes atomically before Phase B, then drain verifies semaphore idle/no dispatch. Only bound canary is admitted.
+- Phase B changes only Step Functions unit TaskDefinition. Both Schedulers stay prior.
+- Phase C has two separate reviewed applies: recovery first, audit second. Reopen only after both accepted.
+- Partial apply or mixed routing remains fenced until a new reviewed convergence plan completes.
+- Successful fence window through both Phase C acceptances is capped at 30 minutes; routine cutoff restores prior routes while remaining safe.
+- Old revisions/grants persist until old Standard/scheduled work drains and rollback retention ends.
+- Static release uploads immutable unit first and root entrypoint last. Rollback restores one prior entrypoint version.
+- CloudFront Free exact distribution/WAF subscription is ACTIVE before DNS; no paid fallback.
+- Logs/evidence exclude signed URLs, object keys, synthetic bodies, credentials, emails and tenant/run/user identifiers.
+- Product cost remains <=USD 8 and aggregate automation freeze is USD 15.
+
+## File Map
+
+| Path | Responsibility |
+|---|---|
+| release/candidate.schema.json | pre-infrastructure immutable artifact binding |
+| release/activation.schema.json | post-Phase-A exact routing binding |
+| release/*.py | canonical build/verify/sign tooling |
+| .github/workflows/verify-production.yml | credential-free PR/main gates |
+| .github/workflows/release-candidate.yml | main/develop candidate creation |
+| .github/workflows/infra-plan.yml | manual exact plan |
+| .github/workflows/infra-apply.yml | manual exact binary apply |
+| .github/workflows/promote-production.yml | orchestrated phased promotion |
+| scripts/promotion/** | pure phase verification/transition helpers |
+| tests/production/delivery/** | manifest/workflow/phase/failure contracts |
+| docs/runbooks/** | operator evidence, rollback, recovery and acceptance |
+
+---
+
+### Task 1: Extend Credential-Free Production CI
+
+**Branch:** ci/prod-delivery-001-validation
+
+**Files:**
+- Create: .github/workflows/verify-production.yml
+- Modify: .github/workflows/python-quality.yml
+- Modify: .github/workflows/web-dashboard.yml
+- Create: tests/production/delivery/test_ci_workflows.py
+
+**Interfaces:**
+- Required jobs: CND/AWS, dashboard, API image, processor image, OCI/SBOM/scan, OpenTofu/policy/cost and manifest/secret scan.
+- Root permissions contents:read; no self-hosted runner or credential.
+
+- [ ] **Step 1: Write workflow contract tests**
+
+Require full-SHA pinned actions, hosted runners, locked dependencies, exact dashboard production env, emulator teardown and no secrets/id-token/packages-write on pull_request.
+
+- [ ] **Step 2: Add dashboard route/build gates**
+
+Production build asserts exact VITE_API_BASE_URL, one API client, versioned activation, bearer origin, tenant header scope and no relative /api.
+
+- [ ] **Step 3: Add OCI and OpenTofu gates**
+
+Build without push, generate SBOM/checksum, scan reviewed severity, validate Compose, tofu/provider lock, OPA cost/secret/ownership.
+
+- [ ] **Step 4: Run local equivalents and actionlint**
+
+    uv run pytest -q tests/production/delivery/test_ci_workflows.py
+    actionlint .github/workflows
+    uv run ruff check .
+    git diff --check
+
+- [ ] **Step 5: Commit**
+
+    git add .github/workflows tests/production/delivery/test_ci_workflows.py
+    git commit -m "ci(prod): validate cnesdata production artifacts"
+
+### Task 2: Define the Candidate Release Manifest
+
+**Branch:** feat/prod-delivery-002-candidate-manifest
+
+**Files:**
+- Create: release/candidate.schema.json
+- Create: release/build_candidate.py
+- Create: release/verify_candidate.py
+- Create: tests/production/delivery/test_candidate_manifest.py
+- Create: .github/workflows/release-candidate.yml
+
+**Interfaces:**
+- Candidate records source SHA/run IDs, release ID, API GHCR digest, processor GHCR digest+expected ECR repo, dashboard checksum, Compose/config checksum, OpenTofu/provider lock and SBOM checksums.
+- No task-definition ARN or promoted ECR digest.
+
+- [ ] **Step 1: Write schema and forbidden-field tests**
+
+Reject taskDefinitionArn, ECR_URI@digest, mutable tag, wrong source/run, missing SBOM/checksum, expired manifest, secret-like keys and noncanonical JSON.
+
+- [ ] **Step 2: Implement deterministic builder/verifier**
+
+Canonical UTF-8 sorted JSON and SHA-256 sidecar. Every artifact is produced by the same successful run/SHA.
+
+- [ ] **Step 3: Implement candidate workflow**
+
+Trigger manually from a green develop commit contained in develop; verify required checks; build/push API+processor GHCR once; upload bounded artifact. packages:write only for its own images.
+
+- [ ] **Step 4: Run tests/actionlint and commit**
+
+    uv run pytest -q tests/production/delivery/test_candidate_manifest.py
+    actionlint .github/workflows/release-candidate.yml
+    git add release .github/workflows/release-candidate.yml tests/production/delivery/test_candidate_manifest.py
+    git commit -m "feat(release): create revision-free candidate manifest"
+
+### Task 3: Add Exact Product Plan and Apply Workflows
+
+**Branch:** ci/prod-delivery-003-plan-apply
+
+**Files:**
+- Create: release/infra-plan.schema.json
+- Create: .github/workflows/infra-plan.yml
+- Create: .github/workflows/infra-apply.yml
+- Create: scripts/promotion/verify_plan_artifact.py
+- Create: tests/production/delivery/test_plan_apply_workflows.py
+
+**Interfaces:**
+- Plan artifact contains binary/redacted plan, source/dependency/provider/backend/policy/cost/drift/expiry data and aggregate digest.
+- Apply inputs plan_run_id, artifact_id, artifact_digest and expected source SHA.
+- Calls exact pinned CnesData plan/deploy reusable gates from personal-infra-live.
+
+- [ ] **Step 1: Write wrong/mixed/expired artifact tests**
+
+All fail before OIDC. Reject cost >8/product or >15 aggregate, protected replacement/deletion, secret in plan, backend mismatch and insufficient validity margin.
+
+- [ ] **Step 2: Write workflow-order/permission tests**
+
+Validation precedes reusable gate and id-token. No apply-on-merge, replan, destroy or -lock=false.
+
+- [ ] **Step 3: Implement plan caller**
+
+Use read-only product plan role, native .tflock and separate coordination lease through reusable workflow. Upload exact artifact.
+
+- [ ] **Step 4: Implement apply caller**
+
+Verify exact artifact/run/SHA/ref/digest/expiry, preflight drift, apply exact binary with native locking, verify state/drift, record redacted evidence.
+
+- [ ] **Step 5: Validate and commit**
+
+    uv run pytest -q tests/production/delivery/test_plan_apply_workflows.py
+    actionlint .github/workflows/infra-plan.yml .github/workflows/infra-apply.yml
+    git add release .github/workflows scripts/promotion tests/production/delivery
+    git commit -m "ci(infra): join exact cnesdata plan and apply"
+
+### Task 4: Implement Byte-Identical Processor Promotion and Phase A
+
+**Branch:** feat/prod-delivery-004-phase-a
+
+**Files:**
+- Create: scripts/promotion/promote_ecr.py
+- Create: scripts/promotion/phase_a.py
+- Create: scripts/promotion/verify_task_revisions.py
+- Create: release/phase-a-evidence.schema.json
+- Create: tests/production/delivery/test_phase_a.py
+
+**Interfaces:**
+- Copies processor GHCR bytes to expected private ECR and verifies exact image digest.
+- Phase A exact plan/apply registers unit/recovery/audit revisions once and dual-authorizes old/new ecs:RunTask without changing state-machine/Schedulers.
+- Evidence records revision ARNs, digest, IAM propagation/readback and clean-state hash.
+
+- [ ] **Step 1: Write byte identity and repository tests**
+
+Reject wrong repo, architecture/media manifest, digest drift, mutable destination and unreviewed vulnerability severity.
+
+- [ ] **Step 2: Write phase state-delta tests**
+
+Permitted addresses/fields are new task revisions and dual grants only. Any state-machine/Scheduler target change fails.
+
+- [ ] **Step 3: Implement idempotent registration**
+
+If exact family/revision definition already exists from this activation, read/verify it; never register another revision on retry.
+
+- [ ] **Step 4: Wait/revalidate IAM propagation**
+
+Prove old and candidate RunTask authorizations with exact roles/network before emitting evidence.
+
+- [ ] **Step 5: Run and commit**
+
+    uv run pytest -q tests/production/delivery/test_phase_a.py
+    git add scripts/promotion release tests/production/delivery/test_phase_a.py
+    git commit -m "feat(promotion): register and dual-authorize phase-a tasks"
+
+### Task 5: Build and Sign the Activation Manifest
+
+**Branch:** feat/prod-delivery-005-activation-manifest
+
+**Files:**
+- Create: release/activation.schema.json
+- Create: release/build_activation.py
+- Create: release/verify_activation.py
+- Create: tests/production/delivery/test_activation_manifest.py
+
+**Interfaces:**
+- Binds candidate manifest SHA-256, release ID, source SHA, ECR_URI@sha256, unit/recovery/audit revision ARNs and Phase A evidence digest.
+- Signed through the approved KMS/evidence gate; contains no secret.
+
+- [ ] **Step 1: Write artifact-mixing tests**
+
+Reject any candidate/revision/digest/evidence from another release/run, re-registered revision, mutable ARN field, wrong state hash and missing signature context.
+
+- [ ] **Step 2: Implement canonical payload and detached signature**
+
+Signature context binds project=cnesdata, environment=prod, schema and release ID. Verifier checks expiry and all referenced evidence before use.
+
+- [ ] **Step 3: Add exact OpenTofu input renderer**
+
+Renderer produces only approved variables and exact revision ARNs; no ignore_changes or out-of-band CLI target mutation.
+
+- [ ] **Step 4: Run and commit**
+
+    uv run pytest -q tests/production/delivery/test_activation_manifest.py
+    git add release tests/production/delivery/test_activation_manifest.py
+    git commit -m "feat(promotion): bind phase-a activation evidence"
+
+### Task 6: Implement Canary Seed, Visibility and Retention Verification
+
+**Branch:** feat/prod-delivery-006-canary
+
+**Files:**
+- Create: scripts/promotion/seed_canary.py
+- Create: scripts/promotion/run_canary.py
+- Create: scripts/promotion/verify_canary.py
+- Create: tests/production/delivery/test_canary.py
+
+**Interfaces:**
+- Seeder PutItem exact release-bound pending event.
+- Verifier Query exact GSI up to 60 seconds, then conditioned GetItem and exact audit GetObject/GetObjectRetention.
+- Runs candidate with canary-only role/resource overrides and exact PassRole.
+
+- [ ] **Step 1: Write IAM/identity denial tests**
+
+Other release/table/index/bucket/object/role is rejected. Seeder cannot read/update. Verifier cannot Scan, list or mutate domain delivery.
+
+- [ ] **Step 2: Write visibility timeout test**
+
+Bounded poll with jitter <=60 seconds; timeout fails closed and no promotion proceeds.
+
+- [ ] **Step 3: Implement canary run**
+
+Pass only canary task/execution roles and resource names. Require COMPLIANCE object retention plus delivered marker matching event/release.
+
+- [ ] **Step 4: Test replay**
+
+Same release is idempotent; mixed/old event cannot satisfy current acceptance.
+
+- [ ] **Step 5: Commit**
+
+    uv run pytest -q tests/production/delivery/test_canary.py
+    git add scripts/promotion tests/production/delivery/test_canary.py
+    git commit -m "feat(promotion): verify release-bound audit canary"
+
+### Task 7: Implement Fence Close, Drain and Phase B
+
+**Branch:** feat/prod-delivery-007-phase-b
+
+**Files:**
+- Create: scripts/promotion/environment_gate.py
+- Create: scripts/promotion/phase_b.py
+- Create: scripts/promotion/verify_routes.py
+- Create: tests/production/delivery/test_phase_b.py
+
+**Interfaces:**
+- Operator assumes release-tagged fence role, closes exact fence item and cannot write semaphore.
+- Drain uses strong reads until semaphore idle/no dispatch, bounded by promotion deadline.
+- Phase B reviewed apply switches only state-machine TaskDefinition to activation unit revision; Schedulers remain prior.
+
+- [ ] **Step 1: Write close-first/race tests**
+
+New initial/recovery acquires fail after close; existing permit drains. Only bound canary can acquire. Direct semaphore update denied.
+
+- [ ] **Step 2: Write plan-delta and route readback tests**
+
+Reject any Scheduler change, new revision registration, IAM grant removal, ignore_changes or out-of-band update. Verify clean state/no drift after apply.
+
+- [ ] **Step 3: Implement bounded drain**
+
+If not drained before safety margin, abort without Phase B and retain/restore prior open state only when no partial mutation occurred.
+
+- [ ] **Step 4: Implement partial-apply fail-closed behavior**
+
+Any uncertain/mixed route leaves fence closed and emits diagnostic evidence for a new reviewed convergence plan.
+
+- [ ] **Step 5: Run and commit**
+
+    uv run pytest -q tests/production/delivery/test_phase_b.py
+    git add scripts/promotion tests/production/delivery/test_phase_b.py
+    git commit -m "feat(promotion): fence and switch unit routing"
+
+### Task 8: Implement API Candidate and Atomic Frontend Promotion
+
+**Branch:** feat/prod-delivery-008-api-static
+
+**Files:**
+- Create: scripts/promotion/build_host_archive.py
+- Create: scripts/promotion/promote_api.py
+- Create: scripts/promotion/publish_dashboard.py
+- Create: scripts/promotion/rollback_api_static.py
+- Create: tests/production/delivery/test_api_static_promotion.py
+- Create: .github/workflows/promote-production.yml
+
+**Interfaces:**
+- Product workflow verifies exact candidate artifact with its ephemeral GITHUB_TOKEN, then invokes immutable personal-infra-live CnesData host gate.
+- API candidate starts on alternate loopback, passes local auth/AWS readiness, switches Nginx, then passes tunneled production hostname smoke.
+- Dashboard immutable unit uploads/verifies before root entrypoint last.
+
+- [ ] **Step 1: Write three-frame host-archive tests**
+
+Envelope/archive/GITHUB_TOKEN bind exact source/run/artifact/digest, GHCR API digest, Compose/config checksums, platform-plan evidence and expiry. Archive has no secret.
+
+- [ ] **Step 2: Write candidate failure injection**
+
+Pull/start/readiness/auth/AWS/local smoke/Nginx validate/switch/tunnel smoke failures preserve or restore prior API; global lease is released.
+
+- [ ] **Step 3: Write static atomicity tests**
+
+Mixed release references, overwrite of immutable prefix and failed asset verification leave root unchanged. Successful rollback restores prior index version and invalidates entrypoints only.
+
+- [ ] **Step 4: Implement workflow up through unit canary boundary**
+
+Workflow coordinates Tasks 4-7, API/static steps and unit canary while fence remains closed. It does not reopen or switch schedulers yet.
+
+- [ ] **Step 5: Validate and commit**
+
+    uv run pytest -q tests/production/delivery/test_api_static_promotion.py
+    actionlint .github/workflows/promote-production.yml
+    git add scripts/promotion .github/workflows/promote-production.yml tests/production/delivery
+    git commit -m "feat(promotion): switch api and static release atomically"
+
+### Task 9: Implement Separate Phase C Recovery and Audit Acceptance
+
+**Branch:** feat/prod-delivery-009-phase-c
+
+**Files:**
+- Create: scripts/promotion/phase_c_recovery.py
+- Create: scripts/promotion/phase_c_audit.py
+- Create: scripts/promotion/accept_routing.py
+- Create: tests/production/delivery/test_phase_c.py
+- Modify: .github/workflows/promote-production.yml
+
+**Interfaces:**
+- First reviewed apply changes only recovery Scheduler revision.
+- After recovery canary, second reviewed apply changes only audit Scheduler revision.
+- Reopen fence only when unit+recovery+audit exact activation revisions are accepted and state is clean.
+
+- [ ] **Step 1: Write phase-specific plan-delta tests**
+
+Recovery plan cannot change unit/audit; audit plan cannot change unit/recovery. Both consume/verify the same activation manifest.
+
+- [ ] **Step 2: Add recovery canary tests**
+
+Force one bounded recovery, verify exact mode/network/role/deadline and failure alarm. Overlap/duplicate passes never exceed one unit task.
+
+- [ ] **Step 3: Add audit canary tests**
+
+Use release-bound pending event, exact cursor behavior and COMPLIANCE proof. Audit remains functional under a simulated cost freeze.
+
+- [ ] **Step 4: Implement route acceptance/reopen**
+
+Strongly read state machine and both Schedulers plus OpenTofu state. Mixed/dirty state cannot reopen.
+
+- [ ] **Step 5: Enforce 30-minute routine window**
+
+Watchdog stops new phase activity before cutoff and initiates prior-route convergence while fence stays closed.
+
+- [ ] **Step 6: Run and commit**
+
+    uv run pytest -q tests/production/delivery/test_phase_c.py
+    actionlint .github/workflows/promote-production.yml
+    git add scripts/promotion .github/workflows/promote-production.yml tests/production/delivery/test_phase_c.py
+    git commit -m "feat(promotion): accept recovery and audit routes separately"
+
+### Task 10: Implement Rollback, Drain and Revision Pruning
+
+**Branch:** feat/prod-delivery-010-rollback-drain
+
+**Files:**
+- Create: scripts/promotion/rollback.py
+- Create: scripts/promotion/drain.py
+- Create: scripts/promotion/prune_revisions.py
+- Create: tests/production/delivery/test_rollback_drain.py
+- Create: docs/runbooks/rollback.md
+
+**Interfaces:**
+- Rollback consumes the prior retained activation manifest and a new reviewed exact OpenTofu plan/apply.
+- Active Standard executions keep their started definition unless safe cancellation is explicitly approved.
+- Prune only revisions older than current/prior and after active old Standard/recovery drain plus retention.
+
+- [ ] **Step 1: Write active-execution and retention tests**
+
+Current, prior, referenced-by-active and within-retention revisions/grants are protected. Only older unreferenced revisions qualify.
+
+- [ ] **Step 2: Write full-route rollback plan tests**
+
+Restore unit/recovery/audit and grants together via declarative plans; no manual state/Dynamo mutation.
+
+- [ ] **Step 3: Implement API/static immediate restore**
+
+Restore previous Nginx upstream/GHCR digest and dashboard entrypoint while processor convergence proceeds fenced.
+
+- [ ] **Step 4: Implement failure-safe pruning**
+
+Readback twice around decision; any uncertainty keeps resources.
+
+- [ ] **Step 5: Run and commit**
+
+    uv run pytest -q tests/production/delivery/test_rollback_drain.py
+    git add scripts/promotion tests/production/delivery/test_rollback_drain.py docs/runbooks/rollback.md
+    git commit -m "feat(ops): retain drain and rollback exact revisions"
+
+### Task 11: Add CloudFront Free, Demo Seed and Real-AWS Smoke Tooling
+
+**Branch:** feat/prod-delivery-011-cutover-smoke
+
+**Files:**
+- Create: scripts/promotion/reconcile_cloudfront_free.py
+- Create: scripts/promotion/seed_demo.py
+- Create: scripts/promotion/smoke_production.py
+- Create: tests/production/delivery/test_cloudfront_free.py
+- Create: tests/production/delivery/test_demo_seed.py
+- Create: tests/production/delivery/test_smoke_redaction.py
+- Create: docs/runbooks/cloudfront-free.md
+- Create: docs/runbooks/demo-seed.md
+
+**Interfaces:**
+- Free reconciliation exact distribution+dedicated WAF+FREE at us-east-1 and ACTIVE; no replacement/cancel/paid action.
+- Demo seed writes one synthetic tenant through a distinct seed role, cannot write semaphore and conditionally rejects non-demo collisions.
+- Smoke output is redacted pass/fail evidence only.
+
+- [ ] **Step 1: Write Free-plan eligibility/refusal tests**
+
+Require account eligibility and phase-one slot availability. Reject any paid tier, ambiguous/conflicting association or inactive result.
+
+- [ ] **Step 2: Write seed-role/idempotency tests**
+
+No GitHub general data-plane write. Exact reviewed seed role; conditional known keys; no bulk delete/Scan; semaphore denied.
+
+- [ ] **Step 3: Implement real-AWS smoke probes**
+
+Cognito standard endpoints+PKCE+audience, membership/cross-tenant denial, CORS, exact Step Functions trust/task, signed-serving metadata->200 envelope->header-free S3 body, Object Lock and Roles Anywhere/CRL evidence.
+
+- [ ] **Step 4: Redact sensitive values**
+
+Never print/store access tokens, SigV4 URLs, object paths, record bodies, emails or IDs. Evidence contains named assertion+timestamp+release hash only.
+
+- [ ] **Step 5: Run fixture tests and commit**
+
+    uv run pytest -q tests/production/delivery/test_cloudfront_free.py tests/production/delivery/test_demo_seed.py tests/production/delivery/test_smoke_redaction.py
+    git add scripts/promotion tests/production/delivery docs/runbooks
+    git commit -m "feat(acceptance): add exact cutover and smoke tooling"
+
+### Task 12: Build the Final Production Operations Gate
+
+**Branch:** test/prod-delivery-012-operations-acceptance
+
+**Files:**
+- Create: tests/production/delivery/test_operations_acceptance.py
+- Create: docs/runbooks/production-promotion.md
+- Create: docs/runbooks/recovery-drill.md
+- Create: docs/runbooks/roles-anywhere-incident.md
+- Create: docs/runbooks/cost-freeze.md
+- Create: docs/runbooks/quarterly-restore.md
+
+**Interfaces:**
+- Produces final preproduction/production checklists and evidence schema.
+- Does not deploy automatically.
+
+- [ ] **Step 1: Encode the pre-production matrix**
+
+All CND/AWS gates; real Dynamo/Object Lock; OIDC rotation/revocation/cross-tenant; fence/dispatch replay; source behavior; outbox cursor/poison; browser contract; credential refresh; VPS IAM; external CA/CRL; Step Functions IAM; manifest/Phase A/B/C; canary; drain/prune; recovery/audit modes/deadlines; gate races; task-hour/counter budget; publishing crash IAM; AWS-012 override; CDN/Free/Cognito/rate/cost policy.
+
+- [ ] **Step 2: Encode the production smoke matrix**
+
+Static/TLS/private origin; Tunnel-only API; standard Cognito endpoints/PKCE/audience; exact Roles Anywhere and CRL revocation; phase evidence/routes/fence; recovery/audit failure behavior; hung recovery stop; overlapping recoveries; one synthetic publication/pointer; 200 serving envelope and second S3 fetch; no leakage; previous release restore.
+
+- [ ] **Step 3: Write incident/recovery drills**
+
+Roles Anywhere: disable profile/trust, update CRL, revoke prior sessions/TokenIssueTime Deny, prove Dynamo/S3/Step Functions denial, retain deny for max session+propagation, rotate leaf, re-enable and test.
+
+- [ ] **Step 4: Write cost-freeze and quarterly restore**
+
+Freeze aborts promotion/new cost while audit/read/backup continue. Quarterly recovery reconstructs API and one synthetic pointer/serving object without modifying production.
+
+- [ ] **Step 5: Run every non-mutating repository gate**
+
+    uv run ruff check .
+    uv run pytest -q tests/production
+    uv run pytest -m "not integration and not postgres and not bigquery and not e2e and not stress and not soak and not spike and not windows_only" -q
+    cd apps/web_dashboard && bun run lint && bun run typecheck && bun run test --run && bun run build
+    tofu -chdir=infra/opentofu fmt -check -recursive
+    tofu -chdir=infra/opentofu init -backend=false -input=false
+    tofu -chdir=infra/opentofu validate -no-color
+    tofu -chdir=infra/opentofu test
+    conftest test tests/fixtures/plans --policy policies
+    actionlint .github/workflows
+    git diff --check
+
+- [ ] **Step 6: Commit**
+
+    git add tests/production/delivery/test_operations_acceptance.py docs/runbooks
+    git commit -m "test(prod): gate cnesdata promotion and recovery"
+
+## Execution Order
+
+Tasks 1-3 are the release/delivery foundation. Task 4 waits for a candidate and infrastructure task definitions. Task 5 waits for Task 4. Task 6 may proceed after Task 5. Task 7 waits for Tasks 5-6. Task 8 waits for Task 7 and the infra-ansible dispatcher. Task 9 waits for Tasks 6-8. Task 10 waits for Task 9. Task 11 may proceed after Tasks 2-3 and joins before final cutover. Task 12 is final.
+
+## Plan Self-Review Record
+
+- Manifest separation: candidate is revision-free; activation exists only after Phase A and binds exact revisions/digest/evidence.
+- Declarative routing: Phase A/B/C all use reviewed exact plans; no ignore_changes or CLI out-of-band update.
+- Fence safety: close-first, strong drain, bound canary and complete-route reopen are consistent across scripts/tests/workflow.
+- Failure safety: partial/mixed routes remain fenced and require reviewed convergence.
+- Rollback: prior API/static can restore promptly; processor uses retained manifest and does not mutate data backward.
+- Identity: product GITHUB_TOKEN validates its own CI evidence; OIDC/SSH credentials come only through pinned personal-infra-live gates.
+- Cost: CloudFront exact FREE, no paid fallback, product <=USD 8 and aggregate freeze at USD 15.
+- Completeness scan: no unresolved marker, automatic deployment, ambiguous evidence or destructive shortcut.
+
+## Execution Handoff
+
+Execute with isolated worktrees and review each PR. Completing these tasks creates delivery machinery and runbooks; the first production plan/apply/promotion is a distinct manual operation after LimnoPulse is accepted and all real-world preflight evidence is current.

--- a/docs/superpowers/plans/2026-08-31-cnesdata-production-infrastructure-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-31-cnesdata-production-infrastructure-implementation-plan.md
@@ -1,0 +1,527 @@
+# CnesData Production Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Define the cost-bounded CnesData production AWS resources in OpenTofu: private static delivery, Cognito, DynamoDB, versioned/Object-Locked S3, ECR/ECS, Step Functions, scheduled recovery/audit, Athena, least-privilege IAM, alarms and product cost policy.
+
+**Architecture:** One product state owns only CnesData resources and consumes narrow shared outputs for backend/KMS/OIDC/Roles Anywhere/Budget/edge coordination. Processing has no service or load balancer: Step Functions and EventBridge Scheduler run immutable Fargate task revisions in public subnets with ephemeral public IP and zero ingress. Promotion registers and routes exact revisions through reviewed phase plans; resource definitions remain declarative and protected.
+
+**Tech Stack:** OpenTofu 1.8+, AWS provider, AWS us-east-2, ACM/WAF us-east-1, S3/CloudFront/OAC, Cognito, DynamoDB, ECR, ECS Fargate, Step Functions Standard, EventBridge Scheduler, Athena, CloudWatch, IAM, OPA/Conftest, pytest.
+
+**Spec:** docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md and docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+
+## Global Constraints
+
+- Start after the runtime-amendments plan is merged and green; infrastructure planning also requires CND-020…025 integrated.
+- Runtime promotion remains blocked until AWS-010…014 and serial acceptance are green.
+- State key is cnesdata/prod/opentofu.tfstate in the shared private S3 backend with native locking.
+- Default provider is us-east-2. Alias global_edge in us-east-1 owns only CloudFront ACM and CLOUDFRONT-scope WAF.
+- Shared state owns KMS/SSM hierarchy, GitHub OIDC role classes, Roles Anywhere trust anchor/profile/role/CRL, Budget action, backup/evidence storage, Cloudflare and VPS. Product state consumes reviewed outputs and never imports shared state with broad read access.
+- Web, data and audit buckets are distinct. Web/data are versioned; audit enables Object Lock at creation and COMPLIANCE 365 days.
+- No bucket is public. S3 Block Public Access and bucket-owner-enforced ownership are mandatory.
+- DynamoDB is one PAY_PER_REQUEST control-plane table, PITR 35 days, deletion protection, TTL-GC only and max 100 reads/25 writes on table/GSIs.
+- ECS has no service, desired count, autoscaling, Spot, NAT, ALB or inbound rule. Unit/recovery/audit use 0.25 vCPU, 0.5-1 GiB, included 20 GiB, public IP and exact zero-ingress groups.
+- Unit semaphore maximum is one. Recovery invocations may overlap but each is bounded. 100 combined task-hours is an alarm/target only.
+- Step Functions Standard and Inline Map only; payload logging is disabled. Maximum 200 start attempts is enforced by runtime counter.
+- Processor ECR retains at most five production rollback digests/30 days, untagged seven days and current/prior protections.
+- Cognito creates resource server identifier https://api.cnesdata.vinisantana.com and scope api.access; public PKCE SPA client; collision-safe managed prefix domain; no SMS/social/M2M/custom domain.
+- Athena is operator-only with 5 GB/query and 100 GB/month cutoff; never an API dependency.
+- Product envelope is USD 8 and aggregate base/max evidence remains below USD 15 freeze.
+- OpenTofu has no provisioner/local-exec and no destroy workflow. Paid CloudFront subscription reconciliation is outside state and exact FREE only.
+
+## Target Layout
+
+    infra/opentofu/
+      modules/
+        control-plane/
+        data-buckets/
+        static-web/
+        cognito/
+        network/
+        processor-registry/
+        processing/
+        schedulers/
+        athena/
+        runtime-iam/
+        observability/
+      env/prod/
+      tests/
+    policies/
+    tests/production/infra/
+    docs/runbooks/
+
+---
+
+### Task 1: Create Product Composition and Ownership Contracts
+
+**Branch:** feat/prod-infra-001-composition
+
+**Files:**
+- Create: infra/opentofu/versions.tf
+- Create: infra/opentofu/providers.tf
+- Create: infra/opentofu/env/prod/main.tf
+- Create: infra/opentofu/env/prod/variables.tf
+- Create: infra/opentofu/env/prod/outputs.tf
+- Create: infra/opentofu/env/prod/backend.hcl.example
+- Create: infra/opentofu/env/prod/shared-outputs.schema.json
+- Create: tests/production/infra/test_composition.py
+
+**Interfaces:**
+- Inputs from shared: account_id, shared KMS ARN, Roles Anywhere API role/profile/trust-anchor/CRL evidence, GitHub role ARNs, budget freeze policy/action contract and state/evidence bucket contract.
+- Outputs to edge: CloudFront domain/distribution ID, ACM DNS validation records and API loopback contract only.
+
+- [ ] **Step 1: Write ownership tests**
+
+Reject aws_kms_key, aws_ssm_parameter, aws_rolesanywhere_*, aws_iam_openid_connect_provider, aws_budgets_*, cloudflare_* and Hostinger resources from the product graph.
+
+- [ ] **Step 2: Write provider-region tests**
+
+Every resource must use default us-east-2 except aws_acm_certificate and CLOUDFRONT WAF through aws.global_edge.
+
+- [ ] **Step 3: Implement pinned provider/backend contract**
+
+Use use_lockfile=true and no DynamoDB lock table. Public backend example contains placeholders only.
+
+- [ ] **Step 4: Add required tags/local naming**
+
+Project=cnesdata, Environment=prod, ManagedBy=opentofu, Owner=vinisantana.
+
+- [ ] **Step 5: Validate and commit**
+
+    tofu -chdir=infra/opentofu init -backend=false -input=false
+    tofu -chdir=infra/opentofu fmt -check -recursive
+    tofu -chdir=infra/opentofu validate -no-color
+    uv run pytest -q tests/production/infra/test_composition.py
+    git add infra/opentofu tests/production/infra
+    git commit -m "feat(infra): define cnesdata production ownership"
+
+### Task 2: Provision the DynamoDB Control Plane
+
+**Branch:** feat/prod-infra-002-control-plane
+
+**Files:**
+- Create: infra/opentofu/modules/control-plane/main.tf
+- Create: infra/opentofu/modules/control-plane/variables.tf
+- Create: infra/opentofu/modules/control-plane/outputs.tf
+- Create: infra/opentofu/modules/control-plane/checks.tf
+- Modify: infra/opentofu/env/prod/main.tf
+- Create: tests/production/infra/test_control_plane.py
+
+**Interfaces:**
+- Produces table ARN/name and exact index ARNs used by runtime policies.
+- Schema/index definitions are generated from the merged DynamoDB adapter access-pattern contract; no convenience GSI is invented.
+
+- [ ] **Step 1: Write plan tests for exact key/index inventory**
+
+Compare to the merged adapter constants. Require PAY_PER_REQUEST, PITR 35, TTL, deletion protection, encryption, table/GSI max throughput and no global replicas/Contributor Insights/autoscaling.
+
+- [ ] **Step 2: Add lifecycle protection tests**
+
+prevent_destroy and replacement policy gate apply to the table; changing key schema fails policy.
+
+- [ ] **Step 3: Implement module and alarms outputs**
+
+Use AWS-owned encryption unless the approved shared KMS policy is proven simpler/cost-neutral; document the selected choice in the PR.
+
+- [ ] **Step 4: Validate and commit**
+
+    uv run pytest -q tests/production/infra/test_control_plane.py packages/cnes_infra/tests/control_plane
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/control-plane infra/opentofu/env/prod tests/production/infra
+    git commit -m "feat(infra): provision bounded control plane"
+
+### Task 3: Provision Data and Object-Locked Audit Buckets
+
+**Branch:** feat/prod-infra-003-data-buckets
+
+**Files:**
+- Create: infra/opentofu/modules/data-buckets/main.tf
+- Create: infra/opentofu/modules/data-buckets/policies.tf
+- Create: infra/opentofu/modules/data-buckets/variables.tf
+- Create: infra/opentofu/modules/data-buckets/outputs.tf
+- Modify: infra/opentofu/env/prod/main.tf
+- Create: tests/production/infra/test_data_buckets.py
+
+**Interfaces:**
+- Data prefixes: raw, normalized, reconciliation, serving, tmp.
+- Audit prefix: audit with Object Lock COMPLIANCE 365.
+- Data CORS exact origin cnesdata, methods GET/HEAD, allowed headers empty, MaxAge 300.
+
+- [ ] **Step 1: Write bucket isolation/public-access tests**
+
+Require distinct buckets, account/bucket public block, TLS, owner-enforced ownership, versioning and no website/ACL.
+
+- [ ] **Step 2: Write lifecycle and immutability tests**
+
+Abort multipart; tmp expires after bounded recovery; published history not deployment-deleted. Audit Object Lock enabled on creation with prevent_destroy and no bypass/delete policy.
+
+- [ ] **Step 3: Write exact S3 CORS tests**
+
+No wildcard, credentials, custom header, PUT/POST or other origin.
+
+- [ ] **Step 4: Implement module and prefix outputs**
+
+Expose exact bucket/prefix ARNs needed by IAM, not broad bucket data sources.
+
+- [ ] **Step 5: Validate and commit**
+
+    uv run pytest -q tests/production/infra/test_data_buckets.py
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/data-buckets infra/opentofu/env/prod tests/production/infra
+    git commit -m "feat(storage): add private data and locked audit buckets"
+
+### Task 4: Provision Cognito Resource Server and PKCE Client
+
+**Branch:** feat/prod-infra-004-cognito
+
+**Files:**
+- Create: infra/opentofu/modules/cognito/main.tf
+- Create: infra/opentofu/modules/cognito/variables.tf
+- Create: infra/opentofu/modules/cognito/outputs.tf
+- Modify: infra/opentofu/env/prod/main.tf
+- Create: tests/production/infra/test_cognito.py
+
+**Interfaces:**
+- Resource server identifier is API origin and custom scope api.access.
+- Outputs issuer, audience, pool/client IDs, managed prefix domain and absolute authorize/token/logout URLs.
+- Managed prefix is collision-safe from environment plus approved unique suffix input.
+
+- [ ] **Step 1: Write exact OAuth tests**
+
+Require code flow, PKCE-compatible public client/no secret, exact callback/logout, openid/email/profile plus API scope, resource server and admin-created demo users only.
+
+- [ ] **Step 2: Write forbidden feature tests**
+
+No custom domain/certificate/DNS, managed-login-v2 dependency, SMS MFA, social IdP or client credentials.
+
+- [ ] **Step 3: Implement deterministic collision-safe prefix**
+
+Suffix is an explicit reviewed non-secret input bound in state; planning rejects empty/out-of-pattern values and reports unavailable domain as blocker.
+
+- [ ] **Step 4: Validate app/output consistency**
+
+Compare outputs to AwsRuntimeSettings/dashboard public-env schema from the runtime plan.
+
+- [ ] **Step 5: Commit**
+
+    uv run pytest -q tests/production/infra/test_cognito.py packages/cnes_infra/tests/aws/test_settings.py
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/cognito infra/opentofu/env/prod tests/production/infra
+    git commit -m "feat(auth): provision cnesdata cognito audience"
+
+### Task 5: Provision Private Static Web Delivery
+
+**Branch:** feat/prod-infra-005-static-web
+
+**Files:**
+- Create: infra/opentofu/modules/static-web/main.tf
+- Create: infra/opentofu/modules/static-web/function.js
+- Create: infra/opentofu/modules/static-web/variables.tf
+- Create: infra/opentofu/modules/static-web/outputs.tf
+- Modify: infra/opentofu/env/prod/main.tf
+- Create: tests/production/infra/test_static_web.py
+- Create: tests/production/infra/test_spa_rewrite.js
+
+**Interfaces:**
+- Private us-east-2 versioned bucket, OAC, CloudFront, dedicated global WAF and ACM.
+- Public name cnesdata.vinisantana.com; Cloudflare DNS is external ownership.
+- Runtime output maps VITE_API_BASE_URL exactly to https://api.cnesdata.vinisantana.com/api/v1.
+
+- [ ] **Step 1: Write OAC/public policy tests**
+
+Bucket reads limited to exact distribution SourceArn. No public ACL/website.
+
+- [ ] **Step 2: Write rewrite/cache/header tests**
+
+Extensionless SPA routes only; exclude assets/extensions/API/metadata. Immutable hashed assets; index/manifest/service-worker bounded no-cache. Security headers and CSP sources are exact.
+
+- [ ] **Step 3: Add release lifecycle below 5 GB**
+
+Retain current/prior units; expire unreferenced noncurrent only after rollback window.
+
+- [ ] **Step 4: Validate and commit**
+
+    node --test tests/production/infra/test_spa_rewrite.js
+    uv run pytest -q tests/production/infra/test_static_web.py
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/static-web infra/opentofu/env/prod tests/production/infra
+    git commit -m "feat(web-infra): add private cnesdata distribution"
+
+### Task 6: Provision Zero-Ingress Public-Subnet Networking
+
+**Branch:** feat/prod-infra-006-network
+
+**Files:**
+- Create: infra/opentofu/modules/network/main.tf
+- Create: infra/opentofu/modules/network/variables.tf
+- Create: infra/opentofu/modules/network/outputs.tf
+- Modify: infra/opentofu/env/prod/main.tf
+- Create: tests/production/infra/test_network.py
+
+**Interfaces:**
+- Produces exact public subnet IDs, route/IGW, zero-ingress SG and optional free S3/DynamoDB gateway endpoint IDs.
+- No NAT, ALB/NLB, public listener or service discovery.
+
+- [ ] **Step 1: Write forbidden-cost/listener tests**
+
+Reject NAT/egress-only internet gateway, load balancer/target group/listener, ECS service, VPC interface endpoint and any ingress rule.
+
+- [ ] **Step 2: Write egress contract tests**
+
+Allow DNS plus TLS/required AWS APIs without opening inbound. Document why ephemeral task public IP is accepted.
+
+- [ ] **Step 3: Implement compact VPC/public subnets**
+
+Use two AZs only if required by account/service validation without adding fixed-cost resources. Gateway endpoints are route-table scoped and free.
+
+- [ ] **Step 4: Cross-check AWS-012 validator inputs**
+
+Plan output exact subnet/SG tuple must pass the runtime production-network test.
+
+- [ ] **Step 5: Commit**
+
+    uv run pytest -q tests/production/infra/test_network.py packages/cnes_infra/tests/executor/test_production_network.py
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/network infra/opentofu/env/prod tests/production/infra
+    git commit -m "feat(network): add zero-ingress fargate egress"
+
+### Task 7: Provision Processor ECR and Immutable ECS Task Families
+
+**Branch:** feat/prod-infra-007-ecs
+
+**Files:**
+- Create: infra/opentofu/modules/processor-registry/**
+- Create: infra/opentofu/modules/processing/ecs.tf
+- Create: infra/opentofu/modules/processing/variables.tf
+- Create: infra/opentofu/modules/processing/outputs.tf
+- Modify: infra/opentofu/env/prod/main.tf
+- Create: tests/production/infra/test_ecr_ecs.py
+
+**Interfaces:**
+- ECR receives byte-identical promoted processor content and exposes repository URI.
+- Module registers exact unit, recovery and audit task definitions from a verified image_digest input.
+- Task roles and execution roles are separate; log payloads disabled/redacted.
+
+- [ ] **Step 1: Write ECR lifecycle/scan tests**
+
+Scan on push; untagged seven days; at most five prod/30 days while retaining explicitly declared current/prior digests.
+
+- [ ] **Step 2: Write task-definition tests**
+
+Linux/x86_64, FARGATE, 0.25 vCPU, bounded memory, 20 GiB, read-only/non-root/no privilege, awslogs seven days, mode-specific command/deadline/env and no secret values.
+
+- [ ] **Step 3: Implement revision inputs for promotion phases**
+
+No mutable tag. image_uri must match ECR_URI@sha256. Candidate manifest does not contain task revision; phase A outputs exact revision ARNs.
+
+- [ ] **Step 4: Validate and commit**
+
+    uv run pytest -q tests/production/infra/test_ecr_ecs.py
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/processor-registry infra/opentofu/modules/processing infra/opentofu/env/prod tests/production/infra
+    git commit -m "feat(processing-infra): register immutable task families"
+
+### Task 8: Provision Step Functions and Exact Service IAM
+
+**Branch:** feat/prod-infra-008-step-functions
+
+**Files:**
+- Create: infra/opentofu/modules/processing/state_machine.asl.json
+- Create: infra/opentofu/modules/processing/step_functions.tf
+- Create: infra/opentofu/modules/runtime-iam/step-functions.tf
+- Create: infra/opentofu/modules/runtime-iam/task-roles.tf
+- Create: tests/production/infra/test_step_functions_iam.py
+
+**Interfaces:**
+- Standard state machine, Inline Map, canonical three waves, MaxConcurrency=1 and exact task revision ARN input.
+- Step Functions role trusts states.amazonaws.com with exact SourceAccount/SourceArn.
+
+- [ ] **Step 1: Write ASL contract tests**
+
+IDs-only input, NORMALIZE/RECONCILE/MATERIALIZE order, bounded jitter retries/catches, no Distributed Map, no execution data logging and exact ECS network parameters.
+
+- [ ] **Step 2: Write IAM positive/negative matrix**
+
+ecs:RunTask exact current/candidate revisions; Describe/Stop Resource:* only where AWS requires; EventBridge managed-rule actions exact; iam:PassRole exact roles and PassedToService; required Logs delivery wildcard action set exact.
+
+- [ ] **Step 3: Implement API/runtime task policies**
+
+API exact machine start/describe, execution describe/stop, control-plane keys and serving GetObject/stat. Processor prefix actions follow the Spec; deny delete/list/raw/audit cross-access.
+
+- [ ] **Step 4: Run runtime validator against rendered ASL**
+
+    uv run pytest -q tests/production/infra/test_step_functions_iam.py packages/cnes_infra/tests/executor
+
+- [ ] **Step 5: Commit**
+
+    git add infra/opentofu/modules/processing infra/opentofu/modules/runtime-iam tests/production/infra
+    git commit -m "feat(processing-infra): add exact step-functions iam"
+
+### Task 9: Provision Recovery and Audit Schedulers
+
+**Branch:** feat/prod-infra-009-schedulers
+
+**Files:**
+- Create: infra/opentofu/modules/schedulers/main.tf
+- Create: infra/opentofu/modules/schedulers/iam.tf
+- Create: infra/opentofu/modules/schedulers/variables.tf
+- Create: infra/opentofu/modules/schedulers/outputs.tf
+- Modify: infra/opentofu/env/prod/main.tf
+- Create: tests/production/infra/test_schedulers.py
+
+**Interfaces:**
+- recover-once every 30 minutes, max retries 0, task deadline/lease 3600, batch 100.
+- dispatch-outbox-once every 30 minutes, max retries 0, deadline 60, limit 100.
+- Separate exact task revisions/roles; public subnets, public IP, zero-ingress SG.
+
+- [ ] **Step 1: Write schedule and retry tests**
+
+Reject flexible time windows that violate cadence, retry attempts >0, shared task role or wrong mode/definition.
+
+- [ ] **Step 2: Write Scheduler trust/PassRole tests**
+
+Trust scheduler.amazonaws.com with exact account/ARN. Pass only matching task/execution role.
+
+- [ ] **Step 3: Implement alarms**
+
+Failed/missed/timed-out invocation and outbox backlog. Audit remains allowed under cost freeze.
+
+- [ ] **Step 4: Validate and commit**
+
+    uv run pytest -q tests/production/infra/test_schedulers.py
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/schedulers infra/opentofu/env/prod tests/production/infra
+    git commit -m "feat(ops-infra): schedule recovery and audit passes"
+
+### Task 10: Add Canary Resources and Promotion Fence IAM
+
+**Branch:** feat/prod-infra-010-canary-fence
+
+**Files:**
+- Create: infra/opentofu/modules/processing/canary.tf
+- Create: infra/opentofu/modules/runtime-iam/canary.tf
+- Create: infra/opentofu/modules/runtime-iam/promotion.tf
+- Create: tests/production/infra/test_canary_fence_iam.py
+
+**Interfaces:**
+- Persistent canary table/bucket owned by OpenTofu.
+- Release-scoped short-session seeder/verifier task/execution roles.
+- Seeder PutItem only exact canary table; verifier exact GSI Query, conditioned GetItem, bound GetObject/GetObjectRetention and exact PassRole.
+- Promotion operator strongly reads gate/semaphore and mutates fence only.
+
+- [ ] **Step 1: Write canary least-privilege matrix**
+
+Reject other release IDs, tables/indexes/buckets, semaphore write, application data read and broad PassRole.
+
+- [ ] **Step 2: Write audit dispatch IAM matrix**
+
+Allow audit lock config/get/put/retention and outbox/cursor LeadingKeys; deny run/fence/semaphore, Scan, Delete, List and BypassGovernanceRetention.
+
+- [ ] **Step 3: Implement resources and release conditions**
+
+Canary event/object keys include release ID; roles have bounded max session and explicit activation input.
+
+- [ ] **Step 4: Validate and commit**
+
+    uv run pytest -q tests/production/infra/test_canary_fence_iam.py
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/processing infra/opentofu/modules/runtime-iam tests/production/infra
+    git commit -m "feat(promotion): add canary and fence boundaries"
+
+### Task 11: Add Athena, Alarms and Cost/Freeze Contracts
+
+**Branch:** feat/prod-infra-011-athena-cost
+
+**Files:**
+- Create: infra/opentofu/modules/athena/**
+- Create: infra/opentofu/modules/observability/**
+- Create: policies/cnesdata.rego
+- Create: schemas/cost-manifest.schema.json
+- Create: tests/production/infra/test_athena_observability_cost.py
+
+**Interfaces:**
+- Operator workgroup enforces 5 GB/query and monthly monitoring 100 GB.
+- Alarms cover API/tunnel reference, DynamoDB, Step Functions, ECS, S3 denial, audit backlog, Athena cutoff, 100 task-hours and 200 attempts.
+- Product outputs exact automation role ARNs eligible for shared freeze policy.
+
+- [ ] **Step 1: Write Athena non-API and cutoff tests**
+
+No API task role action. Workgroup enforce_work_group_configuration=true, bytes cutoff and private result location/lifecycle.
+
+- [ ] **Step 2: Write cost manifest and forbidden-resource policy**
+
+Reject NAT/LB/RDS/multi-region/Container Insights/paid plans. Product min/base/max <=8 and shared aggregate <=15.
+
+- [ ] **Step 3: Write freeze survivability tests**
+
+Freeze targets promotion/API/recovery/Step Functions/Athena new-cost actions; audit delivery, health/readback and backup writes remain. Shared Budget action remains external ownership.
+
+- [ ] **Step 4: Validate and commit**
+
+    conftest test tests/fixtures/plans --policy policies
+    uv run pytest -q tests/production/infra/test_athena_observability_cost.py
+    tofu -chdir=infra/opentofu validate -no-color
+    git add infra/opentofu/modules/athena infra/opentofu/modules/observability policies schemas tests/production/infra
+    git commit -m "feat(cost): bound analytics processing and freeze targets"
+
+### Task 12: Build the Infrastructure Acceptance Gate
+
+**Branch:** test/prod-infra-012-acceptance
+
+**Files:**
+- Create: infra/opentofu/tests/production.tftest.hcl
+- Create: tests/production/infra/test_acceptance.py
+- Create: docs/runbooks/infrastructure-plan.md
+- Create: docs/runbooks/object-lock-capability.md
+- Create: docs/runbooks/roles-anywhere-evidence.md
+- Create: docs/runbooks/cloudfront-free.md
+
+**Interfaces:**
+- Produces no apply workflow.
+- Local gate validates configuration/policy; real-AWS capability checks are separately approved and record redacted evidence.
+
+- [ ] **Step 1: Aggregate resource and IAM contracts**
+
+All Tasks 1-11 plus shared ownership, region, tags, protected resources and no secret/private-key/state content.
+
+- [ ] **Step 2: Add real-AWS capability procedures**
+
+DynamoDB condition/TTL behavior, audit Object Lock COMPLIANCE, external CA/CRL Roles Anywhere acceptance/revocation, Step Functions service IAM, exact ECR digest and CloudFront Free ACTIVE.
+
+- [ ] **Step 3: Add plan rejection fixtures**
+
+Protected deletion/replacement, NAT/ALB, public bucket/ingress, paid CloudFront, cost >8 or aggregate >15, wrong region, mutable image, ignore_changes on routing and secret-like values.
+
+- [ ] **Step 4: Run the complete non-mutating gate**
+
+    tofu -chdir=infra/opentofu fmt -check -recursive
+    tofu -chdir=infra/opentofu init -backend=false -input=false
+    tofu -chdir=infra/opentofu validate -no-color
+    tofu -chdir=infra/opentofu test
+    conftest test tests/fixtures/plans --policy policies
+    uv run pytest -q tests/production/infra
+    git diff --check
+
+- [ ] **Step 5: Commit**
+
+    git add infra/opentofu/tests tests/production/infra docs/runbooks
+    git commit -m "test(infra): gate cnesdata production resources"
+
+## Execution Order
+
+Task 1 is serial. Tasks 2-5 may proceed after it with separate module ownership. Task 6 precedes Tasks 7-9. Task 7 precedes Task 8. Task 8 precedes Tasks 9-10. Task 11 may proceed after Tasks 2-10 have stable outputs. Task 12 is final. Promotion workflows are not implemented here.
+
+## Plan Self-Review Record
+
+- Ownership: shared/edge/host resources are referenced, never recreated.
+- Region: us-east-2 is default and the global edge alias is restricted.
+- Cost: architecture has zero fixed NAT/LB/database cost and product policy <=USD 8.
+- Processing: no idle ECS service; exact revisions/roles and network match runtime validation.
+- Data: browser CORS only on serving-capable data bucket; audit is distinct COMPLIANCE storage.
+- IAM: AWS-required wildcard exceptions are enumerated; all other scope is exact and negative-tested.
+- Promotion readiness: task families/canary/fence outputs support phases without ignore_changes or out-of-band routing.
+- Completeness scan: no unresolved marker, unreviewed paid fallback or destructive automation.
+
+## Execution Handoff
+
+Implement with worktree PRs after runtime amendments are green. A reviewed plan from this module does not authorize apply; the companion operations/delivery plan supplies exact evidence and manual phase workflows.

--- a/docs/superpowers/plans/2026-08-31-cnesdata-production-runtime-amendments-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-31-cnesdata-production-runtime-amendments-implementation-plan.md
@@ -1,0 +1,556 @@
+# CnesData Production Runtime Amendments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Amend the completed CND/AWS runtime with the exact production browser, OIDC, CORS, signed-serving, public-subnet Fargate, environment-gate, recovery and audit-dispatch contracts required before CnesData can be provisioned or promoted.
+
+**Architecture:** Extend stable ports/adapters instead of introducing deployment convenience shortcuts. The dashboard uses one absolute authenticated API client and a second header-free signed S3 fetch. The API remains provider-neutral, uses Cognito only through OIDC configuration, and coordinates starts through a durable fence/semaphore/monthly counter. Processor entrypoints remain one-shot and reuse the canonical coordinator/outbox services.
+
+**Tech Stack:** Python 3.13, FastAPI, boto3/botocore, DynamoDB, S3, Step Functions Standard, ECS Fargate, React 18, TypeScript, Vite, oidc-client-ts, Bun, pytest, Hypothesis, Vitest, Playwright, Docker Compose emulators.
+
+**Spec:** docs/superpowers/specs/2026-08-29-cnesdata-production-deployment-design.md and docs/superpowers/specs/2026-08-29-cnesdata-production-operations-design.md
+
+## Global Constraints
+
+- This plan starts only after CND-020 through CND-025 and AWS-010 through AWS-014 are merged into a green develop. As of the planning review, CND-020…025 remain open; no task may bypass the dependency gate.
+- The inspected planning baseline is develop@976c042f6c3454bb9ca3760d708a84e7d23187e1. Re-read the head and record the dependency-complete execution SHA before Task 1.
+- The existing docs/superpowers/plans/2026-08-23-cnesdata-aws-runtime-profile-implementation-plan.md remains authoritative. This plan modifies its produced files in place and never recreates a parallel AWS adapter/composition.
+- Integration base is develop. Never commit directly to main or develop.
+- Production defaults AWS_REGION=us-east-2. Application examples/tests that intentionally emulate another region must be clearly fixture-local.
+- PROFILE=aws and AUTH_MODE=oidc are mandatory. PostgreSQL, MinIO, Keycloak and BigQuery have no production fallback/import.
+- Dashboard production API base is exactly https://api.cnesdata.vinisantana.com/api/v1. Relative /api is forbidden.
+- Bearer is sent only to https://api.cnesdata.vinisantana.com. X-Tenant-Id is sent only after tenant selection and only for tenant-scoped calls.
+- Activation exists only at /api/v1/activate/confirm. The origin-level legacy route is absent.
+- FastAPI is the sole CORS authority; Nginx forwards OPTIONS unchanged and adds no CORS header.
+- Signed serving returns 200 private/no-store with only url, version_id and expires_in=300. Browser fetch to S3 sends no credentials, cookies, Authorization, X-Tenant-Id or custom header.
+- SigV4 URLs and object keys are bearer-sensitive and absent from logs, telemetry, evidence and persistence.
+- Production AWS-012 requires AssignPublicIp=ENABLED, exact public subnets/security group, zero ingress, FARGATE, max concurrency one, no NAT and no ALB.
+- Environment fence, semaphore and monthly execution counter are canonical durable control-plane items. TTL is garbage collection only.
+- Every initial and recovery StartExecution attempt consumes the shared atomic monthly maximum of 200. The 100 combined Fargate task-hour target is monitoring, not a start gate.
+- Recovery and audit-dispatch entrypoints are separate modes with separate compositions and deadlines.
+- Function body <=50 lines, complexity <=10, line width <=100, file <=500 lines, parameters <=4 and nesting <=3.
+- Package coverage and application coverage gates remain unchanged; Portuguese behavior-oriented test names remain the convention.
+
+## Dependency Interface Gate
+
+Before Task 1 can pass, the exact symbols in the existing AWS runtime plan must exist and its serial AWS-014 acceptance must be green. Additionally verify:
+
+| Symbol | Required behavior |
+|---|---|
+| AwsRuntimeSettings | Existing immutable AWS/profile settings, no static credentials |
+| StepFunctionsExecutor | Canonical start/cancel/status transport only |
+| DynamoDBControlPlane | Existing strongly consistent/conditional adapter base |
+| LocalServingAccess | Canonical membership/pointer authorization before signing |
+| S3ObjectLockAuditSink | Existing COMPLIANCE append behavior |
+| PipelineCoordinator.recover | Canonical bounded recovery semantics |
+| dispatch_once | Existing outbox delivery behavior before cursor extension |
+
+If any import/signature differs, integration first reconciles this plan against the merged implementation in a focused docs-only PR. Do not rename the merged contract inside a production feature branch.
+
+## File Map
+
+| Path | Responsibility |
+|---|---|
+| apps/web_dashboard/src/api/client.ts | sole absolute authenticated API transport |
+| apps/web_dashboard/src/auth/oidc.ts | resource/audience/scope request |
+| apps/web_dashboard/src/api/serving.ts | header-free signed S3 second fetch |
+| apps/central_api/src/central_api/app.py | exact production CORS |
+| apps/central_api/src/central_api/routes/oauth.py | versioned activation path only |
+| apps/central_api/src/central_api/routes/serving.py | 200 signed-serving envelope |
+| packages/cnes_infra/src/cnes_infra/aws/settings.py | production OIDC/network/credential constraints |
+| packages/cnes_infra/src/cnes_infra/executor/step_functions.py | exact production network validator |
+| packages/cnes_domain/src/cnes_domain/ports/environment_gate.py | typed fence/semaphore interface |
+| packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py | conditional gate/counter/cursor operations |
+| apps/data_processor/src/data_processor/aws_entrypoint.py | unit/recover/dispatch allowlist |
+| apps/data_processor/src/data_processor/recovery.py | deadline-bounded recovery |
+| apps/data_processor/src/data_processor/audit_dispatch.py | cursor-aware outbox pass |
+
+---
+
+### Task 1: Materialize the Dependency and Production-Profile Gate
+
+**Branch:** test/prod-001-dependency-gate
+
+**Files:**
+- Create: tests/production/test_dependency_gate.py
+- Create: docs/production-readiness.md
+
+**Interfaces:**
+- Produces no runtime change.
+- Fails until all required CND/AWS imports, signatures and behavior probes are integrated.
+
+- [ ] **Step 1: Write import/signature tests from the table above**
+
+Use inspect.signature plus focused behavior fakes. Also run the existing CND-025 and AWS-014 test entrypoints by exact path.
+
+- [ ] **Step 2: Run on the current baseline**
+
+    uv run pytest -q tests/production/test_dependency_gate.py
+
+Expected on the inspected baseline: FAIL because Phase 2/AWS materialization is incomplete. Stop Tasks 2-12.
+
+- [ ] **Step 3: After dependencies merge, record exact develop SHA and green commands**
+
+Document CND issue/PR completion, AWS plan task completion and test run IDs. This is evidence, not a skip marker.
+
+- [ ] **Step 4: Commit only on a genuinely green dependency head**
+
+    git add tests/production/test_dependency_gate.py docs/production-readiness.md
+    git commit -m "test(prod): require integrated CND and AWS runtime"
+
+### Task 2: Make the Dashboard API Boundary Absolute and Origin-Safe
+
+**Branch:** feat/prod-002-dashboard-api
+
+**Files:**
+- Modify: apps/web_dashboard/src/lib/env.ts
+- Modify: apps/web_dashboard/src/api/client.ts
+- Modify: apps/web_dashboard/src/api/hooks/useActivate.ts
+- Modify: apps/web_dashboard/src/auth/AuthProvider.tsx
+- Modify: apps/web_dashboard/.env.example
+- Create: apps/web_dashboard/tests/unit/api/production-client.test.ts
+- Modify: apps/web_dashboard/tests/unit/lib/env.test.ts
+
+**Interfaces:**
+- ProductionEnv requires VITE_API_BASE_URL exact absolute /api/v1.
+- apiRequest(path, options, tenant?) is the only authenticated fetch.
+- Activation path passed to the client is /activate/confirm, producing /api/v1/activate/confirm.
+
+- [ ] **Step 1: Write failing environment/client tests**
+
+Reject /api/v1, https://wrong.example/api/v1, missing /api/v1 and credentials=include. Assert auth/me and activation use one mocked client and never call global fetch directly.
+
+- [ ] **Step 2: Add origin-token tests**
+
+    it("nao envia bearer fora da origem da API", async () => {
+      await expect(apiRequestAbsolute("https://evil.test/x")).rejects.toThrow(
+        "api_origin_mismatch",
+      )
+      expect(fetch).not.toHaveBeenCalled()
+    })
+
+- [ ] **Step 3: Implement strict URL joining**
+
+Normalize one trailing slash, reject absolute endpoint arguments, query-bearing base and path traversal. Set bearer only after URL.origin equals the configured API origin. Add X-Tenant-Id only when tenant is explicitly required.
+
+- [ ] **Step 4: Move activation to the versioned client**
+
+Remove any origin-level /activate/confirm or relative /api use.
+
+- [ ] **Step 5: Run frontend gates and commit**
+
+    cd apps/web_dashboard
+    bun run lint
+    bun run typecheck
+    bun run test --run
+    bun run build
+    git add src .env.example tests
+    git commit -m "feat(dashboard): enforce production api origin"
+
+### Task 3: Configure OIDC Resource Audience and Standard Endpoints
+
+**Branch:** feat/prod-003-oidc-resource
+
+**Files:**
+- Modify: apps/web_dashboard/src/auth/oidc.ts
+- Modify: apps/web_dashboard/src/lib/env.ts
+- Create: apps/web_dashboard/tests/unit/auth/oidc-production.test.ts
+- Modify: packages/cnes_infra/src/cnes_infra/aws/settings.py
+- Modify: packages/cnes_infra/tests/aws/test_settings.py
+
+**Interfaces:**
+- Dashboard requests openid/profile/email plus https://api.cnesdata.vinisantana.com/api.access.
+- Authorization extraQueryParams.resource is https://api.cnesdata.vinisantana.com.
+- Production settings expose Cognito domain, authorize/token/logout URLs and require OIDC_AUDIENCE equal to the API origin.
+
+- [ ] **Step 1: Write exact OIDC config tests**
+
+Require authorization URL /oauth2/authorize, token URL /oauth2/token, logout /logout, resource parameter and API scope. Reject managed-login-v2/custom-domain assumptions.
+
+- [ ] **Step 2: Write AWS settings consistency tests**
+
+Issuer/user-pool region is us-east-2; audience and resource server identifier are the API origin. Static key fields remain absent.
+
+- [ ] **Step 3: Implement provider-neutral OIDC fields**
+
+The verifier still consumes issuer/audience/JWKS; no Cognito-specific claim enters domain or authorization logic.
+
+- [ ] **Step 4: Run Python/dashboard tests**
+
+    uv run pytest -q packages/cnes_infra/tests/aws/test_settings.py
+    cd apps/web_dashboard && bun run test --run tests/unit/auth/oidc-production.test.ts
+
+- [ ] **Step 5: Commit**
+
+    git add apps/web_dashboard packages/cnes_infra
+    git commit -m "feat(auth): request the production api audience"
+
+### Task 4: Move Activation and Install Exact FastAPI CORS
+
+**Branch:** feat/prod-004-api-cors
+
+**Files:**
+- Modify: apps/central_api/src/central_api/app.py
+- Modify: apps/central_api/src/central_api/routes/oauth.py
+- Modify: apps/central_api/tests/test_oauth_activate_confirm.py
+- Create: apps/central_api/tests/test_production_cors.py
+- Modify: apps/central_api/tests/test_app.py
+
+**Interfaces:**
+- POST /api/v1/activate/confirm is the only activation route.
+- CORS exact origin/method/header contract and allow_credentials=false applies only to the production AWS profile.
+
+- [ ] **Step 1: Write route absence/presence tests**
+
+Assert /activate/confirm not in OpenAPI, /api/v1/activate/confirm present and bearer+tenant authorization behavior unchanged.
+
+- [ ] **Step 2: Write complete preflight matrix**
+
+Allowed: origin cnesdata, methods GET/POST, headers Authorization/Content-Type/X-Tenant-Id. Denied: another origin, PUT/PATCH/DELETE, cookie credentials, wildcard and any additional header.
+
+- [ ] **Step 3: Implement versioned router mount**
+
+Keep route function/service unchanged; change only prefix ownership. Do not create a redirect compatibility route.
+
+- [ ] **Step 4: Install CORSMiddleware as sole authority**
+
+No Nginx header or OPTIONS short-circuit is application code. Error responses still follow the exact origin policy.
+
+- [ ] **Step 5: Run and commit**
+
+    uv run pytest -q apps/central_api/tests/test_oauth_activate_confirm.py apps/central_api/tests/test_production_cors.py apps/central_api/tests/test_app.py
+    git add apps/central_api
+    git commit -m "feat(api): version activation and enforce exact cors"
+
+### Task 5: Replace Signed-Serving Redirect with a 200 Envelope
+
+**Branch:** feat/prod-005-serving-envelope
+
+**Files:**
+- Modify: apps/central_api/src/central_api/serving/aws_signed.py
+- Modify: apps/central_api/src/central_api/routes/serving.py
+- Modify: apps/central_api/tests/serving/test_aws_signed.py
+- Create: apps/central_api/tests/routes/test_production_serving.py
+- Create: apps/web_dashboard/src/api/serving.ts
+- Create: apps/web_dashboard/tests/unit/api/serving.test.ts
+- Modify: tests/integration/aws/test_signed_serving.py
+
+**Interfaces:**
+- ServingResponse(url: SecretStr-like redacted value, version_id: str, expires_in: Literal[300]).
+- First response status 200 and Cache-Control private, no-store.
+- Second fetch is direct S3 credentials=omit with no headers.
+
+- [ ] **Step 1: Write API response-schema tests**
+
+Assert exact keys only, status/cache header, 300 TTL, prior authorization/stat and denial of raw/normalized/reconciliation/tmp/audit prefixes.
+
+- [ ] **Step 2: Write logging/redaction tests**
+
+Exercise success/error and assert signed query/key never appears in caplog, tracing attributes or exception repr.
+
+- [ ] **Step 3: Implement the 200 envelope**
+
+Preserve canonical LocalServingAccess authorization. Generate GET only for the single authorized serving key/version; attach ResponseCacheControl private,no-store where supported.
+
+- [ ] **Step 4: Implement the browser second fetch**
+
+Do not reuse apiRequest. Build fetch(url, {method:"GET", credentials:"omit", redirect:"error", headers:{}}). Reject non-HTTPS or non-S3 signed URL origin patterns configured by the runtime contract.
+
+- [ ] **Step 5: Run backend/frontend/integration tests**
+
+    uv run pytest -q apps/central_api/tests/serving apps/central_api/tests/routes/test_production_serving.py tests/integration/aws/test_signed_serving.py
+    cd apps/web_dashboard && bun run test --run tests/unit/api/serving.test.ts
+
+- [ ] **Step 6: Commit**
+
+    git add apps/central_api apps/web_dashboard tests/integration/aws
+    git commit -m "feat(serving): return a private signed-url envelope"
+
+### Task 6: Apply the Production AWS-012 Network Override
+
+**Branch:** feat/prod-006-fargate-network
+
+**Files:**
+- Modify: packages/cnes_infra/src/cnes_infra/aws/settings.py
+- Modify: packages/cnes_infra/src/cnes_infra/executor/step_functions.py
+- Modify: packages/cnes_infra/tests/executor/test_step_functions.py
+- Create: packages/cnes_infra/tests/executor/test_production_network.py
+- Modify: tests/integration/aws/test_step_functions_ecs.py
+
+**Interfaces:**
+- Production settings contain exact tuple public_subnet_ids and security_group_id, max_concurrency=1.
+- validate_state_machine compares the generated ASL ECS Parameters against those exact values and an inspected zero-ingress network contract.
+
+- [ ] **Step 1: Write the acceptance/rejection matrix**
+
+Accept only ENABLED+exact subnets+exact SG+FARGATE+1+no NAT/ALB. Reject DISABLED, missing/extra/reordered normalized subnet set, SG drift, ingress, EC2 launch, concurrency >1 and forbidden resource markers.
+
+- [ ] **Step 2: Preserve emulator/generic fixture behavior explicitly**
+
+Use a profile/network policy argument; do not weaken the production validator to accept both modes silently.
+
+- [ ] **Step 3: Implement exact comparison**
+
+Normalize subnet tuple deterministically, but do not accept a superset. Validate Inline Map remains non-distributed and no service/desired count is introduced.
+
+- [ ] **Step 4: Run AWS-012/AWS-014 focused suites**
+
+    uv run pytest -q packages/cnes_infra/tests/executor tests/integration/aws/test_step_functions_ecs.py
+
+- [ ] **Step 5: Commit**
+
+    git add packages/cnes_infra tests/integration/aws
+    git commit -m "feat(processing): enforce public-ip fargate profile"
+
+### Task 7: Add Typed Environment Fence and Semaphore Operations
+
+**Branch:** feat/prod-007-environment-gate
+
+**Files:**
+- Create: packages/cnes_domain/src/cnes_domain/ports/environment_gate.py
+- Create: packages/cnes_domain/src/cnes_domain/control_plane/environment_gate.py
+- Create: packages/cnes_domain/tests/ports/test_environment_gate.py
+- Modify: packages/cnes_domain/src/cnes_domain/ports/control_plane.py
+- Modify: packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+- Create: packages/cnes_infra/tests/control_plane/test_environment_gate.py
+
+**Interfaces:**
+- observe_environment_gate() is strongly consistent.
+- Typed commands: AcquireUnitPermit, BindUnitPermit, RenewUnitPermit, ReleaseUnitPermit, ClosePromotionFence and ReopenPromotionFence.
+- Fence and semaphore are separate items; acquire transaction requires open fence.
+
+- [ ] **Step 1: Write pure transition tests**
+
+Cover close-first, acquire/bind/renew/release, only bound canary while fenced, token mismatch, stale generation, TTL non-authority and reopen only matching promotion.
+
+- [ ] **Step 2: Write adapter race tests**
+
+Concurrent acquire winners <=1. A fence close racing acquire either closes before and rejects, or observes the live permit and drain waits; never both closed+new unbound start.
+
+- [ ] **Step 3: Implement immutable entities/commands first**
+
+No AWS imports in cnes_domain. Use aware UTC datetimes and explicit version/fencing tokens.
+
+- [ ] **Step 4: Implement conditional DynamoDB transactions**
+
+Use consistent reads and TransactWriteItems conditions. Expired takeover requires a supplied liveness proof adapter result; never time alone.
+
+- [ ] **Step 5: Run package 100% branch gates and commit**
+
+    uv run pytest packages/cnes_domain/tests/ports/test_environment_gate.py --cov --cov-branch
+    uv run pytest -q packages/cnes_infra/tests/control_plane/test_environment_gate.py
+    git add packages/cnes_domain packages/cnes_infra
+    git commit -m "feat(control-plane): add promotion fence and unit semaphore"
+
+### Task 8: Add the Shared Monthly Execution-Attempt Counter
+
+**Branch:** feat/prod-008-execution-quota
+
+**Files:**
+- Create: packages/cnes_domain/src/cnes_domain/control_plane/execution_quota.py
+- Create: packages/cnes_domain/tests/control_plane/test_execution_quota.py
+- Modify: packages/cnes_domain/src/cnes_domain/ports/control_plane.py
+- Modify: packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+- Create: packages/cnes_infra/tests/control_plane/test_execution_quota.py
+- Modify: apps/central_api/src/central_api/services/run_planning.py
+- Modify: apps/data_processor/src/data_processor/recovery.py
+
+**Interfaces:**
+- consume_execution_attempt(environment, period, now, limit=200) atomically increments before each initial/recovery StartExecution.
+- Same monthly item/limit is used by both callers.
+- Quota rejection performs no Step Functions call and maps to the documented 429/quota result.
+
+- [ ] **Step 1: Write boundary and race tests**
+
+199->200 succeeds; 200->201 rejects. Initial/recovery races total exactly 200. Failed StartExecution still counts as an attempt. TTL deletion is irrelevant.
+
+- [ ] **Step 2: Add service-level no-call tests**
+
+Fake executor records zero calls when quota rejects. The 100 task-hour metric is absent from the decision path.
+
+- [ ] **Step 3: Implement conditional counter and wire both callers**
+
+UTC month key; atomic ADD/condition; no read-then-write race.
+
+- [ ] **Step 4: Run and commit**
+
+    uv run pytest -q packages/cnes_domain/tests/control_plane/test_execution_quota.py packages/cnes_infra/tests/control_plane/test_execution_quota.py apps/central_api/tests apps/data_processor/tests
+    git add packages/cnes_domain packages/cnes_infra apps/central_api apps/data_processor
+    git commit -m "feat(processing): cap monthly execution attempts atomically"
+
+### Task 9: Extend Outbox Delivery with Cursor Paging
+
+**Branch:** feat/prod-009-outbox-cursor
+
+**Files:**
+- Modify: packages/cnes_domain/src/cnes_domain/ports/control_plane.py
+- Modify: packages/cnes_domain/src/cnes_domain/outbox_dispatcher.py
+- Modify: packages/cnes_domain/tests/test_outbox_dispatcher.py
+- Modify: packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+- Create: packages/cnes_infra/tests/control_plane/test_outbox_cursor.py
+
+**Interfaces:**
+- Replaces pending_outbox(limit) with read_outbox_page(cursor, limit) and advance_outbox_cursor(expected, next).
+- A pass advances after evaluating each page, wraps, and retries poison without starving later pages.
+- Delivery marker changes only after S3 COMPLIANCE append succeeds.
+
+- [ ] **Step 1: Write 100-poison plus second-page test**
+
+First page remains pending/retrying; second page still delivers in the same/bounded subsequent pass; cursor wraps and replay is idempotent.
+
+- [ ] **Step 2: Write CAS conflict and crash tests**
+
+Concurrent cursor advancement has one winner. Crash after S3 append/before marker replays the same object idempotently and then marks.
+
+- [ ] **Step 3: Change the port and all fake implementations serially**
+
+This is a shared interface hotspot; no parallel task edits control_plane.py.
+
+- [ ] **Step 4: Implement DynamoDB Query/GetItem/UpdateItem only**
+
+No Scan, DeleteItem or PutItem for the dispatch role path. Strongly revalidate each event.
+
+- [ ] **Step 5: Run full contract harness and commit**
+
+    uv run pytest -q packages/cnes_domain/tests/test_outbox_dispatcher.py packages/cnes_infra/tests/control_plane/test_outbox_cursor.py packages/cnes_infra/tests/contracts
+    git add packages/cnes_domain packages/cnes_infra
+    git commit -m "feat(audit): page outbox without poison starvation"
+
+### Task 10: Add Separate Recovery and Audit-Dispatch Entrypoints
+
+**Branch:** feat/prod-010-processor-modes
+
+**Files:**
+- Modify: apps/data_processor/src/data_processor/aws_entrypoint.py
+- Modify: apps/data_processor/src/data_processor/recovery.py
+- Create: apps/data_processor/src/data_processor/audit_dispatch.py
+- Create: apps/data_processor/src/data_processor/deadline.py
+- Modify: apps/data_processor/tests/test_aws_entrypoint.py
+- Create: apps/data_processor/tests/test_recovery_mode.py
+- Create: apps/data_processor/tests/test_audit_dispatch_mode.py
+- Create: apps/data_processor/tests/test_deadline.py
+
+**Interfaces:**
+- Allowed modes: run-unit, recover-once, dispatch-outbox-once.
+- recover-once builds coordinator only, batch 100, lease/deadline 3600, no unit env or audit sink.
+- dispatch-outbox-once builds control plane+audit sink+UTC clock, limit 100, deadline 60, no unit env.
+
+- [ ] **Step 1: Write mode/env isolation tests**
+
+Each mode rejects another mode's required/forbidden variables and dependency construction. Unknown mode exits terminal configuration code.
+
+- [ ] **Step 2: Write deadline behavior**
+
+PID 1 deadline cancels work, logs bounded event, exits nonzero and never continues past lease. Audit deadline is 60 seconds.
+
+- [ ] **Step 3: Implement small composition factories**
+
+Reuse canonical AwsRuntime client/adapters. Do not instantiate API runtime, normal unit registry in recover, or audit sink in recover.
+
+- [ ] **Step 4: Test overlapping recovery passes**
+
+No global recovery lock, but environment semaphore ensures at most one unit task; losing recoveries do not StartExecution and same-run dispatch CAS remains stable.
+
+- [ ] **Step 5: Run and commit**
+
+    uv run pytest -q apps/data_processor/tests/test_aws_entrypoint.py apps/data_processor/tests/test_recovery_mode.py apps/data_processor/tests/test_audit_dispatch_mode.py apps/data_processor/tests/test_deadline.py
+    git add apps/data_processor
+    git commit -m "feat(processor): separate recovery and audit passes"
+
+### Task 11: Add the Production API Container Credential Contract
+
+**Branch:** feat/prod-011-api-container
+
+**Files:**
+- Modify: apps/central_api/Dockerfile
+- Create: apps/central_api/docker/production-entrypoint.sh
+- Create: deploy/compose.production.yaml
+- Create: deploy/aws/config
+- Create: tests/production/test_api_container.py
+- Create: tests/production/test_compose_contract.py
+- Create: tests/production/test_credential_process.py
+
+**Interfaces:**
+- AWS_PROFILE=cnesdata-production and AWS_CONFIG_FILE point to a read-only config whose credential_process calls aws_signing_helper credential-process --session-duration 3600.
+- Container sees only required helper/config/leaf key material, key readable by fixed UID; no shared static credentials.
+- API binds one loopback port and no CnesData processor runs on the VPS.
+
+- [ ] **Step 1: Write static-image/Compose tests**
+
+Require non-root/read-only/cap-drop/no-new-privileges/limits/health. Reject docker.sock, host network, public port, LimnoPulse path/network and AWS_ACCESS_KEY_ID/SECRET/SESSION.
+
+- [ ] **Step 2: Write botocore advisory-refresh test**
+
+First AWS call invokes helper, calls before advisory window do not, first call inside 15-minute window refreshes once; helper failure fails closed. Use fake clock/process provider, no real certificate.
+
+- [ ] **Step 3: Implement credential_process config**
+
+Exact helper path, certificate/private-key/trust-anchor/profile/role ARNs from mounted public/root-owned files; session duration 3600. No shell interpolation.
+
+- [ ] **Step 4: Build and smoke**
+
+    docker build --tag cnesdata-api:prod-test apps/central_api
+    docker compose -f deploy/compose.production.yaml config --quiet
+    uv run pytest -q tests/production/test_api_container.py tests/production/test_compose_contract.py tests/production/test_credential_process.py
+
+- [ ] **Step 5: Commit**
+
+    git add apps/central_api deploy tests/production
+    git commit -m "feat(api): add roles-anywhere production container"
+
+### Task 12: Build the Runtime Amendment Acceptance Gate
+
+**Branch:** test/prod-012-runtime-acceptance
+
+**Files:**
+- Create: tests/production/test_runtime_acceptance.py
+- Create: docs/runbooks/runtime-acceptance.md
+- Modify: .github/workflows/python-quality.yml
+- Modify: .github/workflows/web-dashboard.yml
+
+**Interfaces:**
+- Extends existing credential-free CI only; no production secret/OIDC on pull requests.
+- Produces a single required runtime-amendments check.
+
+- [ ] **Step 1: Aggregate all production deltas**
+
+Dependency gate, dashboard absolute client, OIDC resource, route/CORS, 200 serving, AWS-012 override, fence/semaphore, quota, cursor outbox, processor modes and credential process.
+
+- [ ] **Step 2: Add negative source checks**
+
+Reject relative production /api, origin-level activation, API log formatting of url, 307 serving response, AssignPublicIp DISABLED, NAT/ALB, static AWS key fields, Scan in new adapters and task-hour start gate.
+
+- [ ] **Step 3: Extend existing hosted-runner jobs**
+
+Run focused suites and emulator-backed integration with unconditional teardown. Keep root permissions contents:read and no secrets/id-token.
+
+- [ ] **Step 4: Run complete quality gates**
+
+    uv run ruff check .
+    uv run pytest -m "not integration and not postgres and not bigquery and not e2e and not stress and not soak and not spike and not windows_only" -q
+    uv run pytest -q tests/production
+    cd apps/web_dashboard && bun run lint && bun run typecheck && bun run test --run && bun run build
+    git diff --check
+
+- [ ] **Step 5: Commit**
+
+    git add tests/production docs/runbooks/runtime-acceptance.md .github/workflows
+    git commit -m "test(prod): gate production runtime amendments"
+
+## Execution Order
+
+Task 1 is a hard gate. Tasks 2 and 6 may start after it. Task 3 waits for Task 2; Tasks 4 and 5 wait for Tasks 2-3. Task 7 is the serial control-plane foundation. Task 8 waits for Task 7. Task 9 is another serial control-plane hotspot and starts after Task 8 merges. Task 10 waits for Tasks 8-9. Task 11 can proceed after Tasks 1 and 3. Task 12 waits for all prior tasks.
+
+## Plan Self-Review Record
+
+- Existing-plan boundary: AWS-010…014 files are extended in place; no duplicate adapter/composition exists.
+- Browser contract: exact API origin, versioned activation, bearer/tenant scoping and header-free S3 fetch align across dashboard/API tests.
+- Processing contract: public-IP Fargate is explicit and does not loosen the generic test profile.
+- Correctness: fence, semaphore, counter and outbox cursor are typed domain operations with conditional adapters.
+- Operations: recovery and audit share the image but not configuration/composition/deadline.
+- Credentials: production uses credential_process; no static keys or shared credential file assumption.
+- Completeness scan: no unresolved marker, skipped dependency or undefined mode.
+
+## Execution Handoff
+
+Do not dispatch any implementation task until the dependency gate can pass on develop. After this plan is merged and green, the production infrastructure plan may consume these exact settings, IAM and task-mode contracts.


### PR DESCRIPTION
## Summary

- adds runtime amendments, production infrastructure and delivery/operations plans
- extends the existing AWS-010…AWS-014 plan rather than duplicating it
- hard-blocks execution until CND-020…025 and AWS-010…014 are integrated and green
- encodes candidate → Phase A → activation manifest → fenced Phase B → separate Phase C recovery/audit

## Safety and cost

- documentation only; no deploy or infrastructure apply
- AWS default `us-east-2`; ACM/WAF/Pricing Plan Manager only in `us-east-1`
- CnesData envelope USD 8; aggregate freeze USD 15; no NAT, ALB, RDS or paid fallback
- synthetic portfolio data only

## Review focus

Please validate the 200 signed-serving handoff, production AWS-012 override, fence/semaphore/counter/outbox contracts, exact IAM boundaries, phased routing evidence and fail-closed rollback behavior.