### PR TITLE
feat(object-store): add filesystem and s3 adapters

### DIFF
--- a/packages/cnes_infra/src/cnes_infra/object_store/_common.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/_common.py
@@ -14,9 +14,9 @@ _CHUNK_SIZE = 1024 * 1024
 def validate_key(key: str) -> str:
     parts = key.split("/")
     if not key or key.startswith("/") or "\\" in key:
-        raise ValueError("invalid_key")
+        raise ValueError("object_key=invalid")
     if any(part in {"", ".", ".."} for part in parts):
-        raise ValueError("invalid_key")
+        raise ValueError("object_key=invalid")
     return key
 
 
@@ -33,4 +33,4 @@ def stream_with_digest(source: BinaryIO, destination: BinaryIO | None = None) ->
 
 def require_digest(actual: str, expected: str) -> None:
     if actual != expected:
-        raise ValueError("sha256_mismatch")
+        raise ValueError("sha256=mismatch")

--- a/packages/cnes_infra/src/cnes_infra/object_store/_common.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/_common.py
@@ -13,7 +13,7 @@ _CHUNK_SIZE = 1024 * 1024
 
 def validate_key(key: str) -> str:
     parts = key.split("/")
-    if not key or key.startswith("/") or "\\" in key:
+    if not key or key.startswith("/") or "\\" in key or "\0" in key:
         raise ValueError("object_key=invalid")
     if any(part in {"", ".", ".."} for part in parts):
         raise ValueError("object_key=invalid")

--- a/packages/cnes_infra/src/cnes_infra/object_store/_common.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/_common.py
@@ -1,0 +1,36 @@
+"""Validação e digest compartilhados por object stores."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import BinaryIO
+
+_CHUNK_SIZE = 1024 * 1024
+
+
+def validate_key(key: str) -> str:
+    parts = key.split("/")
+    if not key or key.startswith("/") or "\\" in key:
+        raise ValueError("invalid_key")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError("invalid_key")
+    return key
+
+
+def stream_with_digest(source: BinaryIO, destination: BinaryIO | None = None) -> tuple[int, str]:
+    digest = sha256()
+    size = 0
+    while chunk := source.read(_CHUNK_SIZE):
+        digest.update(chunk)
+        size += len(chunk)
+        if destination is not None:
+            destination.write(chunk)
+    return size, digest.hexdigest()
+
+
+def require_digest(actual: str, expected: str) -> None:
+    if actual != expected:
+        raise ValueError("sha256_mismatch")

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from secrets import token_hex
 from stat import S_ISREG
 from typing import TYPE_CHECKING
+from weakref import finalize
 
 from cnes_domain.control_plane.errors import Conflict
 from cnes_domain.ports.object_store import ObjectStat
@@ -123,14 +124,19 @@ class FilesystemObjectStore:
     def __init__(
         self, root: str | Path, fault_injector: Callable[[str], None] | None = None
     ) -> None:
-        self._root = Path(root).absolute()
         self._fault_injector = fault_injector
-        _mkdir_durable(self._root)
-        self._ensure_layout()
-        self._recover_startup()
+        root_path = Path(root).absolute()
+        _mkdir_durable(root_path)
+        with ExitStack() as stack:
+            self._root_descriptor = os.open(root_path, _DIRECTORY_FLAGS)
+            stack.callback(os.close, self._root_descriptor)
+            self._ensure_layout()
+            self._recover_startup()
+            self._root_finalizer = finalize(self, os.close, self._root_descriptor)
+            stack.pop_all()
 
     def _ensure_layout(self) -> None:
-        root = os.open(self._root, _DIRECTORY_FLAGS)
+        root = os.dup(self._root_descriptor)
         try:
             internal = _open_or_create_directory(root, _LAYOUT)
             try:
@@ -146,7 +152,7 @@ class FilesystemObjectStore:
     @contextmanager
     def _layout(self) -> Iterator[_Layout]:
         with ExitStack() as stack:
-            root = os.open(self._root, _DIRECTORY_FLAGS)
+            root = os.dup(self._root_descriptor)
             stack.callback(os.close, root)
             internal = os.open(_LAYOUT, _DIRECTORY_FLAGS, dir_fd=root)
             stack.callback(os.close, internal)
@@ -221,19 +227,26 @@ class FilesystemObjectStore:
                 candidate = self._startup_owner(layout.objects, name, identity)
                 if candidate is None:
                     continue
-                key, digest = candidate
+                key, digest, temporary = candidate
                 with self._namespace_lock(layout.locks, digest, blocking=False) as acquired:
                     if acquired:
                         self._recover(layout.objects, key, digest)
+                        continue
+                if self._classify_recovery(layout.objects, temporary, digest):
+                    self._remove_temporary(layout.objects, name)
+                    continue
+                with self._namespace_lock(layout.locks, digest):
+                    self._recover(layout.objects, key, digest)
 
     def _startup_owner(
         self, objects: int, name: str, identity: tuple[str, str]
-    ) -> tuple[str, str] | None:
+    ) -> tuple[str, str, os.stat_result] | None:
         digest = identity[0].removeprefix(_TEMP_PREFIX)
         descriptor = _open_candidate(objects, name)
         if descriptor is None:
             return None
         try:
+            metadata = os.fstat(descriptor)
             owner = _temporary_owner(descriptor)
         finally:
             os.close(descriptor)
@@ -243,7 +256,7 @@ class FilesystemObjectStore:
             key, expected = self._identity(owner[0])
         except ValueError:
             return None
-        return (key, digest) if expected == digest else None
+        return (key, digest, metadata) if expected == digest else None
 
     @staticmethod
     def _remove_temporary(objects: int, name: str) -> None:
@@ -254,19 +267,19 @@ class FilesystemObjectStore:
         os.fsync(objects)
 
     @staticmethod
-    def _classify_recovery(objects: int, temporary: os.stat_result, digest: str) -> None:
+    def _classify_recovery(objects: int, temporary: os.stat_result, digest: str) -> bool:
         try:
             destination = os.open(digest, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=objects)
         except FileNotFoundError:
-            return
+            return False
         try:
             metadata = os.fstat(destination)
         finally:
             os.close(destination)
         if os.path.samestat(temporary, metadata):
-            return
+            return True
         if S_ISREG(metadata.st_mode):
-            return
+            return False
         raise Conflict("destination=invalid")
 
     def _recover(self, objects: int, key: str, digest: str) -> None:

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from enum import Enum
 from hashlib import sha256
 from pathlib import Path
+from stat import S_ISREG
 from typing import TYPE_CHECKING
 
 from cnes_domain.control_plane.errors import Conflict
@@ -49,25 +50,28 @@ def _fsync_directory(directory: Path) -> None:
         os.close(descriptor)
 
 
-def _temporary_namespace(path: Path) -> str | None:
+def _temporary_identity(path: Path) -> tuple[str, str] | None:
     namespace, _, token = path.name.removesuffix(".tmp").rpartition("-")
     digest = namespace.removeprefix(_TEMP_PREFIX)
     if len(digest) != 64 or not token:
         return None
-    return namespace if set(digest) <= _HEX_DIGITS else None
+    return (namespace, token) if set(digest) <= _HEX_DIGITS else None
 
 
-def _temporary_owner(path: Path) -> str | None:
+def _temporary_owner(path: Path) -> tuple[str, str] | None:
+    if not S_ISREG(path.lstat().st_mode):
+        return None
     try:
-        value = os.getxattr(path, _OWNER_XATTR)
+        value = os.getxattr(path, _OWNER_XATTR, follow_symlinks=False)
     except OSError as error:
         if error.errno in _MISSING_XATTR_ERRNOS:
             return None
         raise
     try:
-        return value.decode()
+        ownership = value.decode().split("\0", maxsplit=1)
     except UnicodeDecodeError:
         return None
+    return (ownership[0], ownership[1]) if len(ownership) == 2 else None
 
 
 class FilesystemObjectStore:
@@ -119,9 +123,11 @@ class FilesystemObjectStore:
             yield
 
     def _owned_destination(self, temporary: Path, namespace: str) -> Path | None:
-        owner = _temporary_owner(temporary)
-        if owner is None:
+        identity = _temporary_identity(temporary)
+        ownership = _temporary_owner(temporary)
+        if identity is None or ownership is None or identity[1] != ownership[1]:
             return None
+        owner = ownership[0]
         try:
             destination = self._path(owner)
         except ValueError:
@@ -132,14 +138,15 @@ class FilesystemObjectStore:
 
     def _recover_startup(self) -> None:
         for temporary in self._root.rglob(f"{_TEMP_PREFIX}*.tmp"):
-            namespace = _temporary_namespace(temporary)
-            if namespace is None:
+            identity = _temporary_identity(temporary)
+            if identity is None:
                 continue
+            namespace = identity[0]
             destination = self._owned_destination(temporary, namespace)
             if destination is None:
                 continue
             with self._namespace_lock(temporary.parent, namespace, blocking=False) as acquired:
-                if not acquired or not temporary.exists():
+                if not acquired:
                     continue
                 self._recover(destination, namespace)
 
@@ -152,7 +159,7 @@ class FilesystemObjectStore:
     def _classify_recovery(temporary: Path, destination: Path) -> _RecoveryKind:
         if not destination.exists():
             return _RecoveryKind.ABANDONED
-        if os.path.samestat(temporary.stat(), destination.stat()):
+        if os.path.samestat(temporary.lstat(), destination.stat()):
             return _RecoveryKind.LINKED
         if destination.is_file():
             return _RecoveryKind.LOSING
@@ -168,10 +175,13 @@ class FilesystemObjectStore:
         if recoveries:
             _fsync_directory(destination.parent)
 
-    def _mark_temporary(self, temporary: Path, descriptor: int, destination: Path) -> None:
-        owner = destination.relative_to(self._root).as_posix().encode()
+    def _mark_temporary(
+        self, temporary: Path, descriptor: int, destination: Path, token: str
+    ) -> None:
+        key = destination.relative_to(self._root).as_posix()
+        ownership = f"{key}\0{token}".encode()
         try:
-            os.setxattr(descriptor, _OWNER_XATTR, owner)
+            os.setxattr(descriptor, _OWNER_XATTR, ownership)
             os.fsync(descriptor)
             _fsync_directory(destination.parent)
         except Exception:
@@ -185,8 +195,9 @@ class FilesystemObjectStore:
             dir=destination.parent, prefix=f"{namespace}-", suffix=".tmp"
         )
         temporary = Path(name)
+        token = temporary.name.removesuffix(".tmp").rpartition("-")[2]
         try:
-            self._mark_temporary(temporary, descriptor, destination)
+            self._mark_temporary(temporary, descriptor, destination, token)
             self._fault("temporary_created")
             with os.fdopen(descriptor, "wb") as stream:
                 descriptor = -1

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 
 _TEMP_PREFIX = ".cnes-object-store-"
 _HEX_DIGITS = frozenset("0123456789abcdef")
+_OWNER_XATTR = "user.cnes_object_store_destination"
+_MISSING_XATTR_ERRNOS = frozenset({errno.ENODATA, errno.ENOENT})
 
 
 class _RecoveryKind(Enum):
@@ -53,6 +55,19 @@ def _temporary_namespace(path: Path) -> str | None:
     if len(digest) != 64 or not token:
         return None
     return namespace if set(digest) <= _HEX_DIGITS else None
+
+
+def _temporary_owner(path: Path) -> str | None:
+    try:
+        value = os.getxattr(path, _OWNER_XATTR)
+    except OSError as error:
+        if error.errno in _MISSING_XATTR_ERRNOS:
+            return None
+        raise
+    try:
+        return value.decode()
+    except UnicodeDecodeError:
+        return None
 
 
 class FilesystemObjectStore:
@@ -103,26 +118,30 @@ class FilesystemObjectStore:
         with self._namespace_lock(destination.parent, namespace):
             yield
 
-    def _destination_for_namespace(self, directory: Path, namespace: str) -> Path | None:
-        for candidate in directory.iterdir():
-            key = candidate.relative_to(self._root).as_posix()
-            if self._namespace(key) == namespace:
-                return candidate
-        return None
+    def _owned_destination(self, temporary: Path, namespace: str) -> Path | None:
+        owner = _temporary_owner(temporary)
+        if owner is None:
+            return None
+        try:
+            destination = self._path(owner)
+        except ValueError:
+            return None
+        if destination == temporary or destination.parent != temporary.parent:
+            return None
+        return destination if self._namespace(owner) == namespace else None
 
     def _recover_startup(self) -> None:
         for temporary in self._root.rglob(f"{_TEMP_PREFIX}*.tmp"):
             namespace = _temporary_namespace(temporary)
             if namespace is None:
                 continue
+            destination = self._owned_destination(temporary, namespace)
+            if destination is None:
+                continue
             with self._namespace_lock(temporary.parent, namespace, blocking=False) as acquired:
                 if not acquired or not temporary.exists():
                     continue
-                destination = self._destination_for_namespace(temporary.parent, namespace)
-                if destination is None:
-                    self._remove_temporary(temporary, temporary.parent)
-                else:
-                    self._recover(destination, namespace)
+                self._recover(destination, namespace)
 
     @staticmethod
     def _remove_temporary(temporary: Path, directory: Path) -> None:
@@ -142,10 +161,22 @@ class FilesystemObjectStore:
     def _recover(self, destination: Path, namespace: str) -> None:
         recoveries: set[_RecoveryKind] = set()
         for temporary in destination.parent.glob(f"{namespace}-*.tmp"):
+            if self._owned_destination(temporary, namespace) != destination:
+                continue
             recoveries.add(self._classify_recovery(temporary, destination))
             temporary.unlink(missing_ok=True)
         if recoveries:
             _fsync_directory(destination.parent)
+
+    def _mark_temporary(self, temporary: Path, descriptor: int, destination: Path) -> None:
+        owner = destination.relative_to(self._root).as_posix().encode()
+        try:
+            os.setxattr(descriptor, _OWNER_XATTR, owner)
+            os.fsync(descriptor)
+            _fsync_directory(destination.parent)
+        except Exception:
+            self._remove_temporary(temporary, destination.parent)
+            raise
 
     def _stage(
         self, destination: Path, namespace: str, body: BinaryIO, expected_sha256: str
@@ -155,6 +186,7 @@ class FilesystemObjectStore:
         )
         temporary = Path(name)
         try:
+            self._mark_temporary(temporary, descriptor, destination)
             self._fault("temporary_created")
             with os.fdopen(descriptor, "wb") as stream:
                 descriptor = -1

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -6,13 +6,12 @@ import ctypes
 import errno
 import fcntl
 import os
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
-from enum import Enum
 from hashlib import sha256
 from pathlib import Path
 from secrets import token_hex
-from stat import S_ISLNK, S_ISREG
+from stat import S_ISREG
 from typing import TYPE_CHECKING
 
 from cnes_domain.control_plane.errors import Conflict
@@ -24,32 +23,35 @@ if TYPE_CHECKING:
     from contextlib import AbstractContextManager as ContextManager
     from typing import BinaryIO
 
+_LAYOUT = ".cnes-object-store-internal"
+_OBJECTS = "objects"
+_LOCKS = "locks"
 _TEMP_PREFIX = ".cnes-object-store-"
 _HEX_DIGITS = frozenset("0123456789abcdef")
 _OWNER_XATTR = "user.cnes_object_store_destination"
 _MISSING_XATTR_ERRNOS = frozenset({errno.ENODATA, errno.ENOENT})
-_AT_FDCWD = -100
+_DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
 _AT_EMPTY_PATH = 0x1000
 _LINKAT = ctypes.CDLL(None, use_errno=True).linkat
 _LINKAT.argtypes = (ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_int)
 _LINKAT.restype = ctypes.c_int
 
 
-class _RecoveryKind(Enum):
-    ABANDONED = "abandoned"
-    LINKED = "linked"
-    LOSING = "losing"
+@dataclass(frozen=True, slots=True)
+class _Layout:
+    objects: int
+    locks: int
 
 
 @dataclass(frozen=True, slots=True)
 class _StagedFile:
-    path: Path
+    name: str
     size: int
     digest: str
 
 
 def _fsync_directory(directory: Path) -> None:
-    descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+    descriptor = os.open(directory, _DIRECTORY_FLAGS)
     try:
         os.fsync(descriptor)
     finally:
@@ -67,38 +69,37 @@ def _mkdir_durable(directory: Path) -> None:
         _fsync_directory(path.parent)
 
 
-def _reject_symlink_components(root: Path, path: Path) -> None:
-    current = root
-    for part in path.relative_to(root).parts:
-        current /= part
-        try:
-            mode = current.lstat().st_mode
-        except FileNotFoundError:
-            return
-        if S_ISLNK(mode):
-            raise ValueError("object_path=symlink")
+def _open_or_create_directory(parent: int, name: str) -> int:
+    created = False
+    try:
+        os.mkdir(name, dir_fd=parent)
+        created = True
+    except FileExistsError:
+        pass
+    descriptor = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent)
+    if created:
+        os.fsync(parent)
+    return descriptor
 
 
-def _link_descriptor(descriptor: int, destination: Path) -> None:
-    result = _LINKAT(descriptor, b"", _AT_FDCWD, os.fsencode(destination), _AT_EMPTY_PATH)
+def _link_descriptor(descriptor: int, directory: int, name: str) -> None:
+    result = _LINKAT(descriptor, b"", directory, os.fsencode(name), _AT_EMPTY_PATH)
     if result != 0:
         error = ctypes.get_errno()
-        raise OSError(error, os.strerror(error), destination)
+        raise OSError(error, os.strerror(error), name)
 
 
-def _temporary_identity(path: Path) -> tuple[str, str] | None:
-    namespace, _, token = path.name.removesuffix(".tmp").rpartition("-")
+def _temporary_identity(name: str) -> tuple[str, str] | None:
+    namespace, _, token = name.removesuffix(".tmp").rpartition("-")
     digest = namespace.removeprefix(_TEMP_PREFIX)
     if len(digest) != 64 or not token:
         return None
     return (namespace, token) if set(digest) <= _HEX_DIGITS else None
 
 
-def _temporary_owner(path: Path) -> tuple[str, str] | None:
+def _temporary_owner(descriptor: int) -> tuple[str, str] | None:
     try:
-        if not S_ISREG(path.lstat().st_mode):
-            return None
-        value = os.getxattr(path, _OWNER_XATTR, follow_symlinks=False)
+        value = os.getxattr(descriptor, _OWNER_XATTR)
     except OSError as error:
         if error.errno in _MISSING_XATTR_ERRNOS:
             return None
@@ -110,6 +111,15 @@ def _temporary_owner(path: Path) -> tuple[str, str] | None:
     return (ownership[0], ownership[1]) if len(ownership) == 2 else None
 
 
+def _open_candidate(objects: int, name: str) -> int | None:
+    try:
+        return os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=objects)
+    except OSError as error:
+        if error.errno in {errno.ENOENT, errno.ELOOP}:
+            return None
+        raise
+
+
 class FilesystemObjectStore:
     def __init__(
         self, root: str | Path, fault_injector: Callable[[str], None] | None = None
@@ -117,171 +127,237 @@ class FilesystemObjectStore:
         self._root = Path(root)
         self._fault_injector = fault_injector
         _mkdir_durable(self._root)
+        self._ensure_layout()
         self._recover_startup()
+
+    def _ensure_layout(self) -> None:
+        root = os.open(self._root, _DIRECTORY_FLAGS)
+        try:
+            internal = _open_or_create_directory(root, _LAYOUT)
+            try:
+                objects = _open_or_create_directory(internal, _OBJECTS)
+                os.close(objects)
+                locks = _open_or_create_directory(internal, _LOCKS)
+                os.close(locks)
+            finally:
+                os.close(internal)
+        finally:
+            os.close(root)
+
+    @contextmanager
+    def _layout(self) -> Iterator[_Layout]:
+        with ExitStack() as stack:
+            root = os.open(self._root, _DIRECTORY_FLAGS)
+            stack.callback(os.close, root)
+            internal = os.open(_LAYOUT, _DIRECTORY_FLAGS, dir_fd=root)
+            stack.callback(os.close, internal)
+            objects = os.open(_OBJECTS, _DIRECTORY_FLAGS, dir_fd=internal)
+            stack.callback(os.close, objects)
+            locks = os.open(_LOCKS, _DIRECTORY_FLAGS, dir_fd=internal)
+            stack.callback(os.close, locks)
+            yield _Layout(objects=objects, locks=locks)
 
     def _fault(self, boundary: str) -> None:
         if self._fault_injector is not None:
             self._fault_injector(boundary)
 
-    def _path(self, key: str) -> Path:
-        path = self._root / validate_key(key)
-        _reject_symlink_components(self._root, path)
-        return path
+    @staticmethod
+    def _identity(key: str) -> tuple[str, str]:
+        valid_key = validate_key(key)
+        digest = sha256(valid_key.encode()).hexdigest()
+        return valid_key, digest
 
     @staticmethod
-    def _stat(key: str, path: Path) -> ObjectStat:
-        with path.open("rb") as stream:
+    def _stat_descriptor(key: str, descriptor: int) -> ObjectStat:
+        with os.fdopen(descriptor, "rb") as stream:
             size, digest = stream_with_digest(stream)
         return ObjectStat(key=key, size_bytes=size, sha256=digest)
 
-    @staticmethod
-    def _namespace(key: str) -> str:
-        return f"{_TEMP_PREFIX}{sha256(key.encode()).hexdigest()}"
+    @classmethod
+    def _stat_at(cls, key: str, directory: int, name: str) -> ObjectStat:
+        descriptor = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=directory)
+        return cls._stat_descriptor(key, descriptor)
 
     @contextmanager
-    def _namespace_lock(
-        self, directory: Path, namespace: str, *, blocking: bool = True
-    ) -> Iterator[bool]:
-        lock_path = directory / f"{namespace}.lock"
-        with lock_path.open("a+b") as lock:
+    def _namespace_lock(self, locks: int, digest: str, *, blocking: bool = True) -> Iterator[bool]:
+        descriptor = os.open(
+            f"{digest}.lock", os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600, dir_fd=locks
+        )
+        try:
             flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
             try:
-                fcntl.flock(lock.fileno(), flags)
+                fcntl.flock(descriptor, flags)
             except BlockingIOError:
                 yield False
                 return
             try:
                 yield True
             finally:
-                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
 
-    @contextmanager
-    def _destination_lock(self, destination: Path, namespace: str) -> Iterator[None]:
-        with self._namespace_lock(destination.parent, namespace):
-            yield
-
-    def _owned_destination(self, temporary: Path, namespace: str) -> Path | None:
-        identity = _temporary_identity(temporary)
-        ownership = _temporary_owner(temporary)
-        if identity is None or ownership is None or identity[1] != ownership[1]:
+    def _owned_temporary(
+        self, objects: int, name: str, key: str, digest: str
+    ) -> tuple[int, os.stat_result] | None:
+        identity = _temporary_identity(name)
+        if identity is None or identity[0] != f"{_TEMP_PREFIX}{digest}":
             return None
-        owner = ownership[0]
-        try:
-            destination = self._path(owner)
-        except ValueError:
+        descriptor = _open_candidate(objects, name)
+        if descriptor is None:
             return None
-        if destination == temporary or destination.parent != temporary.parent:
+        metadata = os.fstat(descriptor)
+        owner = _temporary_owner(descriptor) if S_ISREG(metadata.st_mode) else None
+        if owner != (key, identity[1]):
+            os.close(descriptor)
             return None
-        return destination if self._namespace(owner) == namespace else None
+        return descriptor, metadata
 
     def _recover_startup(self) -> None:
-        for temporary in self._root.rglob(f"{_TEMP_PREFIX}*.tmp"):
-            identity = _temporary_identity(temporary)
-            if identity is None:
-                continue
-            namespace = identity[0]
-            destination = self._owned_destination(temporary, namespace)
-            if destination is None:
-                continue
-            with self._namespace_lock(temporary.parent, namespace, blocking=False) as acquired:
-                if not acquired:
+        with self._layout() as layout:
+            for name in os.listdir(layout.objects):
+                identity = _temporary_identity(name)
+                if identity is None:
                     continue
-                self._recover(destination, namespace)
+                candidate = self._startup_owner(layout.objects, name, identity)
+                if candidate is None:
+                    continue
+                key, digest = candidate
+                with self._namespace_lock(layout.locks, digest, blocking=False) as acquired:
+                    if acquired:
+                        self._recover(layout.objects, key, digest)
+
+    def _startup_owner(
+        self, objects: int, name: str, identity: tuple[str, str]
+    ) -> tuple[str, str] | None:
+        digest = identity[0].removeprefix(_TEMP_PREFIX)
+        descriptor = _open_candidate(objects, name)
+        if descriptor is None:
+            return None
+        try:
+            owner = _temporary_owner(descriptor)
+        finally:
+            os.close(descriptor)
+        if owner is None or owner[1] != identity[1]:
+            return None
+        try:
+            key, expected = self._identity(owner[0])
+        except ValueError:
+            return None
+        return (key, digest) if expected == digest else None
 
     @staticmethod
-    def _remove_temporary(temporary: Path, directory: Path) -> None:
-        temporary.unlink(missing_ok=True)
-        _fsync_directory(directory)
+    def _remove_temporary(objects: int, name: str) -> None:
+        try:
+            os.unlink(name, dir_fd=objects)
+        except FileNotFoundError:
+            return
+        os.fsync(objects)
 
     @staticmethod
-    def _classify_recovery(temporary: Path, destination: Path) -> _RecoveryKind:
-        if not destination.exists():
-            return _RecoveryKind.ABANDONED
-        if os.path.samestat(temporary.lstat(), destination.stat()):
-            return _RecoveryKind.LINKED
-        if destination.is_file():
-            return _RecoveryKind.LOSING
+    def _classify_recovery(objects: int, temporary: os.stat_result, digest: str) -> None:
+        try:
+            destination = os.open(digest, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=objects)
+        except FileNotFoundError:
+            return
+        try:
+            metadata = os.fstat(destination)
+        finally:
+            os.close(destination)
+        if os.path.samestat(temporary, metadata):
+            return
+        if S_ISREG(metadata.st_mode):
+            return
         raise Conflict("destination=invalid")
 
-    def _recover(self, destination: Path, namespace: str) -> None:
-        recoveries: set[_RecoveryKind] = set()
-        for temporary in destination.parent.glob(f"{namespace}-*.tmp"):
-            if self._owned_destination(temporary, namespace) != destination:
+    def _recover(self, objects: int, key: str, digest: str) -> None:
+        namespace = f"{_TEMP_PREFIX}{digest}"
+        for name in os.listdir(objects):
+            if not name.startswith(f"{namespace}-"):
                 continue
-            recoveries.add(self._classify_recovery(temporary, destination))
-            temporary.unlink(missing_ok=True)
-        if recoveries:
-            _fsync_directory(destination.parent)
+            owned = self._owned_temporary(objects, name, key, digest)
+            if owned is None:
+                continue
+            descriptor, metadata = owned
+            try:
+                self._classify_recovery(objects, metadata, digest)
+                self._remove_temporary(objects, name)
+            finally:
+                os.close(descriptor)
 
-    def _mark_temporary(self, descriptor: int, destination: Path, token: str) -> None:
-        key = destination.relative_to(self._root).as_posix()
-        ownership = f"{key}\0{token}".encode()
-        os.setxattr(descriptor, _OWNER_XATTR, ownership)
+    def _mark_temporary(self, descriptor: int, key: str, token: str) -> None:
+        os.setxattr(descriptor, _OWNER_XATTR, f"{key}\0{token}".encode())
         os.fsync(descriptor)
 
     def _stage(
-        self, destination: Path, namespace: str, body: BinaryIO, expected_sha256: str
+        self, objects: int, identity: tuple[str, str], body: BinaryIO, expected_sha256: str
     ) -> _StagedFile:
-        descriptor = os.open(destination.parent, os.O_RDWR | os.O_TMPFILE, 0o600)
+        key, digest = identity
+        descriptor = os.open(".", os.O_RDWR | os.O_TMPFILE, 0o600, dir_fd=objects)
         token = token_hex(16)
-        temporary = destination.parent / f"{namespace}-{token}.tmp"
+        name = f"{_TEMP_PREFIX}{digest}-{token}.tmp"
         try:
             self._fault("temporary_created_before_ownership")
-            self._mark_temporary(descriptor, destination, token)
-            _link_descriptor(descriptor, temporary)
-            _fsync_directory(destination.parent)
+            self._mark_temporary(descriptor, key, token)
+            _link_descriptor(descriptor, objects, name)
+            os.fsync(objects)
             self._fault("temporary_created")
             try:
                 stream = os.fdopen(descriptor, "wb")
                 descriptor = -1
                 with stream:
-                    size, digest = stream_with_digest(body, stream)
+                    size, content_digest = stream_with_digest(body, stream)
                     stream.flush()
                     os.fsync(stream.fileno())
             except Exception:
-                self._remove_temporary(temporary, destination.parent)
+                self._remove_temporary(objects, name)
                 raise
             self._fault("file_fsynced")
             try:
-                require_digest(digest, expected_sha256)
+                require_digest(content_digest, expected_sha256)
             except ValueError:
-                self._remove_temporary(temporary, destination.parent)
+                self._remove_temporary(objects, name)
                 raise
-            return _StagedFile(path=temporary, size=size, digest=digest)
-        except Exception:
+            return _StagedFile(name=name, size=size, digest=content_digest)
+        finally:
             if descriptor >= 0:
                 os.close(descriptor)
-            raise
 
-    def _link(self, key: str, destination: Path, staged: _StagedFile) -> tuple[ObjectStat, bool]:
+    def _link(
+        self, key: str, objects: int, digest: str, staged: _StagedFile
+    ) -> tuple[ObjectStat, bool]:
         try:
-            os.link(staged.path, destination)
+            os.link(
+                staged.name,
+                digest,
+                src_dir_fd=objects,
+                dst_dir_fd=objects,
+                follow_symlinks=False,
+            )
         except OSError as error:
             if error.errno != errno.EEXIST:
-                self._remove_temporary(staged.path, destination.parent)
+                self._remove_temporary(objects, staged.name)
                 raise
-            existing = self._stat(key, destination)
-            self._remove_temporary(staged.path, destination.parent)
+            existing = self._stat_at(key, objects, digest)
+            self._remove_temporary(objects, staged.name)
             if existing.sha256 != staged.digest:
                 raise Conflict("object=immutable") from error
             return existing, False
         return ObjectStat(key=key, size_bytes=staged.size, sha256=staged.digest), True
 
     def _publish(self, key: str, body: BinaryIO, expected_sha256: str) -> ObjectStat:
-        destination = self._path(key)
-        _mkdir_durable(destination.parent)
-        namespace = self._namespace(key)
-        with self._destination_lock(destination, namespace):
-            self._recover(destination, namespace)
-            staged = self._stage(destination, namespace, body, expected_sha256)
-            stat, linked = self._link(key, destination, staged)
+        valid_key, digest = self._identity(key)
+        with self._layout() as layout, self._namespace_lock(layout.locks, digest):
+            self._recover(layout.objects, valid_key, digest)
+            staged = self._stage(layout.objects, (valid_key, digest), body, expected_sha256)
+            stat, linked = self._link(valid_key, layout.objects, digest, staged)
             if linked:
                 self._fault("destination_linked")
-                _fsync_directory(destination.parent)
+                os.fsync(layout.objects)
                 self._fault("directory_fsynced")
-            staged.path.unlink(missing_ok=True)
+            self._remove_temporary(layout.objects, staged.name)
             self._fault("temporary_unlinked")
-            _fsync_directory(destination.parent)
+            os.fsync(layout.objects)
             self._fault("directory_final_fsynced")
             return stat
 
@@ -289,11 +365,18 @@ class FilesystemObjectStore:
         return self._publish(key, body, expected_sha256)
 
     def open(self, key: str) -> ContextManager[BinaryIO]:
-        return self._path(key).open("rb")
+        _, digest = self._identity(key)
+        with self._layout() as layout:
+            descriptor = os.open(digest, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=layout.objects)
+        return os.fdopen(descriptor, "rb")
 
     def stat(self, key: str) -> ObjectStat | None:
-        path = self._path(key)
-        return self._stat(key, path) if path.exists() else None
+        valid_key, digest = self._identity(key)
+        with self._layout() as layout:
+            try:
+                return self._stat_at(valid_key, layout.objects, digest)
+            except FileNotFoundError:
+                return None
 
     def promote(self, source_key: str, destination_key: str, expected_sha256: str) -> ObjectStat:
         validate_key(source_key)
@@ -302,11 +385,13 @@ class FilesystemObjectStore:
             return self.put(destination_key, source, expected_sha256)
 
     def delete(self, key: str) -> None:
-        destination = self._path(key)
-        _mkdir_durable(destination.parent)
-        namespace = self._namespace(key)
-        with self._destination_lock(destination, namespace):
-            self._recover(destination, namespace)
-            if destination.exists():
-                destination.unlink()
-                _fsync_directory(destination.parent)
+        valid_key, digest = self._identity(key)
+        with self._layout() as layout, self._namespace_lock(layout.locks, digest):
+            self._recover(layout.objects, valid_key, digest)
+            try:
+                descriptor = os.open(digest, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=layout.objects)
+                os.close(descriptor)
+                os.unlink(digest, dir_fd=layout.objects)
+            except FileNotFoundError:
+                return
+            os.fsync(layout.objects)

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -129,7 +129,7 @@ def _open_regular(directory: int, name: str) -> int:
             name, os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW, dir_fd=directory
         )
     except OSError as error:
-        if error.errno == errno.ELOOP:
+        if error.errno in {errno.ELOOP, errno.ENXIO}:
             raise Conflict("destination=invalid") from error
         raise
     try:

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from typing import BinaryIO
 
 _TEMP_PREFIX = ".cnes-object-store-"
+_HEX_DIGITS = frozenset("0123456789abcdef")
 
 
 class _RecoveryKind(Enum):
@@ -46,6 +47,14 @@ def _fsync_directory(directory: Path) -> None:
         os.close(descriptor)
 
 
+def _temporary_namespace(path: Path) -> str | None:
+    namespace, _, token = path.name.removesuffix(".tmp").rpartition("-")
+    digest = namespace.removeprefix(_TEMP_PREFIX)
+    if len(digest) != 64 or not token:
+        return None
+    return namespace if set(digest) <= _HEX_DIGITS else None
+
+
 class FilesystemObjectStore:
     def __init__(
         self, root: str | Path, fault_injector: Callable[[str], None] | None = None
@@ -53,6 +62,7 @@ class FilesystemObjectStore:
         self._root = Path(root)
         self._fault_injector = fault_injector
         self._root.mkdir(parents=True, exist_ok=True)
+        self._recover_startup()
 
     def _fault(self, boundary: str) -> None:
         if self._fault_injector is not None:
@@ -72,14 +82,47 @@ class FilesystemObjectStore:
         return f"{_TEMP_PREFIX}{sha256(key.encode()).hexdigest()}"
 
     @contextmanager
-    def _destination_lock(self, destination: Path, namespace: str) -> Iterator[None]:
-        lock_path = destination.parent / f"{namespace}.lock"
+    def _namespace_lock(
+        self, directory: Path, namespace: str, *, blocking: bool = True
+    ) -> Iterator[bool]:
+        lock_path = directory / f"{namespace}.lock"
         with lock_path.open("a+b") as lock:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
             try:
-                yield
+                fcntl.flock(lock.fileno(), flags)
+            except BlockingIOError:
+                yield False
+                return
+            try:
+                yield True
             finally:
                 fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+    @contextmanager
+    def _destination_lock(self, destination: Path, namespace: str) -> Iterator[None]:
+        with self._namespace_lock(destination.parent, namespace):
+            yield
+
+    def _destination_for_namespace(self, directory: Path, namespace: str) -> Path | None:
+        for candidate in directory.iterdir():
+            key = candidate.relative_to(self._root).as_posix()
+            if self._namespace(key) == namespace:
+                return candidate
+        return None
+
+    def _recover_startup(self) -> None:
+        for temporary in self._root.rglob(f"{_TEMP_PREFIX}*.tmp"):
+            namespace = _temporary_namespace(temporary)
+            if namespace is None:
+                continue
+            with self._namespace_lock(temporary.parent, namespace, blocking=False) as acquired:
+                if not acquired or not temporary.exists():
+                    continue
+                destination = self._destination_for_namespace(temporary.parent, namespace)
+                if destination is None:
+                    self._remove_temporary(temporary, temporary.parent)
+                else:
+                    self._recover(destination, namespace)
 
     @staticmethod
     def _remove_temporary(temporary: Path, directory: Path) -> None:

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
+import ctypes
 import errno
 import fcntl
 import os
-import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from hashlib import sha256
 from pathlib import Path
-from stat import S_ISREG
+from secrets import token_hex
+from stat import S_ISLNK, S_ISREG
 from typing import TYPE_CHECKING
 
 from cnes_domain.control_plane.errors import Conflict
@@ -27,6 +28,11 @@ _TEMP_PREFIX = ".cnes-object-store-"
 _HEX_DIGITS = frozenset("0123456789abcdef")
 _OWNER_XATTR = "user.cnes_object_store_destination"
 _MISSING_XATTR_ERRNOS = frozenset({errno.ENODATA, errno.ENOENT})
+_AT_FDCWD = -100
+_AT_EMPTY_PATH = 0x1000
+_LINKAT = ctypes.CDLL(None, use_errno=True).linkat
+_LINKAT.argtypes = (ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_int)
+_LINKAT.restype = ctypes.c_int
 
 
 class _RecoveryKind(Enum):
@@ -59,6 +65,25 @@ def _mkdir_durable(directory: Path) -> None:
     for path in reversed(missing):
         path.mkdir(exist_ok=True)
         _fsync_directory(path.parent)
+
+
+def _reject_symlink_components(root: Path, path: Path) -> None:
+    current = root
+    for part in path.relative_to(root).parts:
+        current /= part
+        try:
+            mode = current.lstat().st_mode
+        except FileNotFoundError:
+            return
+        if S_ISLNK(mode):
+            raise ValueError("object_path=symlink")
+
+
+def _link_descriptor(descriptor: int, destination: Path) -> None:
+    result = _LINKAT(descriptor, b"", _AT_FDCWD, os.fsencode(destination), _AT_EMPTY_PATH)
+    if result != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error), destination)
 
 
 def _temporary_identity(path: Path) -> tuple[str, str] | None:
@@ -99,7 +124,9 @@ class FilesystemObjectStore:
             self._fault_injector(boundary)
 
     def _path(self, key: str) -> Path:
-        return self._root / validate_key(key)
+        path = self._root / validate_key(key)
+        _reject_symlink_components(self._root, path)
+        return path
 
     @staticmethod
     def _stat(key: str, path: Path) -> ObjectStat:
@@ -186,35 +213,34 @@ class FilesystemObjectStore:
         if recoveries:
             _fsync_directory(destination.parent)
 
-    def _mark_temporary(
-        self, temporary: Path, descriptor: int, destination: Path, token: str
-    ) -> None:
+    def _mark_temporary(self, descriptor: int, destination: Path, token: str) -> None:
         key = destination.relative_to(self._root).as_posix()
         ownership = f"{key}\0{token}".encode()
-        try:
-            os.setxattr(descriptor, _OWNER_XATTR, ownership)
-            os.fsync(descriptor)
-            _fsync_directory(destination.parent)
-        except Exception:
-            self._remove_temporary(temporary, destination.parent)
-            raise
+        os.setxattr(descriptor, _OWNER_XATTR, ownership)
+        os.fsync(descriptor)
 
     def _stage(
         self, destination: Path, namespace: str, body: BinaryIO, expected_sha256: str
     ) -> _StagedFile:
-        descriptor, name = tempfile.mkstemp(
-            dir=destination.parent, prefix=f"{namespace}-", suffix=".tmp"
-        )
-        temporary = Path(name)
-        token = temporary.name.removesuffix(".tmp").rpartition("-")[2]
+        descriptor = os.open(destination.parent, os.O_RDWR | os.O_TMPFILE, 0o600)
+        token = token_hex(16)
+        temporary = destination.parent / f"{namespace}-{token}.tmp"
         try:
-            self._mark_temporary(temporary, descriptor, destination, token)
+            self._fault("temporary_created_before_ownership")
+            self._mark_temporary(descriptor, destination, token)
+            _link_descriptor(descriptor, temporary)
+            _fsync_directory(destination.parent)
             self._fault("temporary_created")
-            with os.fdopen(descriptor, "wb") as stream:
+            try:
+                stream = os.fdopen(descriptor, "wb")
                 descriptor = -1
-                size, digest = stream_with_digest(body, stream)
-                stream.flush()
-                os.fsync(stream.fileno())
+                with stream:
+                    size, digest = stream_with_digest(body, stream)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+            except Exception:
+                self._remove_temporary(temporary, destination.parent)
+                raise
             self._fault("file_fsynced")
             try:
                 require_digest(digest, expected_sha256)

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -423,5 +423,6 @@ class FilesystemObjectStore:
                 os.close(descriptor)
                 os.unlink(digest, dir_fd=layout.objects)
             except FileNotFoundError:
+                os.fsync(layout.objects)
                 return
             os.fsync(layout.objects)

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -64,6 +64,8 @@ def _mkdir_durable(directory: Path) -> None:
     while not current.exists():
         missing.append(current)
         current = current.parent
+    if not missing:
+        _fsync_directory(directory.parent)
     for path in reversed(missing):
         path.mkdir(exist_ok=True)
         _fsync_directory(path.parent)

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -113,9 +113,9 @@ def _temporary_owner(descriptor: int) -> tuple[str, str] | None:
 
 def _open_candidate(objects: int, name: str) -> int | None:
     try:
-        return os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=objects)
+        return os.open(name, os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW, dir_fd=objects)
     except OSError as error:
-        if error.errno in {errno.ENOENT, errno.ELOOP}:
+        if error.errno in {errno.ENOENT, errno.ENXIO, errno.ELOOP}:
             return None
         raise
 
@@ -247,7 +247,7 @@ class FilesystemObjectStore:
             return None
         try:
             metadata = os.fstat(descriptor)
-            owner = _temporary_owner(descriptor)
+            owner = _temporary_owner(descriptor) if S_ISREG(metadata.st_mode) else None
         finally:
             os.close(descriptor)
         if owner is None or owner[1] != identity[1]:

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -94,7 +94,7 @@ class FilesystemObjectStore:
             return _RecoveryKind.LINKED
         if destination.is_file():
             return _RecoveryKind.LOSING
-        raise Conflict("invalid_destination")
+        raise Conflict("destination=invalid")
 
     def _recover(self, destination: Path, namespace: str) -> None:
         recoveries: set[_RecoveryKind] = set()
@@ -140,7 +140,7 @@ class FilesystemObjectStore:
             existing = self._stat(key, destination)
             self._remove_temporary(staged.path, destination.parent)
             if existing.sha256 != staged.digest:
-                raise Conflict("immutable_object") from error
+                raise Conflict("object=immutable") from error
             return existing, False
         return ObjectStat(key=key, size_bytes=staged.size, sha256=staged.digest), True
 

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -124,9 +124,14 @@ def _open_candidate(objects: int, name: str) -> int | None:
 
 
 def _open_regular(directory: int, name: str) -> int:
-    descriptor = os.open(
-        name, os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW, dir_fd=directory
-    )
+    try:
+        descriptor = os.open(
+            name, os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW, dir_fd=directory
+        )
+    except OSError as error:
+        if error.errno == errno.ELOOP:
+            raise Conflict("destination=invalid") from error
+        raise
     try:
         if not S_ISREG(os.fstat(descriptor).st_mode):
             raise Conflict("destination=invalid")

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -1,0 +1,189 @@
+"""Object store imutável sobre filesystem POSIX."""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import os
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from hashlib import sha256
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.ports.object_store import ObjectStat
+from cnes_infra.object_store._common import require_digest, stream_with_digest, validate_key
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager as ContextManager
+    from typing import BinaryIO
+
+_TEMP_PREFIX = ".cnes-object-store-"
+
+
+class _RecoveryKind(Enum):
+    ABANDONED = "abandoned"
+    LINKED = "linked"
+    LOSING = "losing"
+
+
+@dataclass(frozen=True, slots=True)
+class _StagedFile:
+    path: Path
+    size: int
+    digest: str
+
+
+def _fsync_directory(directory: Path) -> None:
+    descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+class FilesystemObjectStore:
+    def __init__(
+        self, root: str | Path, fault_injector: Callable[[str], None] | None = None
+    ) -> None:
+        self._root = Path(root)
+        self._fault_injector = fault_injector
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def _fault(self, boundary: str) -> None:
+        if self._fault_injector is not None:
+            self._fault_injector(boundary)
+
+    def _path(self, key: str) -> Path:
+        return self._root / validate_key(key)
+
+    @staticmethod
+    def _stat(key: str, path: Path) -> ObjectStat:
+        with path.open("rb") as stream:
+            size, digest = stream_with_digest(stream)
+        return ObjectStat(key=key, size_bytes=size, sha256=digest)
+
+    @staticmethod
+    def _namespace(key: str) -> str:
+        return f"{_TEMP_PREFIX}{sha256(key.encode()).hexdigest()}"
+
+    @contextmanager
+    def _destination_lock(self, destination: Path, namespace: str) -> Iterator[None]:
+        lock_path = destination.parent / f"{namespace}.lock"
+        with lock_path.open("a+b") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+    @staticmethod
+    def _remove_temporary(temporary: Path, directory: Path) -> None:
+        temporary.unlink(missing_ok=True)
+        _fsync_directory(directory)
+
+    @staticmethod
+    def _classify_recovery(temporary: Path, destination: Path) -> _RecoveryKind:
+        if not destination.exists():
+            return _RecoveryKind.ABANDONED
+        if os.path.samestat(temporary.stat(), destination.stat()):
+            return _RecoveryKind.LINKED
+        if destination.is_file():
+            return _RecoveryKind.LOSING
+        raise Conflict("invalid_destination")
+
+    def _recover(self, destination: Path, namespace: str) -> None:
+        recoveries: set[_RecoveryKind] = set()
+        for temporary in destination.parent.glob(f"{namespace}-*.tmp"):
+            recoveries.add(self._classify_recovery(temporary, destination))
+            temporary.unlink(missing_ok=True)
+        if recoveries:
+            _fsync_directory(destination.parent)
+
+    def _stage(
+        self, destination: Path, namespace: str, body: BinaryIO, expected_sha256: str
+    ) -> _StagedFile:
+        descriptor, name = tempfile.mkstemp(
+            dir=destination.parent, prefix=f"{namespace}-", suffix=".tmp"
+        )
+        temporary = Path(name)
+        try:
+            self._fault("temporary_created")
+            with os.fdopen(descriptor, "wb") as stream:
+                descriptor = -1
+                size, digest = stream_with_digest(body, stream)
+                stream.flush()
+                os.fsync(stream.fileno())
+            self._fault("file_fsynced")
+            try:
+                require_digest(digest, expected_sha256)
+            except ValueError:
+                self._remove_temporary(temporary, destination.parent)
+                raise
+            return _StagedFile(path=temporary, size=size, digest=digest)
+        except Exception:
+            if descriptor >= 0:
+                os.close(descriptor)
+            raise
+
+    def _link(self, key: str, destination: Path, staged: _StagedFile) -> tuple[ObjectStat, bool]:
+        try:
+            os.link(staged.path, destination)
+        except OSError as error:
+            if error.errno != errno.EEXIST:
+                self._remove_temporary(staged.path, destination.parent)
+                raise
+            existing = self._stat(key, destination)
+            self._remove_temporary(staged.path, destination.parent)
+            if existing.sha256 != staged.digest:
+                raise Conflict("immutable_object") from error
+            return existing, False
+        return ObjectStat(key=key, size_bytes=staged.size, sha256=staged.digest), True
+
+    def _publish(self, key: str, body: BinaryIO, expected_sha256: str) -> ObjectStat:
+        destination = self._path(key)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        namespace = self._namespace(key)
+        with self._destination_lock(destination, namespace):
+            self._recover(destination, namespace)
+            staged = self._stage(destination, namespace, body, expected_sha256)
+            stat, linked = self._link(key, destination, staged)
+            if linked:
+                self._fault("destination_linked")
+                _fsync_directory(destination.parent)
+                self._fault("directory_fsynced")
+            staged.path.unlink(missing_ok=True)
+            self._fault("temporary_unlinked")
+            _fsync_directory(destination.parent)
+            self._fault("directory_final_fsynced")
+            return stat
+
+    def put(self, key: str, body: BinaryIO, expected_sha256: str) -> ObjectStat:
+        return self._publish(key, body, expected_sha256)
+
+    def open(self, key: str) -> ContextManager[BinaryIO]:
+        return self._path(key).open("rb")
+
+    def stat(self, key: str) -> ObjectStat | None:
+        path = self._path(key)
+        return self._stat(key, path) if path.exists() else None
+
+    def promote(self, source_key: str, destination_key: str, expected_sha256: str) -> ObjectStat:
+        validate_key(source_key)
+        validate_key(destination_key)
+        with self.open(source_key) as source:
+            return self.put(destination_key, source, expected_sha256)
+
+    def delete(self, key: str) -> None:
+        destination = self._path(key)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        namespace = self._namespace(key)
+        with self._destination_lock(destination, namespace):
+            self._recover(destination, namespace)
+            if destination.exists():
+                destination.unlink()
+                _fsync_directory(destination.parent)

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -300,7 +300,11 @@ class FilesystemObjectStore:
             self._fault("temporary_created_before_ownership")
             self._mark_temporary(descriptor, key, token)
             _link_descriptor(descriptor, objects, name)
-            os.fsync(objects)
+            try:
+                os.fsync(objects)
+            except OSError:
+                self._remove_temporary(objects, name)
+                raise
             self._fault("temporary_created")
             try:
                 stream = os.fdopen(descriptor, "wb")

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -65,8 +65,7 @@ def _mkdir_durable(directory: Path) -> None:
     while not current.exists():
         missing.append(current)
         current = current.parent
-    if not missing:
-        _fsync_directory(directory.parent)
+    _fsync_directory(current.parent)
     for path in reversed(missing):
         path.mkdir(exist_ok=True)
         _fsync_directory(path.parent)

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -119,6 +119,19 @@ def _open_candidate(objects: int, name: str) -> int | None:
         raise
 
 
+def _open_regular(directory: int, name: str) -> int:
+    descriptor = os.open(
+        name, os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW, dir_fd=directory
+    )
+    try:
+        if not S_ISREG(os.fstat(descriptor).st_mode):
+            raise Conflict("destination=invalid")
+    except Exception:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
 class FilesystemObjectStore:
     def __init__(
         self, root: str | Path, fault_injector: Callable[[str], None] | None = None
@@ -179,7 +192,7 @@ class FilesystemObjectStore:
 
     @classmethod
     def _stat_at(cls, key: str, directory: int, name: str) -> ObjectStat:
-        descriptor = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=directory)
+        descriptor = _open_regular(directory, name)
         return cls._stat_descriptor(key, descriptor)
 
     @contextmanager
@@ -268,18 +281,14 @@ class FilesystemObjectStore:
     @staticmethod
     def _classify_recovery(objects: int, temporary: os.stat_result, digest: str) -> bool:
         try:
-            destination = os.open(digest, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=objects)
+            destination = _open_regular(objects, digest)
         except FileNotFoundError:
             return False
         try:
             metadata = os.fstat(destination)
         finally:
             os.close(destination)
-        if os.path.samestat(temporary, metadata):
-            return True
-        if S_ISREG(metadata.st_mode):
-            return False
-        raise Conflict("destination=invalid")
+        return os.path.samestat(temporary, metadata)
 
     def _recover(self, objects: int, key: str, digest: str) -> None:
         namespace = f"{_TEMP_PREFIX}{digest}"
@@ -353,8 +362,10 @@ class FilesystemObjectStore:
             if error.errno != errno.EEXIST:
                 self._remove_temporary(objects, staged.name)
                 raise
-            existing = self._stat_at(key, objects, digest)
-            self._remove_temporary(objects, staged.name)
+            try:
+                existing = self._stat_at(key, objects, digest)
+            finally:
+                self._remove_temporary(objects, staged.name)
             if existing.sha256 != staged.digest:
                 raise Conflict("object=immutable") from error
             return existing, False
@@ -386,7 +397,7 @@ class FilesystemObjectStore:
     def open(self, key: str) -> ContextManager[BinaryIO]:
         _, digest = self._identity(key)
         with self._layout() as layout:
-            descriptor = os.open(digest, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=layout.objects)
+            descriptor = _open_regular(layout.objects, digest)
         return os.fdopen(descriptor, "rb")
 
     def stat(self, key: str) -> ObjectStat | None:
@@ -408,7 +419,7 @@ class FilesystemObjectStore:
         with self._layout() as layout, self._namespace_lock(layout.locks, digest):
             self._recover(layout.objects, valid_key, digest)
             try:
-                descriptor = os.open(digest, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=layout.objects)
+                descriptor = _open_regular(layout.objects, digest)
                 os.close(descriptor)
                 os.unlink(digest, dir_fd=layout.objects)
             except FileNotFoundError:

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -50,6 +50,17 @@ def _fsync_directory(directory: Path) -> None:
         os.close(descriptor)
 
 
+def _mkdir_durable(directory: Path) -> None:
+    missing: list[Path] = []
+    current = directory
+    while not current.exists():
+        missing.append(current)
+        current = current.parent
+    for path in reversed(missing):
+        path.mkdir(exist_ok=True)
+        _fsync_directory(path.parent)
+
+
 def _temporary_identity(path: Path) -> tuple[str, str] | None:
     namespace, _, token = path.name.removesuffix(".tmp").rpartition("-")
     digest = namespace.removeprefix(_TEMP_PREFIX)
@@ -59,9 +70,9 @@ def _temporary_identity(path: Path) -> tuple[str, str] | None:
 
 
 def _temporary_owner(path: Path) -> tuple[str, str] | None:
-    if not S_ISREG(path.lstat().st_mode):
-        return None
     try:
+        if not S_ISREG(path.lstat().st_mode):
+            return None
         value = os.getxattr(path, _OWNER_XATTR, follow_symlinks=False)
     except OSError as error:
         if error.errno in _MISSING_XATTR_ERRNOS:
@@ -80,7 +91,7 @@ class FilesystemObjectStore:
     ) -> None:
         self._root = Path(root)
         self._fault_injector = fault_injector
-        self._root.mkdir(parents=True, exist_ok=True)
+        _mkdir_durable(self._root)
         self._recover_startup()
 
     def _fault(self, boundary: str) -> None:
@@ -232,7 +243,7 @@ class FilesystemObjectStore:
 
     def _publish(self, key: str, body: BinaryIO, expected_sha256: str) -> ObjectStat:
         destination = self._path(key)
-        destination.parent.mkdir(parents=True, exist_ok=True)
+        _mkdir_durable(destination.parent)
         namespace = self._namespace(key)
         with self._destination_lock(destination, namespace):
             self._recover(destination, namespace)
@@ -266,7 +277,7 @@ class FilesystemObjectStore:
 
     def delete(self, key: str) -> None:
         destination = self._path(key)
-        destination.parent.mkdir(parents=True, exist_ok=True)
+        _mkdir_durable(destination.parent)
         namespace = self._namespace(key)
         with self._destination_lock(destination, namespace):
             self._recover(destination, namespace)

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -78,6 +78,12 @@ def _open_root(directory: Path) -> int:
     return current
 
 
+def _close_descriptors(descriptors: tuple[int, ...]) -> None:
+    with ExitStack() as stack:
+        for descriptor in descriptors:
+            stack.callback(os.close, descriptor)
+
+
 def _link_descriptor(descriptor: int, directory: int, name: str) -> None:
     result = _LINKAT(descriptor, b"", directory, os.fsencode(name), _AT_EMPTY_PATH)
     if result != 0:
@@ -138,35 +144,36 @@ class FilesystemObjectStore:
         with ExitStack() as stack:
             self._root_descriptor = _open_root(root_path)
             stack.callback(os.close, self._root_descriptor)
-            self._ensure_layout()
+            self._internal_descriptor = _open_or_create_directory(
+                self._root_descriptor, _LAYOUT
+            )
+            stack.callback(os.close, self._internal_descriptor)
+            self._objects_descriptor = _open_or_create_directory(
+                self._internal_descriptor, _OBJECTS
+            )
+            stack.callback(os.close, self._objects_descriptor)
+            self._locks_descriptor = _open_or_create_directory(
+                self._internal_descriptor, _LOCKS
+            )
+            stack.callback(os.close, self._locks_descriptor)
             self._recover_startup()
-            self._root_finalizer = finalize(self, os.close, self._root_descriptor)
+            descriptors = (
+                self._root_descriptor,
+                self._internal_descriptor,
+                self._objects_descriptor,
+                self._locks_descriptor,
+            )
+            self._descriptors_finalizer = finalize(
+                self, _close_descriptors, descriptors
+            )
             stack.pop_all()
-
-    def _ensure_layout(self) -> None:
-        root = os.dup(self._root_descriptor)
-        try:
-            internal = _open_or_create_directory(root, _LAYOUT)
-            try:
-                objects = _open_or_create_directory(internal, _OBJECTS)
-                os.close(objects)
-                locks = _open_or_create_directory(internal, _LOCKS)
-                os.close(locks)
-            finally:
-                os.close(internal)
-        finally:
-            os.close(root)
 
     @contextmanager
     def _layout(self) -> Iterator[_Layout]:
         with ExitStack() as stack:
-            root = os.dup(self._root_descriptor)
-            stack.callback(os.close, root)
-            internal = os.open(_LAYOUT, _DIRECTORY_FLAGS, dir_fd=root)
-            stack.callback(os.close, internal)
-            objects = os.open(_OBJECTS, _DIRECTORY_FLAGS, dir_fd=internal)
+            objects = os.dup(self._objects_descriptor)
             stack.callback(os.close, objects)
-            locks = os.open(_LOCKS, _DIRECTORY_FLAGS, dir_fd=internal)
+            locks = os.dup(self._locks_descriptor)
             stack.callback(os.close, locks)
             yield _Layout(objects=objects, locks=locks)
 

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -46,6 +46,7 @@ class _Layout:
 
 @dataclass(frozen=True, slots=True)
 class _StagedFile:
+    descriptor: int
     name: str
     size: int
     digest: str
@@ -334,8 +335,7 @@ class FilesystemObjectStore:
                 raise
             self._fault("temporary_created")
             try:
-                stream = os.fdopen(descriptor, "wb")
-                descriptor = -1
+                stream = os.fdopen(os.dup(descriptor), "wb")
                 with stream:
                     size, content_digest = stream_with_digest(body, stream)
                     stream.flush()
@@ -349,7 +349,11 @@ class FilesystemObjectStore:
             except ValueError:
                 self._remove_temporary(objects, name)
                 raise
-            return _StagedFile(name=name, size=size, digest=content_digest)
+            staged = _StagedFile(
+                descriptor=descriptor, name=name, size=size, digest=content_digest
+            )
+            descriptor = -1
+            return staged
         finally:
             if descriptor >= 0:
                 os.close(descriptor)
@@ -358,13 +362,7 @@ class FilesystemObjectStore:
         self, key: str, objects: int, digest: str, staged: _StagedFile
     ) -> tuple[ObjectStat, bool]:
         try:
-            os.link(
-                staged.name,
-                digest,
-                src_dir_fd=objects,
-                dst_dir_fd=objects,
-                follow_symlinks=False,
-            )
+            _link_descriptor(staged.descriptor, objects, digest)
         except OSError as error:
             if error.errno != errno.EEXIST:
                 self._remove_temporary(objects, staged.name)
@@ -383,20 +381,23 @@ class FilesystemObjectStore:
         with self._layout() as layout, self._namespace_lock(layout.locks, digest):
             self._recover(layout.objects, valid_key, digest)
             staged = self._stage(layout.objects, (valid_key, digest), body, expected_sha256)
-            stat, linked = self._link(valid_key, layout.objects, digest, staged)
-            if linked:
-                self._fault("destination_linked")
-                try:
-                    os.fsync(layout.objects)
-                except OSError:
-                    self._remove_temporary(layout.objects, staged.name)
-                    raise
-                self._fault("directory_fsynced")
-            self._remove_temporary(layout.objects, staged.name)
-            self._fault("temporary_unlinked")
-            os.fsync(layout.objects)
-            self._fault("directory_final_fsynced")
-            return stat
+            try:
+                stat, linked = self._link(valid_key, layout.objects, digest, staged)
+                if linked:
+                    self._fault("destination_linked")
+                    try:
+                        os.fsync(layout.objects)
+                    except OSError:
+                        self._remove_temporary(layout.objects, staged.name)
+                        raise
+                    self._fault("directory_fsynced")
+                self._remove_temporary(layout.objects, staged.name)
+                self._fault("temporary_unlinked")
+                os.fsync(layout.objects)
+                self._fault("directory_final_fsynced")
+                return stat
+            finally:
+                os.close(staged.descriptor)
 
     def put(self, key: str, body: BinaryIO, expected_sha256: str) -> ObjectStat:
         return self._publish(key, body, expected_sha256)

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -70,15 +70,12 @@ def _mkdir_durable(directory: Path) -> None:
 
 
 def _open_or_create_directory(parent: int, name: str) -> int:
-    created = False
     try:
         os.mkdir(name, dir_fd=parent)
-        created = True
     except FileExistsError:
         pass
     descriptor = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent)
-    if created:
-        os.fsync(parent)
+    os.fsync(parent)
     return descriptor
 
 
@@ -357,7 +354,11 @@ class FilesystemObjectStore:
             stat, linked = self._link(valid_key, layout.objects, digest, staged)
             if linked:
                 self._fault("destination_linked")
-                os.fsync(layout.objects)
+                try:
+                    os.fsync(layout.objects)
+                except OSError:
+                    self._remove_temporary(layout.objects, staged.name)
+                    raise
                 self._fault("directory_fsynced")
             self._remove_temporary(layout.objects, staged.name)
             self._fault("temporary_unlinked")

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -77,7 +77,11 @@ def _open_or_create_directory(parent: int, name: str) -> int:
     except FileExistsError:
         pass
     descriptor = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent)
-    os.fsync(parent)
+    try:
+        os.fsync(parent)
+    except Exception:
+        os.close(descriptor)
+        raise
     return descriptor
 
 
@@ -223,8 +227,12 @@ class FilesystemObjectStore:
         descriptor = _open_candidate(objects, name)
         if descriptor is None:
             return None
-        metadata = os.fstat(descriptor)
-        owner = _temporary_owner(descriptor) if S_ISREG(metadata.st_mode) else None
+        try:
+            metadata = os.fstat(descriptor)
+            owner = _temporary_owner(descriptor) if S_ISREG(metadata.st_mode) else None
+        except Exception:
+            os.close(descriptor)
+            raise
         if owner != (key, identity[1]):
             os.close(descriptor)
             return None

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -290,7 +290,7 @@ class FilesystemObjectStore:
     def _classify_recovery(objects: int, temporary: os.stat_result, digest: str) -> bool:
         try:
             destination = _open_regular(objects, digest)
-        except FileNotFoundError:
+        except (FileNotFoundError, Conflict):
             return False
         try:
             metadata = os.fstat(destination)

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -121,7 +121,7 @@ class FilesystemObjectStore:
     def __init__(
         self, root: str | Path, fault_injector: Callable[[str], None] | None = None
     ) -> None:
-        self._root = Path(root)
+        self._root = Path(root).absolute()
         self._fault_injector = fault_injector
         _mkdir_durable(self._root)
         self._ensure_layout()

--- a/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/filesystem.py
@@ -51,26 +51,6 @@ class _StagedFile:
     digest: str
 
 
-def _fsync_directory(directory: Path) -> None:
-    descriptor = os.open(directory, _DIRECTORY_FLAGS)
-    try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
-
-
-def _mkdir_durable(directory: Path) -> None:
-    missing: list[Path] = []
-    current = directory
-    while not current.exists():
-        missing.append(current)
-        current = current.parent
-    _fsync_directory(current.parent)
-    for path in reversed(missing):
-        path.mkdir(exist_ok=True)
-        _fsync_directory(path.parent)
-
-
 def _open_or_create_directory(parent: int, name: str) -> int:
     try:
         os.mkdir(name, dir_fd=parent)
@@ -83,6 +63,19 @@ def _open_or_create_directory(parent: int, name: str) -> int:
         os.close(descriptor)
         raise
     return descriptor
+
+
+def _open_root(directory: Path) -> int:
+    current = os.open("/", _DIRECTORY_FLAGS)
+    try:
+        for name in directory.parts[1:]:
+            child = _open_or_create_directory(current, name)
+            os.close(current)
+            current = child
+    except Exception:
+        os.close(current)
+        raise
+    return current
 
 
 def _link_descriptor(descriptor: int, directory: int, name: str) -> None:
@@ -142,9 +135,8 @@ class FilesystemObjectStore:
     ) -> None:
         self._fault_injector = fault_injector
         root_path = Path(root).absolute()
-        _mkdir_durable(root_path)
         with ExitStack() as stack:
-            self._root_descriptor = os.open(root_path, _DIRECTORY_FLAGS)
+            self._root_descriptor = _open_root(root_path)
             stack.callback(os.close, self._root_descriptor)
             self._ensure_layout()
             self._recover_startup()

--- a/packages/cnes_infra/src/cnes_infra/object_store/s3.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/s3.py
@@ -1,0 +1,157 @@
+"""Object store imutável sobre S3."""
+
+from __future__ import annotations
+
+from base64 import b64encode
+from dataclasses import dataclass
+from tempfile import TemporaryFile
+from typing import TYPE_CHECKING, Any, Literal
+
+from botocore.exceptions import ClientError
+
+from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.ports.object_store import ObjectStat
+from cnes_infra.object_store._common import require_digest, stream_with_digest, validate_key
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager as ContextManager
+    from datetime import datetime
+    from typing import BinaryIO
+
+
+def _error_code(error: ClientError) -> str:
+    return str(error.response.get("Error", {}).get("Code", ""))
+
+
+def _is_missing(error: ClientError) -> bool:
+    return _error_code(error) in {"404", "NoSuchKey", "NotFound"}
+
+
+@dataclass(frozen=True, slots=True)
+class _StoredObject:
+    stat: ObjectStat
+    metadata_sha256: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class S3Retention:
+    """Configura retenção enviada ao S3."""
+
+    mode: Literal["GOVERNANCE", "COMPLIANCE"]
+    retain_until: datetime
+
+
+class S3ObjectStore:
+    def __init__(
+        self, client: Any, bucket: str, prefix: str = "", retention: S3Retention | None = None
+    ) -> None:
+        self._client = client
+        self._bucket = bucket
+        self._prefix = prefix.strip("/")
+        self._retention = retention
+
+    def _key(self, key: str) -> str:
+        validate_key(key)
+        return f"{self._prefix}/{key}" if self._prefix else key
+
+    def _read_stored(self, key: str) -> _StoredObject | None:
+        try:
+            response = self._client.get_object(Bucket=self._bucket, Key=self._key(key))
+        except ClientError as error:
+            if _is_missing(error):
+                return None
+            raise
+        with response["Body"] as body:
+            size, digest = stream_with_digest(body)
+        stat = ObjectStat(key=key, size_bytes=size, sha256=digest)
+        metadata_sha256 = response.get("Metadata", {}).get("sha256")
+        return _StoredObject(stat=stat, metadata_sha256=metadata_sha256)
+
+    def _read_stat(self, key: str) -> ObjectStat | None:
+        stored = self._read_stored(key)
+        return None if stored is None else stored.stat
+
+    def _put_request(self, key: str, staged: BinaryIO, expected_sha256: str) -> dict[str, Any]:
+        request = {
+            "Body": staged,
+            "Bucket": self._bucket,
+            "IfNoneMatch": "*",
+            "Key": self._key(key),
+            "Metadata": {"sha256": expected_sha256},
+        }
+        if self._retention is not None:
+            request.update(
+                ChecksumAlgorithm="SHA256",
+                ChecksumSHA256=b64encode(bytes.fromhex(expected_sha256)).decode(),
+                ObjectLockMode=self._retention.mode,
+                ObjectLockRetainUntilDate=self._retention.retain_until,
+            )
+        return request
+
+    def _validate_response_checksum(self, response: dict[str, Any], expected_sha256: str) -> None:
+        if self._retention is None:
+            return
+        actual = response.get("ChecksumSHA256")
+        if actual is None:
+            raise ValueError("checksum_response_missing")
+        expected = b64encode(bytes.fromhex(expected_sha256)).decode()
+        if actual != expected:
+            raise ValueError("checksum_response_mismatch")
+
+    def _put_staged(
+        self, key: str, staged: BinaryIO, size: int, expected_sha256: str
+    ) -> ObjectStat:
+        attempt = 0
+        while True:
+            staged.seek(0)
+            try:
+                response = self._client.put_object(
+                    **self._put_request(key, staged, expected_sha256)
+                )
+            except ClientError as error:
+                code = _error_code(error)
+                if code == "BadDigest":
+                    raise ValueError("checksum_rejected") from error
+                if code not in {"ConditionalRequestConflict", "PreconditionFailed"}:
+                    raise
+                existing = self._read_stored(key)
+                if existing is not None:
+                    values = (
+                        existing.stat.size_bytes,
+                        existing.stat.sha256,
+                        existing.metadata_sha256,
+                    )
+                    if values != (size, expected_sha256, expected_sha256):
+                        raise Conflict("immutable_object") from error
+                    return existing.stat
+                if code == "PreconditionFailed" or attempt == 2:
+                    raise Conflict("conditional_request_conflict") from error
+                attempt += 1
+                continue
+            self._validate_response_checksum(response, expected_sha256)
+            return ObjectStat(key=key, size_bytes=size, sha256=expected_sha256)
+
+    def put(self, key: str, body: BinaryIO, expected_sha256: str) -> ObjectStat:
+        validate_key(key)
+        with TemporaryFile("w+b") as staged:
+            size, digest = stream_with_digest(body, staged)
+            require_digest(digest, expected_sha256)
+            staged.seek(0)
+            return self._put_staged(key, staged, size, digest)
+
+    def open(self, key: str) -> ContextManager[BinaryIO]:
+        response = self._client.get_object(Bucket=self._bucket, Key=self._key(key))
+        return response["Body"]
+
+    def stat(self, key: str) -> ObjectStat | None:
+        validate_key(key)
+        return self._read_stat(key)
+
+    def promote(self, source_key: str, destination_key: str, expected_sha256: str) -> ObjectStat:
+        validate_key(source_key)
+        validate_key(destination_key)
+        with self.open(source_key) as source:
+            return self.put(destination_key, source, expected_sha256)
+
+    def delete(self, key: str) -> None:
+        self._client.delete_object(Bucket=self._bucket, Key=self._key(key))

--- a/packages/cnes_infra/src/cnes_infra/object_store/s3.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/s3.py
@@ -31,6 +31,7 @@ def _is_missing(error: ClientError) -> bool:
 class _StoredObject:
     stat: ObjectStat
     metadata_sha256: str | None
+    version_id: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,7 +70,11 @@ class S3ObjectStore:
             size, digest = stream_with_digest(body)
         stat = ObjectStat(key=key, size_bytes=size, sha256=digest)
         metadata_sha256 = response.get("Metadata", {}).get("sha256")
-        return _StoredObject(stat=stat, metadata_sha256=metadata_sha256)
+        return _StoredObject(
+            stat=stat,
+            metadata_sha256=metadata_sha256,
+            version_id=response.get("VersionId"),
+        )
 
     def _read_stat(self, key: str) -> ObjectStat | None:
         stored = self._read_stored(key)
@@ -102,11 +107,17 @@ class S3ObjectStore:
         if actual != expected:
             raise ValueError("checksum_response=mismatch")
 
-    def _validate_replay_retention(self, key: str) -> None:
+    def _validate_replay_retention(self, key: str, version_id: str | None) -> None:
         requested = self._retention
         if requested is None:
             return
-        response = self._client.get_object_retention(Bucket=self._bucket, Key=self._key(key))
+        if not version_id:
+            raise Conflict("retention_version=missing")
+        response = self._client.get_object_retention(
+            Bucket=self._bucket,
+            Key=self._key(key),
+            VersionId=version_id,
+        )
         existing = response.get("Retention", {})
         retain_until = existing.get("RetainUntilDate")
         sufficient_until = (
@@ -140,7 +151,7 @@ class S3ObjectStore:
                     )
                     if values != (size, expected_sha256, expected_sha256):
                         raise Conflict("object=immutable") from error
-                    self._validate_replay_retention(key)
+                    self._validate_replay_retention(key, existing.version_id)
                     return existing.stat
                 if code == "PreconditionFailed" or attempt == 2:
                     raise Conflict("conditional_request=conflict") from error

--- a/packages/cnes_infra/src/cnes_infra/object_store/s3.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/s3.py
@@ -93,10 +93,10 @@ class S3ObjectStore:
             return
         actual = response.get("ChecksumSHA256")
         if actual is None:
-            raise ValueError("checksum_response_missing")
+            raise ValueError("checksum_response=missing")
         expected = b64encode(bytes.fromhex(expected_sha256)).decode()
         if actual != expected:
-            raise ValueError("checksum_response_mismatch")
+            raise ValueError("checksum_response=mismatch")
 
     def _put_staged(
         self, key: str, staged: BinaryIO, size: int, expected_sha256: str
@@ -111,7 +111,7 @@ class S3ObjectStore:
             except ClientError as error:
                 code = _error_code(error)
                 if code == "BadDigest":
-                    raise ValueError("checksum_rejected") from error
+                    raise ValueError("checksum=rejected") from error
                 if code not in {"ConditionalRequestConflict", "PreconditionFailed"}:
                     raise
                 existing = self._read_stored(key)
@@ -122,10 +122,10 @@ class S3ObjectStore:
                         existing.metadata_sha256,
                     )
                     if values != (size, expected_sha256, expected_sha256):
-                        raise Conflict("immutable_object") from error
+                        raise Conflict("object=immutable") from error
                     return existing.stat
                 if code == "PreconditionFailed" or attempt == 2:
-                    raise Conflict("conditional_request_conflict") from error
+                    raise Conflict("conditional_request=conflict") from error
                 attempt += 1
                 continue
             self._validate_response_checksum(response, expected_sha256)

--- a/packages/cnes_infra/src/cnes_infra/object_store/s3.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/s3.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from base64 import b64encode
 from dataclasses import dataclass
+from datetime import datetime
 from tempfile import TemporaryFile
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -15,7 +16,6 @@ from cnes_infra.object_store._common import require_digest, stream_with_digest, 
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager as ContextManager
-    from datetime import datetime
     from typing import BinaryIO
 
 
@@ -98,6 +98,19 @@ class S3ObjectStore:
         if actual != expected:
             raise ValueError("checksum_response=mismatch")
 
+    def _validate_replay_retention(self, key: str) -> None:
+        requested = self._retention
+        if requested is None:
+            return
+        response = self._client.get_object_retention(Bucket=self._bucket, Key=self._key(key))
+        existing = response.get("Retention", {})
+        retain_until = existing.get("RetainUntilDate")
+        sufficient_until = (
+            isinstance(retain_until, datetime) and retain_until >= requested.retain_until
+        )
+        if existing.get("Mode") != requested.mode or not sufficient_until:
+            raise Conflict("retention=insufficient")
+
     def _put_staged(
         self, key: str, staged: BinaryIO, size: int, expected_sha256: str
     ) -> ObjectStat:
@@ -123,6 +136,7 @@ class S3ObjectStore:
                     )
                     if values != (size, expected_sha256, expected_sha256):
                         raise Conflict("object=immutable") from error
+                    self._validate_replay_retention(key)
                     return existing.stat
                 if code == "PreconditionFailed" or attempt == 2:
                     raise Conflict("conditional_request=conflict") from error

--- a/packages/cnes_infra/src/cnes_infra/object_store/s3.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/s3.py
@@ -40,6 +40,10 @@ class S3Retention:
     mode: Literal["GOVERNANCE", "COMPLIANCE"]
     retain_until: datetime
 
+    def __post_init__(self) -> None:
+        if self.retain_until.utcoffset() is None:
+            raise ValueError("retain_until=naive")
+
 
 class S3ObjectStore:
     def __init__(

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -1,0 +1,256 @@
+"""Conformidade do armazenamento de objetos no filesystem."""
+
+import errno
+import fcntl
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.object_store.filesystem import FilesystemObjectStore
+from packages.cnes_infra.tests.contracts.clock import MutableClock
+from packages.cnes_infra.tests.contracts.object_store_contract import (
+    ObjectStoreCase,
+    object_store_cases,
+)
+
+_DURABLE_BOUNDARIES = (
+    "temporary_created",
+    "file_fsynced",
+    "destination_linked",
+    "directory_fsynced",
+    "temporary_unlinked",
+    "directory_final_fsynced",
+)
+
+
+class _SimulatedCrash(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class _CrashAt:
+    boundary: str
+    triggered: bool = False
+
+    def __call__(self, boundary: str) -> None:
+        if boundary == self.boundary and not self.triggered:
+            self.triggered = True
+            raise _SimulatedCrash(boundary)
+
+
+def _adapter_temporaries(root: Path) -> tuple[Path, ...]:
+    return tuple(root.rglob(".cnes-object-store-*.tmp"))
+
+
+def _process_put(root: str, body: bytes, barrier: Any, results: Any) -> None:
+    expected = sha256(body).hexdigest()
+    barrier.wait()
+    try:
+        stat = FilesystemObjectStore(root).put("raw/race", BytesIO(body), expected)
+        results.put(("ok", stat.sha256))
+    except Conflict:
+        results.put(("conflict", expected))
+
+
+def _process_paused_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
+    reached, release, results = controls
+
+    def pause(boundary: str) -> None:
+        if boundary == "temporary_created":
+            reached.set()
+            if not release.wait(timeout=5):
+                raise TimeoutError("release_timeout")
+
+    try:
+        digest = sha256(body).hexdigest()
+        FilesystemObjectStore(root, fault_injector=pause).put("raw/locked", BytesIO(body), digest)
+        results.put("ok")
+    except Exception as error:
+        results.put(type(error).__name__)
+
+
+@pytest.mark.parametrize("case", object_store_cases(), ids=lambda case: case.name)
+def test_cumpre_contrato_compartilhado(
+    case: ObjectStoreCase, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    root = tmp_path_factory.mktemp(case.name)
+    clock = MutableClock(datetime(2026, 7, 15, tzinfo=UTC))
+
+    case.run(FilesystemObjectStore(root), clock)
+
+
+@pytest.mark.parametrize("operation", ["put", "promote"])
+@pytest.mark.parametrize("boundary", _DURABLE_BOUNDARIES)
+def test_recupera_cada_fronteira_duravel_sem_apagar_arquivo_alheio(
+    boundary: str, operation: str, tmp_path: Path
+) -> None:
+    body = b"conteudo-completo"
+    expected = sha256(body).hexdigest()
+    unrelated = tmp_path / ".arquivo-do-usuario"
+    unrelated.write_bytes(b"preservar")
+    source_key = "staging/dados.parquet"
+    if operation == "promote":
+        FilesystemObjectStore(tmp_path).put(source_key, BytesIO(body), expected)
+    crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt(boundary))
+
+    def perform() -> None:
+        if operation == "put":
+            crashing.put("raw/dados.parquet", BytesIO(body), expected)
+        else:
+            crashing.promote(source_key, "raw/dados.parquet", expected)
+
+    with pytest.raises(_SimulatedCrash, match=boundary):
+        perform()
+
+    recovered = FilesystemObjectStore(tmp_path)
+    current = recovered.stat("raw/dados.parquet")
+    assert current is None or (current.size_bytes, current.sha256) == (len(body), expected)
+    assert recovered.put("raw/dados.parquet", BytesIO(body), expected).sha256 == expected
+    with recovered.open("raw/dados.parquet") as stream:
+        assert stream.read() == body
+    assert _adapter_temporaries(tmp_path) == ()
+    assert unrelated.read_bytes() == b"preservar"
+
+
+def test_remove_temporario_perdedor_sem_tocar_destino_valido(tmp_path: Path) -> None:
+    losing = b"perdedor"
+    winner = b"vencedor"
+    key = "raw/dados.parquet"
+    crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
+
+    with pytest.raises(_SimulatedCrash):
+        crashing.put(key, BytesIO(losing), sha256(losing).hexdigest())
+    destination = tmp_path / key
+    destination.write_bytes(winner)
+
+    recovered = FilesystemObjectStore(tmp_path)
+    with pytest.raises(Conflict, match="immutable_object"):
+        recovered.put(key, BytesIO(losing), sha256(losing).hexdigest())
+
+    assert destination.read_bytes() == winner
+    assert _adapter_temporaries(tmp_path) == ()
+
+
+def test_rejeita_destino_invalido_sem_remove_lo_na_recuperacao(tmp_path: Path) -> None:
+    body = b"conteudo"
+    key = "raw/dados.parquet"
+    crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
+
+    with pytest.raises(_SimulatedCrash):
+        crashing.put(key, BytesIO(body), sha256(body).hexdigest())
+    destination = tmp_path / key
+    destination.mkdir()
+
+    with pytest.raises(Conflict, match="invalid_destination"):
+        FilesystemObjectStore(tmp_path).put(key, BytesIO(body), sha256(body).hexdigest())
+
+    assert destination.is_dir()
+
+
+def test_remove_staging_quando_sha256_diverge(tmp_path: Path) -> None:
+    adapter = FilesystemObjectStore(tmp_path)
+
+    with pytest.raises(ValueError, match="sha256_mismatch"):
+        adapter.put("raw/invalido", BytesIO(b"conteudo"), sha256(b"outro").hexdigest())
+
+    assert adapter.stat("raw/invalido") is None
+    assert _adapter_temporaries(tmp_path) == ()
+
+
+def test_nao_faz_fallback_quando_hard_link_e_incompativel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    body = b"conteudo"
+    adapter = FilesystemObjectStore(tmp_path)
+
+    def reject_link(source: Path, destination: Path) -> None:
+        raise OSError(errno.EPERM, "hard_link_incompativel")
+
+    monkeypatch.setattr(os, "link", reject_link)
+
+    with pytest.raises(OSError, match="hard_link_incompativel"):
+        adapter.put("raw/sem-fallback", BytesIO(body), sha256(body).hexdigest())
+
+    assert adapter.stat("raw/sem-fallback") is None
+    assert _adapter_temporaries(tmp_path) == ()
+
+
+def test_delete_de_chave_ausente_e_idempotente(tmp_path: Path) -> None:
+    adapter = FilesystemObjectStore(tmp_path)
+
+    adapter.delete("raw/ausente")
+
+    assert adapter.stat("raw/ausente") is None
+
+
+@pytest.mark.linux_only
+def test_lock_do_destino_bloqueia_outro_processo_durante_staging(tmp_path: Path) -> None:
+    import multiprocessing
+
+    context = multiprocessing.get_context("spawn")
+    reached = context.Event()
+    release = context.Event()
+    results = context.Queue()
+    process = context.Process(
+        target=_process_paused_put,
+        args=(str(tmp_path), b"conteudo", (reached, release, results)),
+    )
+    process.start()
+    assert reached.wait(timeout=5)
+    lock_path = next(tmp_path.rglob(".cnes-object-store-*.lock"))
+
+    with lock_path.open("a+b") as lock:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    release.set()
+    process.join(timeout=10)
+    assert process.exitcode == 0
+    assert results.get(timeout=2) == "ok"
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("identical", [True, False], ids=["identicos", "conflitantes"])
+def test_corrida_entre_processos_publica_um_destino_completo(
+    identical: bool, tmp_path: Path
+) -> None:
+    import multiprocessing
+
+    context = multiprocessing.get_context("spawn")
+    bodies = (b"a" * (2 * 1024 * 1024),) * 2 if identical else (b"a" * 1024, b"b" * 2048)
+    barrier = context.Barrier(3)
+    results = context.Queue()
+    processes = [
+        context.Process(target=_process_put, args=(str(tmp_path), body, barrier, results))
+        for body in bodies
+    ]
+    for process in processes:
+        process.start()
+    barrier.wait()
+    observed = []
+    while any(process.is_alive() for process in processes):
+        try:
+            with FilesystemObjectStore(tmp_path).open("raw/race") as stream:
+                observed.append(stream.read())
+        except FileNotFoundError:
+            pass
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    outcomes = [results.get(timeout=2)[0] for _ in processes]
+    with FilesystemObjectStore(tmp_path).open("raw/race") as stream:
+        published = stream.read()
+    assert published in bodies
+    assert outcomes.count("ok") == (2 if identical else 1)
+    assert outcomes.count("conflict") == (0 if identical else 1)
+    assert all(content in bodies for content in observed)
+    assert sha256(published).hexdigest() == FilesystemObjectStore(tmp_path).stat("raw/race").sha256
+    assert _adapter_temporaries(tmp_path) == ()

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -103,7 +103,6 @@ def test_contrato(case: contract.ObjectStoreCase, tmp_path_factory: pytest.TempP
         patch.chdir(root)
         case.run(adapter, MutableClock(datetime(2026, 7, 15, tzinfo=UTC)))
 
-
 @pytest.mark.linux_only
 def test_fsynca_ancestral(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root, observed, real_fsync = tmp_path / "store", [], os.fsync
@@ -130,7 +129,6 @@ def test_fsynca_ancestral(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     adapter.delete("raw/ausente")
     assert observed == [destination.parent]
 
-
 def test_fecha_diretorio_se_fsync_do_parent_falha(monkeypatch: pytest.MonkeyPatch) -> None:
     close = MagicMock()
     monkeypatch.setattr(os, "mkdir", MagicMock())
@@ -140,7 +138,6 @@ def test_fecha_diretorio_se_fsync_do_parent_falha(monkeypatch: pytest.MonkeyPatc
     with pytest.raises(OSError, match="fsync=failed"):
         _open_or_create_directory(3, "objects")
     close.assert_called_once_with(7)
-
 
 @pytest.mark.parametrize("operation", ["put", "promote"])
 @pytest.mark.parametrize("boundary", _DURABLE_BOUNDARIES)
@@ -344,7 +341,7 @@ def test_recuperacao_preserva_destino_existente(kind: str, tmp_path: Path) -> No
         FilesystemObjectStore(tmp_path).put(key, BytesIO(losing), sha256(losing).hexdigest())
     assert destination.read_bytes() == winner if kind == "file" else destination.is_dir()
     assert kind != "file" or _adapter_temporaries(tmp_path) == ()
-@pytest.mark.parametrize("kind", ["directory", "fifo"])
+@pytest.mark.parametrize("kind", ["directory", "fifo", "symlink"])
 def test_startup_descarta_temp_ante_destino_malformado(kind: str, tmp_path: Path) -> None:
     bad_key, other_key, body = "raw/malformado", "raw/outro", b"conteudo"
     writers = (
@@ -355,9 +352,14 @@ def test_startup_descarta_temp_ante_destino_malformado(kind: str, tmp_path: Path
         with pytest.raises(_SimulatedCrash):
             writer.put(key, BytesIO(body), sha256(body).hexdigest())
     destination = _objects_directory(tmp_path) / sha256(bad_key.encode()).hexdigest()
-    destination.mkdir() if kind == "directory" else os.mkfifo(destination)
+    if kind == "directory":
+        destination.mkdir()
+    elif kind == "fifo":
+        os.mkfifo(destination)
+    else:
+        destination.symlink_to("malformed")
     recovered = FilesystemObjectStore(tmp_path)
-    assert destination.is_dir() if kind == "directory" else destination.is_fifo()
+    assert destination.is_symlink() if kind == "symlink" else destination.exists()
     assert (_adapter_temporaries(tmp_path), recovered.stat(other_key)) == ((), None)
     with pytest.raises(Conflict, match="destination=invalid"):
         recovered.stat(bad_key)
@@ -436,7 +438,6 @@ def test_sem_fallback(link_kind: str, tmp_path: Path, monkeypatch: pytest.Monkey
     assert adapter.stat("raw/sem-fallback") is None
     assert _adapter_temporaries(tmp_path) == (() if attacker is None else (attacker,))
     assert attacker is None or attacker.read_bytes() == b"preservar"
-
 
 @pytest.mark.linux_only
 def test_startup_recupera_apos_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -22,8 +22,7 @@ from packages.cnes_infra.tests.contracts.clock import MutableClock
 
 _DURABLE_BOUNDARIES = (
     "temporary_created", "file_fsynced", "destination_linked", "directory_fsynced",
-    "temporary_unlinked", "directory_final_fsynced",
-)
+    "temporary_unlinked", "directory_final_fsynced",)
 _OWNER_XATTR = "user.cnes_object_store_destination"
 
 
@@ -122,21 +121,18 @@ def test_contrato(case: contract.ObjectStoreCase, tmp_path_factory: pytest.TempP
         adapter = FilesystemObjectStore(root.name)
         patch.chdir(root)
         case.run(adapter, MutableClock(datetime(2026, 7, 15, tzinfo=UTC)))
-        adapter.delete("raw/ausente")
 
 
 @pytest.mark.linux_only
 def test_fsynca_ancestral(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    root = tmp_path / "store"
-    observed: list[Path] = []
-    real_fsync = os.fsync
+    root, observed, real_fsync = tmp_path / "store", [], os.fsync
     def observe_fsync(descriptor: int) -> None:
         target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
         if target.is_dir():
             observed.append(target)
         real_fsync(descriptor)
     monkeypatch.setattr(os, "fsync", observe_fsync)
-    FilesystemObjectStore(root)
+    adapter = FilesystemObjectStore(root)
     assert observed[:4] == [tmp_path.parent, tmp_path, root, next(root.iterdir())]
     observed.clear()
     FilesystemObjectStore(root)
@@ -144,16 +140,20 @@ def test_fsynca_ancestral(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     observed.clear()
     FilesystemObjectStore(root / "nested")
     assert observed[:2] == [tmp_path, root]
+    destination = _objects_directory(root) / sha256(b"raw/ausente").hexdigest()
+    destination.touch()
+    destination.unlink()
+    observed.clear()
+    adapter.delete("raw/ausente")
+    assert observed == [destination.parent]
 
 
 @pytest.mark.parametrize("operation", ["put", "promote"])
 @pytest.mark.parametrize("boundary", _DURABLE_BOUNDARIES)
 def test_recupera_fronteira_duravel(boundary: str, operation: str, tmp_path: Path) -> None:
-    body = b"conteudo-completo"
-    expected = sha256(body).hexdigest()
-    unrelated = tmp_path / ".arquivo-do-usuario"
+    body, expected = b"conteudo-completo", sha256(b"conteudo-completo").hexdigest()
+    unrelated, source_key = tmp_path / ".arquivo-do-usuario", "staging/dados.parquet"
     unrelated.write_bytes(b"preservar")
-    source_key = "staging/dados.parquet"
     FilesystemObjectStore(tmp_path).put(source_key, BytesIO(body), expected)
     crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt(boundary))
     def perform() -> None:

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -24,6 +24,7 @@ from packages.cnes_infra.tests.contracts.clock import MutableClock
 _DURABLE_BOUNDARIES = ("temporary_created_before_ownership", "temporary_created", "file_fsynced",
     "destination_linked", "directory_fsynced",
     "temporary_unlinked", "directory_final_fsynced",)
+_INTERNAL = ".cnes-object-store-internal"
 _OWNER_XATTR = "user.cnes_object_store_destination"
 
 
@@ -365,8 +366,7 @@ def test_fifo_final_nao_bloqueia(tmp_path: Path) -> None:
     FilesystemObjectStore(tmp_path)
     fifo = _objects_directory(tmp_path) / sha256(key.encode()).hexdigest()
     os.mkfifo(fifo)
-    context = multiprocessing.get_context("spawn")
-    results = context.Queue()
+    results = (context := multiprocessing.get_context("spawn")).Queue()
     process = context.Process(target=_process_final, args=(str(tmp_path), results))
     process.start()
     process.join(timeout=1)
@@ -385,19 +385,19 @@ def test_chaves_prefixadas_coexistem(order: tuple[str, str], tmp_path: Path) -> 
         adapter.put(key, BytesIO(bodies[key]), sha256(bodies[key]).hexdigest())
     with adapter.open("a") as parent, adapter.open("a/b") as child:
         assert (parent.read(), child.read()) == (b"pai", b"filho")
-    lock_key = f".cnes-object-store-{sha256(b'a').hexdigest()}.lock"
-    assert adapter.stat(lock_key) is None
-    adapter.put(lock_key, BytesIO(b"lock"), sha256(b"lock").hexdigest())
-    assert adapter.stat(lock_key) is not None
-
-
-def test_root_aberto_nao_segue_ancestral_substituido(tmp_path: Path) -> None:
-    parent, replacement = tmp_path / "original", tmp_path / "replacement"
-    adapter = FilesystemObjectStore(parent / "store")
-    parent.rename(tmp_path / "moved")
-    parent.symlink_to(replacement, target_is_directory=True)
-    adapter.put("raw/objeto", BytesIO(b"conteudo"), sha256(b"conteudo").hexdigest())
-    assert not replacement.exists()
+@pytest.mark.parametrize("relative", ["", _INTERNAL, f"{_INTERNAL}/objects", f"{_INTERNAL}/locks"])
+def test_descritores_nao_seguem_layout_substituido(relative: str, tmp_path: Path) -> None:
+    descriptor_count, parent = len(os.listdir("/proc/self/fd")), tmp_path / "original"
+    adapter = FilesystemObjectStore(root := parent / "store")
+    target = root / relative if relative else parent
+    target.rename(tmp_path / "moved")
+    target.mkdir()
+    key = f".cnes-object-store-{sha256(b'a').hexdigest()}.lock"
+    adapter.put(key, BytesIO(b"conteudo"), sha256(b"conteudo").hexdigest())
+    assert tuple(target.iterdir()) == ()
+    assert adapter.stat(key) is not None
+    del adapter
+    assert len(os.listdir("/proc/self/fd")) == descriptor_count
 
 
 def test_construtor_rejeita_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -30,8 +30,7 @@ _DURABLE_BOUNDARIES = ("temporary_created", "file_fsynced", "destination_linked"
 _OWNER_XATTR = "user.cnes_object_store_destination"
 
 
-class _SimulatedCrash(RuntimeError):
-    pass
+class _SimulatedCrash(RuntimeError): ...
 
 
 @dataclass(slots=True)
@@ -195,7 +194,6 @@ def test_crash_pre_marker_nao_deixa_temporario(tmp_path: Path) -> None:
         tmp_path, fault_injector=_CrashAt("temporary_created_before_ownership")
     )
     body = b"conteudo"
-
     with pytest.raises(_SimulatedCrash, match="boundary=temporary_created_before_ownership"):
         crashing.put("raw/dados.parquet", BytesIO(body), sha256(body).hexdigest())
     assert _adapter_temporaries(tmp_path) == ()
@@ -282,13 +280,13 @@ def test_reabertura_propaga_erro_ao_ler_ownership(
     assert candidate.read_bytes() == b"preservar"
 
 
-@pytest.mark.parametrize("failure", ["ownership", "read", "write", "flush", "fsync", "checksum"])
+@pytest.mark.parametrize("failure", ["owner", "read", "write", "flush", "fsync", "sha", "dir"])
 def test_falha_ordinaria_de_staging_remove_temporario_e_fsynca_diretorio(
     failure: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     adapter = FilesystemObjectStore(tmp_path)
     body = MagicMock(wraps=BytesIO(b"conteudo"))
-    if failure == "ownership":
+    if failure == "owner":
         monkeypatch.setattr(
             os,
             "setxattr",
@@ -318,6 +316,8 @@ def test_falha_ordinaria_de_staging_remove_temporario_e_fsynca_diretorio(
         target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
         if target.is_dir():
             directory_fsyncs += target == _objects_directory(tmp_path)
+            if failure == "dir" and directory_fsyncs == 1:
+                raise OSError(errno.EIO, "staging=failed")
         else:
             regular_fsyncs += 1
             if failure == "fsync" and regular_fsyncs == 2:
@@ -325,14 +325,14 @@ def test_falha_ordinaria_de_staging_remove_temporario_e_fsynca_diretorio(
         real_fsync(descriptor)
 
     monkeypatch.setattr(os, "fsync", failing_fsync)
-    expected = sha256(b"outro" if failure == "checksum" else b"conteudo").hexdigest()
-    error = ValueError if failure == "checksum" else OSError
-    message = "sha256=mismatch" if failure == "checksum" else "staging=failed"
+    expected = sha256(b"outro" if failure == "sha" else b"conteudo").hexdigest()
+    error = ValueError if failure == "sha" else OSError
+    message = "sha256=mismatch" if failure == "sha" else "staging=failed"
     with pytest.raises(error, match=message):
         adapter.put("raw/dados.parquet", body, expected)
 
     assert _adapter_temporaries(tmp_path) == ()
-    assert directory_fsyncs == (0 if failure == "ownership" else 2)
+    assert directory_fsyncs == (0 if failure == "owner" else 2)
 
 
 @pytest.mark.parametrize("kind", ["file", "directory"])

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -201,8 +201,6 @@ def test_scan_ignora_temp_removido(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(os, "open", vanish_before_open)
     FilesystemObjectStore(tmp_path)
     assert removed == [temporary]
-
-
 def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: Path) -> None:
     body, digest = b"conteudo", sha256(b"conteudo").hexdigest()
     adapter = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
@@ -212,8 +210,6 @@ def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: 
     assert _adapter_temporaries(tmp_path) == ()
     with adapter.open("raw/dados.parquet") as stream:
         assert stream.read() == body
-
-
 @pytest.mark.parametrize("alias_kind", ["hard_link", "symlink"])
 @pytest.mark.parametrize("recovery", ["startup", "pre_write"])
 def test_recuperacao_preserva_alias_legal(alias_kind: str, recovery: str, tmp_path: Path) -> None:
@@ -232,8 +228,6 @@ def test_recuperacao_preserva_alias_legal(alias_kind: str, recovery: str, tmp_pa
     else:
         adapter.put(key, BytesIO(body), digest)
     assert (alias.is_symlink(), alias.read_bytes()) == (alias_kind == "symlink", body)
-
-
 def test_reabertura_ignora_owner_invalido(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     FilesystemObjectStore(tmp_path)
     directory = _objects_directory(tmp_path)
@@ -272,8 +266,6 @@ def test_reabertura_ignora_owner_invalido(tmp_path: Path, monkeypatch: pytest.Mo
     assert fifo.exists()
     with pytest.raises(ValueError, match="object_key=invalid"):
         adapter.stat(nul_key)
-
-
 @pytest.mark.parametrize("caller", ["startup", "pre_write"])
 @pytest.mark.parametrize("failure", ["open", "fstat", "xattr"])
 def test_inspecao_de_ownership_fecha_fd(
@@ -300,9 +292,8 @@ def test_inspecao_de_ownership_fecha_fd(
         else (adapter.put, (key, BytesIO(body), sha256(body).hexdigest())))
     with pytest.raises(OSError, match="inspection=failed"):
         target(*args)
-    assert (len(os.listdir("/proc/self/fd")), candidate.read_bytes()) == (descriptor_count, body)
-
-
+    assert len(os.listdir("/proc/self/fd")) <= descriptor_count
+    assert candidate.read_bytes() == body
 @pytest.mark.parametrize("mode", ["owner", "read", "write", "flush", "fsync", "sha", "dir", "dst"])
 def test_falha_staging(mode: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     adapter, body = FilesystemObjectStore(tmp_path), MagicMock(wraps=BytesIO(b"conteudo"))
@@ -343,8 +334,21 @@ def test_falha_staging(mode: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatc
         adapter.put("raw/dados.parquet", body, expected)
     expected_fsyncs = 0 if mode == "owner" else 3 if mode == "dst" else 2
     assert (_adapter_temporaries(tmp_path), directory_fsyncs) == ((), expected_fsyncs)
-
-
+def test_publica_inode_hasheado_apos_staging_substituido(tmp_path: Path) -> None:
+    body, expected, observed = b"conteudo-confiavel", sha256(b"conteudo-confiavel").hexdigest(), []
+    def replace_staging(boundary: str) -> None:
+        if boundary != "file_fsynced":
+            return
+        temporary = _adapter_temporaries(tmp_path)[0]
+        observed.append(temporary.stat().st_ino)
+        (replacement := tmp_path / "replacement").write_bytes(b"conteudo-atacante")
+        temporary.rename(tmp_path / "displaced")
+        replacement.replace(temporary)
+    FilesystemObjectStore(tmp_path, fault_injector=replace_staging).put(
+        "raw/dados.parquet", BytesIO(body), expected)
+    destination = _objects_directory(tmp_path) / sha256(b"raw/dados.parquet").hexdigest()
+    actual = sha256(destination.read_bytes()).hexdigest(), destination.stat().st_ino
+    assert actual == (expected, observed[0])
 @pytest.mark.parametrize("kind", ["file", "directory"])
 def test_recuperacao_preserva_destino_existente(kind: str, tmp_path: Path) -> None:
     losing, winner, key = b"perdedor", b"vencedor", "raw/dados.parquet"
@@ -358,8 +362,6 @@ def test_recuperacao_preserva_destino_existente(kind: str, tmp_path: Path) -> No
         FilesystemObjectStore(tmp_path).put(key, BytesIO(losing), sha256(losing).hexdigest())
     assert destination.read_bytes() == winner if kind == "file" else destination.is_dir()
     assert kind != "file" or _adapter_temporaries(tmp_path) == ()
-
-
 @pytest.mark.linux_only
 def test_fifo_final_nao_bloqueia(tmp_path: Path) -> None:
     key = "raw/dados.parquet"
@@ -376,8 +378,6 @@ def test_fifo_final_nao_bloqueia(tmp_path: Path) -> None:
     assert (process.exitcode, fifo.is_fifo()) == (0, True)
     assert [results.get(timeout=1) for _ in range(5)] == [("Conflict", "destination=invalid")] * 5
     assert _adapter_temporaries(tmp_path) == ()
-
-
 @pytest.mark.parametrize("order", [("a", "a/b"), ("a/b", "a")])
 def test_chaves_prefixadas_coexistem(order: tuple[str, str], tmp_path: Path) -> None:
     adapter, bodies = FilesystemObjectStore(tmp_path), {"a": b"pai", "a/b": b"filho"}
@@ -398,8 +398,6 @@ def test_descritores_nao_seguem_layout_substituido(relative: str, tmp_path: Path
     assert adapter.stat(key) is not None
     del adapter
     assert len(os.listdir("/proc/self/fd")) == descriptor_count
-
-
 def test_construtor_rejeita_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     parent, attacker = tmp_path / "original", tmp_path / "attacker"
     root = parent / "store"
@@ -417,8 +415,6 @@ def test_construtor_rejeita_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     with pytest.raises(OSError):
         FilesystemObjectStore(root)
     assert (parent.is_symlink(), tuple((attacker / "store").iterdir())) == (True, ())
-
-
 @pytest.mark.parametrize("link_kind", ["staging", "publication"])
 def test_sem_fallback(link_kind: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     body, adapter = b"conteudo", FilesystemObjectStore(tmp_path)
@@ -431,7 +427,11 @@ def test_sem_fallback(link_kind: str, tmp_path: Path, monkeypatch: pytest.Monkey
     else:
         attacker = None
         error = OSError(errno.EPERM, "hard_link=incompatible")
-        monkeypatch.setattr(os, "link", MagicMock(side_effect=error))
+        def fail_publication(boundary: str) -> None:
+            if boundary == "file_fsynced":
+                monkeypatch.setattr(
+                    filesystem, "_link_descriptor", MagicMock(side_effect=error))
+        adapter = FilesystemObjectStore(tmp_path, fault_injector=fail_publication)
     with pytest.raises(OSError):
         adapter.put("raw/sem-fallback", BytesIO(body), sha256(body).hexdigest())
     assert adapter.stat("raw/sem-fallback") is None

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from hashlib import sha256
 from io import BytesIO
 from pathlib import Path
+from threading import Event, Thread
 from typing import Any
 
 import pytest
@@ -42,18 +43,28 @@ class _CrashAt:
     def __call__(self, boundary: str) -> None:
         if boundary == self.boundary and not self.triggered:
             self.triggered = True
-            raise _SimulatedCrash(boundary)
+            raise _SimulatedCrash(f"boundary={boundary}")
 
 
 def _adapter_temporaries(root: Path) -> tuple[Path, ...]:
     return tuple(root.rglob(".cnes-object-store-*.tmp"))
 
 
-def _process_put(root: str, body: bytes, barrier: Any, results: Any) -> None:
+def _process_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
+    barrier, results, destination_linked, reader_done = controls
     expected = sha256(body).hexdigest()
+
+    def wait_for_reader(boundary: str) -> None:
+        if boundary == "destination_linked":
+            destination_linked.set()
+            if not reader_done.wait(timeout=5):
+                raise TimeoutError("reader=timeout")
+
     barrier.wait()
     try:
-        stat = FilesystemObjectStore(root).put("raw/race", BytesIO(body), expected)
+        stat = FilesystemObjectStore(root, fault_injector=wait_for_reader).put(
+            "raw/race", BytesIO(body), expected
+        )
         results.put(("ok", stat.sha256))
     except Conflict:
         results.put(("conflict", expected))
@@ -66,7 +77,7 @@ def _process_paused_put(root: str, body: bytes, controls: tuple[Any, ...]) -> No
         if boundary == "temporary_created":
             reached.set()
             if not release.wait(timeout=5):
-                raise TimeoutError("release_timeout")
+                raise TimeoutError("release=timeout")
 
     try:
         digest = sha256(body).hexdigest()
@@ -74,6 +85,21 @@ def _process_paused_put(root: str, body: bytes, controls: tuple[Any, ...]) -> No
         results.put("ok")
     except Exception as error:
         results.put(type(error).__name__)
+
+
+def _read_during_publication(root: str, controls: tuple[Any, ...]) -> None:
+    reader_ready, destination_linked, reader_done, observed = controls
+    reader_ready.set()
+    if not destination_linked.wait(timeout=5):
+        reader_done.set()
+        return
+    try:
+        with FilesystemObjectStore(root).open("raw/race") as stream:
+            observed.append(stream.read())
+    except FileNotFoundError:
+        pass
+    finally:
+        reader_done.set()
 
 
 @pytest.mark.parametrize("case", object_store_cases(), ids=lambda case: case.name)
@@ -106,7 +132,7 @@ def test_recupera_cada_fronteira_duravel_sem_apagar_arquivo_alheio(
         else:
             crashing.promote(source_key, "raw/dados.parquet", expected)
 
-    with pytest.raises(_SimulatedCrash, match=boundary):
+    with pytest.raises(_SimulatedCrash, match=f"boundary={boundary}"):
         perform()
 
     recovered = FilesystemObjectStore(tmp_path)
@@ -131,7 +157,7 @@ def test_remove_temporario_perdedor_sem_tocar_destino_valido(tmp_path: Path) -> 
     destination.write_bytes(winner)
 
     recovered = FilesystemObjectStore(tmp_path)
-    with pytest.raises(Conflict, match="immutable_object"):
+    with pytest.raises(Conflict, match="object=immutable"):
         recovered.put(key, BytesIO(losing), sha256(losing).hexdigest())
 
     assert destination.read_bytes() == winner
@@ -148,7 +174,7 @@ def test_rejeita_destino_invalido_sem_remove_lo_na_recuperacao(tmp_path: Path) -
     destination = tmp_path / key
     destination.mkdir()
 
-    with pytest.raises(Conflict, match="invalid_destination"):
+    with pytest.raises(Conflict, match="destination=invalid"):
         FilesystemObjectStore(tmp_path).put(key, BytesIO(body), sha256(body).hexdigest())
 
     assert destination.is_dir()
@@ -157,11 +183,16 @@ def test_rejeita_destino_invalido_sem_remove_lo_na_recuperacao(tmp_path: Path) -
 def test_remove_staging_quando_sha256_diverge(tmp_path: Path) -> None:
     adapter = FilesystemObjectStore(tmp_path)
 
-    with pytest.raises(ValueError, match="sha256_mismatch"):
+    with pytest.raises(ValueError, match="sha256=mismatch"):
         adapter.put("raw/invalido", BytesIO(b"conteudo"), sha256(b"outro").hexdigest())
 
     assert adapter.stat("raw/invalido") is None
     assert _adapter_temporaries(tmp_path) == ()
+
+
+def test_rejeita_chave_invalida_com_erro_estruturado(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="object_key=invalid"):
+        FilesystemObjectStore(tmp_path).stat("../fora")
 
 
 def test_nao_faz_fallback_quando_hard_link_e_incompativel(
@@ -171,11 +202,11 @@ def test_nao_faz_fallback_quando_hard_link_e_incompativel(
     adapter = FilesystemObjectStore(tmp_path)
 
     def reject_link(source: Path, destination: Path) -> None:
-        raise OSError(errno.EPERM, "hard_link_incompativel")
+        raise OSError(errno.EPERM, "hard_link=incompatible")
 
     monkeypatch.setattr(os, "link", reject_link)
 
-    with pytest.raises(OSError, match="hard_link_incompativel"):
+    with pytest.raises(OSError, match="hard_link=incompatible"):
         adapter.put("raw/sem-fallback", BytesIO(body), sha256(body).hexdigest())
 
     assert adapter.stat("raw/sem-fallback") is None
@@ -227,20 +258,29 @@ def test_corrida_entre_processos_publica_um_destino_completo(
     bodies = (b"a" * (2 * 1024 * 1024),) * 2 if identical else (b"a" * 1024, b"b" * 2048)
     barrier = context.Barrier(3)
     results = context.Queue()
+    destination_linked = context.Event()
+    reader_done = context.Event()
+    reader_ready = Event()
+    observed: list[bytes] = []
+    reader = Thread(
+        target=_read_during_publication,
+        args=(str(tmp_path), (reader_ready, destination_linked, reader_done, observed)),
+    )
+    reader.start()
+    assert reader_ready.wait(timeout=5)
     processes = [
-        context.Process(target=_process_put, args=(str(tmp_path), body, barrier, results))
+        context.Process(
+            target=_process_put,
+            args=(str(tmp_path), body, (barrier, results, destination_linked, reader_done)),
+        )
         for body in bodies
     ]
     for process in processes:
         process.start()
     barrier.wait()
-    observed = []
-    while any(process.is_alive() for process in processes):
-        try:
-            with FilesystemObjectStore(tmp_path).open("raw/race") as stream:
-                observed.append(stream.read())
-        except FileNotFoundError:
-            pass
+    reader.join(timeout=10)
+    assert not reader.is_alive()
+    assert observed
     for process in processes:
         process.join(timeout=10)
         assert process.exitcode == 0

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -2,6 +2,7 @@
 
 import errno
 import fcntl
+import multiprocessing
 import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -54,13 +55,11 @@ def _objects_directory(root: Path) -> Path:
 def _process_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
     barrier, results, destination_linked, reader_done = controls
     expected = sha256(body).hexdigest()
-
     def wait_for_reader(boundary: str) -> None:
         if boundary == "destination_linked":
             destination_linked.set()
             if not reader_done.wait(timeout=5):
                 raise TimeoutError("reader=timeout")
-
     barrier.wait()
     try:
         stat = FilesystemObjectStore(root, fault_injector=wait_for_reader).put(
@@ -148,13 +147,11 @@ def test_recupera_cada_fronteira_duravel_sem_apagar_arquivo_alheio(
     source_key = "staging/dados.parquet"
     FilesystemObjectStore(tmp_path).put(source_key, BytesIO(body), expected)
     crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt(boundary))
-
     def perform() -> None:
         if operation == "put":
             crashing.put("raw/dados.parquet", BytesIO(body), expected)
         else:
             crashing.promote(source_key, "raw/dados.parquet", expected)
-
     with pytest.raises(_SimulatedCrash, match=f"boundary={boundary}"):
         perform()
     recovered = FilesystemObjectStore(tmp_path)
@@ -178,7 +175,6 @@ def test_reabertura_ignora_temporario_removido_durante_scan(
     temporary = _adapter_temporaries(tmp_path)[0]
     removed: list[Path] = []
     real_open = os.open
-
     def vanish_before_open(
         path: Any, flags: int, mode: int = 0o777, *, dir_fd: int | None = None
     ) -> int:
@@ -186,7 +182,6 @@ def test_reabertura_ignora_temporario_removido_durante_scan(
             removed.append(temporary)
             temporary.unlink()
         return real_open(path, flags, mode, dir_fd=dir_fd)
-
     monkeypatch.setattr(os, "open", vanish_before_open)
     FilesystemObjectStore(tmp_path)
     assert removed == [temporary]
@@ -251,11 +246,20 @@ def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> 
         candidate.write_bytes(b"preservar")
         if owner is not None:
             os.setxattr(candidate, _OWNER_XATTR, owner)
-
+    fifo = directory / f".cnes-object-store-{'e' * 64}-writer.tmp"
+    os.mkfifo(fifo)
+    context = multiprocessing.get_context("spawn")
+    process = context.Process(target=FilesystemObjectStore, args=(tmp_path,))
+    process.start()
+    process.join(timeout=1)
+    if process.is_alive():
+        process.terminate()
+    process.join(timeout=1)
+    assert process.exitcode == 0
     adapter = FilesystemObjectStore(tmp_path)
     adapter.put(mismatch_owner, BytesIO(b"novo"), sha256(b"novo").hexdigest())
-
     assert all(candidate.read_bytes() == b"preservar" for candidate in candidates)
+    assert fifo.exists()
 
 
 def test_reabertura_propaga_erro_ao_ler_ownership(
@@ -265,7 +269,6 @@ def test_reabertura_propaga_erro_ao_ler_ownership(
     candidate = _objects_directory(tmp_path) / f".cnes-object-store-{'f' * 64}-writer.tmp"
     candidate.write_bytes(b"preservar")
     real_open = os.open
-
     def deny_candidate(path: Any, *args: Any, **kwargs: Any) -> int:
         if path == candidate.name:
             raise PermissionError(errno.EACCES, "xattr=denied")
@@ -420,7 +423,6 @@ def test_nao_faz_fallback_quando_link_e_incompativel(
 
 @pytest.mark.linux_only
 def test_startup_recupera_apos_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    import multiprocessing
     context = multiprocessing.get_context("spawn")
     reached = context.Event()
     release = context.Event()
@@ -457,8 +459,6 @@ def test_startup_recupera_apos_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 def test_corrida_entre_processos_publica_um_destino_completo(
     identical: bool, tmp_path: Path
 ) -> None:
-    import multiprocessing
-
     context = multiprocessing.get_context("spawn")
     bodies = (b"a" * (2 * 1024 * 1024),) * 2 if identical else (b"a" * 1024, b"b" * 2048)
     barrier = context.Barrier(3)

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -145,6 +145,56 @@ def test_recupera_cada_fronteira_duravel_sem_apagar_arquivo_alheio(
     assert unrelated.read_bytes() == b"preservar"
 
 
+@pytest.mark.parametrize("boundary", ["temporary_created", "file_fsynced"])
+def test_reabre_e_remove_temporario_pre_publicacao_sem_operar_na_chave(
+    boundary: str, tmp_path: Path
+) -> None:
+    valid_key = "raw/valido.parquet"
+    valid_body = b"destino-valido"
+    adapter = FilesystemObjectStore(tmp_path)
+    adapter.put(valid_key, BytesIO(valid_body), sha256(valid_body).hexdigest())
+    unrelated = tmp_path / ".arquivo-do-usuario"
+    unrelated.write_bytes(b"preservar")
+    malformed = (
+        tmp_path / ".cnes-object-store-nao-relacionado.tmp",
+        tmp_path / f".cnes-object-store-{'a' * 64}-.tmp",
+        tmp_path / f".cnes-object-store-{'A' * 64}-token.tmp",
+    )
+    for hidden in malformed:
+        hidden.write_bytes(b"preservar")
+    crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt(boundary))
+    body = b"abandonado"
+    digest = sha256(body).hexdigest()
+
+    with pytest.raises(_SimulatedCrash, match=f"boundary={boundary}"):
+        crashing.put("raw/abandonado.parquet", BytesIO(body), digest)
+
+    recoverable = tuple(path for path in _adapter_temporaries(tmp_path) if path not in malformed)
+    assert recoverable
+    FilesystemObjectStore(tmp_path)
+
+    assert all(not path.exists() for path in recoverable)
+    assert (tmp_path / valid_key).read_bytes() == valid_body
+    assert unrelated.read_bytes() == b"preservar"
+    assert all(hidden.read_bytes() == b"preservar" for hidden in malformed)
+
+
+def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: Path) -> None:
+    body = b"conteudo"
+    digest = sha256(body).hexdigest()
+    adapter = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
+
+    with pytest.raises(_SimulatedCrash, match="boundary=file_fsynced"):
+        adapter.put("raw/dados.parquet", BytesIO(body), digest)
+
+    assert _adapter_temporaries(tmp_path)
+    adapter.put("raw/dados.parquet", BytesIO(body), digest)
+
+    assert _adapter_temporaries(tmp_path) == ()
+    with adapter.open("raw/dados.parquet") as stream:
+        assert stream.read() == body
+
+
 def test_remove_temporario_perdedor_sem_tocar_destino_valido(tmp_path: Path) -> None:
     losing = b"perdedor"
     winner = b"vencedor"

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -22,10 +22,9 @@ from packages.cnes_infra.tests.contracts.object_store_contract import (
     object_store_cases,
 )
 
-_DURABLE_BOUNDARIES = ("temporary_created", "file_fsynced", "destination_linked") + (
-    "directory_fsynced",
-    "temporary_unlinked",
-    "directory_final_fsynced",
+_DURABLE_BOUNDARIES = (
+    "temporary_created", "file_fsynced", "destination_linked",
+    "directory_fsynced", "temporary_unlinked", "directory_final_fsynced",
 )
 _OWNER_XATTR = "user.cnes_object_store_destination"
 
@@ -109,9 +108,12 @@ def test_cumpre_contrato_compartilhado(
     case: ObjectStoreCase, tmp_path_factory: pytest.TempPathFactory
 ) -> None:
     root = tmp_path_factory.mktemp(case.name)
-    adapter = FilesystemObjectStore(root)
-    case.run(adapter, MutableClock(datetime(2026, 7, 15, tzinfo=UTC)))
-    adapter.delete("raw/ausente")
+    with pytest.MonkeyPatch.context() as patch:
+        patch.chdir(root.parent)
+        adapter = FilesystemObjectStore(root.name)
+        patch.chdir(root)
+        case.run(adapter, MutableClock(datetime(2026, 7, 15, tzinfo=UTC)))
+        adapter.delete("raw/ausente")
 
 
 @pytest.mark.linux_only
@@ -310,7 +312,6 @@ def test_falha_ordinaria_remove_temporario_e_fsynca_diretorio(
     real_fsync = os.fsync
     regular_fsyncs = 0
     directory_fsyncs = 0
-
     def failing_fsync(descriptor: int) -> None:
         nonlocal directory_fsyncs, regular_fsyncs
         target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
@@ -323,7 +324,6 @@ def test_falha_ordinaria_remove_temporario_e_fsynca_diretorio(
             if mode == "fsync" and regular_fsyncs == 2:
                 raise OSError(errno.EIO, "staging=failed")
         real_fsync(descriptor)
-
     monkeypatch.setattr(os, "fsync", failing_fsync)
     expected = sha256(b"outro" if mode == "sha" else b"conteudo").hexdigest()
     error = ValueError if mode == "sha" else OSError

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -4,6 +4,7 @@ import errno
 import fcntl
 import multiprocessing
 import os
+import socket
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from hashlib import sha256
@@ -102,7 +103,6 @@ def test_contrato(case: contract.ObjectStoreCase, tmp_path_factory: pytest.TempP
         adapter = FilesystemObjectStore(root.name)
         patch.chdir(root)
         case.run(adapter, MutableClock(datetime(2026, 7, 15, tzinfo=UTC)))
-
 @pytest.mark.linux_only
 def test_fsynca_ancestral(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root, observed, real_fsync = tmp_path / "store", [], os.fsync
@@ -128,7 +128,6 @@ def test_fsynca_ancestral(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     observed.clear()
     adapter.delete("raw/ausente")
     assert observed == [destination.parent]
-
 def test_fecha_diretorio_se_fsync_do_parent_falha(monkeypatch: pytest.MonkeyPatch) -> None:
     close = MagicMock()
     monkeypatch.setattr(os, "mkdir", MagicMock())
@@ -138,7 +137,6 @@ def test_fecha_diretorio_se_fsync_do_parent_falha(monkeypatch: pytest.MonkeyPatc
     with pytest.raises(OSError, match="fsync=failed"):
         _open_or_create_directory(3, "objects")
     close.assert_called_once_with(7)
-
 @pytest.mark.parametrize("operation", ["put", "promote"])
 @pytest.mark.parametrize("boundary", _DURABLE_BOUNDARIES)
 def test_recupera_fronteira_duravel(boundary: str, operation: str, tmp_path: Path) -> None:
@@ -164,8 +162,6 @@ def test_recupera_fronteira_duravel(boundary: str, operation: str, tmp_path: Pat
     with recovered.open(source_key) as stream:
         assert stream.read() == body
     assert unrelated.read_bytes() == b"preservar"
-
-
 def test_scan_ignora_temp_removido(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
     with pytest.raises(_SimulatedCrash, match="boundary=file_fsynced"):
@@ -341,7 +337,7 @@ def test_recuperacao_preserva_destino_existente(kind: str, tmp_path: Path) -> No
         FilesystemObjectStore(tmp_path).put(key, BytesIO(losing), sha256(losing).hexdigest())
     assert destination.read_bytes() == winner if kind == "file" else destination.is_dir()
     assert kind != "file" or _adapter_temporaries(tmp_path) == ()
-@pytest.mark.parametrize("kind", ["directory", "fifo", "symlink"])
+@pytest.mark.parametrize("kind", ["directory", "fifo", "socket", "symlink"])
 def test_startup_descarta_temp_ante_destino_malformado(kind: str, tmp_path: Path) -> None:
     bad_key, other_key, body = "raw/malformado", "raw/outro", b"conteudo"
     writers = (
@@ -356,6 +352,13 @@ def test_startup_descarta_temp_ante_destino_malformado(kind: str, tmp_path: Path
         destination.mkdir()
     elif kind == "fifo":
         os.mkfifo(destination)
+    elif kind == "socket":
+        descriptor = os.open(destination.parent, os.O_RDONLY)
+        try:
+            with socket.socket(socket.AF_UNIX) as endpoint:
+                endpoint.bind(f"/proc/self/fd/{descriptor}/{destination.name}")
+        finally:
+            os.close(descriptor)
     else:
         destination.symlink_to("malformed")
     recovered = FilesystemObjectStore(tmp_path)
@@ -438,7 +441,6 @@ def test_sem_fallback(link_kind: str, tmp_path: Path, monkeypatch: pytest.Monkey
     assert adapter.stat("raw/sem-fallback") is None
     assert _adapter_temporaries(tmp_path) == (() if attacker is None else (attacker,))
     assert attacker is None or attacker.read_bytes() == b"preservar"
-
 @pytest.mark.linux_only
 def test_startup_recupera_apos_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     context = multiprocessing.get_context("spawn")
@@ -465,8 +467,6 @@ def test_startup_recupera_apos_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     process.join(timeout=10)
     assert (process.exitcode, results.get(timeout=2)) == (0, "_SimulatedCrash")
     assert _adapter_temporaries(tmp_path) == ()
-
-
 @pytest.mark.linux_only
 @pytest.mark.parametrize("identical", [True, False], ids=["identicos", "conflitantes"])
 def test_corrida_publica_destino_completo(identical: bool, tmp_path: Path) -> None:

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -16,12 +16,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.object_store import filesystem
 from cnes_infra.object_store.filesystem import FilesystemObjectStore, _open_or_create_directory
 from packages.cnes_infra.tests.contracts import object_store_contract as contract
 from packages.cnes_infra.tests.contracts.clock import MutableClock
 
-_DURABLE_BOUNDARIES = (
-    "temporary_created", "file_fsynced", "destination_linked", "directory_fsynced",
+_DURABLE_BOUNDARIES = ("temporary_created_before_ownership", "temporary_created", "file_fsynced",
+    "destination_linked", "directory_fsynced",
     "temporary_unlinked", "directory_final_fsynced",)
 _OWNER_XATTR = "user.cnes_object_store_destination"
 
@@ -130,13 +131,15 @@ def test_fsynca_ancestral(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
         real_fsync(descriptor)
     monkeypatch.setattr(os, "fsync", observe_fsync)
     adapter = FilesystemObjectStore(root)
-    assert observed[:4] == [tmp_path.parent, tmp_path, root, next(root.iterdir())]
+    internal = next(root.iterdir())
+    expected = [*reversed(root.parents), root, internal, internal]
+    assert observed == expected
     observed.clear()
     FilesystemObjectStore(root)
-    assert observed == [tmp_path, root, next(root.iterdir()), next(root.iterdir())]
+    assert observed == expected
     observed.clear()
     FilesystemObjectStore(root / "nested")
-    assert observed[:2] == [tmp_path, root]
+    assert observed[:len(root.parents) + 1] == [*reversed(root.parents), root]
     destination = _objects_directory(root) / sha256(b"raw/ausente").hexdigest()
     destination.touch()
     destination.unlink()
@@ -199,15 +202,6 @@ def test_scan_ignora_temp_removido(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     assert removed == [temporary]
 
 
-def test_crash_pre_marker_nao_deixa_temporario(tmp_path: Path) -> None:
-    boundary = "temporary_created_before_ownership"
-    crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt(boundary))
-    body = b"conteudo"
-    with pytest.raises(_SimulatedCrash, match="boundary=temporary_created_before_ownership"):
-        crashing.put("raw/dados.parquet", BytesIO(body), sha256(body).hexdigest())
-    assert _adapter_temporaries(tmp_path) == ()
-
-
 def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: Path) -> None:
     body, digest = b"conteudo", sha256(b"conteudo").hexdigest()
     adapter = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
@@ -239,15 +233,19 @@ def test_recuperacao_preserva_alias_legal(alias_kind: str, recovery: str, tmp_pa
     assert (alias.is_symlink(), alias.read_bytes()) == (alias_kind == "symlink", body)
 
 
-def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> None:
+def test_reabertura_ignora_owner_invalido(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     FilesystemObjectStore(tmp_path)
     directory = _objects_directory(tmp_path)
     mismatch_owner, mismatch_digest = "raw/owner.parquet", sha256(b"raw/owner.parquet").hexdigest()
+    nul_key, real_owner = "raw/\0invalida", filesystem._temporary_owner
+    nul_digest = sha256(nul_key.encode()).hexdigest()
+    nul_candidate = directory / f".cnes-object-store-{nul_digest}-writer.tmp"
     candidates = {
         directory / f".cnes-object-store-{'b' * 64}-writer.tmp": None,
         directory / f".cnes-object-store-{'c' * 64}-writer.tmp": b"\xff",
         directory / f".cnes-object-store-{'d' * 64}-writer.tmp": b"../invalid\0writer",
         directory / f".cnes-object-store-{mismatch_digest}-.tmp": b"raw/owner.parquet\0writer",
+        nul_candidate: None,
     }
     for candidate, owner in candidates.items():
         candidate.write_bytes(b"preservar")
@@ -255,6 +253,10 @@ def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> 
             os.setxattr(candidate, _OWNER_XATTR, owner)
     fifo = directory / f".cnes-object-store-{'e' * 64}-writer.tmp"
     os.mkfifo(fifo)
+    def owner(descriptor: int) -> tuple[str, str] | None:
+        matches = os.fstat(descriptor).st_ino == nul_candidate.stat().st_ino
+        return (nul_key, "writer") if matches else real_owner(descriptor)
+    monkeypatch.setattr(filesystem, "_temporary_owner", owner)
     context = multiprocessing.get_context("spawn")
     process = context.Process(target=FilesystemObjectStore, args=(tmp_path,))
     process.start()
@@ -267,6 +269,8 @@ def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> 
     adapter.put(mismatch_owner, BytesIO(b"novo"), sha256(b"novo").hexdigest())
     assert all(candidate.read_bytes() == b"preservar" for candidate in candidates)
     assert fifo.exists()
+    with pytest.raises(ValueError, match="object_key=invalid"):
+        adapter.stat(nul_key)
 
 
 @pytest.mark.parametrize("caller", ["startup", "pre_write"])
@@ -295,8 +299,7 @@ def test_inspecao_de_ownership_fecha_fd(
         else (adapter.put, (key, BytesIO(body), sha256(body).hexdigest())))
     with pytest.raises(OSError, match="inspection=failed"):
         target(*args)
-    assert len(os.listdir("/proc/self/fd")) == descriptor_count
-    assert candidate.read_bytes() == body
+    assert (len(os.listdir("/proc/self/fd")), candidate.read_bytes()) == (descriptor_count, body)
 
 
 @pytest.mark.parametrize("mode", ["owner", "read", "write", "flush", "fsync", "sha", "dir", "dst"])
@@ -337,8 +340,8 @@ def test_falha_staging(mode: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     message = "sha256=mismatch" if mode == "sha" else "staging=failed"
     with pytest.raises(error, match=message):
         adapter.put("raw/dados.parquet", body, expected)
-    assert _adapter_temporaries(tmp_path) == ()
-    assert directory_fsyncs == (0 if mode == "owner" else 3 if mode == "dst" else 2)
+    expected_fsyncs = 0 if mode == "owner" else 3 if mode == "dst" else 2
+    assert (_adapter_temporaries(tmp_path), directory_fsyncs) == ((), expected_fsyncs)
 
 
 @pytest.mark.parametrize("kind", ["file", "directory"])
@@ -348,21 +351,18 @@ def test_recuperacao_preserva_destino_existente(kind: str, tmp_path: Path) -> No
     with pytest.raises(_SimulatedCrash):
         crashing.put(key, BytesIO(losing), sha256(losing).hexdigest())
     destination = _objects_directory(tmp_path) / sha256(key.encode()).hexdigest()
-    if kind == "file":
-        destination.write_bytes(winner)
-    else:
-        destination.mkdir()
+    destination.write_bytes(winner) if kind == "file" else destination.mkdir()
     message = "object=immutable" if kind == "file" else "destination=invalid"
     with pytest.raises(Conflict, match=message):
         FilesystemObjectStore(tmp_path).put(key, BytesIO(losing), sha256(losing).hexdigest())
     assert destination.read_bytes() == winner if kind == "file" else destination.is_dir()
-    if kind == "file":
-        assert _adapter_temporaries(tmp_path) == ()
+    assert kind != "file" or _adapter_temporaries(tmp_path) == ()
 
 
 @pytest.mark.linux_only
 def test_fifo_final_nao_bloqueia(tmp_path: Path) -> None:
-    key, adapter = "raw/dados.parquet", FilesystemObjectStore(tmp_path)
+    key = "raw/dados.parquet"
+    FilesystemObjectStore(tmp_path)
     fifo = _objects_directory(tmp_path) / sha256(key.encode()).hexdigest()
     os.mkfifo(fifo)
     context = multiprocessing.get_context("spawn")
@@ -373,11 +373,8 @@ def test_fifo_final_nao_bloqueia(tmp_path: Path) -> None:
     if process.is_alive():
         process.terminate()
     process.join(timeout=1)
-    assert process.exitcode == 0
+    assert (process.exitcode, fifo.is_fifo()) == (0, True)
     assert [results.get(timeout=1) for _ in range(5)] == [("Conflict", "destination=invalid")] * 5
-    with pytest.raises(Conflict, match="destination=invalid"):
-        adapter.stat(key)
-    assert fifo.is_fifo()
     assert _adapter_temporaries(tmp_path) == ()
 
 
@@ -389,31 +386,37 @@ def test_chaves_prefixadas_coexistem(order: tuple[str, str], tmp_path: Path) -> 
     with adapter.open("a") as parent, adapter.open("a/b") as child:
         assert (parent.read(), child.read()) == (b"pai", b"filho")
     lock_key = f".cnes-object-store-{sha256(b'a').hexdigest()}.lock"
-    adapter.delete("a")
     assert adapter.stat(lock_key) is None
     adapter.put(lock_key, BytesIO(b"lock"), sha256(b"lock").hexdigest())
-    with adapter.open(lock_key) as stream:
-        assert stream.read() == b"lock"
+    assert adapter.stat(lock_key) is not None
 
 
-@pytest.mark.parametrize("ancestor", [False, True], ids=["root", "ancestor"])
-def test_root_aberto_nao_segue_path_substituido(ancestor: bool, tmp_path: Path) -> None:
-    parent = tmp_path / "original"
+def test_root_aberto_nao_segue_ancestral_substituido(tmp_path: Path) -> None:
+    parent, replacement = tmp_path / "original", tmp_path / "replacement"
+    adapter = FilesystemObjectStore(parent / "store")
+    parent.rename(tmp_path / "moved")
+    parent.symlink_to(replacement, target_is_directory=True)
+    adapter.put("raw/objeto", BytesIO(b"conteudo"), sha256(b"conteudo").hexdigest())
+    assert not replacement.exists()
+
+
+def test_construtor_rejeita_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    parent, attacker = tmp_path / "original", tmp_path / "attacker"
     root = parent / "store"
-    adapter = FilesystemObjectStore(root)
-    target = parent if ancestor else root
-    target.rename(tmp_path / "moved")
-    replacement = tmp_path / "replacement"
-    replacement.mkdir()
-    target.symlink_to(replacement, target_is_directory=True)
-    body = b"conteudo"
-    adapter.put("raw/objeto", BytesIO(body), sha256(body).hexdigest())
-    with adapter.open("raw/objeto") as stream:
-        assert stream.read() == body
-    assert adapter.stat("raw/objeto") is not None
-    adapter.delete("raw/objeto")
-    assert adapter.stat("raw/objeto") is None
-    assert tuple(replacement.iterdir()) == ()
+    root.mkdir(parents=True)
+    (attacker / "store").mkdir(parents=True)
+    real_open = os.open
+    def swap_before_open(path: Any, *args: Any, **kwargs: Any) -> int:
+        component_open = path == parent.name and kwargs.get("dir_fd") is not None
+        full_path_open = os.fspath(path) == os.fspath(root)
+        if not parent.is_symlink() and (full_path_open or component_open):
+            parent.rename(tmp_path / "moved")
+            parent.symlink_to(attacker, target_is_directory=True)
+        return real_open(path, *args, **kwargs)
+    monkeypatch.setattr(os, "open", swap_before_open)
+    with pytest.raises(OSError):
+        FilesystemObjectStore(root)
+    assert (parent.is_symlink(), tuple((attacker / "store").iterdir())) == (True, ())
 
 
 @pytest.mark.parametrize("link_kind", ["staging", "publication"])
@@ -460,8 +463,7 @@ def test_startup_recupera_apos_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(fcntl, "flock", release_writer)
     FilesystemObjectStore(tmp_path)
     process.join(timeout=10)
-    assert process.exitcode == 0
-    assert results.get(timeout=2) == "_SimulatedCrash"
+    assert (process.exitcode, results.get(timeout=2)) == (0, "_SimulatedCrash")
     assert _adapter_temporaries(tmp_path) == ()
 
 
@@ -484,17 +486,15 @@ def test_corrida_publica_destino_completo(identical: bool, tmp_path: Path) -> No
         process.start()
     barrier.wait()
     reader.join(timeout=10)
-    assert not reader.is_alive()
-    assert observed
+    assert (reader.is_alive(), bool(observed)) == (False, True)
     for process in processes:
         process.join(timeout=10)
         assert process.exitcode == 0
     outcomes = [results.get(timeout=2)[0] for _ in processes]
     with FilesystemObjectStore(tmp_path).open("raw/race") as stream:
         published = stream.read()
-    assert published in bodies
+    assert (published in bodies, all(content in bodies for content in observed)) == (True, True)
     assert outcomes.count("ok") == (2 if identical else 1)
     assert outcomes.count("conflict") == (0 if identical else 1)
-    assert all(content in bodies for content in observed)
     assert sha256(published).hexdigest() == FilesystemObjectStore(tmp_path).stat("raw/race").sha256
     assert _adapter_temporaries(tmp_path) == ()

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -115,22 +115,23 @@ def test_cumpre_contrato_compartilhado(
 
 
 @pytest.mark.linux_only
-def test_fsynca_pai_de_cada_diretorio_interno_criado(
+def test_fsynca_pai_de_cada_diretorio_interno_criado_ou_existente(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     root = tmp_path / "store"
     observed: list[Path] = []
     real_fsync = os.fsync
-
     def observe_fsync(descriptor: int) -> None:
         target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
         if target.is_dir():
             observed.append(target)
         real_fsync(descriptor)
-
     monkeypatch.setattr(os, "fsync", observe_fsync)
     FilesystemObjectStore(root)
     assert observed[:3] == [tmp_path, root, next(root.iterdir())]
+    observed.clear()
+    FilesystemObjectStore(root)
+    assert observed == [root, next(root.iterdir()), next(root.iterdir())]
 
 
 @pytest.mark.parametrize("operation", ["put", "promote"])
@@ -280,19 +281,19 @@ def test_reabertura_propaga_erro_ao_ler_ownership(
     assert candidate.read_bytes() == b"preservar"
 
 
-@pytest.mark.parametrize("failure", ["owner", "read", "write", "flush", "fsync", "sha", "dir"])
-def test_falha_ordinaria_de_staging_remove_temporario_e_fsynca_diretorio(
-    failure: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("mode", ["owner", "read", "write", "flush", "fsync", "sha", "dir", "dst"])
+def test_falha_ordinaria_remove_temporario_e_fsynca_diretorio(
+    mode: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     adapter = FilesystemObjectStore(tmp_path)
     body = MagicMock(wraps=BytesIO(b"conteudo"))
-    if failure == "owner":
+    if mode == "owner":
         monkeypatch.setattr(
             os,
             "setxattr",
             MagicMock(side_effect=OSError(errno.ENOTSUP, "staging=failed")),
         )
-    if failure == "read":
+    if mode == "read":
         body.read.side_effect = OSError(errno.EIO, "staging=failed")
     real_fdopen = os.fdopen
 
@@ -302,10 +303,9 @@ def test_falha_ordinaria_de_staging_remove_temporario_e_fsynca_diretorio(
         writer.__enter__.return_value = writer
         writer.__exit__.side_effect = stream.__exit__
         writer.fileno.side_effect = stream.fileno
-        getattr(writer, failure).side_effect = OSError(errno.EIO, "staging=failed")
+        getattr(writer, mode).side_effect = OSError(errno.EIO, "staging=failed")
         return writer
-
-    if failure in {"write", "flush"}:
+    if mode in {"write", "flush"}:
         monkeypatch.setattr(os, "fdopen", failing_fdopen)
     real_fsync = os.fsync
     regular_fsyncs = 0
@@ -316,23 +316,23 @@ def test_falha_ordinaria_de_staging_remove_temporario_e_fsynca_diretorio(
         target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
         if target.is_dir():
             directory_fsyncs += target == _objects_directory(tmp_path)
-            if failure == "dir" and directory_fsyncs == 1:
+            if mode in {"dir", "dst"} and directory_fsyncs == (2 if mode == "dst" else 1):
                 raise OSError(errno.EIO, "staging=failed")
         else:
             regular_fsyncs += 1
-            if failure == "fsync" and regular_fsyncs == 2:
+            if mode == "fsync" and regular_fsyncs == 2:
                 raise OSError(errno.EIO, "staging=failed")
         real_fsync(descriptor)
 
     monkeypatch.setattr(os, "fsync", failing_fsync)
-    expected = sha256(b"outro" if failure == "sha" else b"conteudo").hexdigest()
-    error = ValueError if failure == "sha" else OSError
-    message = "sha256=mismatch" if failure == "sha" else "staging=failed"
+    expected = sha256(b"outro" if mode == "sha" else b"conteudo").hexdigest()
+    error = ValueError if mode == "sha" else OSError
+    message = "sha256=mismatch" if mode == "sha" else "staging=failed"
     with pytest.raises(error, match=message):
         adapter.put("raw/dados.parquet", body, expected)
 
     assert _adapter_temporaries(tmp_path) == ()
-    assert directory_fsyncs == (0 if failure == "owner" else 2)
+    assert directory_fsyncs == (0 if mode == "owner" else 3 if mode == "dst" else 2)
 
 
 @pytest.mark.parametrize("kind", ["file", "directory"])

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -29,6 +29,7 @@ _DURABLE_BOUNDARIES = (
     "temporary_unlinked",
     "directory_final_fsynced",
 )
+_OWNER_XATTR = "user.cnes_object_store_destination"
 
 
 class _SimulatedCrash(RuntimeError):
@@ -193,6 +194,98 @@ def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: 
     assert _adapter_temporaries(tmp_path) == ()
     with adapter.open("raw/dados.parquet") as stream:
         assert stream.read() == body
+
+
+def test_reabertura_preserva_objeto_valido_com_nome_de_temporario(tmp_path: Path) -> None:
+    other_key = "raw/outro.parquet"
+    digest = sha256(other_key.encode()).hexdigest()
+    valid_key = f"raw/.cnes-object-store-{digest}-writer.tmp"
+    body = b"objeto-valido"
+    adapter = FilesystemObjectStore(tmp_path)
+    adapter.put(valid_key, BytesIO(body), sha256(body).hexdigest())
+
+    reopened = FilesystemObjectStore(tmp_path)
+
+    with reopened.open(valid_key) as stream:
+        assert stream.read() == body
+
+
+def test_pre_write_preserva_objeto_valido_com_nome_de_temporario(tmp_path: Path) -> None:
+    destination_key = "raw/destino.parquet"
+    digest = sha256(destination_key.encode()).hexdigest()
+    valid_key = f"raw/.cnes-object-store-{digest}-writer.tmp"
+    valid_body = b"objeto-valido"
+    destination_body = b"novo-destino"
+    adapter = FilesystemObjectStore(tmp_path)
+    adapter.put(valid_key, BytesIO(valid_body), sha256(valid_body).hexdigest())
+
+    adapter.put(
+        destination_key,
+        BytesIO(destination_body),
+        sha256(destination_body).hexdigest(),
+    )
+
+    with adapter.open(valid_key) as stream:
+        assert stream.read() == valid_body
+
+
+def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> None:
+    directory = tmp_path / "raw"
+    directory.mkdir()
+    different_parent_owner = "other/owner.parquet"
+    different_parent_digest = sha256(different_parent_owner.encode()).hexdigest()
+    mismatch_owner = "raw/owner.parquet"
+    candidates = {
+        directory / f".cnes-object-store-{'b' * 64}-writer.tmp": None,
+        directory / f".cnes-object-store-{'c' * 64}-writer.tmp": b"\xff",
+        directory / f".cnes-object-store-{'d' * 64}-writer.tmp": b"../invalid",
+        directory / f".cnes-object-store-{different_parent_digest}-writer.tmp": (
+            different_parent_owner.encode()
+        ),
+        directory / f".cnes-object-store-{'e' * 64}-writer.tmp": mismatch_owner.encode(),
+    }
+    for candidate, owner in candidates.items():
+        candidate.write_bytes(b"preservar")
+        if owner is not None:
+            os.setxattr(candidate, _OWNER_XATTR, owner)
+
+    FilesystemObjectStore(tmp_path)
+
+    assert all(candidate.read_bytes() == b"preservar" for candidate in candidates)
+
+
+def test_reabertura_propaga_erro_ao_ler_ownership(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    candidate = tmp_path / f".cnes-object-store-{'f' * 64}-writer.tmp"
+    candidate.write_bytes(b"preservar")
+
+    def deny_xattr(path: os.PathLike[str], attribute: str) -> bytes:
+        raise PermissionError(errno.EACCES, "xattr=denied")
+
+    monkeypatch.setattr(os, "getxattr", deny_xattr)
+
+    with pytest.raises(PermissionError, match="xattr=denied"):
+        FilesystemObjectStore(tmp_path)
+
+    assert candidate.read_bytes() == b"preservar"
+
+
+def test_falha_ao_marcar_ownership_remove_temporario(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = FilesystemObjectStore(tmp_path)
+
+    def reject_xattr(descriptor: int, attribute: str, value: bytes) -> None:
+        raise OSError(errno.ENOTSUP, "xattr=unsupported")
+
+    monkeypatch.setattr(os, "setxattr", reject_xattr)
+
+    with pytest.raises(OSError, match="xattr=unsupported"):
+        adapter.put("raw/dados.parquet", BytesIO(b"conteudo"), sha256(b"conteudo").hexdigest())
+
+    assert adapter.stat("raw/dados.parquet") is None
+    assert _adapter_temporaries(tmp_path) == ()
 
 
 def test_remove_temporario_perdedor_sem_tocar_destino_valido(tmp_path: Path) -> None:

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -229,6 +229,49 @@ def test_pre_write_preserva_objeto_valido_com_nome_de_temporario(tmp_path: Path)
         assert stream.read() == valid_body
 
 
+@pytest.mark.parametrize("recovery", ["startup", "pre_write"])
+def test_recuperacao_preserva_hard_link_legal_com_token_alheio(
+    recovery: str, tmp_path: Path
+) -> None:
+    key = "raw/destino.parquet"
+    body = b"objeto-valido"
+    digest = sha256(body).hexdigest()
+    namespace = sha256(key.encode()).hexdigest()
+    alias = tmp_path / "raw" / f".cnes-object-store-{namespace}-anything.tmp"
+    adapter = FilesystemObjectStore(tmp_path)
+    adapter.put(key, BytesIO(body), digest)
+    os.link(tmp_path / key, alias)
+
+    if recovery == "startup":
+        FilesystemObjectStore(tmp_path)
+    else:
+        adapter.put(key, BytesIO(body), digest)
+
+    assert alias.read_bytes() == body
+
+
+@pytest.mark.parametrize("recovery", ["startup", "pre_write"])
+def test_recuperacao_preserva_symlink_legal_com_token_exato(recovery: str, tmp_path: Path) -> None:
+    key = "raw/destino.parquet"
+    body = b"objeto-valido"
+    digest = sha256(body).hexdigest()
+    adapter = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("destination_linked"))
+
+    with pytest.raises(_SimulatedCrash, match="boundary=destination_linked"):
+        adapter.put(key, BytesIO(body), digest)
+    alias = _adapter_temporaries(tmp_path)[0]
+    alias.unlink()
+    alias.symlink_to(Path(key).name)
+
+    if recovery == "startup":
+        FilesystemObjectStore(tmp_path)
+    else:
+        adapter.put(key, BytesIO(body), digest)
+
+    assert alias.is_symlink()
+    assert alias.read_bytes() == body
+
+
 def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> None:
     directory = tmp_path / "raw"
     directory.mkdir()
@@ -238,11 +281,13 @@ def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> 
     candidates = {
         directory / f".cnes-object-store-{'b' * 64}-writer.tmp": None,
         directory / f".cnes-object-store-{'c' * 64}-writer.tmp": b"\xff",
-        directory / f".cnes-object-store-{'d' * 64}-writer.tmp": b"../invalid",
+        directory / f".cnes-object-store-{'d' * 64}-writer.tmp": b"../invalid\0writer",
         directory / f".cnes-object-store-{different_parent_digest}-writer.tmp": (
-            different_parent_owner.encode()
+            f"{different_parent_owner}\0writer".encode()
         ),
-        directory / f".cnes-object-store-{'e' * 64}-writer.tmp": mismatch_owner.encode(),
+        directory / f".cnes-object-store-{'e' * 64}-writer.tmp": (
+            f"{mismatch_owner}\0writer".encode()
+        ),
     }
     for candidate, owner in candidates.items():
         candidate.write_bytes(b"preservar")
@@ -260,7 +305,7 @@ def test_reabertura_propaga_erro_ao_ler_ownership(
     candidate = tmp_path / f".cnes-object-store-{'f' * 64}-writer.tmp"
     candidate.write_bytes(b"preservar")
 
-    def deny_xattr(path: os.PathLike[str], attribute: str) -> bytes:
+    def deny_xattr(path: os.PathLike[str], attribute: str, *, follow_symlinks: bool) -> bytes:
         raise PermissionError(errno.EACCES, "xattr=denied")
 
     monkeypatch.setattr(os, "getxattr", deny_xattr)

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from cnes_domain.control_plane.errors import Conflict
-from cnes_infra.object_store.filesystem import FilesystemObjectStore
+from cnes_infra.object_store.filesystem import FilesystemObjectStore, _open_or_create_directory
 from packages.cnes_infra.tests.contracts import object_store_contract as contract
 from packages.cnes_infra.tests.contracts.clock import MutableClock
 
@@ -57,15 +57,14 @@ def _process_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
                 raise TimeoutError("reader=timeout")
     barrier.wait()
     try:
-        stat = FilesystemObjectStore(root, fault_injector=wait_for_reader).put(
-            "raw/race", BytesIO(body), expected
-        )
+        adapter = FilesystemObjectStore(root, fault_injector=wait_for_reader)
+        stat = adapter.put("raw/race", BytesIO(body), expected)
         results.put(("ok", stat.sha256))
     except Conflict:
         results.put(("conflict", expected))
 
 
-def _process_paused_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
+def _paused_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
     reached, release, results = controls
     def pause(boundary: str) -> None:
         if boundary == "temporary_created":
@@ -94,8 +93,6 @@ def _process_final(root: str, results: Any) -> None:
                     result.close()
         except Exception as error:
             results.put((type(error).__name__, str(error)))
-        else:
-            results.put(("ok", ""))
 
 
 def _read_during_publication(root: str, controls: tuple[Any, ...]) -> None:
@@ -148,6 +145,17 @@ def test_fsynca_ancestral(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     assert observed == [destination.parent]
 
 
+def test_fecha_diretorio_se_fsync_do_parent_falha(monkeypatch: pytest.MonkeyPatch) -> None:
+    close = MagicMock()
+    monkeypatch.setattr(os, "mkdir", MagicMock())
+    monkeypatch.setattr(os, "open", MagicMock(return_value=7))
+    monkeypatch.setattr(os, "fsync", MagicMock(side_effect=OSError(errno.EIO, "fsync=failed")))
+    monkeypatch.setattr(os, "close", close)
+    with pytest.raises(OSError, match="fsync=failed"):
+        _open_or_create_directory(3, "objects")
+    close.assert_called_once_with(7)
+
+
 @pytest.mark.parametrize("operation", ["put", "promote"])
 @pytest.mark.parametrize("boundary", _DURABLE_BOUNDARIES)
 def test_recupera_fronteira_duravel(boundary: str, operation: str, tmp_path: Path) -> None:
@@ -179,12 +187,9 @@ def test_scan_ignora_temp_removido(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
     with pytest.raises(_SimulatedCrash, match="boundary=file_fsynced"):
         crashing.put("raw/dados.parquet", BytesIO(b"abandonado"), sha256(b"abandonado").hexdigest())
-    temporary = _adapter_temporaries(tmp_path)[0]
-    removed: list[Path] = []
-    real_open = os.open
+    temporary, removed, real_open = _adapter_temporaries(tmp_path)[0], [], os.open
     def vanish_before_open(
-        path: Any, flags: int, mode: int = 0o777, *, dir_fd: int | None = None
-    ) -> int:
+        path: Any, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
         if path == temporary.name and not removed:
             removed.append(temporary)
             temporary.unlink()
@@ -195,9 +200,8 @@ def test_scan_ignora_temp_removido(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 
 
 def test_crash_pre_marker_nao_deixa_temporario(tmp_path: Path) -> None:
-    crashing = FilesystemObjectStore(
-        tmp_path, fault_injector=_CrashAt("temporary_created_before_ownership")
-    )
+    boundary = "temporary_created_before_ownership"
+    crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt(boundary))
     body = b"conteudo"
     with pytest.raises(_SimulatedCrash, match="boundary=temporary_created_before_ownership"):
         crashing.put("raw/dados.parquet", BytesIO(body), sha256(body).hexdigest())
@@ -219,8 +223,7 @@ def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: 
 @pytest.mark.parametrize("recovery", ["startup", "pre_write"])
 def test_recuperacao_preserva_alias_legal(alias_kind: str, recovery: str, tmp_path: Path) -> None:
     key, body = "raw/destino.parquet", b"objeto-valido"
-    digest = sha256(body).hexdigest()
-    namespace = sha256(key.encode()).hexdigest()
+    digest, namespace = sha256(body).hexdigest(), sha256(key.encode()).hexdigest()
     adapter = FilesystemObjectStore(tmp_path)
     alias = _objects_directory(tmp_path) / f".cnes-object-store-{namespace}-writer.tmp"
     if alias_kind == "hard_link":
@@ -266,37 +269,42 @@ def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> 
     assert fifo.exists()
 
 
-def test_propaga_erro_de_ownership(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    FilesystemObjectStore(tmp_path)
-    candidate = _objects_directory(tmp_path) / f".cnes-object-store-{'f' * 64}-writer.tmp"
-    candidate.write_bytes(b"preservar")
-    real_open = os.open
-    def deny_candidate(path: Any, *args: Any, **kwargs: Any) -> int:
-        if path == candidate.name:
-            raise PermissionError(errno.EACCES, "xattr=denied")
-        return real_open(path, *args, **kwargs)
-    monkeypatch.setattr(os, "open", deny_candidate)
-    with pytest.raises(PermissionError, match="xattr=denied"):
-        FilesystemObjectStore(tmp_path)
-    monkeypatch.setattr(os, "open", real_open)
-    monkeypatch.setattr(
-        os, "getxattr", MagicMock(side_effect=PermissionError(errno.EACCES, "xattr=denied"))
-    )
-    with pytest.raises(PermissionError, match="xattr=denied"):
-        FilesystemObjectStore(tmp_path)
-    assert candidate.read_bytes() == b"preservar"
+@pytest.mark.parametrize("caller", ["startup", "pre_write"])
+@pytest.mark.parametrize("failure", ["open", "fstat", "xattr"])
+def test_inspecao_de_ownership_fecha_fd(
+    caller: str, failure: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    key, body = "raw/owner.parquet", b"preservar"
+    adapter, digest = FilesystemObjectStore(tmp_path), sha256(key.encode()).hexdigest()
+    candidate = _objects_directory(tmp_path) / f".cnes-object-store-{digest}-writer.tmp"
+    candidate.write_bytes(body)
+    os.setxattr(candidate, _OWNER_XATTR, f"{key}\0writer".encode())
+    if failure == "open":
+        real_open = os.open
+        def fail_open(path: Any, *args: Any, **kwargs: Any) -> int:
+            if path == candidate.name:
+                raise PermissionError(errno.EACCES, "inspection=failed")
+            return real_open(path, *args, **kwargs)
+        monkeypatch.setattr(os, "open", fail_open)
+    else:
+        syscall = "fstat" if failure == "fstat" else "getxattr"
+        error = OSError(errno.EIO, "inspection=failed")
+        monkeypatch.setattr(os, syscall, MagicMock(side_effect=error))
+    descriptor_count = len(os.listdir("/proc/self/fd"))
+    target, args = (
+        (FilesystemObjectStore, (tmp_path,)) if caller == "startup"
+        else (adapter.put, (key, BytesIO(body), sha256(body).hexdigest())))
+    with pytest.raises(OSError, match="inspection=failed"):
+        target(*args)
+    assert len(os.listdir("/proc/self/fd")) == descriptor_count
+    assert candidate.read_bytes() == body
 
 
 @pytest.mark.parametrize("mode", ["owner", "read", "write", "flush", "fsync", "sha", "dir", "dst"])
-def test_falha_remove_temp_e_fsynca_dir(
-    mode: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_falha_staging(mode: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     adapter, body = FilesystemObjectStore(tmp_path), MagicMock(wraps=BytesIO(b"conteudo"))
     if mode == "owner":
         monkeypatch.setattr(
-            os,
-            "setxattr",
-            MagicMock(side_effect=OSError(errno.ENOTSUP, "staging=failed")),
-        )
+            os, "setxattr", MagicMock(side_effect=OSError(errno.ENOTSUP, "staging=failed")))
     if mode == "read":
         body.read.side_effect = OSError(errno.EIO, "staging=failed")
     real_fdopen = os.fdopen
@@ -310,8 +318,7 @@ def test_falha_remove_temp_e_fsynca_dir(
         return writer
     if mode in {"write", "flush"}:
         monkeypatch.setattr(os, "fdopen", failing_fdopen)
-    real_fsync = os.fsync
-    regular_fsyncs = directory_fsyncs = 0
+    real_fsync, regular_fsyncs, directory_fsyncs = os.fsync, 0, 0
     def failing_fsync(descriptor: int) -> None:
         nonlocal directory_fsyncs, regular_fsyncs
         target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
@@ -410,8 +417,7 @@ def test_root_aberto_nao_segue_path_substituido(ancestor: bool, tmp_path: Path) 
 
 
 @pytest.mark.parametrize("link_kind", ["staging", "publication"])
-def test_link_incompativel_sem_fallback(
-    link_kind: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sem_fallback(link_kind: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     body, adapter = b"conteudo", FilesystemObjectStore(tmp_path)
     if link_kind == "staging":
         directory = _objects_directory(tmp_path)
@@ -435,8 +441,7 @@ def test_startup_recupera_apos_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     context = multiprocessing.get_context("spawn")
     reached, release, results = context.Event(), context.Event(), context.Queue()
     process = context.Process(
-        target=_process_paused_put,
-        args=(str(tmp_path), b"conteudo", (reached, release, results)),)
+        target=_paused_put, args=(str(tmp_path), b"conteudo", (reached, release, results)))
     process.start()
     assert reached.wait(timeout=5)
     lock_path = next(next(tmp_path.rglob("locks")).iterdir())
@@ -468,18 +473,13 @@ def test_corrida_publica_destino_completo(identical: bool, tmp_path: Path) -> No
     barrier, results = context.Barrier(3), context.Queue()
     destination_linked, reader_done = context.Event(), context.Event()
     reader_ready, observed = Event(), []
-    reader = Thread(
-        target=_read_during_publication,
-        args=(str(tmp_path), (reader_ready, destination_linked, reader_done, observed)),)
+    reader_controls = reader_ready, destination_linked, reader_done, observed
+    reader = Thread(target=_read_during_publication, args=(str(tmp_path), reader_controls))
     reader.start()
     assert reader_ready.wait(timeout=5)
-    processes = [
-        context.Process(
-            target=_process_put,
-            args=(str(tmp_path), body, (barrier, results, destination_linked, reader_done)),
-        )
-        for body in bodies
-    ]
+    writer_controls = barrier, results, destination_linked, reader_done
+    processes = [context.Process(target=_process_put, args=(str(tmp_path), body, writer_controls))
+                 for body in bodies]
     for process in processes:
         process.start()
     barrier.wait()

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -49,6 +49,10 @@ def _adapter_temporaries(root: Path) -> tuple[Path, ...]:
     return tuple(root.rglob(".cnes-object-store-*.tmp"))
 
 
+def _objects_directory(root: Path) -> Path:
+    return next(path for path in root.rglob("objects") if path.is_dir())
+
+
 def _process_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
     barrier, results, destination_linked, reader_done = controls
     expected = sha256(body).hexdigest()
@@ -106,18 +110,16 @@ def test_cumpre_contrato_compartilhado(
     case: ObjectStoreCase, tmp_path_factory: pytest.TempPathFactory
 ) -> None:
     root = tmp_path_factory.mktemp(case.name)
-    clock = MutableClock(datetime(2026, 7, 15, tzinfo=UTC))
     adapter = FilesystemObjectStore(root)
-    case.run(adapter, clock)
+    case.run(adapter, MutableClock(datetime(2026, 7, 15, tzinfo=UTC)))
     adapter.delete("raw/ausente")
-    assert adapter.stat("raw/ausente") is None
 
 
 @pytest.mark.linux_only
-def test_fsynca_pai_de_cada_diretorio_criado(
+def test_fsynca_pai_de_cada_diretorio_interno_criado(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    adapter = FilesystemObjectStore(tmp_path)
+    root = tmp_path / "store"
     observed: list[Path] = []
     real_fsync = os.fsync
 
@@ -128,9 +130,8 @@ def test_fsynca_pai_de_cada_diretorio_criado(
         real_fsync(descriptor)
 
     monkeypatch.setattr(os, "fsync", observe_fsync)
-    body = b"conteudo"
-    adapter.put("nivel-1/nivel-2/dados.parquet", BytesIO(body), sha256(body).hexdigest())
-    assert observed[:3] == [tmp_path, tmp_path / "nivel-1", tmp_path / "nivel-1/nivel-2"]
+    FilesystemObjectStore(root)
+    assert observed[:3] == [tmp_path, root, next(root.iterdir())]
 
 
 @pytest.mark.parametrize("operation", ["put", "promote"])
@@ -173,29 +174,30 @@ def test_reabertura_ignora_temporario_removido_durante_scan(
     with pytest.raises(_SimulatedCrash, match="boundary=file_fsynced"):
         crashing.put("raw/dados.parquet", BytesIO(b"abandonado"), sha256(b"abandonado").hexdigest())
     temporary = _adapter_temporaries(tmp_path)[0]
-    real_lstat = Path.lstat
     removed: list[Path] = []
+    real_open = os.open
 
-    def vanish_before_lstat(path: Path) -> os.stat_result:
-        if path == temporary:
-            removed.append(path)
-            path.unlink()
-        return real_lstat(path)
+    def vanish_before_open(
+        path: Any, flags: int, mode: int = 0o777, *, dir_fd: int | None = None
+    ) -> int:
+        if path == temporary.name and not removed:
+            removed.append(temporary)
+            temporary.unlink()
+        return real_open(path, flags, mode, dir_fd=dir_fd)
 
-    monkeypatch.setattr(Path, "lstat", vanish_before_lstat)
+    monkeypatch.setattr(os, "open", vanish_before_open)
     FilesystemObjectStore(tmp_path)
     assert removed == [temporary]
 
 
 def test_crash_pre_marker_nao_deixa_temporario(tmp_path: Path) -> None:
-    key = "raw/dados.parquet"
     crashing = FilesystemObjectStore(
         tmp_path, fault_injector=_CrashAt("temporary_created_before_ownership")
     )
     body = b"conteudo"
 
     with pytest.raises(_SimulatedCrash, match="boundary=temporary_created_before_ownership"):
-        crashing.put(key, BytesIO(body), sha256(body).hexdigest())
+        crashing.put("raw/dados.parquet", BytesIO(body), sha256(body).hexdigest())
     assert _adapter_temporaries(tmp_path) == ()
 
 
@@ -205,66 +207,52 @@ def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: 
     adapter = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
     with pytest.raises(_SimulatedCrash, match="boundary=file_fsynced"):
         adapter.put("raw/dados.parquet", BytesIO(body), digest)
-    assert _adapter_temporaries(tmp_path)
     adapter.put("raw/dados.parquet", BytesIO(body), digest)
     assert _adapter_temporaries(tmp_path) == ()
     with adapter.open("raw/dados.parquet") as stream:
         assert stream.read() == body
 
 
-@pytest.mark.parametrize("alias_kind", ["valid_key", "hard_link", "symlink"])
+@pytest.mark.parametrize("alias_kind", ["hard_link", "symlink"])
 @pytest.mark.parametrize("recovery", ["startup", "pre_write"])
 def test_recuperacao_preserva_alias_legal(alias_kind: str, recovery: str, tmp_path: Path) -> None:
     key = "raw/destino.parquet"
     body = b"objeto-valido"
     digest = sha256(body).hexdigest()
     namespace = sha256(key.encode()).hexdigest()
-    alias = tmp_path / "raw" / f".cnes-object-store-{namespace}-writer.tmp"
     adapter = FilesystemObjectStore(tmp_path)
-    if alias_kind == "valid_key":
-        adapter.put(alias.relative_to(tmp_path).as_posix(), BytesIO(body), digest)
-    elif alias_kind == "hard_link":
+    alias = _objects_directory(tmp_path) / f".cnes-object-store-{namespace}-writer.tmp"
+    if alias_kind == "hard_link":
         adapter.put(key, BytesIO(body), digest)
-        os.link(tmp_path / key, alias)
+        os.link(_objects_directory(tmp_path) / namespace, alias)
     else:
-        crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("destination_linked"))
-        with pytest.raises(_SimulatedCrash, match="boundary=destination_linked"):
-            crashing.put(key, BytesIO(body), digest)
-        alias = _adapter_temporaries(tmp_path)[0]
-        alias.unlink()
-        alias.symlink_to(Path(key).name)
+        adapter.put(key, BytesIO(body), digest)
+        alias.symlink_to(namespace)
     if recovery == "startup":
-        FilesystemObjectStore(tmp_path)
+        adapter = FilesystemObjectStore(tmp_path)
     else:
         adapter.put(key, BytesIO(body), digest)
-    assert alias.is_symlink() == (alias_kind == "symlink")
-    assert alias.read_bytes() == body
+    assert (alias.is_symlink(), alias.read_bytes()) == (alias_kind == "symlink", body)
 
 
 def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> None:
-    directory = tmp_path / "raw"
-    directory.mkdir()
-    different_parent_owner = "other/owner.parquet"
-    different_parent_digest = sha256(different_parent_owner.encode()).hexdigest()
+    FilesystemObjectStore(tmp_path)
+    directory = _objects_directory(tmp_path)
     mismatch_owner = "raw/owner.parquet"
+    mismatch_digest = sha256(mismatch_owner.encode()).hexdigest()
     candidates = {
-        directory / ".cnes-object-store-curto.tmp": None,
         directory / f".cnes-object-store-{'b' * 64}-writer.tmp": None,
         directory / f".cnes-object-store-{'c' * 64}-writer.tmp": b"\xff",
         directory / f".cnes-object-store-{'d' * 64}-writer.tmp": b"../invalid\0writer",
-        directory / f".cnes-object-store-{different_parent_digest}-writer.tmp": (
-            f"{different_parent_owner}\0writer".encode()
-        ),
-        directory / f".cnes-object-store-{'e' * 64}-writer.tmp": (
-            f"{mismatch_owner}\0writer".encode()
-        ),
+        directory / f".cnes-object-store-{mismatch_digest}-.tmp": b"raw/owner.parquet\0writer",
     }
     for candidate, owner in candidates.items():
         candidate.write_bytes(b"preservar")
         if owner is not None:
             os.setxattr(candidate, _OWNER_XATTR, owner)
 
-    FilesystemObjectStore(tmp_path)
+    adapter = FilesystemObjectStore(tmp_path)
+    adapter.put(mismatch_owner, BytesIO(b"novo"), sha256(b"novo").hexdigest())
 
     assert all(candidate.read_bytes() == b"preservar" for candidate in candidates)
 
@@ -272,18 +260,29 @@ def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> 
 def test_reabertura_propaga_erro_ao_ler_ownership(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    candidate = tmp_path / f".cnes-object-store-{'f' * 64}-writer.tmp"
+    FilesystemObjectStore(tmp_path)
+    candidate = _objects_directory(tmp_path) / f".cnes-object-store-{'f' * 64}-writer.tmp"
     candidate.write_bytes(b"preservar")
+    real_open = os.open
+
+    def deny_candidate(path: Any, *args: Any, **kwargs: Any) -> int:
+        if path == candidate.name:
+            raise PermissionError(errno.EACCES, "xattr=denied")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", deny_candidate)
+    with pytest.raises(PermissionError, match="xattr=denied"):
+        FilesystemObjectStore(tmp_path)
+    monkeypatch.setattr(os, "open", real_open)
     monkeypatch.setattr(
         os, "getxattr", MagicMock(side_effect=PermissionError(errno.EACCES, "xattr=denied"))
     )
     with pytest.raises(PermissionError, match="xattr=denied"):
         FilesystemObjectStore(tmp_path)
-
     assert candidate.read_bytes() == b"preservar"
 
 
-@pytest.mark.parametrize("failure", ["ownership", "read", "write", "flush", "content_fsync"])
+@pytest.mark.parametrize("failure", ["ownership", "read", "write", "flush", "fsync", "checksum"])
 def test_falha_ordinaria_de_staging_remove_temporario_e_fsynca_diretorio(
     failure: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -318,31 +317,34 @@ def test_falha_ordinaria_de_staging_remove_temporario_e_fsynca_diretorio(
         nonlocal directory_fsyncs, regular_fsyncs
         target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
         if target.is_dir():
-            directory_fsyncs += target == tmp_path / "raw"
+            directory_fsyncs += target == _objects_directory(tmp_path)
         else:
             regular_fsyncs += 1
-            if failure == "content_fsync" and regular_fsyncs == 2:
+            if failure == "fsync" and regular_fsyncs == 2:
                 raise OSError(errno.EIO, "staging=failed")
         real_fsync(descriptor)
 
     monkeypatch.setattr(os, "fsync", failing_fsync)
-    with pytest.raises(OSError, match="staging=failed"):
-        adapter.put("raw/dados.parquet", body, sha256(b"conteudo").hexdigest())
+    expected = sha256(b"outro" if failure == "checksum" else b"conteudo").hexdigest()
+    error = ValueError if failure == "checksum" else OSError
+    message = "sha256=mismatch" if failure == "checksum" else "staging=failed"
+    with pytest.raises(error, match=message):
+        adapter.put("raw/dados.parquet", body, expected)
 
     assert _adapter_temporaries(tmp_path) == ()
     assert directory_fsyncs == (0 if failure == "ownership" else 2)
 
 
-@pytest.mark.parametrize("destination_kind", ["file", "directory"])
-def test_recuperacao_preserva_destino_existente(destination_kind: str, tmp_path: Path) -> None:
+@pytest.mark.parametrize("kind", ["file", "directory"])
+def test_recuperacao_preserva_destino_existente(kind: str, tmp_path: Path) -> None:
     losing = b"perdedor"
     winner = b"vencedor"
     key = "raw/dados.parquet"
     crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
     with pytest.raises(_SimulatedCrash):
         crashing.put(key, BytesIO(losing), sha256(losing).hexdigest())
-    destination = tmp_path / key
-    if destination_kind == "file":
+    destination = _objects_directory(tmp_path) / sha256(key.encode()).hexdigest()
+    if kind == "file":
         destination.write_bytes(winner)
         message = "object=immutable"
     else:
@@ -350,53 +352,55 @@ def test_recuperacao_preserva_destino_existente(destination_kind: str, tmp_path:
         message = "destination=invalid"
     with pytest.raises(Conflict, match=message):
         FilesystemObjectStore(tmp_path).put(key, BytesIO(losing), sha256(losing).hexdigest())
-    assert (
-        destination.read_bytes() == winner if destination_kind == "file" else destination.is_dir()
-    )
-    if destination_kind == "file":
+    assert destination.read_bytes() == winner if kind == "file" else destination.is_dir()
+    if kind == "file":
         assert _adapter_temporaries(tmp_path) == ()
 
 
-def test_remove_staging_quando_sha256_diverge(tmp_path: Path) -> None:
+@pytest.mark.parametrize("order", [("a", "a/b"), ("a/b", "a")])
+def test_chaves_com_prefixo_coexistem_em_qualquer_ordem(
+    order: tuple[str, str], tmp_path: Path
+) -> None:
     adapter = FilesystemObjectStore(tmp_path)
+    bodies = {"a": b"pai", "a/b": b"filho"}
+    for key in order:
+        adapter.put(key, BytesIO(bodies[key]), sha256(bodies[key]).hexdigest())
+    with adapter.open("a") as parent, adapter.open("a/b") as child:
+        assert (parent.read(), child.read()) == (b"pai", b"filho")
+    lock_key = f".cnes-object-store-{sha256(b'a').hexdigest()}.lock"
+    adapter.delete("a")
+    assert adapter.stat(lock_key) is None
+    adapter.put(lock_key, BytesIO(b"lock"), sha256(b"lock").hexdigest())
+    with adapter.open(lock_key) as stream:
+        assert stream.read() == b"lock"
 
-    with pytest.raises(ValueError, match="sha256=mismatch"):
-        adapter.put("raw/invalido", BytesIO(b"conteudo"), sha256(b"outro").hexdigest())
 
-    assert adapter.stat("raw/invalido") is None
-    assert _adapter_temporaries(tmp_path) == ()
-
-
-def test_rejeita_chave_invalida_com_erro_estruturado(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="object_key=invalid"):
-        FilesystemObjectStore(tmp_path).stat("../fora")
-
-
-@pytest.mark.parametrize("operation", ["put", "open", "stat", "delete"])
-def test_rejeita_componente_symlink_sem_acessar_fora_do_root(
-    operation: str, tmp_path: Path
+def test_troca_adversarial_nao_remove_objeto_externo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     root = tmp_path / "store"
-    outside = tmp_path / "outside"
-    root.mkdir()
-    outside.mkdir()
-    external = outside / "dados.parquet"
-    external.write_bytes(b"externo")
-    (root / "link").symlink_to(outside, target_is_directory=True)
+    key = "inside/dados.parquet"
     adapter = FilesystemObjectStore(root)
-    body = b"novo"
-    actions = {
-        "put": lambda: adapter.put("link/dados.parquet", BytesIO(body), sha256(body).hexdigest()),
-        "open": lambda: adapter.open("link/dados.parquet").close(),
-        "stat": lambda: adapter.stat("link/dados.parquet"),
-        "delete": lambda: adapter.delete("link/dados.parquet"),
-    }
+    adapter.put(key, BytesIO(b"interno"), sha256(b"interno").hexdigest())
+    external = tmp_path / "outside/dados.parquet"
+    external.parent.mkdir()
+    external.write_bytes(b"externo")
+    real_lstat = Path.lstat
+    swapped = False
 
-    with pytest.raises(ValueError, match="object_path=symlink"):
-        actions[operation]()
+    def swap_after_check(path: Path) -> os.stat_result:
+        nonlocal swapped
+        result = real_lstat(path)
+        if path == root / "inside" and not swapped:
+            path.rename(root / "parked")
+            path.symlink_to(external.parent, target_is_directory=True)
+            swapped = True
+        return result
+
+    monkeypatch.setattr(Path, "lstat", swap_after_check)
+    adapter.delete(key)
 
     assert external.read_bytes() == b"externo"
-    assert tuple(outside.glob(".cnes-object-store-*")) == ()
 
 
 @pytest.mark.parametrize("link_kind", ["staging", "publication"])
@@ -406,8 +410,7 @@ def test_nao_faz_fallback_quando_link_e_incompativel(
     body = b"conteudo"
     adapter = FilesystemObjectStore(tmp_path)
     if link_kind == "staging":
-        directory = tmp_path / "raw"
-        directory.mkdir()
+        directory = _objects_directory(tmp_path)
         namespace = sha256(b"raw/sem-fallback").hexdigest()
         attacker = directory / f".cnes-object-store-{namespace}-attacker.tmp"
         attacker.write_bytes(b"preservar")
@@ -437,7 +440,7 @@ def test_lock_do_destino_bloqueia_outro_processo_durante_staging(tmp_path: Path)
     )
     process.start()
     assert reached.wait(timeout=5)
-    lock_path = next(tmp_path.rglob(".cnes-object-store-*.lock"))
+    lock_path = next(next(tmp_path.rglob("locks")).iterdir())
 
     with lock_path.open("a+b") as lock:
         with pytest.raises(BlockingIOError):

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -133,7 +133,7 @@ def test_fsynca_pai_de_cada_diretorio_interno_criado_ou_existente(
     assert observed[:3] == [tmp_path, root, next(root.iterdir())]
     observed.clear()
     FilesystemObjectStore(root)
-    assert observed == [root, next(root.iterdir()), next(root.iterdir())]
+    assert observed == [tmp_path, root, next(root.iterdir()), next(root.iterdir())]
 
 
 @pytest.mark.parametrize("operation", ["put", "promote"])

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -10,6 +10,7 @@ from io import BytesIO
 from pathlib import Path
 from threading import Event, Thread
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -106,7 +107,10 @@ def test_cumpre_contrato_compartilhado(
 ) -> None:
     root = tmp_path_factory.mktemp(case.name)
     clock = MutableClock(datetime(2026, 7, 15, tzinfo=UTC))
-    case.run(FilesystemObjectStore(root), clock)
+    adapter = FilesystemObjectStore(root)
+    case.run(adapter, clock)
+    adapter.delete("raw/ausente")
+    assert adapter.stat("raw/ausente") is None
 
 
 @pytest.mark.linux_only
@@ -139,8 +143,7 @@ def test_recupera_cada_fronteira_duravel_sem_apagar_arquivo_alheio(
     unrelated = tmp_path / ".arquivo-do-usuario"
     unrelated.write_bytes(b"preservar")
     source_key = "staging/dados.parquet"
-    if operation == "promote":
-        FilesystemObjectStore(tmp_path).put(source_key, BytesIO(body), expected)
+    FilesystemObjectStore(tmp_path).put(source_key, BytesIO(body), expected)
     crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt(boundary))
 
     def perform() -> None:
@@ -152,44 +155,15 @@ def test_recupera_cada_fronteira_duravel_sem_apagar_arquivo_alheio(
     with pytest.raises(_SimulatedCrash, match=f"boundary={boundary}"):
         perform()
     recovered = FilesystemObjectStore(tmp_path)
+    assert _adapter_temporaries(tmp_path) == ()
     current = recovered.stat("raw/dados.parquet")
     assert current is None or (current.size_bytes, current.sha256) == (len(body), expected)
     assert recovered.put("raw/dados.parquet", BytesIO(body), expected).sha256 == expected
     with recovered.open("raw/dados.parquet") as stream:
         assert stream.read() == body
-    assert _adapter_temporaries(tmp_path) == ()
+    with recovered.open(source_key) as stream:
+        assert stream.read() == body
     assert unrelated.read_bytes() == b"preservar"
-
-
-@pytest.mark.parametrize("boundary", ["temporary_created", "file_fsynced"])
-def test_reabre_e_remove_temporario_pre_publicacao_sem_operar_na_chave(
-    boundary: str, tmp_path: Path
-) -> None:
-    valid_key = "raw/valido.parquet"
-    valid_body = b"destino-valido"
-    adapter = FilesystemObjectStore(tmp_path)
-    adapter.put(valid_key, BytesIO(valid_body), sha256(valid_body).hexdigest())
-    unrelated = tmp_path / ".arquivo-do-usuario"
-    unrelated.write_bytes(b"preservar")
-    malformed = (
-        tmp_path / ".cnes-object-store-nao-relacionado.tmp",
-        tmp_path / f".cnes-object-store-{'a' * 64}-.tmp",
-        tmp_path / f".cnes-object-store-{'A' * 64}-token.tmp",
-    )
-    for hidden in malformed:
-        hidden.write_bytes(b"preservar")
-    crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt(boundary))
-    body = b"abandonado"
-    digest = sha256(body).hexdigest()
-    with pytest.raises(_SimulatedCrash, match=f"boundary={boundary}"):
-        crashing.put("raw/abandonado.parquet", BytesIO(body), digest)
-    recoverable = tuple(path for path in _adapter_temporaries(tmp_path) if path not in malformed)
-    assert recoverable
-    FilesystemObjectStore(tmp_path)
-    assert all(not path.exists() for path in recoverable)
-    assert (tmp_path / valid_key).read_bytes() == valid_body
-    assert unrelated.read_bytes() == b"preservar"
-    assert all(hidden.read_bytes() == b"preservar" for hidden in malformed)
 
 
 def test_reabertura_ignora_temporario_removido_durante_scan(
@@ -213,6 +187,18 @@ def test_reabertura_ignora_temporario_removido_durante_scan(
     assert removed == [temporary]
 
 
+def test_crash_pre_marker_nao_deixa_temporario(tmp_path: Path) -> None:
+    key = "raw/dados.parquet"
+    crashing = FilesystemObjectStore(
+        tmp_path, fault_injector=_CrashAt("temporary_created_before_ownership")
+    )
+    body = b"conteudo"
+
+    with pytest.raises(_SimulatedCrash, match="boundary=temporary_created_before_ownership"):
+        crashing.put(key, BytesIO(body), sha256(body).hexdigest())
+    assert _adapter_temporaries(tmp_path) == ()
+
+
 def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: Path) -> None:
     body = b"conteudo"
     digest = sha256(body).hexdigest()
@@ -226,65 +212,32 @@ def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: 
         assert stream.read() == body
 
 
+@pytest.mark.parametrize("alias_kind", ["valid_key", "hard_link", "symlink"])
 @pytest.mark.parametrize("recovery", ["startup", "pre_write"])
-def test_recuperacao_preserva_objeto_valido_com_nome_de_temporario(
-    recovery: str, tmp_path: Path
-) -> None:
-    destination_key = "raw/destino.parquet"
-    digest = sha256(destination_key.encode()).hexdigest()
-    valid_key = f"raw/.cnes-object-store-{digest}-writer.tmp"
-    valid_body = b"objeto-valido"
-    adapter = FilesystemObjectStore(tmp_path)
-    adapter.put(valid_key, BytesIO(valid_body), sha256(valid_body).hexdigest())
-    if recovery == "startup":
-        adapter = FilesystemObjectStore(tmp_path)
-    else:
-        body = b"novo-destino"
-        adapter.put(destination_key, BytesIO(body), sha256(body).hexdigest())
-    with adapter.open(valid_key) as stream:
-        assert stream.read() == valid_body
-
-
-@pytest.mark.parametrize("recovery", ["startup", "pre_write"])
-def test_recuperacao_preserva_hard_link_legal_com_token_alheio(
-    recovery: str, tmp_path: Path
-) -> None:
+def test_recuperacao_preserva_alias_legal(alias_kind: str, recovery: str, tmp_path: Path) -> None:
     key = "raw/destino.parquet"
     body = b"objeto-valido"
     digest = sha256(body).hexdigest()
     namespace = sha256(key.encode()).hexdigest()
-    alias = tmp_path / "raw" / f".cnes-object-store-{namespace}-anything.tmp"
+    alias = tmp_path / "raw" / f".cnes-object-store-{namespace}-writer.tmp"
     adapter = FilesystemObjectStore(tmp_path)
-    adapter.put(key, BytesIO(body), digest)
-    os.link(tmp_path / key, alias)
-
+    if alias_kind == "valid_key":
+        adapter.put(alias.relative_to(tmp_path).as_posix(), BytesIO(body), digest)
+    elif alias_kind == "hard_link":
+        adapter.put(key, BytesIO(body), digest)
+        os.link(tmp_path / key, alias)
+    else:
+        crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("destination_linked"))
+        with pytest.raises(_SimulatedCrash, match="boundary=destination_linked"):
+            crashing.put(key, BytesIO(body), digest)
+        alias = _adapter_temporaries(tmp_path)[0]
+        alias.unlink()
+        alias.symlink_to(Path(key).name)
     if recovery == "startup":
         FilesystemObjectStore(tmp_path)
     else:
         adapter.put(key, BytesIO(body), digest)
-
-    assert alias.read_bytes() == body
-
-
-@pytest.mark.parametrize("recovery", ["startup", "pre_write"])
-def test_recuperacao_preserva_symlink_legal_com_token_exato(recovery: str, tmp_path: Path) -> None:
-    key = "raw/destino.parquet"
-    body = b"objeto-valido"
-    digest = sha256(body).hexdigest()
-    adapter = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("destination_linked"))
-
-    with pytest.raises(_SimulatedCrash, match="boundary=destination_linked"):
-        adapter.put(key, BytesIO(body), digest)
-    alias = _adapter_temporaries(tmp_path)[0]
-    alias.unlink()
-    alias.symlink_to(Path(key).name)
-
-    if recovery == "startup":
-        FilesystemObjectStore(tmp_path)
-    else:
-        adapter.put(key, BytesIO(body), digest)
-
-    assert alias.is_symlink()
+    assert alias.is_symlink() == (alias_kind == "symlink")
     assert alias.read_bytes() == body
 
 
@@ -295,6 +248,7 @@ def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> 
     different_parent_digest = sha256(different_parent_owner.encode()).hexdigest()
     mismatch_owner = "raw/owner.parquet"
     candidates = {
+        directory / ".cnes-object-store-curto.tmp": None,
         directory / f".cnes-object-store-{'b' * 64}-writer.tmp": None,
         directory / f".cnes-object-store-{'c' * 64}-writer.tmp": b"\xff",
         directory / f".cnes-object-store-{'d' * 64}-writer.tmp": b"../invalid\0writer",
@@ -320,68 +274,87 @@ def test_reabertura_propaga_erro_ao_ler_ownership(
 ) -> None:
     candidate = tmp_path / f".cnes-object-store-{'f' * 64}-writer.tmp"
     candidate.write_bytes(b"preservar")
-
-    def deny_xattr(path: os.PathLike[str], attribute: str, *, follow_symlinks: bool) -> bytes:
-        raise PermissionError(errno.EACCES, "xattr=denied")
-
-    monkeypatch.setattr(os, "getxattr", deny_xattr)
-
+    monkeypatch.setattr(
+        os, "getxattr", MagicMock(side_effect=PermissionError(errno.EACCES, "xattr=denied"))
+    )
     with pytest.raises(PermissionError, match="xattr=denied"):
         FilesystemObjectStore(tmp_path)
 
     assert candidate.read_bytes() == b"preservar"
 
 
-def test_falha_ao_marcar_ownership_remove_temporario(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("failure", ["ownership", "read", "write", "flush", "content_fsync"])
+def test_falha_ordinaria_de_staging_remove_temporario_e_fsynca_diretorio(
+    failure: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     adapter = FilesystemObjectStore(tmp_path)
+    body = MagicMock(wraps=BytesIO(b"conteudo"))
+    if failure == "ownership":
+        monkeypatch.setattr(
+            os,
+            "setxattr",
+            MagicMock(side_effect=OSError(errno.ENOTSUP, "staging=failed")),
+        )
+    if failure == "read":
+        body.read.side_effect = OSError(errno.EIO, "staging=failed")
+    real_fdopen = os.fdopen
 
-    def reject_xattr(descriptor: int, attribute: str, value: bytes) -> None:
-        raise OSError(errno.ENOTSUP, "xattr=unsupported")
+    def failing_fdopen(*args: Any, **kwargs: Any) -> MagicMock:
+        stream = real_fdopen(*args, **kwargs)
+        writer = MagicMock(wraps=stream)
+        writer.__enter__.return_value = writer
+        writer.__exit__.side_effect = stream.__exit__
+        writer.fileno.side_effect = stream.fileno
+        getattr(writer, failure).side_effect = OSError(errno.EIO, "staging=failed")
+        return writer
 
-    monkeypatch.setattr(os, "setxattr", reject_xattr)
+    if failure in {"write", "flush"}:
+        monkeypatch.setattr(os, "fdopen", failing_fdopen)
+    real_fsync = os.fsync
+    regular_fsyncs = 0
+    directory_fsyncs = 0
 
-    with pytest.raises(OSError, match="xattr=unsupported"):
-        adapter.put("raw/dados.parquet", BytesIO(b"conteudo"), sha256(b"conteudo").hexdigest())
+    def failing_fsync(descriptor: int) -> None:
+        nonlocal directory_fsyncs, regular_fsyncs
+        target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
+        if target.is_dir():
+            directory_fsyncs += target == tmp_path / "raw"
+        else:
+            regular_fsyncs += 1
+            if failure == "content_fsync" and regular_fsyncs == 2:
+                raise OSError(errno.EIO, "staging=failed")
+        real_fsync(descriptor)
 
-    assert adapter.stat("raw/dados.parquet") is None
+    monkeypatch.setattr(os, "fsync", failing_fsync)
+    with pytest.raises(OSError, match="staging=failed"):
+        adapter.put("raw/dados.parquet", body, sha256(b"conteudo").hexdigest())
+
     assert _adapter_temporaries(tmp_path) == ()
+    assert directory_fsyncs == (0 if failure == "ownership" else 2)
 
 
-def test_remove_temporario_perdedor_sem_tocar_destino_valido(tmp_path: Path) -> None:
+@pytest.mark.parametrize("destination_kind", ["file", "directory"])
+def test_recuperacao_preserva_destino_existente(destination_kind: str, tmp_path: Path) -> None:
     losing = b"perdedor"
     winner = b"vencedor"
     key = "raw/dados.parquet"
     crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
-
     with pytest.raises(_SimulatedCrash):
         crashing.put(key, BytesIO(losing), sha256(losing).hexdigest())
     destination = tmp_path / key
-    destination.write_bytes(winner)
-
-    recovered = FilesystemObjectStore(tmp_path)
-    with pytest.raises(Conflict, match="object=immutable"):
-        recovered.put(key, BytesIO(losing), sha256(losing).hexdigest())
-
-    assert destination.read_bytes() == winner
-    assert _adapter_temporaries(tmp_path) == ()
-
-
-def test_rejeita_destino_invalido_sem_remove_lo_na_recuperacao(tmp_path: Path) -> None:
-    body = b"conteudo"
-    key = "raw/dados.parquet"
-    crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
-
-    with pytest.raises(_SimulatedCrash):
-        crashing.put(key, BytesIO(body), sha256(body).hexdigest())
-    destination = tmp_path / key
-    destination.mkdir()
-
-    with pytest.raises(Conflict, match="destination=invalid"):
-        FilesystemObjectStore(tmp_path).put(key, BytesIO(body), sha256(body).hexdigest())
-
-    assert destination.is_dir()
+    if destination_kind == "file":
+        destination.write_bytes(winner)
+        message = "object=immutable"
+    else:
+        destination.mkdir()
+        message = "destination=invalid"
+    with pytest.raises(Conflict, match=message):
+        FilesystemObjectStore(tmp_path).put(key, BytesIO(losing), sha256(losing).hexdigest())
+    assert (
+        destination.read_bytes() == winner if destination_kind == "file" else destination.is_dir()
+    )
+    if destination_kind == "file":
+        assert _adapter_temporaries(tmp_path) == ()
 
 
 def test_remove_staging_quando_sha256_diverge(tmp_path: Path) -> None:
@@ -399,30 +372,55 @@ def test_rejeita_chave_invalida_com_erro_estruturado(tmp_path: Path) -> None:
         FilesystemObjectStore(tmp_path).stat("../fora")
 
 
-def test_nao_faz_fallback_quando_hard_link_e_incompativel(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("operation", ["put", "open", "stat", "delete"])
+def test_rejeita_componente_symlink_sem_acessar_fora_do_root(
+    operation: str, tmp_path: Path
+) -> None:
+    root = tmp_path / "store"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    external = outside / "dados.parquet"
+    external.write_bytes(b"externo")
+    (root / "link").symlink_to(outside, target_is_directory=True)
+    adapter = FilesystemObjectStore(root)
+    body = b"novo"
+    actions = {
+        "put": lambda: adapter.put("link/dados.parquet", BytesIO(body), sha256(body).hexdigest()),
+        "open": lambda: adapter.open("link/dados.parquet").close(),
+        "stat": lambda: adapter.stat("link/dados.parquet"),
+        "delete": lambda: adapter.delete("link/dados.parquet"),
+    }
+
+    with pytest.raises(ValueError, match="object_path=symlink"):
+        actions[operation]()
+
+    assert external.read_bytes() == b"externo"
+    assert tuple(outside.glob(".cnes-object-store-*")) == ()
+
+
+@pytest.mark.parametrize("link_kind", ["staging", "publication"])
+def test_nao_faz_fallback_quando_link_e_incompativel(
+    link_kind: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     body = b"conteudo"
     adapter = FilesystemObjectStore(tmp_path)
-
-    def reject_link(source: Path, destination: Path) -> None:
-        raise OSError(errno.EPERM, "hard_link=incompatible")
-
-    monkeypatch.setattr(os, "link", reject_link)
-
-    with pytest.raises(OSError, match="hard_link=incompatible"):
+    if link_kind == "staging":
+        directory = tmp_path / "raw"
+        directory.mkdir()
+        namespace = sha256(b"raw/sem-fallback").hexdigest()
+        attacker = directory / f".cnes-object-store-{namespace}-attacker.tmp"
+        attacker.write_bytes(b"preservar")
+        monkeypatch.setattr("cnes_infra.object_store.filesystem.token_hex", lambda size: "attacker")
+    else:
+        attacker = None
+        error = OSError(errno.EPERM, "hard_link=incompatible")
+        monkeypatch.setattr(os, "link", MagicMock(side_effect=error))
+    with pytest.raises(OSError):
         adapter.put("raw/sem-fallback", BytesIO(body), sha256(body).hexdigest())
-
     assert adapter.stat("raw/sem-fallback") is None
-    assert _adapter_temporaries(tmp_path) == ()
-
-
-def test_delete_de_chave_ausente_e_idempotente(tmp_path: Path) -> None:
-    adapter = FilesystemObjectStore(tmp_path)
-
-    adapter.delete("raw/ausente")
-
-    assert adapter.stat("raw/ausente") is None
+    assert _adapter_temporaries(tmp_path) == (() if attacker is None else (attacker,))
+    assert attacker is None or attacker.read_bytes() == b"preservar"
 
 
 @pytest.mark.linux_only
@@ -488,7 +486,6 @@ def test_corrida_entre_processos_publica_um_destino_completo(
     for process in processes:
         process.join(timeout=10)
         assert process.exitcode == 0
-
     outcomes = [results.get(timeout=2)[0] for _ in processes]
     with FilesystemObjectStore(tmp_path).open("raw/race") as stream:
         published = stream.read()

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -26,11 +26,7 @@ _DURABLE_BOUNDARIES = ("temporary_created_before_ownership", "temporary_created"
     "temporary_unlinked", "directory_final_fsynced",)
 _INTERNAL = ".cnes-object-store-internal"
 _OWNER_XATTR = "user.cnes_object_store_destination"
-
-
 class _SimulatedCrash(RuntimeError): ...
-
-
 @dataclass(slots=True)
 class _CrashAt:
     boundary: str
@@ -39,16 +35,10 @@ class _CrashAt:
         if boundary == self.boundary and not self.triggered:
             self.triggered = True
             raise _SimulatedCrash(f"boundary={boundary}")
-
-
 def _adapter_temporaries(root: Path) -> tuple[Path, ...]:
     return tuple(root.rglob(".cnes-object-store-*.tmp"))
-
-
 def _objects_directory(root: Path) -> Path:
     return next(path for path in root.rglob("objects") if path.is_dir())
-
-
 def _process_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
     barrier, results, destination_linked, reader_done = controls
     expected = sha256(body).hexdigest()
@@ -64,8 +54,6 @@ def _process_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
         results.put(("ok", stat.sha256))
     except Conflict:
         results.put(("conflict", expected))
-
-
 def _paused_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
     reached, release, results = controls
     def pause(boundary: str) -> None:
@@ -80,8 +68,6 @@ def _paused_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
         results.put("ok")
     except Exception as error:
         results.put(type(error).__name__)
-
-
 def _process_final(root: str, results: Any) -> None:
     key, adapter = "raw/dados.parquet", FilesystemObjectStore(root)
     operations = (("stat", b""), ("open", b""), ("delete", b""), ("put", b"a"), ("put", b"b"))
@@ -95,8 +81,6 @@ def _process_final(root: str, results: Any) -> None:
                     result.close()
         except Exception as error:
             results.put((type(error).__name__, str(error)))
-
-
 def _read_during_publication(root: str, controls: tuple[Any, ...]) -> None:
     reader_ready, destination_linked, reader_done, observed = controls
     reader_ready.set()
@@ -110,8 +94,6 @@ def _read_during_publication(root: str, controls: tuple[Any, ...]) -> None:
         pass
     finally:
         reader_done.set()
-
-
 @pytest.mark.parametrize("case", contract.object_store_cases(), ids=lambda case: case.name)
 def test_contrato(case: contract.ObjectStoreCase, tmp_path_factory: pytest.TempPathFactory) -> None:
     root = tmp_path_factory.mktemp(case.name)
@@ -362,6 +344,23 @@ def test_recuperacao_preserva_destino_existente(kind: str, tmp_path: Path) -> No
         FilesystemObjectStore(tmp_path).put(key, BytesIO(losing), sha256(losing).hexdigest())
     assert destination.read_bytes() == winner if kind == "file" else destination.is_dir()
     assert kind != "file" or _adapter_temporaries(tmp_path) == ()
+@pytest.mark.parametrize("kind", ["directory", "fifo"])
+def test_startup_descarta_temp_ante_destino_malformado(kind: str, tmp_path: Path) -> None:
+    bad_key, other_key, body = "raw/malformado", "raw/outro", b"conteudo"
+    writers = (
+        FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced")),
+        FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced")),
+    )
+    for writer, key in zip(writers, (bad_key, other_key), strict=True):
+        with pytest.raises(_SimulatedCrash):
+            writer.put(key, BytesIO(body), sha256(body).hexdigest())
+    destination = _objects_directory(tmp_path) / sha256(bad_key.encode()).hexdigest()
+    destination.mkdir() if kind == "directory" else os.mkfifo(destination)
+    recovered = FilesystemObjectStore(tmp_path)
+    assert destination.is_dir() if kind == "directory" else destination.is_fifo()
+    assert (_adapter_temporaries(tmp_path), recovered.stat(other_key)) == ((), None)
+    with pytest.raises(Conflict, match="destination=invalid"):
+        recovered.stat(bad_key)
 @pytest.mark.linux_only
 def test_fifo_final_nao_bloqueia(tmp_path: Path) -> None:
     key = "raw/dados.parquet"

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -79,7 +79,7 @@ def _process_paused_put(root: str, body: bytes, controls: tuple[Any, ...]) -> No
             reached.set()
             if not release.wait(timeout=5):
                 raise TimeoutError("release=timeout")
-
+            raise _SimulatedCrash("writer=crashed")
     try:
         digest = sha256(body).hexdigest()
         FilesystemObjectStore(root, fault_injector=pause).put("raw/locked", BytesIO(body), digest)
@@ -375,32 +375,24 @@ def test_chaves_com_prefixo_coexistem_em_qualquer_ordem(
         assert stream.read() == b"lock"
 
 
-def test_troca_adversarial_nao_remove_objeto_externo(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    root = tmp_path / "store"
-    key = "inside/dados.parquet"
+@pytest.mark.parametrize("ancestor", [False, True], ids=["root", "ancestor"])
+def test_root_aberto_nao_segue_path_substituido(ancestor: bool, tmp_path: Path) -> None:
+    parent = tmp_path / "original"
+    root = parent / "store"
     adapter = FilesystemObjectStore(root)
-    adapter.put(key, BytesIO(b"interno"), sha256(b"interno").hexdigest())
-    external = tmp_path / "outside/dados.parquet"
-    external.parent.mkdir()
-    external.write_bytes(b"externo")
-    real_lstat = Path.lstat
-    swapped = False
-
-    def swap_after_check(path: Path) -> os.stat_result:
-        nonlocal swapped
-        result = real_lstat(path)
-        if path == root / "inside" and not swapped:
-            path.rename(root / "parked")
-            path.symlink_to(external.parent, target_is_directory=True)
-            swapped = True
-        return result
-
-    monkeypatch.setattr(Path, "lstat", swap_after_check)
-    adapter.delete(key)
-
-    assert external.read_bytes() == b"externo"
+    target = parent if ancestor else root
+    target.rename(tmp_path / "moved")
+    replacement = tmp_path / "replacement"
+    replacement.mkdir()
+    target.symlink_to(replacement, target_is_directory=True)
+    body = b"conteudo"
+    adapter.put("raw/objeto", BytesIO(body), sha256(body).hexdigest())
+    with adapter.open("raw/objeto") as stream:
+        assert stream.read() == body
+    assert adapter.stat("raw/objeto") is not None
+    adapter.delete("raw/objeto")
+    assert adapter.stat("raw/objeto") is None
+    assert tuple(replacement.iterdir()) == ()
 
 
 @pytest.mark.parametrize("link_kind", ["staging", "publication"])
@@ -427,9 +419,8 @@ def test_nao_faz_fallback_quando_link_e_incompativel(
 
 
 @pytest.mark.linux_only
-def test_lock_do_destino_bloqueia_outro_processo_durante_staging(tmp_path: Path) -> None:
+def test_startup_recupera_apos_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     import multiprocessing
-
     context = multiprocessing.get_context("spawn")
     reached = context.Event()
     release = context.Event()
@@ -441,15 +432,24 @@ def test_lock_do_destino_bloqueia_outro_processo_durante_staging(tmp_path: Path)
     process.start()
     assert reached.wait(timeout=5)
     lock_path = next(next(tmp_path.rglob("locks")).iterdir())
-
     with lock_path.open("a+b") as lock:
         with pytest.raises(BlockingIOError):
             fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-
-    release.set()
+    real_flock = fcntl.flock
+    def release_writer(descriptor: int, operation: int) -> None:
+        if operation & fcntl.LOCK_NB:
+            try:
+                return real_flock(descriptor, operation)
+            finally:
+                release.set()
+        release.set()
+        return real_flock(descriptor, operation)
+    monkeypatch.setattr(fcntl, "flock", release_writer)
+    FilesystemObjectStore(tmp_path)
     process.join(timeout=10)
     assert process.exitcode == 0
-    assert results.get(timeout=2) == "ok"
+    assert results.get(timeout=2) == "_SimulatedCrash"
+    assert _adapter_temporaries(tmp_path) == ()
 
 
 @pytest.mark.linux_only

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -129,10 +129,13 @@ def test_fsynca_pai_de_cada_diretorio_interno_criado_ou_existente(
         real_fsync(descriptor)
     monkeypatch.setattr(os, "fsync", observe_fsync)
     FilesystemObjectStore(root)
-    assert observed[:3] == [tmp_path, root, next(root.iterdir())]
+    assert observed[:4] == [tmp_path.parent, tmp_path, root, next(root.iterdir())]
     observed.clear()
     FilesystemObjectStore(root)
     assert observed == [tmp_path, root, next(root.iterdir()), next(root.iterdir())]
+    observed.clear()
+    FilesystemObjectStore(root / "nested")
+    assert observed[:2] == [tmp_path, root]
 
 
 @pytest.mark.parametrize("operation", ["put", "promote"])
@@ -273,7 +276,6 @@ def test_reabertura_propaga_erro_ao_ler_ownership(
         if path == candidate.name:
             raise PermissionError(errno.EACCES, "xattr=denied")
         return real_open(path, *args, **kwargs)
-
     monkeypatch.setattr(os, "open", deny_candidate)
     with pytest.raises(PermissionError, match="xattr=denied"):
         FilesystemObjectStore(tmp_path)
@@ -301,7 +303,6 @@ def test_falha_ordinaria_remove_temporario_e_fsynca_diretorio(
     if mode == "read":
         body.read.side_effect = OSError(errno.EIO, "staging=failed")
     real_fdopen = os.fdopen
-
     def failing_fdopen(*args: Any, **kwargs: Any) -> MagicMock:
         stream = real_fdopen(*args, **kwargs)
         writer = MagicMock(wraps=stream)
@@ -333,7 +334,6 @@ def test_falha_ordinaria_remove_temporario_e_fsynca_diretorio(
     message = "sha256=mismatch" if mode == "sha" else "staging=failed"
     with pytest.raises(error, match=message):
         adapter.put("raw/dados.parquet", body, expected)
-
     assert _adapter_temporaries(tmp_path) == ()
     assert directory_fsyncs == (0 if mode == "owner" else 3 if mode == "dst" else 2)
 

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -21,10 +21,7 @@ from packages.cnes_infra.tests.contracts.object_store_contract import (
     object_store_cases,
 )
 
-_DURABLE_BOUNDARIES = (
-    "temporary_created",
-    "file_fsynced",
-    "destination_linked",
+_DURABLE_BOUNDARIES = ("temporary_created", "file_fsynced", "destination_linked") + (
     "directory_fsynced",
     "temporary_unlinked",
     "directory_final_fsynced",
@@ -109,8 +106,27 @@ def test_cumpre_contrato_compartilhado(
 ) -> None:
     root = tmp_path_factory.mktemp(case.name)
     clock = MutableClock(datetime(2026, 7, 15, tzinfo=UTC))
-
     case.run(FilesystemObjectStore(root), clock)
+
+
+@pytest.mark.linux_only
+def test_fsynca_pai_de_cada_diretorio_criado(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = FilesystemObjectStore(tmp_path)
+    observed: list[Path] = []
+    real_fsync = os.fsync
+
+    def observe_fsync(descriptor: int) -> None:
+        target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
+        if target.is_dir():
+            observed.append(target)
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", observe_fsync)
+    body = b"conteudo"
+    adapter.put("nivel-1/nivel-2/dados.parquet", BytesIO(body), sha256(body).hexdigest())
+    assert observed[:3] == [tmp_path, tmp_path / "nivel-1", tmp_path / "nivel-1/nivel-2"]
 
 
 @pytest.mark.parametrize("operation", ["put", "promote"])
@@ -135,7 +151,6 @@ def test_recupera_cada_fronteira_duravel_sem_apagar_arquivo_alheio(
 
     with pytest.raises(_SimulatedCrash, match=f"boundary={boundary}"):
         perform()
-
     recovered = FilesystemObjectStore(tmp_path)
     current = recovered.stat("raw/dados.parquet")
     assert current is None or (current.size_bytes, current.sha256) == (len(body), expected)
@@ -166,65 +181,66 @@ def test_reabre_e_remove_temporario_pre_publicacao_sem_operar_na_chave(
     crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt(boundary))
     body = b"abandonado"
     digest = sha256(body).hexdigest()
-
     with pytest.raises(_SimulatedCrash, match=f"boundary={boundary}"):
         crashing.put("raw/abandonado.parquet", BytesIO(body), digest)
-
     recoverable = tuple(path for path in _adapter_temporaries(tmp_path) if path not in malformed)
     assert recoverable
     FilesystemObjectStore(tmp_path)
-
     assert all(not path.exists() for path in recoverable)
     assert (tmp_path / valid_key).read_bytes() == valid_body
     assert unrelated.read_bytes() == b"preservar"
     assert all(hidden.read_bytes() == b"preservar" for hidden in malformed)
 
 
+def test_reabertura_ignora_temporario_removido_durante_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
+    with pytest.raises(_SimulatedCrash, match="boundary=file_fsynced"):
+        crashing.put("raw/dados.parquet", BytesIO(b"abandonado"), sha256(b"abandonado").hexdigest())
+    temporary = _adapter_temporaries(tmp_path)[0]
+    real_lstat = Path.lstat
+    removed: list[Path] = []
+
+    def vanish_before_lstat(path: Path) -> os.stat_result:
+        if path == temporary:
+            removed.append(path)
+            path.unlink()
+        return real_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", vanish_before_lstat)
+    FilesystemObjectStore(tmp_path)
+    assert removed == [temporary]
+
+
 def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: Path) -> None:
     body = b"conteudo"
     digest = sha256(body).hexdigest()
     adapter = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
-
     with pytest.raises(_SimulatedCrash, match="boundary=file_fsynced"):
         adapter.put("raw/dados.parquet", BytesIO(body), digest)
-
     assert _adapter_temporaries(tmp_path)
     adapter.put("raw/dados.parquet", BytesIO(body), digest)
-
     assert _adapter_temporaries(tmp_path) == ()
     with adapter.open("raw/dados.parquet") as stream:
         assert stream.read() == body
 
 
-def test_reabertura_preserva_objeto_valido_com_nome_de_temporario(tmp_path: Path) -> None:
-    other_key = "raw/outro.parquet"
-    digest = sha256(other_key.encode()).hexdigest()
-    valid_key = f"raw/.cnes-object-store-{digest}-writer.tmp"
-    body = b"objeto-valido"
-    adapter = FilesystemObjectStore(tmp_path)
-    adapter.put(valid_key, BytesIO(body), sha256(body).hexdigest())
-
-    reopened = FilesystemObjectStore(tmp_path)
-
-    with reopened.open(valid_key) as stream:
-        assert stream.read() == body
-
-
-def test_pre_write_preserva_objeto_valido_com_nome_de_temporario(tmp_path: Path) -> None:
+@pytest.mark.parametrize("recovery", ["startup", "pre_write"])
+def test_recuperacao_preserva_objeto_valido_com_nome_de_temporario(
+    recovery: str, tmp_path: Path
+) -> None:
     destination_key = "raw/destino.parquet"
     digest = sha256(destination_key.encode()).hexdigest()
     valid_key = f"raw/.cnes-object-store-{digest}-writer.tmp"
     valid_body = b"objeto-valido"
-    destination_body = b"novo-destino"
     adapter = FilesystemObjectStore(tmp_path)
     adapter.put(valid_key, BytesIO(valid_body), sha256(valid_body).hexdigest())
-
-    adapter.put(
-        destination_key,
-        BytesIO(destination_body),
-        sha256(destination_body).hexdigest(),
-    )
-
+    if recovery == "startup":
+        adapter = FilesystemObjectStore(tmp_path)
+    else:
+        body = b"novo-destino"
+        adapter.put(destination_key, BytesIO(body), sha256(body).hexdigest())
     with adapter.open(valid_key) as stream:
         assert stream.read() == valid_body
 

--- a/packages/cnes_infra/tests/object_store/test_filesystem.py
+++ b/packages/cnes_infra/tests/object_store/test_filesystem.py
@@ -17,15 +17,12 @@ import pytest
 
 from cnes_domain.control_plane.errors import Conflict
 from cnes_infra.object_store.filesystem import FilesystemObjectStore
+from packages.cnes_infra.tests.contracts import object_store_contract as contract
 from packages.cnes_infra.tests.contracts.clock import MutableClock
-from packages.cnes_infra.tests.contracts.object_store_contract import (
-    ObjectStoreCase,
-    object_store_cases,
-)
 
 _DURABLE_BOUNDARIES = (
-    "temporary_created", "file_fsynced", "destination_linked",
-    "directory_fsynced", "temporary_unlinked", "directory_final_fsynced",
+    "temporary_created", "file_fsynced", "destination_linked", "directory_fsynced",
+    "temporary_unlinked", "directory_final_fsynced",
 )
 _OWNER_XATTR = "user.cnes_object_store_destination"
 
@@ -37,7 +34,6 @@ class _SimulatedCrash(RuntimeError): ...
 class _CrashAt:
     boundary: str
     triggered: bool = False
-
     def __call__(self, boundary: str) -> None:
         if boundary == self.boundary and not self.triggered:
             self.triggered = True
@@ -72,7 +68,6 @@ def _process_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
 
 def _process_paused_put(root: str, body: bytes, controls: tuple[Any, ...]) -> None:
     reached, release, results = controls
-
     def pause(boundary: str) -> None:
         if boundary == "temporary_created":
             reached.set()
@@ -85,6 +80,23 @@ def _process_paused_put(root: str, body: bytes, controls: tuple[Any, ...]) -> No
         results.put("ok")
     except Exception as error:
         results.put(type(error).__name__)
+
+
+def _process_final(root: str, results: Any) -> None:
+    key, adapter = "raw/dados.parquet", FilesystemObjectStore(root)
+    operations = (("stat", b""), ("open", b""), ("delete", b""), ("put", b"a"), ("put", b"b"))
+    for operation, body in operations:
+        try:
+            if operation == "put":
+                adapter.put(key, BytesIO(body), sha256(body).hexdigest())
+            else:
+                result = getattr(adapter, operation)(key)
+                if operation == "open":
+                    result.close()
+        except Exception as error:
+            results.put((type(error).__name__, str(error)))
+        else:
+            results.put(("ok", ""))
 
 
 def _read_during_publication(root: str, controls: tuple[Any, ...]) -> None:
@@ -102,10 +114,8 @@ def _read_during_publication(root: str, controls: tuple[Any, ...]) -> None:
         reader_done.set()
 
 
-@pytest.mark.parametrize("case", object_store_cases(), ids=lambda case: case.name)
-def test_cumpre_contrato_compartilhado(
-    case: ObjectStoreCase, tmp_path_factory: pytest.TempPathFactory
-) -> None:
+@pytest.mark.parametrize("case", contract.object_store_cases(), ids=lambda case: case.name)
+def test_contrato(case: contract.ObjectStoreCase, tmp_path_factory: pytest.TempPathFactory) -> None:
     root = tmp_path_factory.mktemp(case.name)
     with pytest.MonkeyPatch.context() as patch:
         patch.chdir(root.parent)
@@ -116,9 +126,7 @@ def test_cumpre_contrato_compartilhado(
 
 
 @pytest.mark.linux_only
-def test_fsynca_pai_de_cada_diretorio_interno_criado_ou_existente(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_fsynca_ancestral(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = tmp_path / "store"
     observed: list[Path] = []
     real_fsync = os.fsync
@@ -140,9 +148,7 @@ def test_fsynca_pai_de_cada_diretorio_interno_criado_ou_existente(
 
 @pytest.mark.parametrize("operation", ["put", "promote"])
 @pytest.mark.parametrize("boundary", _DURABLE_BOUNDARIES)
-def test_recupera_cada_fronteira_duravel_sem_apagar_arquivo_alheio(
-    boundary: str, operation: str, tmp_path: Path
-) -> None:
+def test_recupera_fronteira_duravel(boundary: str, operation: str, tmp_path: Path) -> None:
     body = b"conteudo-completo"
     expected = sha256(body).hexdigest()
     unrelated = tmp_path / ".arquivo-do-usuario"
@@ -169,9 +175,7 @@ def test_recupera_cada_fronteira_duravel_sem_apagar_arquivo_alheio(
     assert unrelated.read_bytes() == b"preservar"
 
 
-def test_reabertura_ignora_temporario_removido_durante_scan(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_scan_ignora_temp_removido(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
     with pytest.raises(_SimulatedCrash, match="boundary=file_fsynced"):
         crashing.put("raw/dados.parquet", BytesIO(b"abandonado"), sha256(b"abandonado").hexdigest())
@@ -201,8 +205,7 @@ def test_crash_pre_marker_nao_deixa_temporario(tmp_path: Path) -> None:
 
 
 def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: Path) -> None:
-    body = b"conteudo"
-    digest = sha256(body).hexdigest()
+    body, digest = b"conteudo", sha256(b"conteudo").hexdigest()
     adapter = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
     with pytest.raises(_SimulatedCrash, match="boundary=file_fsynced"):
         adapter.put("raw/dados.parquet", BytesIO(body), digest)
@@ -215,8 +218,7 @@ def test_nova_escrita_recupera_temporario_abandonado_no_mesmo_adapter(tmp_path: 
 @pytest.mark.parametrize("alias_kind", ["hard_link", "symlink"])
 @pytest.mark.parametrize("recovery", ["startup", "pre_write"])
 def test_recuperacao_preserva_alias_legal(alias_kind: str, recovery: str, tmp_path: Path) -> None:
-    key = "raw/destino.parquet"
-    body = b"objeto-valido"
+    key, body = "raw/destino.parquet", b"objeto-valido"
     digest = sha256(body).hexdigest()
     namespace = sha256(key.encode()).hexdigest()
     adapter = FilesystemObjectStore(tmp_path)
@@ -237,8 +239,7 @@ def test_recuperacao_preserva_alias_legal(alias_kind: str, recovery: str, tmp_pa
 def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> None:
     FilesystemObjectStore(tmp_path)
     directory = _objects_directory(tmp_path)
-    mismatch_owner = "raw/owner.parquet"
-    mismatch_digest = sha256(mismatch_owner.encode()).hexdigest()
+    mismatch_owner, mismatch_digest = "raw/owner.parquet", sha256(b"raw/owner.parquet").hexdigest()
     candidates = {
         directory / f".cnes-object-store-{'b' * 64}-writer.tmp": None,
         directory / f".cnes-object-store-{'c' * 64}-writer.tmp": b"\xff",
@@ -265,9 +266,7 @@ def test_reabertura_preserva_lookalikes_sem_ownership_valido(tmp_path: Path) -> 
     assert fifo.exists()
 
 
-def test_reabertura_propaga_erro_ao_ler_ownership(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_propaga_erro_de_ownership(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     FilesystemObjectStore(tmp_path)
     candidate = _objects_directory(tmp_path) / f".cnes-object-store-{'f' * 64}-writer.tmp"
     candidate.write_bytes(b"preservar")
@@ -289,11 +288,9 @@ def test_reabertura_propaga_erro_ao_ler_ownership(
 
 
 @pytest.mark.parametrize("mode", ["owner", "read", "write", "flush", "fsync", "sha", "dir", "dst"])
-def test_falha_ordinaria_remove_temporario_e_fsynca_diretorio(
-    mode: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    adapter = FilesystemObjectStore(tmp_path)
-    body = MagicMock(wraps=BytesIO(b"conteudo"))
+def test_falha_remove_temp_e_fsynca_dir(
+    mode: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter, body = FilesystemObjectStore(tmp_path), MagicMock(wraps=BytesIO(b"conteudo"))
     if mode == "owner":
         monkeypatch.setattr(
             os,
@@ -314,8 +311,7 @@ def test_falha_ordinaria_remove_temporario_e_fsynca_diretorio(
     if mode in {"write", "flush"}:
         monkeypatch.setattr(os, "fdopen", failing_fdopen)
     real_fsync = os.fsync
-    regular_fsyncs = 0
-    directory_fsyncs = 0
+    regular_fsyncs = directory_fsyncs = 0
     def failing_fsync(descriptor: int) -> None:
         nonlocal directory_fsyncs, regular_fsyncs
         target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
@@ -340,19 +336,16 @@ def test_falha_ordinaria_remove_temporario_e_fsynca_diretorio(
 
 @pytest.mark.parametrize("kind", ["file", "directory"])
 def test_recuperacao_preserva_destino_existente(kind: str, tmp_path: Path) -> None:
-    losing = b"perdedor"
-    winner = b"vencedor"
-    key = "raw/dados.parquet"
+    losing, winner, key = b"perdedor", b"vencedor", "raw/dados.parquet"
     crashing = FilesystemObjectStore(tmp_path, fault_injector=_CrashAt("file_fsynced"))
     with pytest.raises(_SimulatedCrash):
         crashing.put(key, BytesIO(losing), sha256(losing).hexdigest())
     destination = _objects_directory(tmp_path) / sha256(key.encode()).hexdigest()
     if kind == "file":
         destination.write_bytes(winner)
-        message = "object=immutable"
     else:
         destination.mkdir()
-        message = "destination=invalid"
+    message = "object=immutable" if kind == "file" else "destination=invalid"
     with pytest.raises(Conflict, match=message):
         FilesystemObjectStore(tmp_path).put(key, BytesIO(losing), sha256(losing).hexdigest())
     assert destination.read_bytes() == winner if kind == "file" else destination.is_dir()
@@ -360,12 +353,30 @@ def test_recuperacao_preserva_destino_existente(kind: str, tmp_path: Path) -> No
         assert _adapter_temporaries(tmp_path) == ()
 
 
+@pytest.mark.linux_only
+def test_fifo_final_nao_bloqueia(tmp_path: Path) -> None:
+    key, adapter = "raw/dados.parquet", FilesystemObjectStore(tmp_path)
+    fifo = _objects_directory(tmp_path) / sha256(key.encode()).hexdigest()
+    os.mkfifo(fifo)
+    context = multiprocessing.get_context("spawn")
+    results = context.Queue()
+    process = context.Process(target=_process_final, args=(str(tmp_path), results))
+    process.start()
+    process.join(timeout=1)
+    if process.is_alive():
+        process.terminate()
+    process.join(timeout=1)
+    assert process.exitcode == 0
+    assert [results.get(timeout=1) for _ in range(5)] == [("Conflict", "destination=invalid")] * 5
+    with pytest.raises(Conflict, match="destination=invalid"):
+        adapter.stat(key)
+    assert fifo.is_fifo()
+    assert _adapter_temporaries(tmp_path) == ()
+
+
 @pytest.mark.parametrize("order", [("a", "a/b"), ("a/b", "a")])
-def test_chaves_com_prefixo_coexistem_em_qualquer_ordem(
-    order: tuple[str, str], tmp_path: Path
-) -> None:
-    adapter = FilesystemObjectStore(tmp_path)
-    bodies = {"a": b"pai", "a/b": b"filho"}
+def test_chaves_prefixadas_coexistem(order: tuple[str, str], tmp_path: Path) -> None:
+    adapter, bodies = FilesystemObjectStore(tmp_path), {"a": b"pai", "a/b": b"filho"}
     for key in order:
         adapter.put(key, BytesIO(bodies[key]), sha256(bodies[key]).hexdigest())
     with adapter.open("a") as parent, adapter.open("a/b") as child:
@@ -399,11 +410,9 @@ def test_root_aberto_nao_segue_path_substituido(ancestor: bool, tmp_path: Path) 
 
 
 @pytest.mark.parametrize("link_kind", ["staging", "publication"])
-def test_nao_faz_fallback_quando_link_e_incompativel(
-    link_kind: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    body = b"conteudo"
-    adapter = FilesystemObjectStore(tmp_path)
+def test_link_incompativel_sem_fallback(
+    link_kind: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    body, adapter = b"conteudo", FilesystemObjectStore(tmp_path)
     if link_kind == "staging":
         directory = _objects_directory(tmp_path)
         namespace = sha256(b"raw/sem-fallback").hexdigest()
@@ -424,13 +433,10 @@ def test_nao_faz_fallback_quando_link_e_incompativel(
 @pytest.mark.linux_only
 def test_startup_recupera_apos_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     context = multiprocessing.get_context("spawn")
-    reached = context.Event()
-    release = context.Event()
-    results = context.Queue()
+    reached, release, results = context.Event(), context.Event(), context.Queue()
     process = context.Process(
         target=_process_paused_put,
-        args=(str(tmp_path), b"conteudo", (reached, release, results)),
-    )
+        args=(str(tmp_path), b"conteudo", (reached, release, results)),)
     process.start()
     assert reached.wait(timeout=5)
     lock_path = next(next(tmp_path.rglob("locks")).iterdir())
@@ -456,21 +462,15 @@ def test_startup_recupera_apos_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 @pytest.mark.linux_only
 @pytest.mark.parametrize("identical", [True, False], ids=["identicos", "conflitantes"])
-def test_corrida_entre_processos_publica_um_destino_completo(
-    identical: bool, tmp_path: Path
-) -> None:
+def test_corrida_publica_destino_completo(identical: bool, tmp_path: Path) -> None:
     context = multiprocessing.get_context("spawn")
     bodies = (b"a" * (2 * 1024 * 1024),) * 2 if identical else (b"a" * 1024, b"b" * 2048)
-    barrier = context.Barrier(3)
-    results = context.Queue()
-    destination_linked = context.Event()
-    reader_done = context.Event()
-    reader_ready = Event()
-    observed: list[bytes] = []
+    barrier, results = context.Barrier(3), context.Queue()
+    destination_linked, reader_done = context.Event(), context.Event()
+    reader_ready, observed = Event(), []
     reader = Thread(
         target=_read_during_publication,
-        args=(str(tmp_path), (reader_ready, destination_linked, reader_done, observed)),
-    )
+        args=(str(tmp_path), (reader_ready, destination_linked, reader_done, observed)),)
     reader.start()
     assert reader_ready.wait(timeout=5)
     processes = [

--- a/packages/cnes_infra/tests/object_store/test_s3.py
+++ b/packages/cnes_infra/tests/object_store/test_s3.py
@@ -70,13 +70,13 @@ def _stub_retention_replay(
     )
     stubber.add_response(
         "get_object",
-        _object_response(body, digest),
+        _object_response(body, digest) | {"VersionId": "verified-version"},
         {"Bucket": "bucket", "Key": "locked/objeto"},
     )
     stubber.add_response(
         "get_object_retention",
         response,
-        {"Bucket": "bucket", "Key": "locked/objeto"},
+        {"Bucket": "bucket", "Key": "locked/objeto", "VersionId": "verified-version"},
     )
 
 
@@ -361,6 +361,23 @@ def test_rejeita_replay_412_quando_retencao_existente_nao_satisfaz_pedido(
             retention=S3Retention(mode="COMPLIANCE", retain_until=retain_until),
         )
         with pytest.raises(Conflict, match="retention=insufficient"):
+            adapter.put("locked/objeto", BytesIO(body), digest)
+        stubber.assert_no_pending_responses()
+
+
+def test_rejeita_replay_retido_sem_version_id_verificado() -> None:
+    body, retain_until = b"conteudo-retido", datetime(2036, 1, 1, tzinfo=UTC)
+    digest, client = sha256(body).hexdigest(), _client()
+    with Stubber(client) as stubber:
+        stubber.add_client_error(
+            "put_object", service_error_code="PreconditionFailed", http_status_code=412,
+            expected_params=_retention_params(body, retain_until))
+        stubber.add_response(
+            "get_object", _object_response(body, digest),
+            {"Bucket": "bucket", "Key": "locked/objeto"})
+        adapter = S3ObjectStore(client, "bucket", retention=S3Retention(
+            mode="COMPLIANCE", retain_until=retain_until))
+        with pytest.raises(Conflict, match="retention_version=missing"):
             adapter.put("locked/objeto", BytesIO(body), digest)
         stubber.assert_no_pending_responses()
 

--- a/packages/cnes_infra/tests/object_store/test_s3.py
+++ b/packages/cnes_infra/tests/object_store/test_s3.py
@@ -1,0 +1,308 @@
+"""Conformidade do armazenamento de objetos no S3."""
+
+from base64 import b64encode
+from datetime import UTC, datetime
+from hashlib import sha256
+from io import BytesIO
+from typing import Any
+
+import boto3
+import pytest
+from botocore import UNSIGNED
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from botocore.stub import ANY, Stubber
+from moto import mock_aws
+
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.object_store.s3 import S3ObjectStore, S3Retention
+from packages.cnes_infra.tests.contracts.clock import MutableClock
+from packages.cnes_infra.tests.contracts.object_store_contract import (
+    ObjectStoreCase,
+    object_store_cases,
+)
+
+
+def _client() -> Any:
+    return boto3.client(
+        "s3",
+        region_name="us-east-1",
+        config=Config(signature_version=UNSIGNED),
+    )
+
+
+def _put_params(key: str, digest: str) -> dict[str, Any]:
+    return {
+        "Body": ANY,
+        "Bucket": "bucket",
+        "IfNoneMatch": "*",
+        "Key": key,
+        "Metadata": {"sha256": digest},
+    }
+
+
+def _object_response(body: bytes, metadata_sha256: str | None) -> dict[str, Any]:
+    metadata = {} if metadata_sha256 is None else {"sha256": metadata_sha256}
+    return {"Body": BytesIO(body), "ContentLength": len(body), "Metadata": metadata}
+
+
+def _retention_params(body: bytes, retain_until: datetime) -> dict[str, Any]:
+    digest = sha256(body).hexdigest()
+    return {
+        **_put_params("locked/objeto", digest),
+        "ChecksumAlgorithm": "SHA256",
+        "ChecksumSHA256": b64encode(bytes.fromhex(digest)).decode(),
+        "ObjectLockMode": "COMPLIANCE",
+        "ObjectLockRetainUntilDate": retain_until,
+    }
+
+
+@mock_aws
+@pytest.mark.parametrize("case", object_store_cases(), ids=lambda case: case.name)
+def test_cumpre_contrato_compartilhado(case: ObjectStoreCase) -> None:
+    client = boto3.client("s3", region_name="us-east-1")
+    client.create_bucket(Bucket="contract-bucket")
+    clock = MutableClock(datetime(2026, 7, 15, tzinfo=UTC))
+
+    case.run(S3ObjectStore(client, "contract-bucket"), clock)
+
+
+def test_repete_put_condicional_limitado_apos_409_sem_destino() -> None:
+    body = b"conteudo"
+    digest = sha256(body).hexdigest()
+    client = _client()
+    params = _put_params("raw/objeto", digest)
+
+    with Stubber(client) as stubber:
+        stubber.add_client_error(
+            "put_object",
+            service_error_code="ConditionalRequestConflict",
+            http_status_code=409,
+            expected_params=params,
+        )
+        stubber.add_client_error(
+            "get_object",
+            service_error_code="NoSuchKey",
+            http_status_code=404,
+            expected_params={"Bucket": "bucket", "Key": "raw/objeto"},
+        )
+        stubber.add_response("put_object", {}, params)
+
+        stat = S3ObjectStore(client, "bucket").put("raw/objeto", BytesIO(body), digest)
+
+    assert (stat.size_bytes, stat.sha256) == (len(body), digest)
+
+
+def test_interrompe_retry_condicional_apos_tres_respostas_409() -> None:
+    body = b"conteudo"
+    digest = sha256(body).hexdigest()
+    client = _client()
+    params = _put_params("raw/objeto", digest)
+
+    with Stubber(client) as stubber:
+        for _ in range(3):
+            stubber.add_client_error(
+                "put_object",
+                service_error_code="ConditionalRequestConflict",
+                http_status_code=409,
+                expected_params=params,
+            )
+            stubber.add_client_error(
+                "get_object",
+                service_error_code="NoSuchKey",
+                http_status_code=404,
+                expected_params={"Bucket": "bucket", "Key": "raw/objeto"},
+            )
+
+        with pytest.raises(Conflict, match="conditional_request_conflict"):
+            S3ObjectStore(client, "bucket").put("raw/objeto", BytesIO(body), digest)
+
+
+def test_propaga_erro_put_nao_condicional_e_preserva_prefixo() -> None:
+    body = b"conteudo"
+    digest = sha256(body).hexdigest()
+    client = _client()
+    params = _put_params("tenant/raw/objeto", digest)
+
+    with Stubber(client) as stubber:
+        stubber.add_client_error(
+            "put_object",
+            service_error_code="AccessDenied",
+            http_status_code=403,
+            expected_params=params,
+        )
+
+        with pytest.raises(ClientError, match="AccessDenied"):
+            S3ObjectStore(client, "bucket", prefix="tenant").put(
+                "raw/objeto", BytesIO(body), digest
+            )
+
+
+def test_propaga_erro_get_diferente_de_nao_encontrado() -> None:
+    client = _client()
+
+    with Stubber(client) as stubber:
+        stubber.add_client_error(
+            "get_object",
+            service_error_code="AccessDenied",
+            http_status_code=403,
+            expected_params={"Bucket": "bucket", "Key": "raw/objeto"},
+        )
+
+        with pytest.raises(ClientError, match="AccessDenied"):
+            S3ObjectStore(client, "bucket").stat("raw/objeto")
+
+
+def test_rejeita_sha256_local_antes_de_acessar_s3() -> None:
+    client = _client()
+
+    with Stubber(client):
+        with pytest.raises(ValueError, match="sha256_mismatch"):
+            S3ObjectStore(client, "bucket").put(
+                "raw/objeto", BytesIO(b"conteudo"), sha256(b"outro").hexdigest()
+            )
+
+
+def test_promote_faz_get_e_put_condicional_sem_copy() -> None:
+    body = b"promovido"
+    digest = sha256(body).hexdigest()
+    client = _client()
+
+    with Stubber(client) as stubber:
+        stubber.add_response(
+            "get_object",
+            _object_response(body, digest),
+            {"Bucket": "bucket", "Key": "staging/objeto"},
+        )
+        stubber.add_response("put_object", {}, _put_params("raw/objeto", digest))
+
+        stat = S3ObjectStore(client, "bucket").promote("staging/objeto", "raw/objeto", digest)
+
+    assert (stat.size_bytes, stat.sha256) == (len(body), digest)
+
+
+def test_aceita_412_quando_metadata_e_corpo_confirmam_destino() -> None:
+    body = b"conteudo"
+    digest = sha256(body).hexdigest()
+    client = _client()
+    params = _put_params("raw/objeto", digest)
+
+    with Stubber(client) as stubber:
+        stubber.add_client_error(
+            "put_object",
+            service_error_code="PreconditionFailed",
+            http_status_code=412,
+            expected_params=params,
+        )
+        stubber.add_response(
+            "get_object",
+            _object_response(body, digest),
+            {"Bucket": "bucket", "Key": "raw/objeto"},
+        )
+
+        stat = S3ObjectStore(client, "bucket").put("raw/objeto", BytesIO(body), digest)
+
+    assert (stat.size_bytes, stat.sha256) == (len(body), digest)
+
+
+@pytest.mark.parametrize("metadata_sha256", [None, "0" * 64], ids=["ausente", "divergente"])
+def test_rejeita_412_quando_metadata_nao_confirma_destino(
+    metadata_sha256: str | None,
+) -> None:
+    body = b"conteudo"
+    digest = sha256(body).hexdigest()
+    client = _client()
+    params = _put_params("raw/objeto", digest)
+
+    with Stubber(client) as stubber:
+        stubber.add_client_error(
+            "put_object",
+            service_error_code="PreconditionFailed",
+            http_status_code=412,
+            expected_params=params,
+        )
+        stubber.add_response(
+            "get_object",
+            _object_response(body, metadata_sha256),
+            {"Bucket": "bucket", "Key": "raw/objeto"},
+        )
+
+        with pytest.raises(Conflict, match="immutable_object"):
+            S3ObjectStore(client, "bucket").put("raw/objeto", BytesIO(body), digest)
+
+
+def test_envia_retencao_e_sha256_explicito_e_valida_resposta() -> None:
+    body = b"conteudo-retido"
+    digest = sha256(body).hexdigest()
+    checksum = b64encode(bytes.fromhex(digest)).decode()
+    retain_until = datetime(2036, 1, 1, tzinfo=UTC)
+    client = _client()
+
+    with Stubber(client) as stubber:
+        stubber.add_response(
+            "put_object",
+            {"ChecksumSHA256": checksum},
+            _retention_params(body, retain_until),
+        )
+        adapter = S3ObjectStore(
+            client,
+            "bucket",
+            retention=S3Retention(mode="COMPLIANCE", retain_until=retain_until),
+        )
+
+        stat = adapter.put("locked/objeto", BytesIO(body), digest)
+
+    assert (stat.size_bytes, stat.sha256) == (len(body), digest)
+
+
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [({}, "checksum_response_missing"), ({"ChecksumSHA256": "AAAA"}, "checksum_response_mismatch")],
+    ids=["ausente", "divergente"],
+)
+def test_rejeita_checksum_de_resposta_ausente_ou_divergente(
+    response: dict[str, str], message: str
+) -> None:
+    body = b"conteudo-retido"
+    digest = sha256(body).hexdigest()
+    retain_until = datetime(2036, 1, 1, tzinfo=UTC)
+    client = _client()
+
+    with Stubber(client) as stubber:
+        stubber.add_response("put_object", response, _retention_params(body, retain_until))
+        adapter = S3ObjectStore(
+            client,
+            "bucket",
+            retention=S3Retention(mode="COMPLIANCE", retain_until=retain_until),
+        )
+
+        with pytest.raises(ValueError, match=message):
+            adapter.put("locked/objeto", BytesIO(body), digest)
+
+
+def test_rejeita_baddigest_do_s3() -> None:
+    body = b"conteudo-retido"
+    digest = sha256(body).hexdigest()
+    retain_until = datetime(2036, 1, 1, tzinfo=UTC)
+    client = _client()
+
+    with Stubber(client) as stubber:
+        stubber.add_client_error(
+            "put_object",
+            service_error_code="BadDigest",
+            http_status_code=400,
+            expected_params=_retention_params(body, retain_until),
+        )
+        adapter = S3ObjectStore(
+            client,
+            "bucket",
+            retention=S3Retention(mode="COMPLIANCE", retain_until=retain_until),
+        )
+
+        with pytest.raises(ValueError, match="checksum_rejected"):
+            adapter.put("locked/objeto", BytesIO(body), digest)
+
+
+@pytest.mark.skip(reason="retention_enforcement_requires_real_aws")
+def test_enforcement_de_retencao_requer_aws_real() -> None:
+    raise AssertionError("real_aws_required")

--- a/packages/cnes_infra/tests/object_store/test_s3.py
+++ b/packages/cnes_infra/tests/object_store/test_s3.py
@@ -114,7 +114,7 @@ def test_interrompe_retry_condicional_apos_tres_respostas_409() -> None:
                 expected_params={"Bucket": "bucket", "Key": "raw/objeto"},
             )
 
-        with pytest.raises(Conflict, match="conditional_request_conflict"):
+        with pytest.raises(Conflict, match="conditional_request=conflict"):
             S3ObjectStore(client, "bucket").put("raw/objeto", BytesIO(body), digest)
 
 
@@ -157,7 +157,7 @@ def test_rejeita_sha256_local_antes_de_acessar_s3() -> None:
     client = _client()
 
     with Stubber(client):
-        with pytest.raises(ValueError, match="sha256_mismatch"):
+        with pytest.raises(ValueError, match="sha256=mismatch"):
             S3ObjectStore(client, "bucket").put(
                 "raw/objeto", BytesIO(b"conteudo"), sha256(b"outro").hexdigest()
             )
@@ -227,7 +227,7 @@ def test_rejeita_412_quando_metadata_nao_confirma_destino(
             {"Bucket": "bucket", "Key": "raw/objeto"},
         )
 
-        with pytest.raises(Conflict, match="immutable_object"):
+        with pytest.raises(Conflict, match="object=immutable"):
             S3ObjectStore(client, "bucket").put("raw/objeto", BytesIO(body), digest)
 
 
@@ -257,7 +257,7 @@ def test_envia_retencao_e_sha256_explicito_e_valida_resposta() -> None:
 
 @pytest.mark.parametrize(
     ("response", "message"),
-    [({}, "checksum_response_missing"), ({"ChecksumSHA256": "AAAA"}, "checksum_response_mismatch")],
+    [({}, "checksum_response=missing"), ({"ChecksumSHA256": "AAAA"}, "checksum_response=mismatch")],
     ids=["ausente", "divergente"],
 )
 def test_rejeita_checksum_de_resposta_ausente_ou_divergente(
@@ -299,10 +299,10 @@ def test_rejeita_baddigest_do_s3() -> None:
             retention=S3Retention(mode="COMPLIANCE", retain_until=retain_until),
         )
 
-        with pytest.raises(ValueError, match="checksum_rejected"):
+        with pytest.raises(ValueError, match="checksum=rejected"):
             adapter.put("locked/objeto", BytesIO(body), digest)
 
 
 @pytest.mark.skip(reason="retention_enforcement_requires_real_aws")
 def test_enforcement_de_retencao_requer_aws_real() -> None:
-    raise AssertionError("real_aws_required")
+    raise AssertionError("real_aws=required")

--- a/packages/cnes_infra/tests/object_store/test_s3.py
+++ b/packages/cnes_infra/tests/object_store/test_s3.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from hashlib import sha256
 from io import BytesIO
 from typing import Any
+from unittest.mock import MagicMock
 
 import boto3
 import pytest
@@ -275,6 +276,19 @@ def test_envia_retencao_e_sha256_explicito_e_valida_resposta() -> None:
         stat = adapter.put("locked/objeto", BytesIO(body), digest)
 
     assert (stat.size_bytes, stat.sha256) == (len(body), digest)
+
+
+def test_rejeita_retencao_naive_antes_de_acessar_cliente() -> None:
+    client = MagicMock()
+    with pytest.raises(ValueError, match="retain_until=naive"):
+        S3ObjectStore(
+            client,
+            "bucket",
+            retention=S3Retention(
+                "COMPLIANCE", datetime(2036, 1, 1, tzinfo=UTC).replace(tzinfo=None)
+            ),
+        )
+    client.assert_not_called()
 
 
 @pytest.mark.parametrize("extra_days", [0, 1], ids=["igual", "maior"])

--- a/packages/cnes_infra/tests/object_store/test_s3.py
+++ b/packages/cnes_infra/tests/object_store/test_s3.py
@@ -291,6 +291,13 @@ def test_rejeita_retencao_naive_antes_de_acessar_cliente() -> None:
     client.assert_not_called()
 
 
+def test_rejeita_chave_nul_antes_de_acessar_s3() -> None:
+    client = MagicMock()
+    with pytest.raises(ValueError, match="object_key=invalid"):
+        S3ObjectStore(client, "bucket").put("raw/\0objeto", BytesIO(b"x"), sha256(b"x").hexdigest())
+    assert client.mock_calls == []
+
+
 @pytest.mark.parametrize("extra_days", [0, 1], ids=["igual", "maior"])
 def test_aceita_replay_412_quando_retencao_existente_satisfaz_pedido(
     extra_days: int,

--- a/packages/cnes_infra/tests/object_store/test_s3.py
+++ b/packages/cnes_infra/tests/object_store/test_s3.py
@@ -1,7 +1,7 @@
 """Conformidade do armazenamento de objetos no S3."""
 
 from base64 import b64encode
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from hashlib import sha256
 from io import BytesIO
 from typing import Any
@@ -55,6 +55,28 @@ def _retention_params(body: bytes, retain_until: datetime) -> dict[str, Any]:
         "ObjectLockMode": "COMPLIANCE",
         "ObjectLockRetainUntilDate": retain_until,
     }
+
+
+def _stub_retention_replay(
+    stubber: Stubber, body: bytes, retain_until: datetime, response: dict[str, Any]
+) -> None:
+    digest = sha256(body).hexdigest()
+    stubber.add_client_error(
+        "put_object",
+        service_error_code="PreconditionFailed",
+        http_status_code=412,
+        expected_params=_retention_params(body, retain_until),
+    )
+    stubber.add_response(
+        "get_object",
+        _object_response(body, digest),
+        {"Bucket": "bucket", "Key": "locked/objeto"},
+    )
+    stubber.add_response(
+        "get_object_retention",
+        response,
+        {"Bucket": "bucket", "Key": "locked/objeto"},
+    )
 
 
 @mock_aws
@@ -253,6 +275,73 @@ def test_envia_retencao_e_sha256_explicito_e_valida_resposta() -> None:
         stat = adapter.put("locked/objeto", BytesIO(body), digest)
 
     assert (stat.size_bytes, stat.sha256) == (len(body), digest)
+
+
+@pytest.mark.parametrize("extra_days", [0, 1], ids=["igual", "maior"])
+def test_aceita_replay_412_quando_retencao_existente_satisfaz_pedido(
+    extra_days: int,
+) -> None:
+    body = b"conteudo-retido"
+    digest = sha256(body).hexdigest()
+    retain_until = datetime(2036, 1, 1, tzinfo=UTC)
+    response = {
+        "Retention": {
+            "Mode": "COMPLIANCE",
+            "RetainUntilDate": retain_until + timedelta(days=extra_days),
+        }
+    }
+    client = _client()
+
+    with Stubber(client) as stubber:
+        _stub_retention_replay(stubber, body, retain_until, response)
+        adapter = S3ObjectStore(
+            client,
+            "bucket",
+            retention=S3Retention(mode="COMPLIANCE", retain_until=retain_until),
+        )
+        stat = adapter.put("locked/objeto", BytesIO(body), digest)
+        stubber.assert_no_pending_responses()
+
+    assert (stat.size_bytes, stat.sha256) == (len(body), digest)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {},
+        {
+            "Retention": {
+                "Mode": "COMPLIANCE",
+                "RetainUntilDate": datetime(2035, 12, 31, tzinfo=UTC),
+            }
+        },
+        {
+            "Retention": {
+                "Mode": "GOVERNANCE",
+                "RetainUntilDate": datetime(2036, 1, 1, tzinfo=UTC),
+            }
+        },
+    ],
+    ids=["ausente", "menor", "modo-divergente"],
+)
+def test_rejeita_replay_412_quando_retencao_existente_nao_satisfaz_pedido(
+    response: dict[str, Any],
+) -> None:
+    body = b"conteudo-retido"
+    digest = sha256(body).hexdigest()
+    retain_until = datetime(2036, 1, 1, tzinfo=UTC)
+    client = _client()
+
+    with Stubber(client) as stubber:
+        _stub_retention_replay(stubber, body, retain_until, response)
+        adapter = S3ObjectStore(
+            client,
+            "bucket",
+            retention=S3Retention(mode="COMPLIANCE", retain_until=retain_until),
+        )
+        with pytest.raises(Conflict, match="retention=insufficient"):
+            adapter.put("locked/objeto", BytesIO(body), digest)
+        stubber.assert_no_pending_responses()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Objetivo

Implementar os adapters filesystem e S3 de `ObjectStorePort` com publicação imutável,
validação SHA-256, recuperação de crash e concorrência segura.

## Allowlist alterada

- `packages/cnes_infra/src/cnes_infra/object_store/_common.py`
- `packages/cnes_infra/src/cnes_infra/object_store/filesystem.py`
- `packages/cnes_infra/src/cnes_infra/object_store/s3.py`
- `packages/cnes_infra/tests/object_store/test_filesystem.py`
- `packages/cnes_infra/tests/object_store/test_s3.py`

## Decisões e riscos

- Filesystem publica por hard link sem overwrite, sob lock process-safe por destino, com
  temporários sibling e recuperação limitada ao namespace do adapter.
- A recuperação valida arquivo regular, chave de destino e token exclusivo em xattr sem
  seguir links. Filesystems sem xattr/hard-link compatíveis falham antes da publicação.
- Componentes symlink são rejeitados antes do backend. O staging exige Linux `O_TMPFILE`,
  `linkat(AT_EMPTY_PATH)` e xattr gravável; não existe fallback nomeado inseguro.
- Chaves lógicas usam layout físico separado e aceitam prefixos coexistentes; locks e
  recuperação ficam fora do namespace endereçável, com operações presas a dirfds no-follow.
- S3 usa staging local, `IfNoneMatch="*"`, comparação após 412 e retry condicional limitado
  após 409; não há PUT/copy final incondicional.
- `S3Retention` envia Object Lock e checksum SHA-256 explícito, validando a resposta.
- Moto comprova apenas conformidade básica; Stubber cobre requests e falhas. O PR não alega
  WORM real.
- O gate global conhecido `chaos_infra` e a cobertura agregada histórica permanecem fora da
  allowlist; os módulos novos têm 100% branch.

## Evidência RED/GREEN

- RED inicial: módulos `filesystem` e `s3` ausentes.
- REDs focados: recuperação nas seis fronteiras duráveis, cleanup após digest inválido,
  409/412, retenção/checksum e leitura concorrente não-vazia.
- GREEN final do controller: `88 passed, 1 skipped`, com 100% line/branch nos três módulos;
  Ruff focado e global verdes.
- Review independente encontrou um teste concorrente potencialmente vacuoso e mensagens fora
  de `key=value`; ambos foram corrigidos em `09f0da6` e a re-revisão foi aprovada.
- O review do PR encontrou ausência de recuperação no startup. As correções até `bf52109`
  adicionam scanner restrito, identidade persistida e regressões contra aliases hard-link e
  symlink; a re-revisão independente não encontrou quebra nova.
- A rodada final persiste cada novo elo da hierarquia de diretórios e tolera candidatos que
  desaparecem durante o scanner concorrente. O gate de packages ficou em `1085 passed,
  7 skipped` com 100%.
- A rodada excepcional elimina a janela pré-xattr com staging não nomeado, rejeita paths com
  symlink e remove/fsynca staging após falhas ordinárias. Packages: `1092 passed, 7 skipped`,
  100%.
- A refatoração final separa objetos/locks do espaço lógico e usa dirfds no-follow;
  packages: `1088 passed, 7 skipped`, 100%.
- A última janela de erro remove o staging recém-linkado quando o `fsync` do diretório falha;
  packages: `1089 passed, 7 skipped`, 100%.
- O fechamento final remove e sincroniza o staging quando o `fsync` posterior à publicação
  falha e sincroniza parents de diretórios internos já existentes; as duas regressões foram
  comprovadas RED antes da correção.
- A raiz relativa é ancorada na construção; os cinco casos compartilhados foram comprovados
  RED após `chdir` e GREEN no root original.
- Replay S3 com retenção valida modo e prazo existentes antes de aceitar o objeto, sem extensão
  automática; a reabertura do root sincroniza seu parent. Seis regressões foram comprovadas RED.
- O root fica pinado por descritor durante o lifetime e recovery aguarda a decisão de locks
  ativos sem bloquear leitores após publicação; três regressões concorrentes passaram.
- Recovery abre candidatos de forma não bloqueante e ignora nodes não regulares; o caso FIFO
  foi comprovado RED em subprocesso com timeout e GREEN sem deixar processos residuais.
- Ao criar apenas um sufixo do root, o parent do primeiro ancestral existente também é
  sincronizado antes dos descendentes.
- Entradas finais não regulares são abertas sem bloqueio e rejeitadas em stat/open/delete/put;
  cinco paths FIFO foram comprovados RED por timeout e GREEN sem processos residuais.
- Delete idempotente sincroniza o diretório também quando a entrada já está ausente, fechando
  a janela de um unlink anterior ainda não durável.
- Retenção rejeita datetime naive; descritores são fechados se fsync ou inspeção de ownership
  falham, comprovado por mocks e contagem real em `/proc/self/fd`.
- O root é percorrido/criado desde `/` por dirfds no-follow e fica ancorado desde o início;
  chaves NUL são rejeitadas em filesystem e S3 antes de qualquer operação externa.
- Root/internal/objects/locks permanecem pinados pelo lifetime; operações duplicam apenas os
  descritores originais e cleanup parcial/final devolve o fd count ao baseline.
- O staging mantém o descritor do inode hasheado até `linkat(AT_EMPTY_PATH)` publicar esse
  mesmo inode; substituição concorrente de pathname não publica bytes não verificados.
- Recovery de startup trata destino digest não regular como losing writer, remove o temporário
  owned sob lock e segue outras chaves; operações públicas continuam retornando `Conflict`.
- Destino simbólico durante recovery agora normaliza `ELOOP` como destino inválido: descarta
  apenas o temporário owned, preserva o link malformado e mantém `Conflict` nas operações públicas.
- Destino socket Unix segue a mesma classificação de destino inválido (`ENXIO`): recovery não
  aborta, preserva o socket malformado e remove somente o temporário que lhe pertence.
- Replay S3 com retenção exige o `VersionId` do objeto que teve checksum validado e usa esse
  mesmo ID na consulta de retenção; ausência da versão falha fechada antes da chamada desvinculada.

## SHA testado

`e693c37bca596bd2db5ee5d868c70e6991c94290`

Refs #124
