### PR TITLE
feat(control-plane): add sqlite adapter

### DIFF
--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -256,9 +256,7 @@ class SQLiteControlPlane:
             OutboxEvent,
         )
         if current is not None:
-            if current != event:
-                raise Conflict("outbox_event_conflict")
-            return
+            raise Conflict("outbox_event_conflict")
         connection.execute(
             "INSERT INTO outbox_events "
             "(event_id, tenant_id, created_at, delivered_at, data) VALUES (?, ?, ?, ?, ?)",
@@ -272,8 +270,6 @@ class SQLiteControlPlane:
         with self.write_transaction() as connection:
             current = self.get_job_record(connection, job.tenant_id, job.job_id)
             if current is not None:
-                if current != job:
-                    raise Conflict("job_conflict")
                 validate_job_creation_replay(connection, job, event)
                 return current
             self.put_outbox_event(connection, event, job.tenant_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -244,7 +244,9 @@ class SQLiteControlPlane:
                 serialize_model(job),
             ),
         )
-    def put_outbox_event(self, connection: sqlite3.Connection, event: OutboxEvent) -> None:
+    def put_outbox_event(self, connection, event: OutboxEvent, tenant_id: str) -> None:
+        if event.tenant_id != tenant_id:
+            raise Conflict("outbox_event_tenant_mismatch")
         if event.delivered_at is not None:
             raise Conflict("outbox_event_already_delivered")
         current = _fetch_one(
@@ -261,9 +263,7 @@ class SQLiteControlPlane:
             "INSERT INTO outbox_events "
             "(event_id, tenant_id, created_at, delivered_at, data) VALUES (?, ?, ?, ?, ?)",
             (
-                event.event_id,
-                event.tenant_id,
-                event.created_at.isoformat(),
+                event.event_id, event.tenant_id, event.created_at.isoformat(),
                 None if event.delivered_at is None else event.delivered_at.isoformat(),
                 serialize_model(event),
             ),
@@ -276,9 +276,9 @@ class SQLiteControlPlane:
                     raise Conflict("job_conflict")
                 validate_job_creation_replay(connection, job, event)
                 return current
+            self.put_outbox_event(connection, event, job.tenant_id)
             self.put_job_record(connection, job)
             put_job_creation_write(connection, job, event)
-            self.put_outbox_event(connection, event)
             return job
     def list_claimable_jobs(
         self, tenant_id: str, agent_id: str, limit: int

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -26,7 +26,9 @@ from cnes_infra.control_plane.sqlite_schema import (
     deserialize_model,
     initialize_schema,
     is_network_filesystem,
+    put_job_creation_write,
     serialize_model,
+    validate_job_creation_replay,
 )
 
 if TYPE_CHECKING:
@@ -219,14 +221,15 @@ class SQLiteControlPlane:
     def get_job(self, tenant_id: str, job_id: str) -> Job | None:
         with self.read_connection() as connection:
             return self.get_job_record(connection, tenant_id, job_id)
-
     def put_job_record(self, connection: sqlite3.Connection, job: Job) -> None:
         connection.execute(
             "INSERT INTO jobs (tenant_id, job_id, agent_id, source_type, file_subtype, "
-            "competencia, state, created_at, data) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "competencia, state, lease_until, created_at, data) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT (tenant_id, job_id) DO UPDATE SET agent_id = excluded.agent_id, "
             "source_type = excluded.source_type, file_subtype = excluded.file_subtype, "
             "competencia = excluded.competencia, state = excluded.state, "
+            "lease_until = excluded.lease_until, "
             "created_at = excluded.created_at, data = excluded.data",
             (
                 job.tenant_id,
@@ -236,6 +239,7 @@ class SQLiteControlPlane:
                 job.file_subtype,
                 job.competencia,
                 job.state.value,
+                None if job.lease_until is None else job.lease_until.isoformat(),
                 job.created_at.isoformat(),
                 serialize_model(job),
             ),
@@ -270,11 +274,12 @@ class SQLiteControlPlane:
             if current is not None:
                 if current != job:
                     raise Conflict("job_conflict")
+                validate_job_creation_replay(connection, job, event)
                 return current
             self.put_job_record(connection, job)
+            put_job_creation_write(connection, job, event)
             self.put_outbox_event(connection, event)
             return job
-
     def list_claimable_jobs(
         self, tenant_id: str, agent_id: str, limit: int
     ) -> tuple[Job, ...]:
@@ -282,21 +287,17 @@ class SQLiteControlPlane:
             agent = self.get_agent_record(connection, tenant_id, agent_id)
             if agent is None or agent.state is AgentState.REVOKED:
                 return ()
-            jobs = _fetch_all(
+            return _fetch_all(
                 connection,
                 "SELECT data FROM jobs WHERE tenant_id = ? AND agent_id = ? "
-                "ORDER BY created_at, job_id",
-                (tenant_id, agent_id),
+                "AND (state IN (?, ?) OR (state = ? AND "
+                "(lease_until IS NULL OR lease_until <= ?))) "
+                "ORDER BY created_at, job_id LIMIT ?",
+                (tenant_id, agent_id, JobState.PENDING.value,
+                 JobState.FAILED_RETRYABLE.value, JobState.LEASED.value,
+                 self.now().isoformat(), limit),
                 Job,
             )
-        claimable = [
-            job
-            for job in jobs
-            if job.state in {JobState.PENDING, JobState.FAILED_RETRYABLE}
-            or (job.state is JobState.LEASED
-                and (job.lease_until is None or job.lease_until <= self.now()))
-        ]
-        return tuple(claimable[:limit])
 
     def claim_job(self, command: ClaimJob) -> Job | None:
         return sqlite_claims.claim_job(self, command)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
         RunUnit,
     )
 
-_BUSY_TIMEOUT_MS = 100
+_BUSY_TIMEOUT_MS = 5000
 class _SQLiteBusyError(RuntimeError):
     pass
 
@@ -111,7 +111,6 @@ class SQLiteControlPlane:
             isolation_level=None,
         )
         connection.execute("PRAGMA foreign_keys=ON")
-        connection.execute("PRAGMA busy_timeout=100")
         return connection
 
     def initialize(self) -> None:
@@ -306,12 +305,20 @@ class SQLiteControlPlane:
         return sqlite_claims.renew_job_lease(self, command)
 
     def put_manifest_record(
-        self, connection: sqlite3.Connection, manifest: RawManifestRecord
-    ) -> None:
+        self, connection: sqlite3.Connection, manifest: RawManifestRecord) -> None:
+        current = _fetch_one(
+            connection,
+            "SELECT data FROM raw_manifests WHERE tenant_id = ? AND manifest_id = ?",
+            (manifest.tenant_id, manifest.manifest_id),
+            type(manifest),
+        )
+        if current is not None:
+            if current != manifest:
+                raise Conflict("manifest_immutable")
+            return
         connection.execute(
             "INSERT INTO raw_manifests (tenant_id, manifest_id, agent_id, source_type, "
-            "file_subtype, competencia, created_at, data) VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
-            "ON CONFLICT (tenant_id, manifest_id) DO UPDATE SET data = excluded.data",
+            "file_subtype, competencia, created_at, data) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 manifest.tenant_id,
                 manifest.manifest_id,

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -96,7 +96,6 @@ def _is_network_filesystem(path: Path) -> bool:
 
 class SQLiteControlPlane:
     """Persiste o plano de controle em um arquivo SQLite local."""
-
     def __init__(self, database_path: Path, clock: Callable[[], datetime]) -> None:
         self._database_path = Path(database_path)
         self._clock = clock
@@ -294,7 +293,8 @@ class SQLiteControlPlane:
             job
             for job in jobs
             if job.state in {JobState.PENDING, JobState.FAILED_RETRYABLE}
-            or (job.state is JobState.LEASED and job.lease_until <= self.now())
+            or (job.state is JobState.LEASED
+                and (job.lease_until is None or job.lease_until <= self.now()))
         ]
         return tuple(claimable[:limit])
 

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -244,8 +244,9 @@ class SQLiteControlPlane:
                 serialize_model(job),
             ),
         )
-
     def put_outbox_event(self, connection: sqlite3.Connection, event: OutboxEvent) -> None:
+        if event.delivered_at is not None:
+            raise Conflict("outbox_event_already_delivered")
         current = _fetch_one(
             connection,
             "SELECT data FROM outbox_events WHERE event_id = ?",
@@ -267,7 +268,6 @@ class SQLiteControlPlane:
                 serialize_model(event),
             ),
         )
-
     def create_job(self, job: Job, event: OutboxEvent) -> Job:
         with self.write_transaction() as connection:
             current = self.get_job_record(connection, job.tenant_id, job.job_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -21,15 +21,18 @@ from cnes_domain.control_plane.entities import (
 )
 from cnes_domain.control_plane.enums import AgentState, JobState
 from cnes_domain.control_plane.errors import Conflict, NotFound
-from cnes_infra.control_plane import sqlite_claims, sqlite_idempotency, sqlite_publication
+from cnes_infra.control_plane import (
+    sqlite_claims,
+    sqlite_idempotency,
+    sqlite_job,
+    sqlite_publication,
+)
 from cnes_infra.control_plane.sqlite_schema import (
     _SQLiteWALUnavailable,
     deserialize_model,
     initialize_schema,
     is_network_filesystem,
-    put_job_creation_write,
     serialize_model,
-    validate_job_creation_replay,
 )
 
 if TYPE_CHECKING:
@@ -267,15 +270,7 @@ class SQLiteControlPlane:
             ),
         )
     def create_job(self, job: Job, event: OutboxEvent) -> Job:
-        with self.write_transaction() as connection:
-            current = self.get_job_record(connection, job.tenant_id, job.job_id)
-            if current is not None:
-                validate_job_creation_replay(connection, job, event)
-                return current
-            self.put_outbox_event(connection, event, job.tenant_id)
-            self.put_job_record(connection, job)
-            put_job_creation_write(connection, job, event)
-            return job
+        return sqlite_job.create_job(self, job, event)
     def list_claimable_jobs(
         self, tenant_id: str, agent_id: str, limit: int
     ) -> tuple[Job, ...]:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -1,0 +1,491 @@
+"""SQLite control-plane adapter."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from cnes_domain.control_plane.entities import (
+    AccessRequest,
+    Agent,
+    Job,
+    Membership,
+    OutboxEvent,
+    Run,
+    Tenant,
+)
+from cnes_domain.control_plane.enums import AgentState, JobState
+from cnes_domain.control_plane.errors import Conflict, NotFound
+from cnes_infra.control_plane import sqlite_claims, sqlite_idempotency, sqlite_publication
+from cnes_infra.control_plane.sqlite_schema import (
+    deserialize_model,
+    initialize_schema,
+    serialize_model,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from datetime import datetime
+
+    from cnes_domain.control_plane.commands import (
+        BeginIdempotency,
+        BindRunDispatch,
+        CancelJob,
+        ClaimJob,
+        ClaimRunUnit,
+        CommitRunUnit,
+        CompleteJob,
+        FailJob,
+        FailRunUnit,
+        FinalizeRunCancellation,
+        FinishRunDispatch,
+        IdempotencyOutcome,
+        PublishDataset,
+        PutRunUnits,
+        RenewJobLease,
+        ReserveRunDispatch,
+        TransitionRun,
+    )
+    from cnes_domain.control_plane.entities import (
+        DatasetPointer,
+        DatasetVersion,
+        ManifestRef,
+        RawManifestRecord,
+        RunDispatch,
+        RunUnit,
+    )
+
+_BUSY_TIMEOUT_MS = 100
+_NETWORK_FILESYSTEMS = {"9p", "afs", "cifs", "fuse.sshfs", "nfs", "nfs4", "smbfs"}
+class _SQLiteBusyError(RuntimeError):
+    pass
+
+
+class _SQLiteFilesystemError(RuntimeError):
+    pass
+
+
+def _fetch_one[Model: BaseModel](
+    connection: sqlite3.Connection,
+    statement: str,
+    parameters: tuple[Any, ...],
+    model: type[Model],
+) -> Model | None:
+    row = connection.execute(statement, parameters).fetchone()
+    return None if row is None else deserialize_model(row[0], model)
+
+
+def _fetch_all[Model: BaseModel](
+    connection: sqlite3.Connection,
+    statement: str,
+    parameters: tuple[Any, ...],
+    model: type[Model],
+) -> tuple[Model, ...]:
+    rows = connection.execute(statement, parameters).fetchall()
+    return tuple(deserialize_model(row[0], model) for row in rows)
+
+
+def _is_network_filesystem(path: Path) -> bool:
+    try:
+        mounts = Path("/proc/self/mounts").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+    resolved = path.parent.resolve()
+    matches = []
+    for line in mounts:
+        fields = line.split()
+        if len(fields) >= 3 and resolved.is_relative_to(Path(fields[1])):
+            matches.append((len(fields[1]), fields[2]))
+    return bool(matches and max(matches)[1] in _NETWORK_FILESYSTEMS)
+
+
+class SQLiteControlPlane:
+    """Persiste o plano de controle em um arquivo SQLite local."""
+
+    def __init__(self, database_path: Path, clock: Callable[[], datetime]) -> None:
+        self._database_path = Path(database_path)
+        self._clock = clock
+
+    def now(self) -> datetime:
+        return self._clock()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(
+            self._database_path,
+            timeout=_BUSY_TIMEOUT_MS / 1000,
+            isolation_level=None,
+        )
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("PRAGMA busy_timeout=100")
+        return connection
+
+    def initialize(self) -> None:
+        if _is_network_filesystem(self._database_path):
+            raise _SQLiteFilesystemError("sqlite_network_filesystem")
+        try:
+            initialize_schema(self._connect, self._database_path)
+        except (OSError, sqlite3.Error) as error:
+            raise _SQLiteFilesystemError("sqlite_filesystem") from error
+
+    @contextmanager
+    def read_connection(self) -> Iterator[sqlite3.Connection]:
+        try:
+            connection = self._connect()
+        except sqlite3.Error as error:
+            raise _SQLiteFilesystemError("sqlite_filesystem") from error
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    @contextmanager
+    def write_transaction(self) -> Iterator[sqlite3.Connection]:
+        with self.read_connection() as connection:
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                yield connection
+                connection.commit()
+            except sqlite3.OperationalError as error:
+                connection.rollback()
+                if "locked" in str(error).lower() or "busy" in str(error).lower():
+                    raise _SQLiteBusyError("sqlite_busy") from error
+                raise
+            except Exception:
+                connection.rollback()
+                raise
+
+    def get_tenant(self, tenant_id: str) -> Tenant | None:
+        with self.read_connection() as connection:
+            return _fetch_one(
+                connection,
+                "SELECT data FROM tenants WHERE tenant_id = ?",
+                (tenant_id,),
+                Tenant,
+            )
+
+    def put_tenant(self, tenant: Tenant) -> None:
+        with self.write_transaction() as connection:
+            connection.execute(
+                "INSERT INTO tenants (tenant_id, data) VALUES (?, ?) "
+                "ON CONFLICT (tenant_id) DO UPDATE SET data = excluded.data",
+                (tenant.tenant_id, serialize_model(tenant)),
+            )
+
+    def get_membership(self, tenant_id: str, user_id: str) -> Membership | None:
+        with self.read_connection() as connection:
+            return _fetch_one(
+                connection,
+                "SELECT data FROM memberships WHERE tenant_id = ? AND user_id = ?",
+                (tenant_id, user_id),
+                Membership,
+            )
+
+    def put_membership(self, membership: Membership) -> None:
+        with self.write_transaction() as connection:
+            connection.execute(
+                "INSERT INTO memberships (tenant_id, user_id, data) VALUES (?, ?, ?) "
+                "ON CONFLICT (tenant_id, user_id) DO UPDATE SET data = excluded.data",
+                (membership.tenant_id, membership.user_id, serialize_model(membership)),
+            )
+
+    def get_agent_record(
+        self, connection: sqlite3.Connection, tenant_id: str, agent_id: str
+    ) -> Agent | None:
+        return _fetch_one(
+            connection,
+            "SELECT data FROM agents WHERE tenant_id = ? AND agent_id = ?",
+            (tenant_id, agent_id),
+            Agent,
+        )
+
+    def get_agent(self, tenant_id: str, agent_id: str) -> Agent | None:
+        with self.read_connection() as connection:
+            return self.get_agent_record(connection, tenant_id, agent_id)
+
+    def put_agent(self, agent: Agent) -> None:
+        with self.write_transaction() as connection:
+            connection.execute(
+                "INSERT INTO agents (tenant_id, agent_id, state, data) VALUES (?, ?, ?, ?) "
+                "ON CONFLICT (tenant_id, agent_id) DO UPDATE SET "
+                "state = excluded.state, data = excluded.data",
+                (agent.tenant_id, agent.agent_id, agent.state.value, serialize_model(agent)),
+            )
+
+    def get_job_record(
+        self, connection: sqlite3.Connection, tenant_id: str, job_id: str
+    ) -> Job | None:
+        return _fetch_one(
+            connection,
+            "SELECT data FROM jobs WHERE tenant_id = ? AND job_id = ?",
+            (tenant_id, job_id),
+            Job,
+        )
+
+    def get_job(self, tenant_id: str, job_id: str) -> Job | None:
+        with self.read_connection() as connection:
+            return self.get_job_record(connection, tenant_id, job_id)
+
+    def put_job_record(self, connection: sqlite3.Connection, job: Job) -> None:
+        connection.execute(
+            "INSERT INTO jobs (tenant_id, job_id, agent_id, source_type, file_subtype, "
+            "competencia, state, created_at, data) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT (tenant_id, job_id) DO UPDATE SET agent_id = excluded.agent_id, "
+            "source_type = excluded.source_type, file_subtype = excluded.file_subtype, "
+            "competencia = excluded.competencia, state = excluded.state, "
+            "created_at = excluded.created_at, data = excluded.data",
+            (
+                job.tenant_id,
+                job.job_id,
+                job.agent_id,
+                job.source_type,
+                job.file_subtype,
+                job.competencia,
+                job.state.value,
+                job.created_at.isoformat(),
+                serialize_model(job),
+            ),
+        )
+
+    def put_outbox_event(self, connection: sqlite3.Connection, event: OutboxEvent) -> None:
+        current = _fetch_one(
+            connection,
+            "SELECT data FROM outbox_events WHERE event_id = ?",
+            (event.event_id,),
+            OutboxEvent,
+        )
+        if current is not None:
+            if current != event:
+                raise Conflict("outbox_event_conflict")
+            return
+        connection.execute(
+            "INSERT INTO outbox_events "
+            "(event_id, tenant_id, created_at, delivered_at, data) VALUES (?, ?, ?, ?, ?)",
+            (
+                event.event_id,
+                event.tenant_id,
+                event.created_at.isoformat(),
+                None if event.delivered_at is None else event.delivered_at.isoformat(),
+                serialize_model(event),
+            ),
+        )
+
+    def create_job(self, job: Job, event: OutboxEvent) -> Job:
+        with self.write_transaction() as connection:
+            current = self.get_job_record(connection, job.tenant_id, job.job_id)
+            if current is not None:
+                if current != job:
+                    raise Conflict("job_conflict")
+                return current
+            self.put_job_record(connection, job)
+            self.put_outbox_event(connection, event)
+            return job
+
+    def list_claimable_jobs(
+        self, tenant_id: str, agent_id: str, limit: int
+    ) -> tuple[Job, ...]:
+        with self.read_connection() as connection:
+            agent = self.get_agent_record(connection, tenant_id, agent_id)
+            if agent is None or agent.state is AgentState.REVOKED:
+                return ()
+            jobs = _fetch_all(
+                connection,
+                "SELECT data FROM jobs WHERE tenant_id = ? AND agent_id = ? "
+                "ORDER BY created_at, job_id",
+                (tenant_id, agent_id),
+                Job,
+            )
+        claimable = [
+            job
+            for job in jobs
+            if job.state in {JobState.PENDING, JobState.FAILED_RETRYABLE}
+            or (job.state is JobState.LEASED and job.lease_until <= self.now())
+        ]
+        return tuple(claimable[:limit])
+
+    def claim_job(self, command: ClaimJob) -> Job | None:
+        return sqlite_claims.claim_job(self, command)
+
+    def renew_job_lease(self, command: RenewJobLease) -> Job:
+        return sqlite_claims.renew_job_lease(self, command)
+
+    def put_manifest_record(
+        self, connection: sqlite3.Connection, manifest: RawManifestRecord
+    ) -> None:
+        connection.execute(
+            "INSERT INTO raw_manifests (tenant_id, manifest_id, agent_id, source_type, "
+            "file_subtype, competencia, created_at, data) VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT (tenant_id, manifest_id) DO UPDATE SET data = excluded.data",
+            (
+                manifest.tenant_id,
+                manifest.manifest_id,
+                manifest.agent_id,
+                manifest.source_type,
+                manifest.file_subtype,
+                manifest.competencia,
+                manifest.created_at.isoformat(),
+                serialize_model(manifest),
+            ),
+        )
+
+    def complete_job(self, command: CompleteJob, event: OutboxEvent) -> Job:
+        return sqlite_claims.complete_job(self, command, event)
+
+    def fail_job(self, command: FailJob, event: OutboxEvent) -> Job:
+        return sqlite_claims.fail_job(self, command, event)
+
+    def pending_outbox(self, limit: int) -> tuple[OutboxEvent, ...]:
+        with self.read_connection() as connection:
+            return _fetch_all(
+                connection,
+                "SELECT data FROM outbox_events WHERE delivered_at IS NULL "
+                "ORDER BY created_at, event_id LIMIT ?",
+                (limit,),
+                OutboxEvent,
+            )
+
+    def mark_outbox_delivered(self, event_id: str, delivered_at: datetime) -> None:
+        with self.write_transaction() as connection:
+            event = _fetch_one(
+                connection,
+                "SELECT data FROM outbox_events WHERE event_id = ?",
+                (event_id,),
+                OutboxEvent,
+            )
+            if event is None:
+                raise NotFound("outbox_event_missing")
+            delivered = event.model_copy(update={"delivered_at": delivered_at})
+            connection.execute(
+                "UPDATE outbox_events SET delivered_at = ?, data = ? WHERE event_id = ?",
+                (delivered_at.isoformat(), serialize_model(delivered), event_id),
+            )
+
+    def latest_succeeded_job(self, *args: str) -> Job | None:
+        return sqlite_publication.latest_succeeded_job(self, args)
+
+    def list_raw_manifest_chain(self, *args: Any) -> tuple[ManifestRef, ...]:
+        return sqlite_publication.list_raw_manifest_chain(self, args)
+
+    def cancel_job(self, command: CancelJob, event: OutboxEvent) -> Job:
+        return sqlite_claims.cancel_job(self, command, event)
+
+    def put_run(self, run: Run) -> None:
+        sqlite_publication.put_run(self, run)
+
+    @staticmethod
+    def decode_run(payload: str) -> Run:
+        return deserialize_model(payload, Run)
+
+    def get_run_record(
+        self, connection: sqlite3.Connection, tenant_id: str, run_id: str
+    ) -> Run | None:
+        return _fetch_one(
+            connection,
+            "SELECT data FROM runs WHERE tenant_id = ? AND run_id = ?",
+            (tenant_id, run_id),
+            Run,
+        )
+
+    def put_run_record(self, connection: sqlite3.Connection, run: Run) -> None:
+        connection.execute(
+            "INSERT INTO runs (tenant_id, run_id, competencia, dataset_name, state, "
+            "created_at, data) VALUES (?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT (tenant_id, run_id) DO UPDATE SET competencia = excluded.competencia, "
+            "dataset_name = excluded.dataset_name, state = excluded.state, "
+            "created_at = excluded.created_at, data = excluded.data",
+            (
+                run.tenant_id,
+                run.run_id,
+                run.competencia,
+                run.dataset_name,
+                run.state.value,
+                run.created_at.isoformat(),
+                serialize_model(run),
+            ),
+        )
+        connection.execute(
+            "DELETE FROM run_dependencies WHERE tenant_id = ? AND run_id = ?",
+            (run.tenant_id, run.run_id),
+        )
+        connection.executemany(
+            "INSERT INTO run_dependencies "
+            "(tenant_id, run_id, source_type, file_subtype, required) VALUES (?, ?, ?, ?, ?)",
+            (
+                (run.tenant_id, run.run_id, item.source_type, item.file_subtype, item.required)
+                for item in run.dependencies
+            ),
+        )
+
+    def get_run(self, tenant_id: str, run_id: str) -> Run | None:
+        return sqlite_publication.get_run(self, tenant_id, run_id)
+
+    def list_waiting_runs_for_dependency(self, *args: Any) -> tuple[Run, ...]:
+        return sqlite_publication.list_waiting_runs(self, args)
+
+    def list_recoverable_runs(self, now: datetime, limit: int = 100) -> tuple[Run, ...]:
+        return sqlite_publication.list_recoverable_runs(self, now, limit)
+
+    def transition_run(self, command: TransitionRun, event: OutboxEvent) -> Run:
+        return sqlite_publication.transition_run(self, command, event)
+
+    def put_run_units(self, command: PutRunUnits) -> tuple[RunUnit, ...]:
+        return sqlite_claims.put_run_units(self, command)
+
+    def list_run_units(self, tenant_id: str, run_id: str) -> tuple[RunUnit, ...]:
+        return sqlite_claims.list_run_units(self, tenant_id, run_id)
+
+    def claim_run_unit(self, command: ClaimRunUnit) -> RunUnit | None:
+        return sqlite_claims.claim_run_unit(self, command)
+
+    def commit_run_unit(self, command: CommitRunUnit, event: OutboxEvent) -> RunUnit:
+        return sqlite_claims.commit_run_unit(self, command, event)
+
+    def fail_run_unit(self, command: FailRunUnit, event: OutboxEvent) -> RunUnit:
+        return sqlite_claims.fail_run_unit(self, command, event)
+
+    def finalize_run_cancellation(
+        self, command: FinalizeRunCancellation, event: OutboxEvent
+    ) -> Run:
+        return sqlite_claims.finalize_run_cancellation(self, command, event)
+
+    def reserve_run_dispatch(self, command: ReserveRunDispatch) -> RunDispatch:
+        return sqlite_claims.reserve_run_dispatch(self, command)
+
+    def bind_run_dispatch(self, command: BindRunDispatch) -> RunDispatch:
+        return sqlite_claims.bind_run_dispatch(self, command)
+
+    def finish_run_dispatch(self, command: FinishRunDispatch) -> RunDispatch:
+        return sqlite_claims.finish_run_dispatch(self, command)
+
+    def get_active_run_dispatch(self, tenant_id: str, run_id: str) -> RunDispatch | None:
+        return sqlite_claims.get_active_run_dispatch(self, tenant_id, run_id)
+
+    def begin_idempotency(self, command: BeginIdempotency) -> IdempotencyOutcome:
+        return sqlite_idempotency.begin_idempotency(self, command)
+
+    def publish_dataset(self, command: PublishDataset) -> DatasetPointer:
+        return sqlite_publication.publish_dataset(self, command)
+
+    def get_dataset_pointer(self, tenant_id: str, dataset_name: str) -> DatasetPointer | None:
+        return sqlite_publication.get_dataset_pointer(self, tenant_id, dataset_name)
+
+    def get_dataset_version(
+        self, tenant_id: str, dataset_name: str, version_id: str
+    ) -> DatasetVersion | None:
+        return sqlite_publication.get_dataset_version(
+            self, (tenant_id, dataset_name, version_id)
+        )
+
+    def put_access_request(self, request: AccessRequest, event: OutboxEvent) -> None:
+        sqlite_publication.put_access_request(self, request, event)
+
+    def get_access_request(self, tenant_id: str, request_id: str) -> AccessRequest | None:
+        return sqlite_publication.get_access_request(self, tenant_id, request_id)
+
+    def decide_access_request(
+        self, request: AccessRequest, event: OutboxEvent
+    ) -> AccessRequest:
+        return sqlite_publication.decide_access_request(self, request, event)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from contextlib import contextmanager
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -33,7 +34,6 @@ from cnes_infra.control_plane.sqlite_schema import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
-    from datetime import datetime
 
     from cnes_domain.control_plane.commands import (
         BeginIdempotency,
@@ -344,6 +344,8 @@ class SQLiteControlPlane:
             )
 
     def mark_outbox_delivered(self, event_id: str, delivered_at: datetime) -> None:
+        if delivered_at.tzinfo is None or delivered_at.utcoffset() != timedelta(0):
+            raise ValueError("datetime_not_utc")
         with self.write_transaction() as connection:
             event = _fetch_one(
                 connection,

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -318,16 +318,15 @@ class SQLiteControlPlane:
             return
         connection.execute(
             "INSERT INTO raw_manifests (tenant_id, manifest_id, agent_id, source_type, "
-            "file_subtype, competencia, created_at, data) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            "file_subtype, competencia, snapshot_id, base_snapshot_id, sequence, "
+            "previous_manifest_sha256, manifest_sha256, created_at, data) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
-                manifest.tenant_id,
-                manifest.manifest_id,
-                manifest.agent_id,
-                manifest.source_type,
-                manifest.file_subtype,
-                manifest.competencia,
-                manifest.created_at.isoformat(),
-                serialize_model(manifest),
+                manifest.tenant_id, manifest.manifest_id, manifest.agent_id,
+                manifest.source_type, manifest.file_subtype, manifest.competencia,
+                manifest.snapshot_id, manifest.base_snapshot_id, manifest.sequence,
+                manifest.previous_manifest_sha256, manifest.manifest_sha256,
+                manifest.created_at.isoformat(), serialize_model(manifest),
             ),
         )
 

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -22,8 +22,10 @@ from cnes_domain.control_plane.enums import AgentState, JobState
 from cnes_domain.control_plane.errors import Conflict, NotFound
 from cnes_infra.control_plane import sqlite_claims, sqlite_idempotency, sqlite_publication
 from cnes_infra.control_plane.sqlite_schema import (
+    _SQLiteWALUnavailable,
     deserialize_model,
     initialize_schema,
+    is_network_filesystem,
     serialize_model,
 )
 
@@ -60,7 +62,6 @@ if TYPE_CHECKING:
     )
 
 _BUSY_TIMEOUT_MS = 100
-_NETWORK_FILESYSTEMS = {"9p", "afs", "cifs", "fuse.sshfs", "nfs", "nfs4", "smbfs"}
 class _SQLiteBusyError(RuntimeError):
     pass
 
@@ -90,17 +91,7 @@ def _fetch_all[Model: BaseModel](
 
 
 def _is_network_filesystem(path: Path) -> bool:
-    try:
-        mounts = Path("/proc/self/mounts").read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return False
-    resolved = path.parent.resolve()
-    matches = []
-    for line in mounts:
-        fields = line.split()
-        if len(fields) >= 3 and resolved.is_relative_to(Path(fields[1])):
-            matches.append((len(fields[1]), fields[2]))
-    return bool(matches and max(matches)[1] in _NETWORK_FILESYSTEMS)
+    return is_network_filesystem(path)
 
 
 class SQLiteControlPlane:
@@ -128,6 +119,8 @@ class SQLiteControlPlane:
             raise _SQLiteFilesystemError("sqlite_network_filesystem")
         try:
             initialize_schema(self._connect, self._database_path)
+        except _SQLiteWALUnavailable as error:
+            raise _SQLiteFilesystemError("sqlite_wal_unavailable") from error
         except (OSError, sqlite3.Error) as error:
             raise _SQLiteFilesystemError("sqlite_filesystem") from error
 
@@ -363,11 +356,17 @@ class SQLiteControlPlane:
                 (delivered_at.isoformat(), serialize_model(delivered), event_id),
             )
 
-    def latest_succeeded_job(self, *args: str) -> Job | None:
-        return sqlite_publication.latest_succeeded_job(self, args)
+    def latest_succeeded_job(self, *args: str, **kwargs: str) -> Job | None:
+        values = sqlite_publication.normalize_long_call(
+            args, kwargs, sqlite_publication.LATEST_JOB_FIELDS
+        )
+        return sqlite_publication.latest_succeeded_job(self, values)
 
-    def list_raw_manifest_chain(self, *args: Any) -> tuple[ManifestRef, ...]:
-        return sqlite_publication.list_raw_manifest_chain(self, args)
+    def list_raw_manifest_chain(self, *args: Any, **kwargs: Any) -> tuple[ManifestRef, ...]:
+        values = sqlite_publication.normalize_long_call(
+            args, kwargs, sqlite_publication.DEPENDENCY_FIELDS, 31
+        )
+        return sqlite_publication.list_raw_manifest_chain(self, values)
 
     def cancel_job(self, command: CancelJob, event: OutboxEvent) -> Job:
         return sqlite_claims.cancel_job(self, command, event)
@@ -422,8 +421,11 @@ class SQLiteControlPlane:
     def get_run(self, tenant_id: str, run_id: str) -> Run | None:
         return sqlite_publication.get_run(self, tenant_id, run_id)
 
-    def list_waiting_runs_for_dependency(self, *args: Any) -> tuple[Run, ...]:
-        return sqlite_publication.list_waiting_runs(self, args)
+    def list_waiting_runs_for_dependency(self, *args: Any, **kwargs: Any) -> tuple[Run, ...]:
+        values = sqlite_publication.normalize_long_call(
+            args, kwargs, sqlite_publication.DEPENDENCY_FIELDS, 100
+        )
+        return sqlite_publication.list_waiting_runs(self, values)
 
     def list_recoverable_runs(self, now: datetime, limit: int = 100) -> tuple[Run, ...]:
         return sqlite_publication.list_recoverable_runs(self, now, limit)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -337,11 +337,11 @@ def finish_run_dispatch(store: Any, command: FinishRunDispatch) -> RunDispatch:
         dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)
         if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
             raise Conflict("dispatch_stale")
-        if dispatch.lease_until <= command.finished_at:
-            raise Conflict("dispatch_expired")
         if dispatch.state is DispatchState.TERMINAL:
             validate_run_dispatch_finish(connection, command)
             return dispatch
+        if dispatch.lease_until <= command.finished_at:
+            raise Conflict("dispatch_expired")
         finished = dispatch.model_copy(
             update={"state": DispatchState.TERMINAL, "terminal_outcome": command.outcome}
         )

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -348,7 +348,9 @@ def claim_run_unit(store: Any, command: ClaimRunUnit) -> RunUnit | None:
         if invalid or not valid_dispatch:
             return None
         claimable = unit.state in {RunUnitState.PENDING, RunUnitState.FAILED_RETRYABLE}
-        claimable |= unit.state is RunUnitState.LEASED and unit.lease_until <= command.now
+        claimable |= unit.state is RunUnitState.LEASED and (
+            unit.dispatch_id != command.dispatch_id or unit.lease_until <= command.now
+        )
         if not claimable:
             return None
         claimed = unit.model_copy(

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -22,6 +22,7 @@ from cnes_infra.control_plane.sqlite_schema import (
     put_run_unit_terminal_write,
     serialize_model,
     validate_job_terminal_replay,
+    validate_run_dispatch_wave,
     validate_run_unit_terminal_replay,
 )
 
@@ -68,7 +69,8 @@ def claim_job(store: Any, command: ClaimJob) -> Job | None:
         if job is None or agent is None or agent.state is AgentState.REVOKED:
             return None
         retryable = job.state in {JobState.PENDING, JobState.FAILED_RETRYABLE}
-        expired = job.state is JobState.LEASED and job.lease_until <= command.now
+        expired = job.state is JobState.LEASED and (
+            job.lease_until is None or job.lease_until <= command.now)
         if not retryable and not expired:
             return None
         claimed = job.model_copy(
@@ -258,10 +260,9 @@ def _has_live_unit_lease(connection: Any, dispatch: RunDispatch, now: Any) -> bo
 
 def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:
+        validate_run_dispatch_wave(connection, command)
         current = _get_dispatch(connection, command.tenant_id, command.run_id)
         same_wave = current is not None and current.wave_id == command.wave_id
-        if same_wave and current.unit_ids != command.unit_ids:
-            raise Conflict("dispatch_units_conflict")
         replay = (
             same_wave
             and current.lease_until > command.now

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -305,6 +305,9 @@ def get_active_run_dispatch(store: Any, tenant_id: str, run_id: str) -> RunDispa
 
 def bind_run_dispatch(store: Any, command: BindRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:
+        run = store.get_run_record(connection, command.tenant_id, command.run_id)
+        if run is None or run.state is not RunState.PROCESSING:
+            raise Conflict("parent_not_processing")
         dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)
         if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
             raise Conflict("dispatch_stale")

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -16,20 +16,22 @@ from cnes_domain.control_plane.enums import (
 )
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
 from cnes_domain.control_plane.transitions import transition_run, transition_run_unit
+from cnes_infra.control_plane.sqlite_dispatch import (
+    put_run_dispatch_bind,
+    put_run_dispatch_finish,
+    validate_run_dispatch_bind,
+    validate_run_dispatch_finish,
+)
 from cnes_infra.control_plane.sqlite_schema import (
     deserialize_model,
     put_job_cancellation,
     put_job_terminal_write,
     put_run_cancellation,
-    put_run_dispatch_bind,
-    put_run_dispatch_finish,
     put_run_unit_terminal_write,
     serialize_model,
     validate_job_cancellation,
     validate_job_terminal_replay,
     validate_run_cancellation,
-    validate_run_dispatch_bind,
-    validate_run_dispatch_finish,
     validate_run_dispatch_wave,
     validate_run_unit_terminal_replay,
 )
@@ -335,19 +337,19 @@ def bind_run_dispatch(store: Any, command: BindRunDispatch) -> RunDispatch:
         return started
 def finish_run_dispatch(store: Any, command: FinishRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:
+        replay = validate_run_dispatch_finish(connection, command)
+        if replay is not None:
+            return replay
         dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)
         if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
             raise Conflict("dispatch_stale")
-        if dispatch.state is DispatchState.TERMINAL:
-            validate_run_dispatch_finish(connection, command)
-            return dispatch
         if dispatch.lease_until <= command.finished_at:
             raise Conflict("dispatch_expired")
         finished = dispatch.model_copy(
             update={"state": DispatchState.TERMINAL, "terminal_outcome": command.outcome}
         )
         _put_dispatch(connection, finished)
-        put_run_dispatch_finish(connection, command)
+        put_run_dispatch_finish(connection, command, finished)
         return finished
 
 def claim_run_unit(store: Any, command: ClaimRunUnit) -> RunUnit | None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -52,7 +52,6 @@ if TYPE_CHECKING:
     )
     from cnes_domain.control_plane.entities import Job, OutboxEvent
 
-
 def _validate_job_fence(store: Any, connection: Any, command: Any) -> Job:
     job = store.get_job_record(connection, command.tenant_id, command.job_id)
     agent = None if job is None else store.get_agent_record(connection, job.tenant_id, job.agent_id)
@@ -67,7 +66,6 @@ def _validate_job_fence(store: Any, connection: Any, command: Any) -> Job:
     if job.lease_until is None or job.lease_until <= store.now():
         raise LeaseLost("lease_expired")
     return job
-
 
 def claim_job(store: Any, command: ClaimJob) -> Job | None:
     with store.write_transaction() as connection:
@@ -93,7 +91,6 @@ def claim_job(store: Any, command: ClaimJob) -> Job | None:
         store.put_job_record(connection, claimed)
         return claimed
 
-
 def renew_job_lease(store: Any, command: RenewJobLease) -> Job:
     with store.write_transaction() as connection:
         job = _validate_job_fence(store, connection, command)
@@ -102,7 +99,6 @@ def renew_job_lease(store: Any, command: RenewJobLease) -> Job:
         )
         store.put_job_record(connection, renewed)
         return renewed
-
 
 def _validate_manifest_identity(job: Job, manifest: Any) -> None:
     expected = (
@@ -115,7 +111,6 @@ def _validate_manifest_identity(job: Job, manifest: Any) -> None:
     )
     if actual != expected:
         raise Conflict("manifest_identity_mismatch")
-
 
 def complete_job(store: Any, command: CompleteJob, event: OutboxEvent) -> Job:
     with store.write_transaction() as connection:
@@ -177,14 +172,12 @@ def cancel_job(store: Any, command: CancelJob, event: OutboxEvent) -> Job:
         put_job_cancellation(connection, command, event)
         return canceled
 
-
 def _list_run_units(connection: Any, tenant_id: str, run_id: str) -> tuple[RunUnit, ...]:
     rows = connection.execute(
         "SELECT data FROM run_units WHERE tenant_id = ? AND run_id = ? ORDER BY unit_id",
         (tenant_id, run_id),
     ).fetchall()
     return tuple(deserialize_model(row[0], RunUnit) for row in rows)
-
 
 def list_run_units(store: Any, tenant_id: str, run_id: str) -> tuple[RunUnit, ...]:
     with store.read_connection() as connection:
@@ -269,6 +262,10 @@ def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch
         run = store.get_run_record(connection, command.tenant_id, command.run_id)
         if run is None or run.state is not RunState.PROCESSING:
             raise Conflict("parent_not_processing")
+        registered = {unit.unit_id for unit in _list_run_units(
+            connection, command.tenant_id, command.run_id)}
+        if any(unit_id not in registered for unit_id in command.unit_ids):
+            raise Conflict("dispatch_unit_missing")
         validate_run_dispatch_wave(connection, command)
         current = _get_dispatch(connection, command.tenant_id, command.run_id)
         same_wave = current is not None and current.wave_id == command.wave_id
@@ -303,7 +300,13 @@ def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch
 
 def get_active_run_dispatch(store: Any, tenant_id: str, run_id: str) -> RunDispatch | None:
     with store.read_connection() as connection:
-        dispatch = _get_dispatch(connection, tenant_id, run_id)
+        row = connection.execute(
+            "SELECT d.data FROM run_dispatches d JOIN runs r "
+            "ON r.tenant_id = d.tenant_id AND r.run_id = d.run_id "
+            "WHERE d.tenant_id = ? AND d.run_id = ? AND r.state = ?",
+            (tenant_id, run_id, RunState.PROCESSING.value),
+        ).fetchone()
+    dispatch = None if row is None else deserialize_model(row[0], RunDispatch)
     if dispatch is None or dispatch.state is DispatchState.TERMINAL:
         return None
     return dispatch if dispatch.lease_until > store.now() else None
@@ -350,7 +353,6 @@ def finish_run_dispatch(store: Any, command: FinishRunDispatch) -> RunDispatch:
         put_run_dispatch_finish(connection, command)
         return finished
 
-
 def claim_run_unit(store: Any, command: ClaimRunUnit) -> RunUnit | None:
     with store.write_transaction() as connection:
         units = _list_run_units(connection, command.tenant_id, command.run_id)
@@ -386,7 +388,6 @@ def claim_run_unit(store: Any, command: ClaimRunUnit) -> RunUnit | None:
         _put_run_unit(connection, claimed)
         return claimed
 
-
 def _validate_unit_fence(store: Any, connection: Any, command: Any) -> tuple[RunUnit, Any]:
     units = _list_run_units(connection, command.tenant_id, command.run_id)
     unit = next((item for item in units if item.unit_id == command.unit_id), None)
@@ -411,7 +412,6 @@ def _validate_unit_fence(store: Any, connection: Any, command: Any) -> tuple[Run
     if unit.lease_until is None or unit.lease_until <= store.now():
         raise LeaseLost("lease_expired")
     return unit, run
-
 
 def commit_run_unit(store: Any, command: CommitRunUnit, event: OutboxEvent) -> RunUnit:
     with store.write_transaction() as connection:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -247,16 +247,16 @@ def _put_dispatch(connection: Any, dispatch: RunDispatch) -> None:
     )
 
 
-def _has_live_unit_lease(connection: Any, dispatch: RunDispatch, now: Any) -> bool:
-    units = _list_run_units(connection, dispatch.tenant_id, dispatch.run_id)
+def _has_live_unit_lease(connection: Any, command: Any, dispatch: RunDispatch | None) -> bool:
+    units = _list_run_units(connection, command.tenant_id, command.run_id)
+    affected = set(command.unit_ids) | (set(dispatch.unit_ids) if dispatch else set())
     return any(
-        unit.dispatch_id == dispatch.dispatch_id
+        unit.unit_id in affected
         and unit.state is RunUnitState.LEASED
-        and unit.lease_until > now
+        and unit.lease_until is not None
+        and unit.lease_until > command.now
         for unit in units
     )
-
-
 def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:
         run = store.get_run_record(connection, command.tenant_id, command.run_id)
@@ -278,7 +278,7 @@ def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch
             return current
         live = current and current.state is not DispatchState.TERMINAL
         lease_live = current is not None and current.lease_until > command.now
-        if live and (lease_live or _has_live_unit_lease(connection, current, command.now)):
+        if _has_live_unit_lease(connection, command, current) or (live and lease_live):
             raise Conflict("dispatch_live")
         generation = 1 if current is None else current.generation + 1
         identity = "\x1f".join(
@@ -296,8 +296,6 @@ def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch
         )
         _put_dispatch(connection, dispatch)
         return dispatch
-
-
 def get_active_run_dispatch(store: Any, tenant_id: str, run_id: str) -> RunDispatch | None:
     with store.read_connection() as connection:
         row = connection.execute(

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -201,13 +201,14 @@ def put_run_units(store: Any, command: PutRunUnits) -> tuple[RunUnit, ...]:
         if run is None or run.state is not command.expected_run_state:
             raise Conflict("run_state_conflict")
         current = _list_run_units(connection, command.tenant_id, command.run_id)
+        canonical = tuple(sorted(command.units, key=lambda unit: unit.unit_id))
         if current:
-            if current != command.units:
+            if current != canonical:
                 raise Conflict("units_conflict")
             return current
-        for unit in command.units:
+        for unit in canonical:
             _put_run_unit(connection, unit)
-        return command.units
+        return canonical
 
 
 def _get_dispatch(connection: Any, tenant_id: str, run_id: str) -> RunDispatch | None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -319,9 +319,6 @@ def bind_run_dispatch(store: Any, command: BindRunDispatch) -> RunDispatch:
         dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)
         if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
             raise Conflict("dispatch_stale")
-        if dispatch.state is DispatchState.STARTED:
-            validate_run_dispatch_bind(connection, command)
-            return dispatch
         if dispatch.lease_until <= command.now:
             raise Conflict("dispatch_expired")
         if dispatch.state is not DispatchState.RESERVED:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -90,10 +90,30 @@ def renew_job_lease(store: Any, command: RenewJobLease) -> Job:
         return renewed
 
 
+def _validate_manifest_identity(job: Job, manifest: Any) -> None:
+    expected = (
+        job.agent_id,
+        job.source_type,
+        job.file_subtype,
+        job.competencia,
+        job.requested_snapshot_mode,
+    )
+    actual = (
+        manifest.agent_id,
+        manifest.source_type,
+        manifest.file_subtype,
+        manifest.competencia,
+        manifest.snapshot_mode,
+    )
+    if actual != expected:
+        raise Conflict("manifest_identity_mismatch")
+
+
 def complete_job(store: Any, command: CompleteJob, event: OutboxEvent) -> Job:
     with store.write_transaction() as connection:
         job = _validate_job_fence(store, connection, command)
         manifest = command.manifest
+        _validate_manifest_identity(job, manifest)
         completed = job.model_copy(
             update={
                 "state": JobState.SUCCEEDED,
@@ -400,7 +420,8 @@ def fail_run_unit(store: Any, command: FailRunUnit, event: OutboxEvent) -> RunUn
         _put_run_unit(connection, failed)
         if state is RunUnitState.SUCCEEDED_DEGRADED:
             source = f"{unit.source_type}/{unit.file_subtype}"
-            updated = run.model_copy(update={"missing_sources": (*run.missing_sources, source)})
+            missing_sources = tuple(dict.fromkeys((*run.missing_sources, source)))
+            updated = run.model_copy(update={"missing_sources": missing_sources})
             store.put_run_record(connection, updated)
         store.put_outbox_event(connection, event)
         return failed

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -310,6 +310,9 @@ def get_active_run_dispatch(store: Any, tenant_id: str, run_id: str) -> RunDispa
 
 def bind_run_dispatch(store: Any, command: BindRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:
+        replay = validate_run_dispatch_bind(connection, command)
+        if replay is not None:
+            return replay
         run = store.get_run_record(connection, command.tenant_id, command.run_id)
         if run is None or run.state is not RunState.PROCESSING:
             raise Conflict("parent_not_processing")
@@ -331,7 +334,7 @@ def bind_run_dispatch(store: Any, command: BindRunDispatch) -> RunDispatch:
             }
         )
         _put_dispatch(connection, started)
-        put_run_dispatch_bind(connection, command)
+        put_run_dispatch_bind(connection, command, started)
         return started
 def finish_run_dispatch(store: Any, command: FinishRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -21,12 +21,14 @@ from cnes_infra.control_plane.sqlite_schema import (
     put_job_cancellation,
     put_job_terminal_write,
     put_run_cancellation,
+    put_run_dispatch_bind,
     put_run_dispatch_finish,
     put_run_unit_terminal_write,
     serialize_model,
     validate_job_cancellation,
     validate_job_terminal_replay,
     validate_run_cancellation,
+    validate_run_dispatch_bind,
     validate_run_dispatch_finish,
     validate_run_dispatch_wave,
     validate_run_unit_terminal_replay,
@@ -314,12 +316,11 @@ def bind_run_dispatch(store: Any, command: BindRunDispatch) -> RunDispatch:
         dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)
         if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
             raise Conflict("dispatch_stale")
+        if dispatch.state is DispatchState.STARTED:
+            validate_run_dispatch_bind(connection, command)
+            return dispatch
         if dispatch.lease_until <= command.now:
             raise Conflict("dispatch_expired")
-        if dispatch.state is DispatchState.STARTED:
-            if dispatch.execution_ref != command.execution_ref:
-                raise Conflict("execution_conflict")
-            return dispatch
         if dispatch.state is not DispatchState.RESERVED:
             raise Conflict("dispatch_terminal")
         started = dispatch.model_copy(
@@ -330,8 +331,8 @@ def bind_run_dispatch(store: Any, command: BindRunDispatch) -> RunDispatch:
             }
         )
         _put_dispatch(connection, started)
+        put_run_dispatch_bind(connection, command)
         return started
-
 def finish_run_dispatch(store: Any, command: FinishRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:
         dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -16,7 +16,12 @@ from cnes_domain.control_plane.enums import (
 )
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
 from cnes_domain.control_plane.transitions import transition_run, transition_run_unit
-from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
+from cnes_infra.control_plane.sqlite_schema import (
+    deserialize_model,
+    get_job_terminal_write,
+    put_job_terminal_write,
+    serialize_model,
+)
 
 if TYPE_CHECKING:
     from cnes_domain.control_plane.commands import (
@@ -39,9 +44,7 @@ if TYPE_CHECKING:
 
 def _validate_job_fence(store: Any, connection: Any, command: Any) -> Job:
     job = store.get_job_record(connection, command.tenant_id, command.job_id)
-    agent = None if job is None else store.get_agent_record(
-        connection, job.tenant_id, job.agent_id
-    )
+    agent = None if job is None else store.get_agent_record(connection, job.tenant_id, job.agent_id)
     if job is None or job.state is not JobState.LEASED:
         raise LeaseLost("job_not_leased")
     if agent is None or agent.state is AgentState.REVOKED:
@@ -59,8 +62,7 @@ def claim_job(store: Any, command: ClaimJob) -> Job | None:
     with store.write_transaction() as connection:
         job = store.get_job_record(connection, command.tenant_id, command.job_id)
         agent = None if job is None else store.get_agent_record(
-            connection, job.tenant_id, job.agent_id
-        )
+            connection, job.tenant_id, job.agent_id)
         if job is None or agent is None or agent.state is AgentState.REVOKED:
             return None
         retryable = job.state in {JobState.PENDING, JobState.FAILED_RETRYABLE}
@@ -92,27 +94,46 @@ def renew_job_lease(store: Any, command: RenewJobLease) -> Job:
 
 def _validate_manifest_identity(job: Job, manifest: Any) -> None:
     expected = (
-        job.tenant_id,
-        job.agent_id,
-        job.source_type,
-        job.file_subtype,
-        job.competencia,
-        job.requested_snapshot_mode,
+        job.tenant_id, job.agent_id, job.source_type,
+        job.file_subtype, job.competencia, job.requested_snapshot_mode,
     )
     actual = (
-        manifest.tenant_id,
-        manifest.agent_id,
-        manifest.source_type,
-        manifest.file_subtype,
-        manifest.competencia,
-        manifest.snapshot_mode,
+        manifest.tenant_id, manifest.agent_id, manifest.source_type,
+        manifest.file_subtype, manifest.competencia, manifest.snapshot_mode,
     )
     if actual != expected:
         raise Conflict("manifest_identity_mismatch")
 
 
+def _validate_terminal_replay(connection: Any, job: Job, command: Any, event: Any) -> None:
+    manifest = getattr(command, "manifest", None)
+    operation = "complete" if manifest is not None else "fail"
+    canonical = (operation, serialize_model(command), serialize_model(event))
+    current = get_job_terminal_write(connection, command.tenant_id, command.job_id)
+    if manifest is not None:
+        result_matches = (
+            job.state is JobState.SUCCEEDED
+            and job.fencing_token == command.fencing_token
+            and job.result_manifest_id == manifest.manifest_id
+            and job.result_manifest_key == manifest.manifest_key
+        )
+    else:
+        expected = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
+        result_matches = (
+            job.state is expected
+            and job.fencing_token == command.fencing_token
+            and job.error_code == command.error_code
+        )
+    if current != canonical or not result_matches:
+        raise Conflict("job_terminal_conflict")
+
+
 def complete_job(store: Any, command: CompleteJob, event: OutboxEvent) -> Job:
     with store.write_transaction() as connection:
+        job = store.get_job_record(connection, command.tenant_id, command.job_id)
+        if job is not None and job.state is JobState.SUCCEEDED:
+            _validate_terminal_replay(connection, job, command, event)
+            return job
         job = _validate_job_fence(store, connection, command)
         manifest = command.manifest
         _validate_manifest_identity(job, manifest)
@@ -127,12 +148,18 @@ def complete_job(store: Any, command: CompleteJob, event: OutboxEvent) -> Job:
         )
         store.put_job_record(connection, completed)
         store.put_manifest_record(connection, manifest)
+        put_job_terminal_write(connection, "complete", command, event)
         store.put_outbox_event(connection, event)
         return completed
 
 
 def fail_job(store: Any, command: FailJob, event: OutboxEvent) -> Job:
     with store.write_transaction() as connection:
+        job = store.get_job_record(connection, command.tenant_id, command.job_id)
+        failed_states = {JobState.FAILED_RETRYABLE, JobState.FAILED_FINAL}
+        if job is not None and job.state in failed_states:
+            _validate_terminal_replay(connection, job, command, event)
+            return job
         job = _validate_job_fence(store, connection, command)
         state = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
         failed = job.model_copy(
@@ -144,6 +171,7 @@ def fail_job(store: Any, command: FailJob, event: OutboxEvent) -> Job:
             }
         )
         store.put_job_record(connection, failed)
+        put_job_terminal_write(connection, "fail", command, event)
         store.put_outbox_event(connection, event)
         return failed
 
@@ -259,6 +287,8 @@ def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch
             and current.state in {DispatchState.RESERVED, DispatchState.STARTED}
         )
         if replay:
+            if current.unit_ids != command.unit_ids:
+                raise Conflict("dispatch_units_conflict")
             return current
         live = current and current.state is not DispatchState.TERMINAL
         lease_live = current is not None and current.lease_until > command.now

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -260,6 +260,9 @@ def _has_live_unit_lease(connection: Any, dispatch: RunDispatch, now: Any) -> bo
 
 def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:
+        run = store.get_run_record(connection, command.tenant_id, command.run_id)
+        if run is None or run.state is not RunState.PROCESSING:
+            raise Conflict("parent_not_processing")
         validate_run_dispatch_wave(connection, command)
         current = _get_dispatch(connection, command.tenant_id, command.run_id)
         same_wave = current is not None and current.wave_id == command.wave_id

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -255,6 +255,7 @@ def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch
             current
             and current.wave_id == command.wave_id
             and current.lease_until > command.now
+            and current.state in {DispatchState.RESERVED, DispatchState.STARTED}
         )
         if replay:
             return current
@@ -373,10 +374,14 @@ def _validate_unit_fence(store: Any, connection: Any, command: Any) -> tuple[Run
         raise LeaseLost("parent_not_processing")
     if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
         raise LeaseLost("dispatch_mismatch")
+    if dispatch.state not in {DispatchState.RESERVED, DispatchState.STARTED}:
+        raise LeaseLost("dispatch_inactive")
     if dispatch.lease_until <= store.now():
         raise LeaseLost("dispatch_expired")
     if unit is None or unit.state is not RunUnitState.LEASED:
         raise LeaseLost("unit_not_leased")
+    if unit.dispatch_id != command.dispatch_id:
+        raise LeaseLost("unit_dispatch_mismatch")
     if unit.lease_owner != command.owner:
         raise LeaseLost("owner_mismatch")
     if unit.fencing_token != command.fencing_token:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -202,8 +202,6 @@ def _put_run_unit(connection: Any, unit: RunUnit) -> None:
 def put_run_units(store: Any, command: PutRunUnits) -> tuple[RunUnit, ...]:
     with store.write_transaction() as connection:
         run = store.get_run_record(connection, command.tenant_id, command.run_id)
-        if run is None or run.state is not command.expected_run_state:
-            raise Conflict("run_state_conflict")
         current = _list_run_units(connection, command.tenant_id, command.run_id)
         canonical = tuple(sorted(command.units, key=lambda unit: unit.unit_id))
         registry = "\x1e".join(serialize_model(unit) for unit in canonical)
@@ -214,6 +212,8 @@ def put_run_units(store: Any, command: PutRunUnits) -> tuple[RunUnit, ...]:
             if row[0] != registry:
                 raise Conflict("units_conflict")
             return current
+        if run is None or run.state is not command.expected_run_state:
+            raise Conflict("run_state_conflict")
         for unit in canonical:
             _put_run_unit(connection, unit)
         connection.execute(

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -18,9 +18,11 @@ from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
 from cnes_domain.control_plane.transitions import transition_run, transition_run_unit
 from cnes_infra.control_plane.sqlite_schema import (
     deserialize_model,
-    get_job_terminal_write,
     put_job_terminal_write,
+    put_run_unit_terminal_write,
     serialize_model,
+    validate_job_terminal_replay,
+    validate_run_unit_terminal_replay,
 )
 
 if TYPE_CHECKING:
@@ -105,34 +107,11 @@ def _validate_manifest_identity(job: Job, manifest: Any) -> None:
         raise Conflict("manifest_identity_mismatch")
 
 
-def _validate_terminal_replay(connection: Any, job: Job, command: Any, event: Any) -> None:
-    manifest = getattr(command, "manifest", None)
-    operation = "complete" if manifest is not None else "fail"
-    canonical = (operation, serialize_model(command), serialize_model(event))
-    current = get_job_terminal_write(connection, command.tenant_id, command.job_id)
-    if manifest is not None:
-        result_matches = (
-            job.state is JobState.SUCCEEDED
-            and job.fencing_token == command.fencing_token
-            and job.result_manifest_id == manifest.manifest_id
-            and job.result_manifest_key == manifest.manifest_key
-        )
-    else:
-        expected = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
-        result_matches = (
-            job.state is expected
-            and job.fencing_token == command.fencing_token
-            and job.error_code == command.error_code
-        )
-    if current != canonical or not result_matches:
-        raise Conflict("job_terminal_conflict")
-
-
 def complete_job(store: Any, command: CompleteJob, event: OutboxEvent) -> Job:
     with store.write_transaction() as connection:
         job = store.get_job_record(connection, command.tenant_id, command.job_id)
         if job is not None and job.state is JobState.SUCCEEDED:
-            _validate_terminal_replay(connection, job, command, event)
+            validate_job_terminal_replay(connection, job, command, event)
             return job
         job = _validate_job_fence(store, connection, command)
         manifest = command.manifest
@@ -158,7 +137,7 @@ def fail_job(store: Any, command: FailJob, event: OutboxEvent) -> Job:
         job = store.get_job_record(connection, command.tenant_id, command.job_id)
         failed_states = {JobState.FAILED_RETRYABLE, JobState.FAILED_FINAL}
         if job is not None and job.state in failed_states:
-            _validate_terminal_replay(connection, job, command, event)
+            validate_job_terminal_replay(connection, job, command, event)
             return job
         job = _validate_job_fence(store, connection, command)
         state = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
@@ -426,6 +405,12 @@ def _validate_unit_fence(store: Any, connection: Any, command: Any) -> tuple[Run
 
 def commit_run_unit(store: Any, command: CommitRunUnit, event: OutboxEvent) -> RunUnit:
     with store.write_transaction() as connection:
+        current = next(
+            (unit for unit in _list_run_units(connection, command.tenant_id, command.run_id)
+             if unit.unit_id == command.unit_id), None
+        )
+        if current is not None and current.state is RunUnitState.SUCCEEDED:
+            return validate_run_unit_terminal_replay(connection, current, command, event)
         unit, run = _validate_unit_fence(store, connection, command)
         completed = transition_run_unit(unit, RunUnitState.SUCCEEDED, run).model_copy(
             update={
@@ -435,12 +420,24 @@ def commit_run_unit(store: Any, command: CommitRunUnit, event: OutboxEvent) -> R
             }
         )
         _put_run_unit(connection, completed)
+        put_run_unit_terminal_write(connection, "commit", command, event)
         store.put_outbox_event(connection, event)
         return completed
 
 
 def fail_run_unit(store: Any, command: FailRunUnit, event: OutboxEvent) -> RunUnit:
     with store.write_transaction() as connection:
+        current = next(
+            (unit for unit in _list_run_units(connection, command.tenant_id, command.run_id)
+             if unit.unit_id == command.unit_id), None
+        )
+        terminal = {
+            RunUnitState.FAILED_RETRYABLE,
+            RunUnitState.FAILED_FINAL,
+            RunUnitState.SUCCEEDED_DEGRADED,
+        }
+        if current is not None and current.state in terminal:
+            return validate_run_unit_terminal_replay(connection, current, command, event)
         unit, run = _validate_unit_fence(store, connection, command)
         optional = any(
             (item.source_type, item.file_subtype) == (unit.source_type, unit.file_subtype)
@@ -458,6 +455,7 @@ def fail_run_unit(store: Any, command: FailRunUnit, event: OutboxEvent) -> RunUn
         )
         failed = transition_run_unit(failed, state, run)
         _put_run_unit(connection, failed)
+        put_run_unit_terminal_write(connection, "fail", command, event)
         if state is RunUnitState.SUCCEEDED_DEGRADED:
             source = f"{unit.source_type}/{unit.file_subtype}"
             missing_sources = tuple(dict.fromkeys((*run.missing_sources, source)))

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -1,0 +1,434 @@
+"""SQLite lease and fencing operations."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from hashlib import sha256
+from typing import TYPE_CHECKING, Any
+
+from cnes_domain.control_plane.entities import RunDispatch, RunUnit
+from cnes_domain.control_plane.enums import (
+    AgentState,
+    DispatchState,
+    JobState,
+    RunState,
+    RunUnitState,
+)
+from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
+from cnes_domain.control_plane.transitions import transition_run, transition_run_unit
+from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
+
+if TYPE_CHECKING:
+    from cnes_domain.control_plane.commands import (
+        BindRunDispatch,
+        CancelJob,
+        ClaimJob,
+        ClaimRunUnit,
+        CommitRunUnit,
+        CompleteJob,
+        FailJob,
+        FailRunUnit,
+        FinalizeRunCancellation,
+        FinishRunDispatch,
+        PutRunUnits,
+        RenewJobLease,
+        ReserveRunDispatch,
+    )
+    from cnes_domain.control_plane.entities import Job, OutboxEvent
+
+
+def _validate_job_fence(store: Any, connection: Any, command: Any) -> Job:
+    job = store.get_job_record(connection, command.tenant_id, command.job_id)
+    agent = None if job is None else store.get_agent_record(
+        connection, job.tenant_id, job.agent_id
+    )
+    if job is None or job.state is not JobState.LEASED:
+        raise LeaseLost("job_not_leased")
+    if agent is None or agent.state is AgentState.REVOKED:
+        raise LeaseLost("agent_revoked")
+    if job.lease_owner != command.owner:
+        raise LeaseLost("owner_mismatch")
+    if job.fencing_token != command.fencing_token:
+        raise FenceRejected("fence_mismatch")
+    if job.lease_until is None or job.lease_until <= store.now():
+        raise LeaseLost("lease_expired")
+    return job
+
+
+def claim_job(store: Any, command: ClaimJob) -> Job | None:
+    with store.write_transaction() as connection:
+        job = store.get_job_record(connection, command.tenant_id, command.job_id)
+        agent = None if job is None else store.get_agent_record(
+            connection, job.tenant_id, job.agent_id
+        )
+        if job is None or agent is None or agent.state is AgentState.REVOKED:
+            return None
+        retryable = job.state in {JobState.PENDING, JobState.FAILED_RETRYABLE}
+        expired = job.state is JobState.LEASED and job.lease_until <= command.now
+        if not retryable and not expired:
+            return None
+        claimed = job.model_copy(
+            update={
+                "state": JobState.LEASED,
+                "attempt": job.attempt + 1,
+                "fencing_token": job.fencing_token + 1,
+                "lease_owner": command.owner,
+                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+            }
+        )
+        store.put_job_record(connection, claimed)
+        return claimed
+
+
+def renew_job_lease(store: Any, command: RenewJobLease) -> Job:
+    with store.write_transaction() as connection:
+        job = _validate_job_fence(store, connection, command)
+        renewed = job.model_copy(
+            update={"lease_until": command.now + timedelta(seconds=command.lease_seconds)}
+        )
+        store.put_job_record(connection, renewed)
+        return renewed
+
+
+def complete_job(store: Any, command: CompleteJob, event: OutboxEvent) -> Job:
+    with store.write_transaction() as connection:
+        job = _validate_job_fence(store, connection, command)
+        manifest = command.manifest
+        completed = job.model_copy(
+            update={
+                "state": JobState.SUCCEEDED,
+                "lease_owner": None,
+                "lease_until": None,
+                "result_manifest_id": manifest.manifest_id,
+                "result_manifest_key": manifest.manifest_key,
+            }
+        )
+        store.put_job_record(connection, completed)
+        store.put_manifest_record(connection, manifest)
+        store.put_outbox_event(connection, event)
+        return completed
+
+
+def fail_job(store: Any, command: FailJob, event: OutboxEvent) -> Job:
+    with store.write_transaction() as connection:
+        job = _validate_job_fence(store, connection, command)
+        state = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
+        failed = job.model_copy(
+            update={
+                "state": state,
+                "lease_owner": None,
+                "lease_until": None,
+                "error_code": command.error_code,
+            }
+        )
+        store.put_job_record(connection, failed)
+        store.put_outbox_event(connection, event)
+        return failed
+
+
+def cancel_job(store: Any, command: CancelJob, event: OutboxEvent) -> Job:
+    with store.write_transaction() as connection:
+        job = store.get_job_record(connection, command.tenant_id, command.job_id)
+        if job is None:
+            raise Conflict("job_missing")
+        if job.state is JobState.CANCEL_REQUESTED:
+            return job
+        if job.state is not JobState.LEASED:
+            raise Conflict("job_not_leased")
+        canceled = job.model_copy(update={"state": JobState.CANCEL_REQUESTED})
+        store.put_job_record(connection, canceled)
+        store.put_outbox_event(connection, event)
+        return canceled
+
+
+def _list_run_units(connection: Any, tenant_id: str, run_id: str) -> tuple[RunUnit, ...]:
+    rows = connection.execute(
+        "SELECT data FROM run_units WHERE tenant_id = ? AND run_id = ? ORDER BY unit_id",
+        (tenant_id, run_id),
+    ).fetchall()
+    return tuple(deserialize_model(row[0], RunUnit) for row in rows)
+
+
+def list_run_units(store: Any, tenant_id: str, run_id: str) -> tuple[RunUnit, ...]:
+    with store.read_connection() as connection:
+        return _list_run_units(connection, tenant_id, run_id)
+
+
+def _put_run_unit(connection: Any, unit: RunUnit) -> None:
+    connection.execute(
+        "INSERT INTO run_units (tenant_id, run_id, unit_id, state, lease_until, "
+        "dispatch_id, data) VALUES (?, ?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT (tenant_id, run_id, unit_id) DO UPDATE SET state = excluded.state, "
+        "lease_until = excluded.lease_until, dispatch_id = excluded.dispatch_id, "
+        "data = excluded.data",
+        (
+            unit.tenant_id,
+            unit.run_id,
+            unit.unit_id,
+            unit.state.value,
+            None if unit.lease_until is None else unit.lease_until.isoformat(),
+            unit.dispatch_id,
+            serialize_model(unit),
+        ),
+    )
+
+
+def put_run_units(store: Any, command: PutRunUnits) -> tuple[RunUnit, ...]:
+    with store.write_transaction() as connection:
+        run = store.get_run_record(connection, command.tenant_id, command.run_id)
+        if run is None or run.state is not command.expected_run_state:
+            raise Conflict("run_state_conflict")
+        current = _list_run_units(connection, command.tenant_id, command.run_id)
+        if current:
+            if current != command.units:
+                raise Conflict("units_conflict")
+            return current
+        for unit in command.units:
+            _put_run_unit(connection, unit)
+        return command.units
+
+
+def _get_dispatch(connection: Any, tenant_id: str, run_id: str) -> RunDispatch | None:
+    row = connection.execute(
+        "SELECT data FROM run_dispatches WHERE tenant_id = ? AND run_id = ?",
+        (tenant_id, run_id),
+    ).fetchone()
+    return None if row is None else deserialize_model(row[0], RunDispatch)
+
+
+def _put_dispatch(connection: Any, dispatch: RunDispatch) -> None:
+    connection.execute(
+        "INSERT INTO run_dispatches (tenant_id, run_id, dispatch_id, wave_id, generation, "
+        "state, lease_until, data) VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT (tenant_id, run_id) DO UPDATE SET dispatch_id = excluded.dispatch_id, "
+        "wave_id = excluded.wave_id, generation = excluded.generation, state = excluded.state, "
+        "lease_until = excluded.lease_until, data = excluded.data",
+        (
+            dispatch.tenant_id,
+            dispatch.run_id,
+            dispatch.dispatch_id,
+            dispatch.wave_id,
+            dispatch.generation,
+            dispatch.state.value,
+            dispatch.lease_until.isoformat(),
+            serialize_model(dispatch),
+        ),
+    )
+
+
+def _has_live_unit_lease(connection: Any, dispatch: RunDispatch, now: Any) -> bool:
+    units = _list_run_units(connection, dispatch.tenant_id, dispatch.run_id)
+    return any(
+        unit.dispatch_id == dispatch.dispatch_id
+        and unit.state is RunUnitState.LEASED
+        and unit.lease_until > now
+        for unit in units
+    )
+
+
+def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch:
+    with store.write_transaction() as connection:
+        current = _get_dispatch(connection, command.tenant_id, command.run_id)
+        replay = (
+            current
+            and current.wave_id == command.wave_id
+            and current.lease_until > command.now
+        )
+        if replay:
+            return current
+        live = current and current.state is not DispatchState.TERMINAL
+        lease_live = current is not None and current.lease_until > command.now
+        if live and (lease_live or _has_live_unit_lease(connection, current, command.now)):
+            raise Conflict("dispatch_live")
+        generation = 1 if current is None else current.generation + 1
+        identity = "\x1f".join(
+            (command.tenant_id, command.run_id, command.wave_id, str(generation), *command.unit_ids)
+        )
+        dispatch = RunDispatch(
+            tenant_id=command.tenant_id,
+            run_id=command.run_id,
+            wave_id=command.wave_id,
+            dispatch_id=sha256(identity.encode()).hexdigest()[:16],
+            generation=generation,
+            unit_ids=command.unit_ids,
+            state=DispatchState.RESERVED,
+            lease_until=command.now + timedelta(seconds=command.lease_seconds),
+        )
+        _put_dispatch(connection, dispatch)
+        return dispatch
+
+
+def get_active_run_dispatch(store: Any, tenant_id: str, run_id: str) -> RunDispatch | None:
+    with store.read_connection() as connection:
+        dispatch = _get_dispatch(connection, tenant_id, run_id)
+    if dispatch is None or dispatch.state is DispatchState.TERMINAL:
+        return None
+    return dispatch if dispatch.lease_until > store.now() else None
+
+
+def bind_run_dispatch(store: Any, command: BindRunDispatch) -> RunDispatch:
+    with store.write_transaction() as connection:
+        dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)
+        if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
+            raise Conflict("dispatch_stale")
+        if dispatch.lease_until <= command.now:
+            raise Conflict("dispatch_expired")
+        if dispatch.state is DispatchState.STARTED:
+            if dispatch.execution_ref != command.execution_ref:
+                raise Conflict("execution_conflict")
+            return dispatch
+        if dispatch.state is not DispatchState.RESERVED:
+            raise Conflict("dispatch_terminal")
+        started = dispatch.model_copy(
+            update={
+                "state": DispatchState.STARTED,
+                "execution_ref": command.execution_ref,
+                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+            }
+        )
+        _put_dispatch(connection, started)
+        return started
+
+
+def finish_run_dispatch(store: Any, command: FinishRunDispatch) -> RunDispatch:
+    with store.write_transaction() as connection:
+        dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)
+        if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
+            raise Conflict("dispatch_stale")
+        if dispatch.lease_until <= command.finished_at:
+            raise Conflict("dispatch_expired")
+        if dispatch.state is DispatchState.TERMINAL:
+            if dispatch.terminal_outcome != command.outcome:
+                raise Conflict("outcome_conflict")
+            return dispatch
+        finished = dispatch.model_copy(
+            update={"state": DispatchState.TERMINAL, "terminal_outcome": command.outcome}
+        )
+        _put_dispatch(connection, finished)
+        return finished
+
+
+def claim_run_unit(store: Any, command: ClaimRunUnit) -> RunUnit | None:
+    with store.write_transaction() as connection:
+        units = _list_run_units(connection, command.tenant_id, command.run_id)
+        unit = next((item for item in units if item.unit_id == command.unit_id), None)
+        run = store.get_run_record(connection, command.tenant_id, command.run_id)
+        dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)
+        valid_dispatch = (
+            dispatch is not None
+            and dispatch.dispatch_id == command.dispatch_id
+            and dispatch.state is not DispatchState.TERMINAL
+            and dispatch.lease_until > command.now
+            and command.unit_id in dispatch.unit_ids
+        )
+        invalid = unit is None or run is None or run.state is not RunState.PROCESSING
+        if invalid or not valid_dispatch:
+            return None
+        claimable = unit.state in {RunUnitState.PENDING, RunUnitState.FAILED_RETRYABLE}
+        claimable |= unit.state is RunUnitState.LEASED and unit.lease_until <= command.now
+        if not claimable:
+            return None
+        claimed = unit.model_copy(
+            update={
+                "state": RunUnitState.LEASED,
+                "attempt": unit.attempt + 1,
+                "fencing_token": unit.fencing_token + 1,
+                "lease_owner": command.owner,
+                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+                "dispatch_id": command.dispatch_id,
+            }
+        )
+        _put_run_unit(connection, claimed)
+        return claimed
+
+
+def _validate_unit_fence(store: Any, connection: Any, command: Any) -> tuple[RunUnit, Any]:
+    units = _list_run_units(connection, command.tenant_id, command.run_id)
+    unit = next((item for item in units if item.unit_id == command.unit_id), None)
+    run = store.get_run_record(connection, command.tenant_id, command.run_id)
+    dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)
+    if run is None or run.state is not RunState.PROCESSING:
+        raise LeaseLost("parent_not_processing")
+    if dispatch is None or dispatch.dispatch_id != command.dispatch_id:
+        raise LeaseLost("dispatch_mismatch")
+    if dispatch.lease_until <= store.now():
+        raise LeaseLost("dispatch_expired")
+    if unit is None or unit.state is not RunUnitState.LEASED:
+        raise LeaseLost("unit_not_leased")
+    if unit.lease_owner != command.owner:
+        raise LeaseLost("owner_mismatch")
+    if unit.fencing_token != command.fencing_token:
+        raise FenceRejected("fence_mismatch")
+    if unit.lease_until is None or unit.lease_until <= store.now():
+        raise LeaseLost("lease_expired")
+    return unit, run
+
+
+def commit_run_unit(store: Any, command: CommitRunUnit, event: OutboxEvent) -> RunUnit:
+    with store.write_transaction() as connection:
+        unit, run = _validate_unit_fence(store, connection, command)
+        completed = transition_run_unit(unit, RunUnitState.SUCCEEDED, run).model_copy(
+            update={
+                "lease_owner": None,
+                "lease_until": None,
+                "output_manifests": command.output_manifests,
+            }
+        )
+        _put_run_unit(connection, completed)
+        store.put_outbox_event(connection, event)
+        return completed
+
+
+def fail_run_unit(store: Any, command: FailRunUnit, event: OutboxEvent) -> RunUnit:
+    with store.write_transaction() as connection:
+        unit, run = _validate_unit_fence(store, connection, command)
+        optional = any(
+            (item.source_type, item.file_subtype) == (unit.source_type, unit.file_subtype)
+            and not item.required
+            for item in run.dependencies
+        )
+        if command.retryable:
+            state = RunUnitState.FAILED_RETRYABLE
+        elif optional:
+            state = RunUnitState.SUCCEEDED_DEGRADED
+        else:
+            state = RunUnitState.FAILED_FINAL
+        failed = unit.model_copy(
+            update={"error_code": command.error_code, "lease_owner": None, "lease_until": None}
+        )
+        failed = transition_run_unit(failed, state, run)
+        _put_run_unit(connection, failed)
+        if state is RunUnitState.SUCCEEDED_DEGRADED:
+            source = f"{unit.source_type}/{unit.file_subtype}"
+            updated = run.model_copy(update={"missing_sources": (*run.missing_sources, source)})
+            store.put_run_record(connection, updated)
+        store.put_outbox_event(connection, event)
+        return failed
+
+
+def finalize_run_cancellation(
+    store: Any, command: FinalizeRunCancellation, event: OutboxEvent
+) -> Any:
+    with store.write_transaction() as connection:
+        run = store.get_run_record(connection, command.tenant_id, command.run_id)
+        if run is not None and run.state is RunState.CANCELED:
+            return run
+        if run is None or run.state is not RunState.CANCEL_REQUESTED:
+            raise Conflict("run_not_canceling")
+        terminal = {
+            RunUnitState.SUCCEEDED,
+            RunUnitState.SUCCEEDED_DEGRADED,
+            RunUnitState.FAILED_FINAL,
+            RunUnitState.CANCELED,
+        }
+        units = _list_run_units(connection, command.tenant_id, command.run_id)
+        for unit in units:
+            if unit.state not in terminal:
+                canceled = transition_run_unit(unit, RunUnitState.CANCELED, run).model_copy(
+                    update={"lease_owner": None, "lease_until": None}
+                )
+                _put_run_unit(connection, canceled)
+        canceled_run = transition_run(run, RunState.CANCELED)
+        store.put_run_record(connection, canceled_run)
+        store.put_outbox_event(connection, event)
+        return canceled_run

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -19,9 +19,11 @@ from cnes_domain.control_plane.transitions import transition_run, transition_run
 from cnes_infra.control_plane.sqlite_schema import (
     deserialize_model,
     put_job_terminal_write,
+    put_run_dispatch_finish,
     put_run_unit_terminal_write,
     serialize_model,
     validate_job_terminal_replay,
+    validate_run_dispatch_finish,
     validate_run_dispatch_wave,
     validate_run_unit_terminal_replay,
 )
@@ -302,7 +304,6 @@ def get_active_run_dispatch(store: Any, tenant_id: str, run_id: str) -> RunDispa
         return None
     return dispatch if dispatch.lease_until > store.now() else None
 
-
 def bind_run_dispatch(store: Any, command: BindRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:
         run = store.get_run_record(connection, command.tenant_id, command.run_id)
@@ -329,7 +330,6 @@ def bind_run_dispatch(store: Any, command: BindRunDispatch) -> RunDispatch:
         _put_dispatch(connection, started)
         return started
 
-
 def finish_run_dispatch(store: Any, command: FinishRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:
         dispatch = _get_dispatch(connection, command.tenant_id, command.run_id)
@@ -338,13 +338,13 @@ def finish_run_dispatch(store: Any, command: FinishRunDispatch) -> RunDispatch:
         if dispatch.lease_until <= command.finished_at:
             raise Conflict("dispatch_expired")
         if dispatch.state is DispatchState.TERMINAL:
-            if dispatch.terminal_outcome != command.outcome:
-                raise Conflict("outcome_conflict")
+            validate_run_dispatch_finish(connection, command)
             return dispatch
         finished = dispatch.model_copy(
             update={"state": DispatchState.TERMINAL, "terminal_outcome": command.outcome}
         )
         _put_dispatch(connection, finished)
+        put_run_dispatch_finish(connection, command)
         return finished
 
 

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -19,10 +19,12 @@ from cnes_domain.control_plane.transitions import transition_run, transition_run
 from cnes_infra.control_plane.sqlite_schema import (
     deserialize_model,
     put_job_terminal_write,
+    put_run_cancellation,
     put_run_dispatch_finish,
     put_run_unit_terminal_write,
     serialize_model,
     validate_job_terminal_replay,
+    validate_run_cancellation,
     validate_run_dispatch_finish,
     validate_run_dispatch_wave,
     validate_run_unit_terminal_replay,
@@ -470,31 +472,28 @@ def fail_run_unit(store: Any, command: FailRunUnit, event: OutboxEvent) -> RunUn
             store.put_run_record(connection, updated)
         store.put_outbox_event(connection, event)
         return failed
-
-
 def finalize_run_cancellation(
     store: Any, command: FinalizeRunCancellation, event: OutboxEvent
 ) -> Any:
     with store.write_transaction() as connection:
         run = store.get_run_record(connection, command.tenant_id, command.run_id)
         if run is not None and run.state is RunState.CANCELED:
+            validate_run_cancellation(connection, command, event)
             return run
         if run is None or run.state is not RunState.CANCEL_REQUESTED:
             raise Conflict("run_not_canceling")
         terminal = {
-            RunUnitState.SUCCEEDED,
-            RunUnitState.SUCCEEDED_DEGRADED,
-            RunUnitState.FAILED_FINAL,
-            RunUnitState.CANCELED,
+            RunUnitState.SUCCEEDED, RunUnitState.SUCCEEDED_DEGRADED,
+            RunUnitState.FAILED_FINAL, RunUnitState.CANCELED,
         }
         units = _list_run_units(connection, command.tenant_id, command.run_id)
         for unit in units:
             if unit.state not in terminal:
                 canceled = transition_run_unit(unit, RunUnitState.CANCELED, run).model_copy(
-                    update={"lease_owner": None, "lease_until": None}
-                )
+                    update={"lease_owner": None, "lease_until": None})
                 _put_run_unit(connection, canceled)
         canceled_run = transition_run(run, RunState.CANCELED)
         store.put_run_record(connection, canceled_run)
+        put_run_cancellation(connection, command, event)
         store.put_outbox_event(connection, event)
         return canceled_run

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -259,15 +259,15 @@ def _has_live_unit_lease(connection: Any, dispatch: RunDispatch, now: Any) -> bo
 def reserve_run_dispatch(store: Any, command: ReserveRunDispatch) -> RunDispatch:
     with store.write_transaction() as connection:
         current = _get_dispatch(connection, command.tenant_id, command.run_id)
+        same_wave = current is not None and current.wave_id == command.wave_id
+        if same_wave and current.unit_ids != command.unit_ids:
+            raise Conflict("dispatch_units_conflict")
         replay = (
-            current
-            and current.wave_id == command.wave_id
+            same_wave
             and current.lease_until > command.now
             and current.state in {DispatchState.RESERVED, DispatchState.STARTED}
         )
         if replay:
-            if current.unit_ids != command.unit_ids:
-                raise Conflict("dispatch_units_conflict")
             return current
         live = current and current.state is not DispatchState.TERMINAL
         lease_live = current is not None and current.lease_until > command.now

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -182,8 +182,6 @@ def _list_run_units(connection: Any, tenant_id: str, run_id: str) -> tuple[RunUn
 def list_run_units(store: Any, tenant_id: str, run_id: str) -> tuple[RunUnit, ...]:
     with store.read_connection() as connection:
         return _list_run_units(connection, tenant_id, run_id)
-
-
 def _put_run_unit(connection: Any, unit: RunUnit) -> None:
     connection.execute(
         "INSERT INTO run_units (tenant_id, run_id, unit_id, state, lease_until, "
@@ -201,8 +199,6 @@ def _put_run_unit(connection: Any, unit: RunUnit) -> None:
             serialize_model(unit),
         ),
     )
-
-
 def put_run_units(store: Any, command: PutRunUnits) -> tuple[RunUnit, ...]:
     with store.write_transaction() as connection:
         run = store.get_run_record(connection, command.tenant_id, command.run_id)
@@ -210,23 +206,26 @@ def put_run_units(store: Any, command: PutRunUnits) -> tuple[RunUnit, ...]:
             raise Conflict("run_state_conflict")
         current = _list_run_units(connection, command.tenant_id, command.run_id)
         canonical = tuple(sorted(command.units, key=lambda unit: unit.unit_id))
+        registry = "\x1e".join(serialize_model(unit) for unit in canonical)
+        row = connection.execute(
+            "SELECT unit_registry_data FROM runs WHERE tenant_id = ? AND run_id = ?",
+            (command.tenant_id, command.run_id)).fetchone()
         if current:
-            if current != canonical:
+            if row[0] != registry:
                 raise Conflict("units_conflict")
             return current
         for unit in canonical:
             _put_run_unit(connection, unit)
+        connection.execute(
+            "UPDATE runs SET unit_registry_data = ? WHERE tenant_id = ? AND run_id = ?",
+            (registry, command.tenant_id, command.run_id))
         return canonical
-
-
 def _get_dispatch(connection: Any, tenant_id: str, run_id: str) -> RunDispatch | None:
     row = connection.execute(
         "SELECT data FROM run_dispatches WHERE tenant_id = ? AND run_id = ?",
         (tenant_id, run_id),
     ).fetchone()
     return None if row is None else deserialize_model(row[0], RunDispatch)
-
-
 def _put_dispatch(connection: Any, dispatch: RunDispatch) -> None:
     connection.execute(
         "INSERT INTO run_dispatches (tenant_id, run_id, dispatch_id, wave_id, generation, "

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -18,11 +18,13 @@ from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
 from cnes_domain.control_plane.transitions import transition_run, transition_run_unit
 from cnes_infra.control_plane.sqlite_schema import (
     deserialize_model,
+    put_job_cancellation,
     put_job_terminal_write,
     put_run_cancellation,
     put_run_dispatch_finish,
     put_run_unit_terminal_write,
     serialize_model,
+    validate_job_cancellation,
     validate_job_terminal_replay,
     validate_run_cancellation,
     validate_run_dispatch_finish,
@@ -131,13 +133,11 @@ def complete_job(store: Any, command: CompleteJob, event: OutboxEvent) -> Job:
                 "result_manifest_key": manifest.manifest_key,
             }
         )
+        store.put_outbox_event(connection, event, command.tenant_id)
         store.put_job_record(connection, completed)
         store.put_manifest_record(connection, manifest)
         put_job_terminal_write(connection, "complete", command, event)
-        store.put_outbox_event(connection, event)
         return completed
-
-
 def fail_job(store: Any, command: FailJob, event: OutboxEvent) -> Job:
     with store.write_transaction() as connection:
         job = store.get_job_record(connection, command.tenant_id, command.job_id)
@@ -155,24 +155,24 @@ def fail_job(store: Any, command: FailJob, event: OutboxEvent) -> Job:
                 "error_code": command.error_code,
             }
         )
+        store.put_outbox_event(connection, event, command.tenant_id)
         store.put_job_record(connection, failed)
         put_job_terminal_write(connection, "fail", command, event)
-        store.put_outbox_event(connection, event)
         return failed
-
-
 def cancel_job(store: Any, command: CancelJob, event: OutboxEvent) -> Job:
     with store.write_transaction() as connection:
         job = store.get_job_record(connection, command.tenant_id, command.job_id)
         if job is None:
             raise Conflict("job_missing")
         if job.state is JobState.CANCEL_REQUESTED:
+            validate_job_cancellation(connection, command, event)
             return job
         if job.state is not JobState.LEASED:
             raise Conflict("job_not_leased")
         canceled = job.model_copy(update={"state": JobState.CANCEL_REQUESTED})
+        store.put_outbox_event(connection, event, command.tenant_id)
         store.put_job_record(connection, canceled)
-        store.put_outbox_event(connection, event)
+        put_job_cancellation(connection, command, event)
         return canceled
 
 
@@ -428,9 +428,9 @@ def commit_run_unit(store: Any, command: CommitRunUnit, event: OutboxEvent) -> R
                 "output_manifests": command.output_manifests,
             }
         )
+        store.put_outbox_event(connection, event, command.tenant_id)
         _put_run_unit(connection, completed)
         put_run_unit_terminal_write(connection, "commit", command, event)
-        store.put_outbox_event(connection, event)
         return completed
 
 
@@ -463,6 +463,7 @@ def fail_run_unit(store: Any, command: FailRunUnit, event: OutboxEvent) -> RunUn
             update={"error_code": command.error_code, "lease_owner": None, "lease_until": None}
         )
         failed = transition_run_unit(failed, state, run)
+        store.put_outbox_event(connection, event, command.tenant_id)
         _put_run_unit(connection, failed)
         put_run_unit_terminal_write(connection, "fail", command, event)
         if state is RunUnitState.SUCCEEDED_DEGRADED:
@@ -470,7 +471,6 @@ def fail_run_unit(store: Any, command: FailRunUnit, event: OutboxEvent) -> RunUn
             missing_sources = tuple(dict.fromkeys((*run.missing_sources, source)))
             updated = run.model_copy(update={"missing_sources": missing_sources})
             store.put_run_record(connection, updated)
-        store.put_outbox_event(connection, event)
         return failed
 def finalize_run_cancellation(
     store: Any, command: FinalizeRunCancellation, event: OutboxEvent
@@ -487,6 +487,7 @@ def finalize_run_cancellation(
             RunUnitState.FAILED_FINAL, RunUnitState.CANCELED,
         }
         units = _list_run_units(connection, command.tenant_id, command.run_id)
+        store.put_outbox_event(connection, event, command.tenant_id)
         for unit in units:
             if unit.state not in terminal:
                 canceled = transition_run_unit(unit, RunUnitState.CANCELED, run).model_copy(
@@ -495,5 +496,4 @@ def finalize_run_cancellation(
         canceled_run = transition_run(run, RunState.CANCELED)
         store.put_run_record(connection, canceled_run)
         put_run_cancellation(connection, command, event)
-        store.put_outbox_event(connection, event)
         return canceled_run

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -92,6 +92,7 @@ def renew_job_lease(store: Any, command: RenewJobLease) -> Job:
 
 def _validate_manifest_identity(job: Job, manifest: Any) -> None:
     expected = (
+        job.tenant_id,
         job.agent_id,
         job.source_type,
         job.file_subtype,
@@ -99,6 +100,7 @@ def _validate_manifest_identity(job: Job, manifest: Any) -> None:
         job.requested_snapshot_mode,
     )
     actual = (
+        manifest.tenant_id,
         manifest.agent_id,
         manifest.source_type,
         manifest.file_subtype,

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_dispatch.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_dispatch.py
@@ -1,0 +1,62 @@
+"""SQLite dispatch replay operations."""
+from __future__ import annotations
+
+from typing import Any
+
+from cnes_domain.control_plane.entities import RunDispatch
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
+
+
+def put_run_dispatch_bind(connection: Any, command: Any, dispatch: Any) -> None:
+    connection.execute(
+        "INSERT INTO run_dispatch_bind_writes "
+        "(tenant_id, run_id, dispatch_id, command_data, response_data) VALUES (?, ?, ?, ?, ?)",
+        (
+            command.tenant_id,
+            command.run_id,
+            command.dispatch_id,
+            serialize_model(command),
+            serialize_model(dispatch),
+        ),
+    )
+
+
+def validate_run_dispatch_bind(connection: Any, command: Any) -> RunDispatch | None:
+    row = connection.execute(
+        "SELECT command_data, response_data FROM run_dispatch_bind_writes "
+        "WHERE tenant_id = ? AND run_id = ? AND dispatch_id = ?",
+        (command.tenant_id, command.run_id, command.dispatch_id),
+    ).fetchone()
+    if row is None:
+        return None
+    if row[0] != serialize_model(command):
+        raise Conflict("dispatch_bind_conflict")
+    return None if row[1] is None else deserialize_model(row[1], RunDispatch)
+
+
+def put_run_dispatch_finish(connection: Any, command: Any, dispatch: Any) -> None:
+    connection.execute(
+        "INSERT INTO run_dispatch_terminal_writes "
+        "(tenant_id, run_id, dispatch_id, command_data, response_data) VALUES (?, ?, ?, ?, ?)",
+        (
+            command.tenant_id,
+            command.run_id,
+            command.dispatch_id,
+            serialize_model(command),
+            serialize_model(dispatch),
+        ),
+    )
+
+
+def validate_run_dispatch_finish(connection: Any, command: Any) -> RunDispatch | None:
+    row = connection.execute(
+        "SELECT command_data, response_data FROM run_dispatch_terminal_writes "
+        "WHERE tenant_id = ? AND run_id = ? AND dispatch_id = ?",
+        (command.tenant_id, command.run_id, command.dispatch_id),
+    ).fetchone()
+    if row is None:
+        return None
+    if row[0] != serialize_model(command):
+        raise Conflict("dispatch_finish_conflict")
+    return None if row[1] is None else deserialize_model(row[1], RunDispatch)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_idempotency.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_idempotency.py
@@ -1,0 +1,44 @@
+"""SQLite idempotency operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from cnes_domain.control_plane.commands import IdempotencyOutcome
+from cnes_domain.control_plane.entities import IdempotencyRecord
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
+
+if TYPE_CHECKING:
+    from cnes_domain.control_plane.commands import BeginIdempotency
+
+
+def begin_idempotency(store: Any, command: BeginIdempotency) -> IdempotencyOutcome:
+    with store.write_transaction() as connection:
+        row = connection.execute(
+            "SELECT data FROM idempotency_records "
+            "WHERE tenant_id = ? AND scope = ? AND key = ?",
+            (command.tenant_id, command.scope, command.key),
+        ).fetchone()
+        current = None if row is None else deserialize_model(row[0], IdempotencyRecord)
+        if current is not None and current.expires_at > command.now:
+            if current.request_hash != command.request_hash:
+                raise Conflict("idempotency_hash_conflict")
+            return IdempotencyOutcome(record=current, created=False)
+        record = IdempotencyRecord(
+            tenant_id=command.tenant_id,
+            scope=command.scope,
+            key=command.key,
+            request_hash=command.request_hash,
+            status="CREATED",
+            resource_id=command.resource_id,
+            created_at=command.now,
+            expires_at=command.expires_at,
+        )
+        connection.execute(
+            "INSERT INTO idempotency_records (tenant_id, scope, key, data) "
+            "VALUES (?, ?, ?, ?) ON CONFLICT (tenant_id, scope, key) "
+            "DO UPDATE SET data = excluded.data",
+            (record.tenant_id, record.scope, record.key, serialize_model(record)),
+        )
+        return IdempotencyOutcome(record=record, created=True)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_job.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_job.py
@@ -1,0 +1,31 @@
+"""SQLite job creation validation."""
+from __future__ import annotations
+
+from typing import Any
+
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.control_plane.sqlite_schema import (
+    put_job_creation_write,
+    validate_job_creation_replay,
+)
+
+
+def validate_initial_job(job: Any) -> None:
+    values = (job.attempt, job.fencing_token, job.lease_owner, job.lease_until)
+    results = (job.result_manifest_id, job.result_manifest_key, job.error_code)
+    if job.state is not JobState.PENDING or values != (0, 0, None, None) or any(results):
+        raise Conflict("job_initial_state_invalid")
+
+
+def create_job(store: Any, job: Any, event: Any) -> Any:
+    with store.write_transaction() as connection:
+        current = store.get_job_record(connection, job.tenant_id, job.job_id)
+        if current is not None:
+            validate_job_creation_replay(connection, job, event)
+            return current
+        validate_initial_job(job)
+        store.put_outbox_event(connection, event, job.tenant_id)
+        store.put_job_record(connection, job)
+        put_job_creation_write(connection, job, event)
+        return job

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
@@ -89,6 +89,8 @@ def _migrate_access_snapshot(db: sqlite3.Connection) -> None:
     columns = {row[1] for row in db.execute("PRAGMA table_info(access_requests)")}
     if "creation_request_data" not in columns:
         db.execute("ALTER TABLE access_requests ADD COLUMN creation_request_data TEXT")
+    if "creation_event_data" not in columns:
+        db.execute("ALTER TABLE access_requests ADD COLUMN creation_event_data TEXT")
     rows = db.execute(
         "SELECT tenant_id, request_id, data FROM access_requests "
         "WHERE creation_request_data IS NULL"
@@ -102,6 +104,12 @@ def _migrate_access_snapshot(db: sqlite3.Connection) -> None:
             "AND request_id = ?",
             (serialize_model(original), tenant_id, request_id),
         )
+
+
+def _migrate_publication_response(db: sqlite3.Connection) -> None:
+    columns = {row[1] for row in db.execute("PRAGMA table_info(dataset_publications)")}
+    if "response_data" not in columns:
+        db.execute("ALTER TABLE dataset_publications ADD COLUMN response_data TEXT")
 
 
 def _migrate_run_units(db: sqlite3.Connection) -> None:
@@ -128,4 +136,5 @@ def migrate_schema(db: sqlite3.Connection) -> None:
     _migrate_finish_responses(db)
     _migrate_job_snapshot(db)
     _migrate_access_snapshot(db)
+    _migrate_publication_response(db)
     _migrate_run_units(db)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
@@ -1,0 +1,53 @@
+"""SQLite control-plane migrations."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cnes_domain.control_plane.entities import AccessRequest
+from cnes_domain.control_plane.enums import AccessRequestState
+from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
+
+if TYPE_CHECKING:
+    import sqlite3
+
+
+def migrate_schema(db: sqlite3.Connection) -> None:
+    job_columns = {row[1] for row in db.execute("PRAGMA table_info(job_creation_writes)")}
+    if "job_data" not in job_columns:
+        db.execute("ALTER TABLE job_creation_writes ADD COLUMN job_data TEXT")
+    db.execute(
+        "UPDATE job_creation_writes SET job_data = (SELECT data FROM jobs WHERE "
+        "jobs.tenant_id = job_creation_writes.tenant_id "
+        "AND jobs.job_id = job_creation_writes.job_id) WHERE job_data IS NULL"
+    )
+    run_columns = {row[1] for row in db.execute("PRAGMA table_info(runs)")}
+    if "unit_registry_data" not in run_columns:
+        db.execute("ALTER TABLE runs ADD COLUMN unit_registry_data TEXT")
+    access_columns = {row[1] for row in db.execute("PRAGMA table_info(access_requests)")}
+    if "creation_request_data" not in access_columns:
+        db.execute("ALTER TABLE access_requests ADD COLUMN creation_request_data TEXT")
+    for tenant_id, request_id, data in db.execute(
+        "SELECT tenant_id, request_id, data FROM access_requests "
+        "WHERE creation_request_data IS NULL"
+    ):
+        original = deserialize_model(data, AccessRequest).model_copy(
+            update={"state": AccessRequestState.PENDING, "decided_by": None, "decided_at": None}
+        )
+        db.execute(
+            "UPDATE access_requests SET creation_request_data = ? WHERE "
+            "tenant_id = ? AND request_id = ?",
+            (serialize_model(original), tenant_id, request_id),
+        )
+    rows = db.execute(
+        "SELECT tenant_id, run_id FROM runs WHERE unit_registry_data IS NULL"
+    ).fetchall()
+    for tenant_id, run_id in rows:
+        units = db.execute(
+            "SELECT data FROM run_units WHERE tenant_id = ? AND run_id = ? ORDER BY unit_id",
+            (tenant_id, run_id),
+        ).fetchall()
+        if units:
+            db.execute(
+                "UPDATE runs SET unit_registry_data = ? WHERE tenant_id = ? AND run_id = ?",
+                ("\x1e".join(row[0] for row in units), tenant_id, run_id),
+            )

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
@@ -12,6 +12,15 @@ if TYPE_CHECKING:
 
 
 def migrate_schema(db: sqlite3.Connection) -> None:
+    bind_columns = {row[1] for row in db.execute("PRAGMA table_info(run_dispatch_bind_writes)")}
+    if "response_data" not in bind_columns:
+        db.execute("ALTER TABLE run_dispatch_bind_writes ADD COLUMN response_data TEXT")
+    db.execute(
+        "UPDATE run_dispatch_bind_writes SET response_data = (SELECT data FROM "
+        "run_dispatches WHERE run_dispatches.tenant_id = run_dispatch_bind_writes.tenant_id "
+        "AND run_dispatches.run_id = run_dispatch_bind_writes.run_id) "
+        "WHERE response_data IS NULL"
+    )
     job_columns = {row[1] for row in db.execute("PRAGMA table_info(job_creation_writes)")}
     if "job_data" not in job_columns:
         db.execute("ALTER TABLE job_creation_writes ADD COLUMN job_data TEXT")

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
@@ -5,8 +5,8 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from cnes_domain.control_plane.commands import BindRunDispatch, FinishRunDispatch
-from cnes_domain.control_plane.entities import AccessRequest, RunDispatch
-from cnes_domain.control_plane.enums import AccessRequestState, DispatchState
+from cnes_domain.control_plane.entities import AccessRequest, Job, RunDispatch
+from cnes_domain.control_plane.enums import AccessRequestState, DispatchState, JobState
 from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
 
 if TYPE_CHECKING:
@@ -78,11 +78,27 @@ def _migrate_job_snapshot(db: sqlite3.Connection) -> None:
     columns = {row[1] for row in db.execute("PRAGMA table_info(job_creation_writes)")}
     if "job_data" not in columns:
         db.execute("ALTER TABLE job_creation_writes ADD COLUMN job_data TEXT")
-    db.execute(
-        "UPDATE job_creation_writes SET job_data = (SELECT data FROM jobs WHERE "
-        "jobs.tenant_id = job_creation_writes.tenant_id "
-        "AND jobs.job_id = job_creation_writes.job_id) WHERE job_data IS NULL"
+    rows = db.execute(
+        "SELECT w.tenant_id, w.job_id, j.data FROM job_creation_writes w JOIN jobs j "
+        "ON j.tenant_id = w.tenant_id AND j.job_id = w.job_id WHERE w.job_data IS NULL"
     )
+    for tenant_id, job_id, data in rows:
+        job = deserialize_model(data, Job).model_copy(
+            update={
+                "state": JobState.PENDING,
+                "attempt": 0,
+                "fencing_token": 0,
+                "lease_owner": None,
+                "lease_until": None,
+                "result_manifest_id": None,
+                "result_manifest_key": None,
+                "error_code": None,
+            }
+        )
+        db.execute(
+            "UPDATE job_creation_writes SET job_data = ? WHERE tenant_id = ? AND job_id = ?",
+            (serialize_model(job), tenant_id, job_id),
+        )
 
 
 def _migrate_access_snapshot(db: sqlite3.Connection) -> None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from cnes_domain.control_plane.commands import BindRunDispatch, FinishRunDispatch
-from cnes_domain.control_plane.entities import AccessRequest, Job, RunDispatch
+from cnes_domain.control_plane.commands import BindRunDispatch, FinishRunDispatch, PublishDataset
+from cnes_domain.control_plane.entities import AccessRequest, DatasetPointer, Job, RunDispatch
 from cnes_domain.control_plane.enums import AccessRequestState, DispatchState, JobState
 from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
 
@@ -126,6 +126,29 @@ def _migrate_publication_response(db: sqlite3.Connection) -> None:
     columns = {row[1] for row in db.execute("PRAGMA table_info(dataset_publications)")}
     if "response_data" not in columns:
         db.execute("ALTER TABLE dataset_publications ADD COLUMN response_data TEXT")
+    rows = db.execute(
+        "SELECT p.tenant_id, p.dataset_name, p.version_id, p.data, d.data "
+        "FROM dataset_publications p LEFT JOIN dataset_pointers d "
+        "ON d.tenant_id = p.tenant_id AND d.dataset_name = p.dataset_name "
+        "AND d.pointer_name = 'current' WHERE p.response_data IS NULL"
+    )
+    for tenant_id, dataset_name, version_id, data, pointer_data in rows:
+        command = deserialize_model(data, PublishDataset)
+        permit = command.publication_permit.model_copy(update={"binding_context": None})
+        db.execute(
+            "UPDATE dataset_publications SET data = ? WHERE tenant_id = ? AND dataset_name = ? "
+            "AND version_id = ?",
+            (serialize_model(command.model_copy(update={"publication_permit": permit})), tenant_id,
+             dataset_name, version_id),
+        )
+        if pointer_data is not None:
+            pointer = deserialize_model(pointer_data, DatasetPointer)
+            if pointer.version_id == version_id:
+                db.execute(
+                    "UPDATE dataset_publications SET response_data = ? WHERE tenant_id = ? "
+                    "AND dataset_name = ? AND version_id = ?",
+                    (serialize_model(pointer), tenant_id, dataset_name, version_id),
+                )
 
 
 def _migrate_run_units(db: sqlite3.Connection) -> None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_migration.py
@@ -1,52 +1,113 @@
 """SQLite control-plane migrations."""
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from cnes_domain.control_plane.entities import AccessRequest
-from cnes_domain.control_plane.enums import AccessRequestState
+from cnes_domain.control_plane.commands import BindRunDispatch, FinishRunDispatch
+from cnes_domain.control_plane.entities import AccessRequest, RunDispatch
+from cnes_domain.control_plane.enums import AccessRequestState, DispatchState
 from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
 
 if TYPE_CHECKING:
     import sqlite3
 
 
-def migrate_schema(db: sqlite3.Connection) -> None:
-    bind_columns = {row[1] for row in db.execute("PRAGMA table_info(run_dispatch_bind_writes)")}
-    if "response_data" not in bind_columns:
+def _add_bind_response_column(db: sqlite3.Connection) -> None:
+    columns = {row[1] for row in db.execute("PRAGMA table_info(run_dispatch_bind_writes)")}
+    if "response_data" not in columns:
         db.execute("ALTER TABLE run_dispatch_bind_writes ADD COLUMN response_data TEXT")
-    db.execute(
-        "UPDATE run_dispatch_bind_writes SET response_data = (SELECT data FROM "
-        "run_dispatches WHERE run_dispatches.tenant_id = run_dispatch_bind_writes.tenant_id "
-        "AND run_dispatches.run_id = run_dispatch_bind_writes.run_id) "
-        "WHERE response_data IS NULL"
+
+
+def _migrate_bind_responses(db: sqlite3.Connection) -> None:
+    _add_bind_response_column(db)
+    rows = db.execute(
+        "SELECT b.tenant_id, b.run_id, b.dispatch_id, b.command_data, d.data "
+        "FROM run_dispatch_bind_writes b LEFT JOIN run_dispatches d "
+        "ON d.tenant_id = b.tenant_id AND d.run_id = b.run_id AND d.dispatch_id = b.dispatch_id "
+        "WHERE b.response_data IS NULL"
     )
-    job_columns = {row[1] for row in db.execute("PRAGMA table_info(job_creation_writes)")}
-    if "job_data" not in job_columns:
+    for tenant_id, run_id, dispatch_id, command_data, data in rows:
+        if data is None:
+            continue
+        command = deserialize_model(command_data, BindRunDispatch)
+        dispatch = deserialize_model(data, RunDispatch).model_copy(
+            update={
+                "state": DispatchState.STARTED,
+                "execution_ref": command.execution_ref,
+                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+                "terminal_outcome": None,
+            }
+        )
+        db.execute(
+            "UPDATE run_dispatch_bind_writes SET response_data = ? WHERE tenant_id = ? "
+            "AND run_id = ? AND dispatch_id = ?",
+            (serialize_model(dispatch), tenant_id, run_id, dispatch_id),
+        )
+
+
+def _add_finish_response_column(db: sqlite3.Connection) -> None:
+    columns = {row[1] for row in db.execute("PRAGMA table_info(run_dispatch_terminal_writes)")}
+    if "response_data" not in columns:
+        db.execute("ALTER TABLE run_dispatch_terminal_writes ADD COLUMN response_data TEXT")
+
+
+def _migrate_finish_responses(db: sqlite3.Connection) -> None:
+    _add_finish_response_column(db)
+    rows = db.execute(
+        "SELECT b.tenant_id, b.run_id, b.dispatch_id, b.command_data, d.data "
+        "FROM run_dispatch_terminal_writes b LEFT JOIN run_dispatches d "
+        "ON d.tenant_id = b.tenant_id AND d.run_id = b.run_id AND d.dispatch_id = b.dispatch_id "
+        "WHERE b.response_data IS NULL"
+    )
+    for tenant_id, run_id, dispatch_id, command_data, data in rows:
+        if data is None:
+            continue
+        command = deserialize_model(command_data, FinishRunDispatch)
+        dispatch = deserialize_model(data, RunDispatch).model_copy(
+            update={"state": DispatchState.TERMINAL, "terminal_outcome": command.outcome}
+        )
+        db.execute(
+            "UPDATE run_dispatch_terminal_writes SET response_data = ? WHERE tenant_id = ? "
+            "AND run_id = ? AND dispatch_id = ?",
+            (serialize_model(dispatch), tenant_id, run_id, dispatch_id),
+        )
+
+
+def _migrate_job_snapshot(db: sqlite3.Connection) -> None:
+    columns = {row[1] for row in db.execute("PRAGMA table_info(job_creation_writes)")}
+    if "job_data" not in columns:
         db.execute("ALTER TABLE job_creation_writes ADD COLUMN job_data TEXT")
     db.execute(
         "UPDATE job_creation_writes SET job_data = (SELECT data FROM jobs WHERE "
         "jobs.tenant_id = job_creation_writes.tenant_id "
         "AND jobs.job_id = job_creation_writes.job_id) WHERE job_data IS NULL"
     )
-    run_columns = {row[1] for row in db.execute("PRAGMA table_info(runs)")}
-    if "unit_registry_data" not in run_columns:
-        db.execute("ALTER TABLE runs ADD COLUMN unit_registry_data TEXT")
-    access_columns = {row[1] for row in db.execute("PRAGMA table_info(access_requests)")}
-    if "creation_request_data" not in access_columns:
+
+
+def _migrate_access_snapshot(db: sqlite3.Connection) -> None:
+    columns = {row[1] for row in db.execute("PRAGMA table_info(access_requests)")}
+    if "creation_request_data" not in columns:
         db.execute("ALTER TABLE access_requests ADD COLUMN creation_request_data TEXT")
-    for tenant_id, request_id, data in db.execute(
+    rows = db.execute(
         "SELECT tenant_id, request_id, data FROM access_requests "
         "WHERE creation_request_data IS NULL"
-    ):
+    )
+    for tenant_id, request_id, data in rows:
         original = deserialize_model(data, AccessRequest).model_copy(
             update={"state": AccessRequestState.PENDING, "decided_by": None, "decided_at": None}
         )
         db.execute(
-            "UPDATE access_requests SET creation_request_data = ? WHERE "
-            "tenant_id = ? AND request_id = ?",
+            "UPDATE access_requests SET creation_request_data = ? WHERE tenant_id = ? "
+            "AND request_id = ?",
             (serialize_model(original), tenant_id, request_id),
         )
+
+
+def _migrate_run_units(db: sqlite3.Connection) -> None:
+    columns = {row[1] for row in db.execute("PRAGMA table_info(runs)")}
+    if "unit_registry_data" not in columns:
+        db.execute("ALTER TABLE runs ADD COLUMN unit_registry_data TEXT")
     rows = db.execute(
         "SELECT tenant_id, run_id FROM runs WHERE unit_registry_data IS NULL"
     ).fetchall()
@@ -60,3 +121,11 @@ def migrate_schema(db: sqlite3.Connection) -> None:
                 "UPDATE runs SET unit_registry_data = ? WHERE tenant_id = ? AND run_id = ?",
                 ("\x1e".join(row[0] for row in units), tenant_id, run_id),
             )
+
+
+def migrate_schema(db: sqlite3.Connection) -> None:
+    _migrate_bind_responses(db)
+    _migrate_finish_responses(db)
+    _migrate_job_snapshot(db)
+    _migrate_access_snapshot(db)
+    _migrate_run_units(db)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -16,7 +16,12 @@ from cnes_domain.control_plane.entities import (
 from cnes_domain.control_plane.enums import AccessRequestState, JobState, RunState
 from cnes_domain.control_plane.errors import Conflict
 from cnes_domain.control_plane.transitions import transition_run as apply_run_transition
-from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
+from cnes_infra.control_plane.sqlite_schema import (
+    deserialize_model,
+    put_access_request_decision,
+    serialize_model,
+    validate_access_request_decision,
+)
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -204,8 +209,8 @@ def transition_run(store: Any, command: TransitionRun, event: OutboxEvent) -> Ru
         updated = apply_run_transition(run, command.new_state).model_copy(
             update={"missing_sources": command.missing_sources}
         )
+        store.put_outbox_event(connection, event, command.tenant_id)
         store.put_run_record(connection, updated)
-        store.put_outbox_event(connection, event)
         return updated
 
 
@@ -335,11 +340,11 @@ def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
             version_id=version.version_id,
             updated_at=store.now(),
         )
+        store.put_outbox_event(connection, command.event, version.tenant_id)
         _put_version(connection, version)
         _put_publication(connection, command)
         _put_pointer(connection, result)
         store.put_run_record(connection, updated)
-        store.put_outbox_event(connection, command.event)
         return result
 
 
@@ -368,12 +373,14 @@ def get_access_request(store: Any, tenant_id: str, request_id: str) -> AccessReq
 
 def put_access_request(store: Any, request: AccessRequest, event: OutboxEvent) -> None:
     with store.write_transaction() as connection:
+        if request.state is not AccessRequestState.PENDING:
+            raise Conflict("access_request_creation_state")
         current = _get_access_request(connection, request.tenant_id, request.request_id)
         if current is not None and current != request:
             raise Conflict("access_request_conflict")
         if current is None:
+            store.put_outbox_event(connection, event, request.tenant_id)
             _put_access_request(connection, request)
-            store.put_outbox_event(connection, event)
 
 
 def decide_access_request(store: Any, request: AccessRequest, event: OutboxEvent) -> AccessRequest:
@@ -387,9 +394,11 @@ def decide_access_request(store: Any, request: AccessRequest, event: OutboxEvent
         if request.state not in {AccessRequestState.APPROVED, AccessRequestState.REJECTED}:
             raise Conflict("access_request_decision_state")
         if current == request:
+            validate_access_request_decision(connection, request, event)
             return request
         if current.state is not AccessRequestState.PENDING:
             raise Conflict("access_request_state_conflict")
+        store.put_outbox_event(connection, event, request.tenant_id)
         _put_access_request(connection, request)
-        store.put_outbox_event(connection, event)
+        put_access_request_decision(connection, request, event)
         return request

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -278,6 +278,8 @@ def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
         run = store.get_run_record(connection, version.tenant_id, version.run_id)
         if run is None or run.state is not RunState.PUBLISHING:
             raise Conflict("run_not_publishing")
+        if run.dataset_name != version.dataset_name:
+            raise Conflict("run_dataset_mismatch")
         updated = run.model_copy(
             update={"state": command.final_state, "missing_sources": command.missing_sources}
         )

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -32,6 +32,7 @@ LATEST_JOB_FIELDS = (
     "competencia",
 )
 DEPENDENCY_FIELDS = ("tenant_id", "source_type", "file_subtype", "competencia", "limit")
+_HEAD_SCAN_PAGES = 4
 
 
 def normalize_long_call(
@@ -111,17 +112,20 @@ def _select_raw_chain(
     connection: Any, identity: tuple[str, ...], limit: int,
 ) -> tuple[RawManifestRecord, ...]:
     cursor = (None, None, None, None)
-    while True:
+    page_size = max(limit, 1)
+    remaining = page_size * _HEAD_SCAN_PAGES
+    while remaining:
         rows = connection.execute(
             "SELECT data, created_at, agent_id, snapshot_id, manifest_id FROM raw_manifests "
             "WHERE tenant_id = ? AND source_type = ? AND file_subtype = ? AND competencia = ? "
             "AND (? IS NULL OR (created_at, agent_id, snapshot_id, manifest_id) "
             "< (?, ?, ?, ?)) ORDER BY created_at DESC, agent_id DESC, snapshot_id DESC, "
             "manifest_id DESC LIMIT ?",
-            (*identity, cursor[0], *cursor, max(limit, 1)),
+            (*identity, cursor[0], *cursor, min(page_size, remaining)),
         ).fetchall()
         if not rows:
             return ()
+        remaining -= len(rows)
         for row in rows:
             head = deserialize_model(row[0], RawManifestRecord)
             chain = _build_ancestry(connection, identity, head, limit)
@@ -130,6 +134,7 @@ def _select_raw_chain(
             if len(chain) == head.sequence:
                 return chain
         cursor = tuple(rows[-1][1:])
+    return ()
 
 
 def list_raw_manifest_chain(store: Any, values: tuple[Any, ...]) -> tuple[ManifestRef, ...]:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -76,8 +76,23 @@ def latest_succeeded_job(store: Any, values: tuple[str, ...]) -> Job | None:
     return None if row is None else deserialize_model(row[0], Job)
 
 
+def _predecessors(
+    connection: Any, identity: tuple[str, ...], current: RawManifestRecord, limit: int
+) -> tuple[RawManifestRecord, ...]:
+    rows = connection.execute(
+        "SELECT data FROM raw_manifests WHERE tenant_id = ? AND source_type = ? "
+        "AND file_subtype = ? AND competencia = ? AND agent_id = ? AND sequence = ? "
+        "AND manifest_sha256 = ? AND (snapshot_id = ? OR base_snapshot_id = ?) "
+        "ORDER BY created_at DESC, snapshot_id DESC LIMIT ?",
+        (*identity, current.agent_id, current.sequence - 1,
+         current.previous_manifest_sha256, current.base_snapshot_id,
+         current.base_snapshot_id, max(limit, 1)),
+    )
+    return tuple(deserialize_model(row[0], RawManifestRecord) for row in rows)
+
+
 def _build_ancestry(
-    records: tuple[RawManifestRecord, ...], current: RawManifestRecord, limit: int
+    connection: Any, identity: tuple[str, ...], current: RawManifestRecord, limit: int
 ) -> tuple[RawManifestRecord, ...] | None:
     paths = [(current, (current,))]
     while paths:
@@ -86,53 +101,41 @@ def _build_ancestry(
             return None
         if item.sequence == 1:
             return tuple(reversed(ancestry))
-        predecessors = sorted(
-            (candidate for candidate in records
-             if candidate.sequence == item.sequence - 1
-             and candidate.manifest_sha256 == item.previous_manifest_sha256),
-            key=lambda candidate: (candidate.created_at, candidate.snapshot_id),
-            reverse=True,
-        )
+        predecessors = _predecessors(connection, identity, item, limit)
         paths.extend((predecessor, (*ancestry, predecessor))
                      for predecessor in reversed(predecessors))
     return ()
 
 
 def _select_raw_chain(
-    records: tuple[RawManifestRecord, ...], limit: int,
+    connection: Any, identity: tuple[str, ...], limit: int,
 ) -> tuple[RawManifestRecord, ...]:
-    heads = sorted(
-        records,
-        key=lambda item: (item.created_at, item.agent_id, item.snapshot_id),
-        reverse=True,
-    )
-    for head in heads:
-        base = head.snapshot_id if head.sequence == 1 else head.base_snapshot_id
-        branch = tuple(
-            item
-            for item in records
-            if item.agent_id == head.agent_id
-            and base in (item.snapshot_id, item.base_snapshot_id)
-            and item.sequence <= head.sequence
-        )
-        chain = _build_ancestry(branch, head, limit)
-        if chain is None:
+    cursor = (None, None, None)
+    while True:
+        rows = connection.execute(
+            "SELECT data, created_at, agent_id, snapshot_id FROM raw_manifests "
+            "WHERE tenant_id = ? AND source_type = ? AND file_subtype = ? AND competencia = ? "
+            "AND (? IS NULL OR (created_at, agent_id, snapshot_id) < (?, ?, ?)) "
+            "ORDER BY created_at DESC, agent_id DESC, snapshot_id DESC LIMIT ?",
+            (*identity, cursor[0], *cursor, max(limit, 1)),
+        ).fetchall()
+        if not rows:
             return ()
-        if len(chain) == head.sequence:
-            return chain
-    return ()
+        for row in rows:
+            head = deserialize_model(row[0], RawManifestRecord)
+            chain = _build_ancestry(connection, identity, head, limit)
+            if chain is None:
+                return ()
+            if len(chain) == head.sequence:
+                return chain
+        cursor = tuple(rows[-1][1:])
 
 
 def list_raw_manifest_chain(store: Any, values: tuple[Any, ...]) -> tuple[ManifestRef, ...]:
     tenant_id, source_type, file_subtype, competencia, limit = values
+    identity = (tenant_id, source_type, file_subtype, competencia)
     with store.read_connection() as connection:
-        rows = connection.execute(
-            "SELECT data FROM raw_manifests WHERE tenant_id = ? AND source_type = ? "
-            "AND file_subtype = ? AND competencia = ?",
-            (tenant_id, source_type, file_subtype, competencia),
-        ).fetchall()
-    records = tuple(deserialize_model(row[0], RawManifestRecord) for row in rows)
-    selected = _select_raw_chain(records, limit)
+        selected = _select_raw_chain(connection, identity, limit)
     return tuple(
         ManifestRef(manifest_id=item.manifest_id, manifest_key=item.manifest_key)
         for item in selected

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -293,6 +293,8 @@ def _validate_publication_replay(
 
 
 def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
+    if command.pointer_name != "current":
+        raise Conflict("pointer_name_not_current")
     version = command.version
     with store.write_transaction() as connection:
         current_version = _get_version(

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from cnes_domain.control_plane.commands import PublishDataset
@@ -99,29 +100,35 @@ def _predecessors(
     return tuple(deserialize_model(row[0], RawManifestRecord) for row in rows)
 
 
-def _build_ancestry(
-    connection: Any, identity: tuple[str, ...], current: RawManifestRecord, limit: int
-) -> tuple[RawManifestRecord, ...] | None:
+@dataclass
+class _AncestrySearch:
+    identity: tuple[str, ...]
+    remaining: int
+    predecessors: dict[Any, tuple[RawManifestRecord, ...]]
+
+
+def _build_ancestry(connection: Any, identity: Any, current: RawManifestRecord, limit: int):
+    search = identity if isinstance(identity, _AncestrySearch) else _AncestrySearch(
+        identity, max(limit, 1) * _HEAD_SCAN_PAGES, {})
     paths = [(current, (current,))]
-    predecessors_by_key = {}
     expanded = set()
-    remaining = max(limit, 1) * _HEAD_SCAN_PAGES
     while paths:
         item, ancestry = paths.pop()
         if item.manifest_id in expanded:
             continue
-        if remaining == 0:
+        if search.remaining == 0:
             return None
         expanded.add(item.manifest_id)
-        remaining -= 1
+        search.remaining -= 1
         if len(ancestry) > limit:
             return None
         if item.sequence == 1:
             return tuple(reversed(ancestry))
         key = (item.agent_id, item.sequence, item.previous_manifest_sha256, item.base_snapshot_id)
-        if key not in predecessors_by_key:
-            predecessors_by_key[key] = _predecessors(connection, identity, item, limit)
-        predecessors = predecessors_by_key[key]
+        if key not in search.predecessors:
+            search.predecessors[key] = _predecessors(
+                connection, search.identity, item, limit)
+        predecessors = search.predecessors[key]
         paths.extend((predecessor, (*ancestry, predecessor))
                      for predecessor in reversed(predecessors))
     return ()
@@ -133,6 +140,7 @@ def _select_raw_chain(
     cursor = (None, None, None, None)
     page_size = max(limit, 1)
     remaining = page_size * _HEAD_SCAN_PAGES
+    search = _AncestrySearch(identity, remaining, {})
     while remaining:
         rows = connection.execute(
             "SELECT data, created_at, agent_id, snapshot_id, manifest_id FROM raw_manifests "
@@ -147,7 +155,7 @@ def _select_raw_chain(
         remaining -= len(rows)
         for row in rows:
             head = deserialize_model(row[0], RawManifestRecord)
-            chain = _build_ancestry(connection, identity, head, limit)
+            chain = _build_ancestry(connection, search, head, limit)
             if chain is None:
                 return ()
             if len(chain) == head.sequence:
@@ -288,10 +296,12 @@ def _put_version(connection: Any, version: DatasetVersion) -> None:
 
 def _put_publication(connection: Any, command: PublishDataset) -> None:
     version = command.version
+    permit = command.publication_permit.model_copy(update={"binding_context": None})
+    canonical = command.model_copy(update={"publication_permit": permit})
     connection.execute(
         "INSERT INTO dataset_publications (tenant_id, dataset_name, version_id, data) "
         "VALUES (?, ?, ?, ?)",
-        (version.tenant_id, version.dataset_name, version.version_id, serialize_model(command)),
+        (version.tenant_id, version.dataset_name, version.version_id, serialize_model(canonical)),
     )
 
 
@@ -319,6 +329,8 @@ def _validate_publication_replay(
         and run.state is command.final_state
         and run.missing_sources == command.missing_sources
     )
+    permit = command.publication_permit.model_copy(update={"binding_context": None})
+    command = command.model_copy(update={"publication_permit": permit})
     if canonical != command or not terminal_matches:
         raise Conflict("publication_replay_conflict")
     return pointer

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from itertools import pairwise
 from typing import TYPE_CHECKING, Any
 
 from cnes_domain.control_plane.entities import (
@@ -76,6 +75,28 @@ def latest_succeeded_job(store: Any, values: tuple[str, ...]) -> Job | None:
     return None if row is None else deserialize_model(row[0], Job)
 
 
+def _build_ancestry(
+    records: tuple[RawManifestRecord, ...], current: RawManifestRecord
+) -> tuple[RawManifestRecord, ...]:
+    if current.sequence == 1:
+        return (current,)
+    predecessors = sorted(
+        (
+            item
+            for item in records
+            if item.sequence == current.sequence - 1
+            and item.manifest_sha256 == current.previous_manifest_sha256
+        ),
+        key=lambda item: (item.created_at, item.snapshot_id),
+        reverse=True,
+    )
+    for predecessor in predecessors:
+        ancestry = _build_ancestry(records, predecessor)
+        if ancestry:
+            return (*ancestry, current)
+    return ()
+
+
 def _select_raw_chain(
     records: tuple[RawManifestRecord, ...],
 ) -> tuple[RawManifestRecord, ...]:
@@ -86,23 +107,16 @@ def _select_raw_chain(
     )
     for head in heads:
         base = head.snapshot_id if head.sequence == 1 else head.base_snapshot_id
-        chain = sorted(
-            (
-                item
-                for item in records
-                if item.agent_id == head.agent_id
-                and base in (item.snapshot_id, item.base_snapshot_id)
-                and item.sequence <= head.sequence
-            ),
-            key=lambda item: item.sequence,
+        branch = tuple(
+            item
+            for item in records
+            if item.agent_id == head.agent_id
+            and base in (item.snapshot_id, item.base_snapshot_id)
+            and item.sequence <= head.sequence
         )
-        hashes_match = all(
-            current.previous_manifest_sha256 == previous.manifest_sha256
-            for previous, current in pairwise(chain)
-        )
-        contiguous = [item.sequence for item in chain] == list(range(1, head.sequence + 1))
-        if contiguous and hashes_match:
-            return tuple(chain)
+        chain = _build_ancestry(branch, head)
+        if len(chain) == head.sequence:
+            return chain
     return ()
 
 
@@ -166,7 +180,7 @@ def list_recoverable_runs(store: Any, now: datetime, limit: int) -> tuple[Run, .
     with store.read_connection() as connection:
         rows = connection.execute(
             "SELECT data FROM runs WHERE state IN (?, ?, ?, ?) "
-            "ORDER BY created_at, run_id LIMIT ?",
+            "ORDER BY created_at, tenant_id, run_id LIMIT ?",
             (*states, limit),
         ).fetchall()
     return tuple(store.decode_run(row[0]) for row in rows)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -103,13 +103,25 @@ def _build_ancestry(
     connection: Any, identity: tuple[str, ...], current: RawManifestRecord, limit: int
 ) -> tuple[RawManifestRecord, ...] | None:
     paths = [(current, (current,))]
+    predecessors_by_key = {}
+    expanded = set()
+    remaining = max(limit, 1) * _HEAD_SCAN_PAGES
     while paths:
         item, ancestry = paths.pop()
+        if item.manifest_id in expanded:
+            continue
+        if remaining == 0:
+            return None
+        expanded.add(item.manifest_id)
+        remaining -= 1
         if len(ancestry) > limit:
             return None
         if item.sequence == 1:
             return tuple(reversed(ancestry))
-        predecessors = _predecessors(connection, identity, item, limit)
+        key = (item.agent_id, item.sequence, item.previous_manifest_sha256, item.base_snapshot_id)
+        if key not in predecessors_by_key:
+            predecessors_by_key[key] = _predecessors(connection, identity, item, limit)
+        predecessors = predecessors_by_key[key]
         paths.extend((predecessor, (*ancestry, predecessor))
                      for predecessor in reversed(predecessors))
     return ()

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -19,8 +19,10 @@ from cnes_domain.control_plane.transitions import transition_run as apply_run_tr
 from cnes_infra.control_plane.sqlite_schema import (
     deserialize_model,
     put_access_request_decision,
+    put_run_transition,
     serialize_model,
     validate_access_request_decision,
+    validate_run_transition,
 )
 
 if TYPE_CHECKING:
@@ -204,6 +206,9 @@ def list_recoverable_runs(store: Any, now: datetime, limit: int) -> tuple[Run, .
 def transition_run(store: Any, command: TransitionRun, event: OutboxEvent) -> Run:
     with store.write_transaction() as connection:
         run = store.get_run_record(connection, command.tenant_id, command.run_id)
+        if run is not None and run.state is command.new_state:
+            validate_run_transition(connection, command, event)
+            return run
         if run is None or run.state is not command.expected_state:
             raise Conflict("run_state_conflict")
         updated = apply_run_transition(run, command.new_state).model_copy(
@@ -211,6 +216,7 @@ def transition_run(store: Any, command: TransitionRun, event: OutboxEvent) -> Ru
         )
         store.put_outbox_event(connection, event, command.tenant_id)
         store.put_run_record(connection, updated)
+        put_run_transition(connection, command, event)
         return updated
 
 

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -376,11 +376,12 @@ def _get_access_request(
     return None if row is None else deserialize_model(row[0], AccessRequest)
 
 
-def _put_access_request(connection: Any, request: AccessRequest) -> None:
+def _put_access_request(connection: Any, request: AccessRequest, event: OutboxEvent) -> None:
     connection.execute(
-        "INSERT INTO access_requests (tenant_id, request_id, data) VALUES (?, ?, ?) "
+        "INSERT INTO access_requests (tenant_id, request_id, data, creation_event_data) "
+        "VALUES (?, ?, ?, ?) "
         "ON CONFLICT (tenant_id, request_id) DO UPDATE SET data = excluded.data",
-        (request.tenant_id, request.request_id, serialize_model(request)),
+        (request.tenant_id, request.request_id, serialize_model(request), serialize_model(event)),
     )
 
 
@@ -396,9 +397,16 @@ def put_access_request(store: Any, request: AccessRequest, event: OutboxEvent) -
         current = _get_access_request(connection, request.tenant_id, request.request_id)
         if current is not None and current != request:
             raise Conflict("access_request_conflict")
-        if current is None:
-            store.put_outbox_event(connection, event, request.tenant_id)
-            _put_access_request(connection, request)
+        if current is not None:
+            row = connection.execute(
+                "SELECT creation_event_data FROM access_requests "
+                "WHERE tenant_id = ? AND request_id = ?",
+                (request.tenant_id, request.request_id)).fetchone()
+            if row is None or row[0] != serialize_model(event):
+                raise Conflict("access_request_creation_conflict")
+            return
+        store.put_outbox_event(connection, event, request.tenant_id)
+        _put_access_request(connection, request, event)
 
 
 def decide_access_request(store: Any, request: AccessRequest, event: OutboxEvent) -> AccessRequest:
@@ -417,6 +425,6 @@ def decide_access_request(store: Any, request: AccessRequest, event: OutboxEvent
         if current.state is not AccessRequestState.PENDING:
             raise Conflict("access_request_state_conflict")
         store.put_outbox_event(connection, event, request.tenant_id)
-        _put_access_request(connection, request)
+        _put_access_request(connection, request, event)
         put_access_request_decision(connection, request, event)
         return request

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -271,15 +271,6 @@ def get_dataset_version(store: Any, values: tuple[str, str, str]) -> DatasetVers
         return _get_version(connection, *values)
 
 
-def _get_publication(connection: Any, version: DatasetVersion) -> PublishDataset | None:
-    row = connection.execute(
-        "SELECT data FROM dataset_publications "
-        "WHERE tenant_id = ? AND dataset_name = ? AND version_id = ?",
-        (version.tenant_id, version.dataset_name, version.version_id),
-    ).fetchone()
-    return None if row is None else deserialize_model(row[0], PublishDataset)
-
-
 def _put_version(connection: Any, version: DatasetVersion) -> None:
     connection.execute(
         "INSERT INTO dataset_versions (tenant_id, dataset_name, version_id, data) "
@@ -293,14 +284,16 @@ def _put_version(connection: Any, version: DatasetVersion) -> None:
     )
 
 
-def _put_publication(connection: Any, command: PublishDataset) -> None:
+def _put_publication(connection: Any, command: PublishDataset, result: DatasetPointer) -> None:
     version = command.version
     permit = command.publication_permit.model_copy(update={"binding_context": None})
     canonical = command.model_copy(update={"publication_permit": permit})
     connection.execute(
-        "INSERT INTO dataset_publications (tenant_id, dataset_name, version_id, data) "
-        "VALUES (?, ?, ?, ?)",
-        (version.tenant_id, version.dataset_name, version.version_id, serialize_model(canonical)),
+        "INSERT INTO dataset_publications "
+        "(tenant_id, dataset_name, version_id, data, response_data) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (version.tenant_id, version.dataset_name, version.version_id, serialize_model(canonical),
+         serialize_model(result)),
     )
 
 
@@ -319,9 +312,14 @@ def _put_pointer(connection: Any, pointer: DatasetPointer) -> None:
 
 
 def _validate_publication_replay(
-    store: Any, connection: Any, command: PublishDataset, pointer: DatasetPointer
-) -> DatasetPointer:
-    canonical = _get_publication(connection, command.version)
+    store: Any, connection: Any, command: PublishDataset, pointer: DatasetPointer | None
+) -> DatasetPointer | None:
+    row = connection.execute(
+        "SELECT data, response_data FROM dataset_publications "
+        "WHERE tenant_id = ? AND dataset_name = ? AND version_id = ?",
+        (command.version.tenant_id, command.version.dataset_name, command.version.version_id),
+    ).fetchone()
+    canonical = None if row is None else deserialize_model(row[0], PublishDataset)
     run = store.get_run_record(connection, command.version.tenant_id, command.version.run_id)
     terminal_matches = (
         run is not None
@@ -332,7 +330,7 @@ def _validate_publication_replay(
     command = command.model_copy(update={"publication_permit": permit})
     if canonical != command or not terminal_matches:
         raise Conflict("publication_replay_conflict")
-    return pointer
+    return pointer if row[1] is None else deserialize_model(row[1], DatasetPointer)
 
 
 def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
@@ -349,8 +347,7 @@ def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
         if current_version is not None:
             if current_version != version:
                 raise Conflict("version_immutable")
-            if pointer is not None and pointer.version_id == version.version_id:
-                return _validate_publication_replay(store, connection, command, pointer)
+            return _validate_publication_replay(store, connection, command, pointer)
         actual = None if pointer is None else pointer.version_id
         if actual != command.expected_version_id:
             raise Conflict("pointer_cas")
@@ -359,6 +356,8 @@ def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
             raise Conflict("run_not_publishing")
         if run.dataset_name != version.dataset_name:
             raise Conflict("run_dataset_mismatch")
+        if version.run_manifest_key.split("/")[2] != run.competencia:
+            raise Conflict("run_competencia_mismatch")
         updated = run.model_copy(
             update={"state": command.final_state, "missing_sources": command.missing_sources}
         )
@@ -371,7 +370,7 @@ def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
         )
         store.put_outbox_event(connection, command.event, version.tenant_id)
         _put_version(connection, version)
-        _put_publication(connection, command)
+        _put_publication(connection, command, result)
         _put_pointer(connection, result)
         store.put_run_record(connection, updated)
         return result

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -226,8 +226,7 @@ def list_recoverable_runs(store: Any, now: datetime, limit: int) -> tuple[Run, .
 def transition_run(store: Any, command: TransitionRun, event: OutboxEvent) -> Run:
     with store.write_transaction() as connection:
         run = store.get_run_record(connection, command.tenant_id, command.run_id)
-        if run is not None and run.state is command.new_state:
-            validate_run_transition(connection, command, event)
+        if run is not None and validate_run_transition(connection, command, event):
             return run
         if run is None or run.state is not command.expected_state:
             raise Conflict("run_state_conflict")
@@ -390,10 +389,12 @@ def _get_access_request(
 
 def _put_access_request(connection: Any, request: AccessRequest, event: OutboxEvent) -> None:
     connection.execute(
-        "INSERT INTO access_requests (tenant_id, request_id, data, creation_event_data) "
-        "VALUES (?, ?, ?, ?) "
+        "INSERT INTO access_requests "
+        "(tenant_id, request_id, data, creation_request_data, creation_event_data) "
+        "VALUES (?, ?, ?, ?, ?) "
         "ON CONFLICT (tenant_id, request_id) DO UPDATE SET data = excluded.data",
-        (request.tenant_id, request.request_id, serialize_model(request), serialize_model(event)),
+        (request.tenant_id, request.request_id, serialize_model(request),
+         serialize_model(request), serialize_model(event)),
     )
 
 
@@ -407,14 +408,14 @@ def put_access_request(store: Any, request: AccessRequest, event: OutboxEvent) -
         if request.state is not AccessRequestState.PENDING:
             raise Conflict("access_request_creation_state")
         current = _get_access_request(connection, request.tenant_id, request.request_id)
-        if current is not None and current != request:
-            raise Conflict("access_request_conflict")
         if current is not None:
             row = connection.execute(
-                "SELECT creation_event_data FROM access_requests "
+                "SELECT creation_request_data, creation_event_data FROM access_requests "
                 "WHERE tenant_id = ? AND request_id = ?",
                 (request.tenant_id, request.request_id)).fetchone()
-            if row is None or row[0] != serialize_model(event):
+            if row is None or row[0] != serialize_model(request):
+                raise Conflict("access_request_conflict")
+            if row[1] != serialize_model(event):
                 raise Conflict("access_request_creation_conflict")
             return
         store.put_outbox_event(connection, event, request.tenant_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -77,29 +77,29 @@ def latest_succeeded_job(store: Any, values: tuple[str, ...]) -> Job | None:
 
 
 def _build_ancestry(
-    records: tuple[RawManifestRecord, ...], current: RawManifestRecord
-) -> tuple[RawManifestRecord, ...]:
-    if current.sequence == 1:
-        return (current,)
-    predecessors = sorted(
-        (
-            item
-            for item in records
-            if item.sequence == current.sequence - 1
-            and item.manifest_sha256 == current.previous_manifest_sha256
-        ),
-        key=lambda item: (item.created_at, item.snapshot_id),
-        reverse=True,
-    )
-    for predecessor in predecessors:
-        ancestry = _build_ancestry(records, predecessor)
-        if ancestry:
-            return (*ancestry, current)
+    records: tuple[RawManifestRecord, ...], current: RawManifestRecord, limit: int
+) -> tuple[RawManifestRecord, ...] | None:
+    paths = [(current, (current,))]
+    while paths:
+        item, ancestry = paths.pop()
+        if len(ancestry) > limit:
+            return None
+        if item.sequence == 1:
+            return tuple(reversed(ancestry))
+        predecessors = sorted(
+            (candidate for candidate in records
+             if candidate.sequence == item.sequence - 1
+             and candidate.manifest_sha256 == item.previous_manifest_sha256),
+            key=lambda candidate: (candidate.created_at, candidate.snapshot_id),
+            reverse=True,
+        )
+        paths.extend((predecessor, (*ancestry, predecessor))
+                     for predecessor in reversed(predecessors))
     return ()
 
 
 def _select_raw_chain(
-    records: tuple[RawManifestRecord, ...],
+    records: tuple[RawManifestRecord, ...], limit: int,
 ) -> tuple[RawManifestRecord, ...]:
     heads = sorted(
         records,
@@ -115,7 +115,9 @@ def _select_raw_chain(
             and base in (item.snapshot_id, item.base_snapshot_id)
             and item.sequence <= head.sequence
         )
-        chain = _build_ancestry(branch, head)
+        chain = _build_ancestry(branch, head, limit)
+        if chain is None:
+            return ()
         if len(chain) == head.sequence:
             return chain
     return ()
@@ -130,9 +132,7 @@ def list_raw_manifest_chain(store: Any, values: tuple[Any, ...]) -> tuple[Manife
             (tenant_id, source_type, file_subtype, competencia),
         ).fetchall()
     records = tuple(deserialize_model(row[0], RawManifestRecord) for row in rows)
-    selected = _select_raw_chain(records)
-    if len(selected) > limit:
-        return ()
+    selected = _select_raw_chain(records, limit)
     return tuple(
         ManifestRef(manifest_id=item.manifest_id, manifest_key=item.manifest_key)
         for item in selected

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -1,0 +1,294 @@
+"""SQLite run discovery and dataset publication operations."""
+
+from __future__ import annotations
+
+from itertools import pairwise
+from typing import TYPE_CHECKING, Any
+
+from cnes_domain.control_plane.entities import (
+    AccessRequest,
+    DatasetPointer,
+    DatasetVersion,
+    Job,
+    ManifestRef,
+    RawManifestRecord,
+)
+from cnes_domain.control_plane.enums import AccessRequestState, JobState, RunState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.control_plane.transitions import transition_run as apply_run_transition
+from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from cnes_domain.control_plane.commands import PublishDataset, TransitionRun
+    from cnes_domain.control_plane.entities import OutboxEvent, Run
+
+
+def latest_succeeded_job(store: Any, values: tuple[str, ...]) -> Job | None:
+    tenant_id, agent_id, source_type, file_subtype, competencia = values
+    with store.read_connection() as connection:
+        row = connection.execute(
+            "SELECT data FROM jobs WHERE tenant_id = ? AND agent_id = ? "
+            "AND source_type = ? AND file_subtype = ? AND competencia = ? "
+            "AND state = ? ORDER BY created_at DESC, job_id DESC LIMIT 1",
+            (
+                tenant_id,
+                agent_id,
+                source_type,
+                file_subtype,
+                competencia,
+                JobState.SUCCEEDED.value,
+            ),
+        ).fetchone()
+    return None if row is None else deserialize_model(row[0], Job)
+
+
+def _select_raw_chain(
+    records: tuple[RawManifestRecord, ...],
+) -> tuple[RawManifestRecord, ...]:
+    heads = sorted(
+        records,
+        key=lambda item: (item.created_at, item.agent_id, item.snapshot_id),
+        reverse=True,
+    )
+    for head in heads:
+        base = head.snapshot_id if head.sequence == 1 else head.base_snapshot_id
+        chain = sorted(
+            (
+                item
+                for item in records
+                if item.agent_id == head.agent_id
+                and base in (item.snapshot_id, item.base_snapshot_id)
+                and item.sequence <= head.sequence
+            ),
+            key=lambda item: item.sequence,
+        )
+        hashes_match = all(
+            current.previous_manifest_sha256 == previous.manifest_sha256
+            for previous, current in pairwise(chain)
+        )
+        contiguous = [item.sequence for item in chain] == list(range(1, head.sequence + 1))
+        if contiguous and hashes_match:
+            return tuple(chain)
+    return ()
+
+
+def list_raw_manifest_chain(store: Any, values: tuple[Any, ...]) -> tuple[ManifestRef, ...]:
+    tenant_id, source_type, file_subtype, competencia, limit = values
+    with store.read_connection() as connection:
+        rows = connection.execute(
+            "SELECT data FROM raw_manifests WHERE tenant_id = ? AND source_type = ? "
+            "AND file_subtype = ? AND competencia = ?",
+            (tenant_id, source_type, file_subtype, competencia),
+        ).fetchall()
+    records = tuple(deserialize_model(row[0], RawManifestRecord) for row in rows)
+    selected = _select_raw_chain(records)
+    if len(selected) > limit:
+        return ()
+    return tuple(
+        ManifestRef(manifest_id=item.manifest_id, manifest_key=item.manifest_key)
+        for item in selected
+    )
+
+
+def put_run(store: Any, run: Run) -> None:
+    with store.write_transaction() as connection:
+        store.put_run_record(connection, run)
+
+
+def get_run(store: Any, tenant_id: str, run_id: str) -> Run | None:
+    with store.read_connection() as connection:
+        return store.get_run_record(connection, tenant_id, run_id)
+
+
+def list_waiting_runs(store: Any, values: tuple[Any, ...]) -> tuple[Run, ...]:
+    tenant_id, source_type, file_subtype, competencia, limit = values
+    with store.read_connection() as connection:
+        rows = connection.execute(
+            "SELECT r.data FROM runs r JOIN run_dependencies d "
+            "ON d.tenant_id = r.tenant_id AND d.run_id = r.run_id "
+            "WHERE r.tenant_id = ? AND d.source_type = ? AND d.file_subtype = ? "
+            "AND r.competencia = ? AND r.state = ? "
+            "ORDER BY r.created_at, r.run_id LIMIT ?",
+            (
+                tenant_id,
+                source_type,
+                file_subtype,
+                competencia,
+                RunState.WAITING_INPUTS.value,
+                limit,
+            ),
+        ).fetchall()
+    return tuple(store.decode_run(row[0]) for row in rows)
+
+
+def list_recoverable_runs(store: Any, now: datetime, limit: int) -> tuple[Run, ...]:
+    del now
+    states = (
+        RunState.WAITING_INPUTS.value,
+        RunState.PROCESSING.value,
+        RunState.PUBLISHING.value,
+        RunState.CANCEL_REQUESTED.value,
+    )
+    with store.read_connection() as connection:
+        rows = connection.execute(
+            "SELECT data FROM runs WHERE state IN (?, ?, ?, ?) "
+            "ORDER BY created_at, run_id LIMIT ?",
+            (*states, limit),
+        ).fetchall()
+    return tuple(store.decode_run(row[0]) for row in rows)
+
+
+def transition_run(store: Any, command: TransitionRun, event: OutboxEvent) -> Run:
+    with store.write_transaction() as connection:
+        run = store.get_run_record(connection, command.tenant_id, command.run_id)
+        if run is None or run.state is not command.expected_state:
+            raise Conflict("run_state_conflict")
+        updated = apply_run_transition(run, command.new_state).model_copy(
+            update={"missing_sources": command.missing_sources}
+        )
+        store.put_run_record(connection, updated)
+        store.put_outbox_event(connection, event)
+        return updated
+
+
+def _get_version(
+    connection: Any, tenant_id: str, dataset_name: str, version_id: str
+) -> DatasetVersion | None:
+    row = connection.execute(
+        "SELECT data FROM dataset_versions "
+        "WHERE tenant_id = ? AND dataset_name = ? AND version_id = ?",
+        (tenant_id, dataset_name, version_id),
+    ).fetchone()
+    return None if row is None else deserialize_model(row[0], DatasetVersion)
+
+
+def _get_pointer(
+    connection: Any, tenant_id: str, dataset_name: str, pointer_name: str
+) -> DatasetPointer | None:
+    row = connection.execute(
+        "SELECT data FROM dataset_pointers "
+        "WHERE tenant_id = ? AND dataset_name = ? AND pointer_name = ?",
+        (tenant_id, dataset_name, pointer_name),
+    ).fetchone()
+    return None if row is None else deserialize_model(row[0], DatasetPointer)
+
+
+def get_dataset_pointer(store: Any, tenant_id: str, dataset_name: str) -> DatasetPointer | None:
+    with store.read_connection() as connection:
+        return _get_pointer(connection, tenant_id, dataset_name, "current")
+
+
+def get_dataset_version(store: Any, values: tuple[str, str, str]) -> DatasetVersion | None:
+    with store.read_connection() as connection:
+        return _get_version(connection, *values)
+
+
+def _put_version(connection: Any, version: DatasetVersion) -> None:
+    connection.execute(
+        "INSERT INTO dataset_versions (tenant_id, dataset_name, version_id, data) "
+        "VALUES (?, ?, ?, ?)",
+        (
+            version.tenant_id,
+            version.dataset_name,
+            version.version_id,
+            serialize_model(version),
+        ),
+    )
+
+
+def _put_pointer(connection: Any, pointer: DatasetPointer) -> None:
+    connection.execute(
+        "INSERT INTO dataset_pointers (tenant_id, dataset_name, pointer_name, data) "
+        "VALUES (?, ?, ?, ?) ON CONFLICT (tenant_id, dataset_name, pointer_name) "
+        "DO UPDATE SET data = excluded.data",
+        (
+            pointer.tenant_id,
+            pointer.dataset_name,
+            pointer.pointer_name,
+            serialize_model(pointer),
+        ),
+    )
+
+
+def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
+    version = command.version
+    with store.write_transaction() as connection:
+        current_version = _get_version(
+            connection, version.tenant_id, version.dataset_name, version.version_id
+        )
+        pointer = _get_pointer(
+            connection, version.tenant_id, version.dataset_name, command.pointer_name
+        )
+        if current_version is not None:
+            if current_version != version:
+                raise Conflict("version_immutable")
+            if pointer is not None and pointer.version_id == version.version_id:
+                return pointer
+        actual = None if pointer is None else pointer.version_id
+        if actual != command.expected_version_id:
+            raise Conflict("pointer_cas")
+        run = store.get_run_record(connection, version.tenant_id, version.run_id)
+        if run is None or run.state is not RunState.PUBLISHING:
+            raise Conflict("run_not_publishing")
+        updated = run.model_copy(
+            update={"state": command.final_state, "missing_sources": command.missing_sources}
+        )
+        result = DatasetPointer(
+            tenant_id=version.tenant_id,
+            dataset_name=version.dataset_name,
+            pointer_name=command.pointer_name,
+            version_id=version.version_id,
+            updated_at=store.now(),
+        )
+        _put_version(connection, version)
+        _put_pointer(connection, result)
+        store.put_run_record(connection, updated)
+        store.put_outbox_event(connection, command.event)
+        return result
+
+
+def _get_access_request(
+    connection: Any, tenant_id: str, request_id: str
+) -> AccessRequest | None:
+    row = connection.execute(
+        "SELECT data FROM access_requests WHERE tenant_id = ? AND request_id = ?",
+        (tenant_id, request_id),
+    ).fetchone()
+    return None if row is None else deserialize_model(row[0], AccessRequest)
+
+
+def _put_access_request(connection: Any, request: AccessRequest) -> None:
+    connection.execute(
+        "INSERT INTO access_requests (tenant_id, request_id, data) VALUES (?, ?, ?) "
+        "ON CONFLICT (tenant_id, request_id) DO UPDATE SET data = excluded.data",
+        (request.tenant_id, request.request_id, serialize_model(request)),
+    )
+
+
+def get_access_request(store: Any, tenant_id: str, request_id: str) -> AccessRequest | None:
+    with store.read_connection() as connection:
+        return _get_access_request(connection, tenant_id, request_id)
+
+
+def put_access_request(store: Any, request: AccessRequest, event: OutboxEvent) -> None:
+    with store.write_transaction() as connection:
+        current = _get_access_request(connection, request.tenant_id, request.request_id)
+        if current is not None and current != request:
+            raise Conflict("access_request_conflict")
+        if current is None:
+            _put_access_request(connection, request)
+            store.put_outbox_event(connection, event)
+
+
+def decide_access_request(store: Any, request: AccessRequest, event: OutboxEvent) -> AccessRequest:
+    with store.write_transaction() as connection:
+        current = _get_access_request(connection, request.tenant_id, request.request_id)
+        if current == request:
+            return request
+        if current is None or current.state is not AccessRequestState.PENDING:
+            raise Conflict("access_request_state_conflict")
+        _put_access_request(connection, request)
+        store.put_outbox_event(connection, event)
+        return request

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -110,13 +110,14 @@ def _build_ancestry(
 def _select_raw_chain(
     connection: Any, identity: tuple[str, ...], limit: int,
 ) -> tuple[RawManifestRecord, ...]:
-    cursor = (None, None, None)
+    cursor = (None, None, None, None)
     while True:
         rows = connection.execute(
-            "SELECT data, created_at, agent_id, snapshot_id FROM raw_manifests "
+            "SELECT data, created_at, agent_id, snapshot_id, manifest_id FROM raw_manifests "
             "WHERE tenant_id = ? AND source_type = ? AND file_subtype = ? AND competencia = ? "
-            "AND (? IS NULL OR (created_at, agent_id, snapshot_id) < (?, ?, ?)) "
-            "ORDER BY created_at DESC, agent_id DESC, snapshot_id DESC LIMIT ?",
+            "AND (? IS NULL OR (created_at, agent_id, snapshot_id, manifest_id) "
+            "< (?, ?, ?, ?)) ORDER BY created_at DESC, agent_id DESC, snapshot_id DESC, "
+            "manifest_id DESC LIMIT ?",
             (*identity, cursor[0], *cursor, max(limit, 1)),
         ).fetchall()
         if not rows:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -24,6 +24,38 @@ if TYPE_CHECKING:
     from cnes_domain.control_plane.commands import PublishDataset, TransitionRun
     from cnes_domain.control_plane.entities import OutboxEvent, Run
 
+LATEST_JOB_FIELDS = (
+    "tenant_id",
+    "agent_id",
+    "source_type",
+    "file_subtype",
+    "competencia",
+)
+DEPENDENCY_FIELDS = ("tenant_id", "source_type", "file_subtype", "competencia", "limit")
+
+
+def normalize_long_call(
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    fields: tuple[str, ...],
+    default_limit: int | None = None,
+) -> tuple[Any, ...]:
+    if len(args) > len(fields):
+        raise TypeError(f"too_many_arguments={len(args)}")
+    values = dict(zip(fields, args, strict=False))
+    for name, value in kwargs.items():
+        if name not in fields:
+            raise TypeError(f"unexpected_argument={name}")
+        if name in values:
+            raise TypeError(f"duplicate_argument={name}")
+        values[name] = value
+    if default_limit is not None and "limit" not in values:
+        values["limit"] = default_limit
+    missing = tuple(name for name in fields if name not in values)
+    if missing:
+        raise TypeError(f"missing_arguments={','.join(missing)}")
+    return tuple(values[name] for name in fields)
+
 
 def latest_succeeded_job(store: Any, values: tuple[str, ...]) -> Job | None:
     tenant_id, agent_id, source_type, file_subtype, competencia = values

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from cnes_domain.control_plane.commands import PublishDataset
 from cnes_domain.control_plane.entities import (
     AccessRequest,
     DatasetPointer,
@@ -20,7 +21,7 @@ from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from cnes_domain.control_plane.commands import PublishDataset, TransitionRun
+    from cnes_domain.control_plane.commands import TransitionRun
     from cnes_domain.control_plane.entities import OutboxEvent, Run
 
 LATEST_JOB_FIELDS = (
@@ -231,6 +232,15 @@ def get_dataset_version(store: Any, values: tuple[str, str, str]) -> DatasetVers
         return _get_version(connection, *values)
 
 
+def _get_publication(connection: Any, version: DatasetVersion) -> PublishDataset | None:
+    row = connection.execute(
+        "SELECT data FROM dataset_publications "
+        "WHERE tenant_id = ? AND dataset_name = ? AND version_id = ?",
+        (version.tenant_id, version.dataset_name, version.version_id),
+    ).fetchone()
+    return None if row is None else deserialize_model(row[0], PublishDataset)
+
+
 def _put_version(connection: Any, version: DatasetVersion) -> None:
     connection.execute(
         "INSERT INTO dataset_versions (tenant_id, dataset_name, version_id, data) "
@@ -241,6 +251,15 @@ def _put_version(connection: Any, version: DatasetVersion) -> None:
             version.version_id,
             serialize_model(version),
         ),
+    )
+
+
+def _put_publication(connection: Any, command: PublishDataset) -> None:
+    version = command.version
+    connection.execute(
+        "INSERT INTO dataset_publications (tenant_id, dataset_name, version_id, data) "
+        "VALUES (?, ?, ?, ?)",
+        (version.tenant_id, version.dataset_name, version.version_id, serialize_model(command)),
     )
 
 
@@ -258,6 +277,21 @@ def _put_pointer(connection: Any, pointer: DatasetPointer) -> None:
     )
 
 
+def _validate_publication_replay(
+    store: Any, connection: Any, command: PublishDataset, pointer: DatasetPointer
+) -> DatasetPointer:
+    canonical = _get_publication(connection, command.version)
+    run = store.get_run_record(connection, command.version.tenant_id, command.version.run_id)
+    terminal_matches = (
+        run is not None
+        and run.state is command.final_state
+        and run.missing_sources == command.missing_sources
+    )
+    if canonical != command or not terminal_matches:
+        raise Conflict("publication_replay_conflict")
+    return pointer
+
+
 def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
     version = command.version
     with store.write_transaction() as connection:
@@ -271,7 +305,7 @@ def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
             if current_version != version:
                 raise Conflict("version_immutable")
             if pointer is not None and pointer.version_id == version.version_id:
-                return pointer
+                return _validate_publication_replay(store, connection, command, pointer)
         actual = None if pointer is None else pointer.version_id
         if actual != command.expected_version_id:
             raise Conflict("pointer_cas")
@@ -291,6 +325,7 @@ def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:
             updated_at=store.now(),
         )
         _put_version(connection, version)
+        _put_publication(connection, command)
         _put_pointer(connection, result)
         store.put_run_record(connection, updated)
         store.put_outbox_event(connection, command.event)
@@ -333,9 +368,16 @@ def put_access_request(store: Any, request: AccessRequest, event: OutboxEvent) -
 def decide_access_request(store: Any, request: AccessRequest, event: OutboxEvent) -> AccessRequest:
     with store.write_transaction() as connection:
         current = _get_access_request(connection, request.tenant_id, request.request_id)
+        if current is None:
+            raise Conflict("access_request_state_conflict")
+        identity = (current.tenant_id, current.request_id, current.user_id)
+        if identity != (request.tenant_id, request.request_id, request.user_id):
+            raise Conflict("access_request_identity_conflict")
+        if request.state not in {AccessRequestState.APPROVED, AccessRequestState.REJECTED}:
+            raise Conflict("access_request_decision_state")
         if current == request:
             return request
-        if current is None or current.state is not AccessRequestState.PENDING:
+        if current.state is not AccessRequestState.PENDING:
             raise Conflict("access_request_state_conflict")
         _put_access_request(connection, request)
         store.put_outbox_event(connection, event)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -330,7 +330,9 @@ def _validate_publication_replay(
     command = command.model_copy(update={"publication_permit": permit})
     if canonical != command or not terminal_matches:
         raise Conflict("publication_replay_conflict")
-    return pointer if row[1] is None else deserialize_model(row[1], DatasetPointer)
+    if row[1] is None:
+        raise Conflict("publication_replay_response_missing")
+    return deserialize_model(row[1], DatasetPointer)
 
 
 def publish_dataset(store: Any, command: PublishDataset) -> DatasetPointer:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -247,30 +247,20 @@ CREATE TABLE IF NOT EXISTS outbox_events (
     data TEXT NOT NULL
 );
 """
-
 _NETWORK_FILESYSTEMS = {"9p", "afs", "cifs", "fuse.sshfs", "nfs", "nfs4", "smbfs"}
 _NETWORK_PATH_PREFIXES = ("//", "smb:/", "nfs:/", "afp:/", "/net/", "/Network/Servers/")
-
-
 class _SQLiteWALUnavailable(RuntimeError):
     pass
-
 def serialize_model(model: BaseModel) -> str:
     return json.dumps(model.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
-
-
 def deserialize_model[Model: BaseModel](payload: str, model: type[Model]) -> Model:
     return model.model_validate_json(payload)
-
-
 def put_job_creation_write(connection: Any, job: Any, event: Any) -> None:
     connection.execute(
         "INSERT INTO job_creation_writes (tenant_id, job_id, job_data, event_data) "
         "VALUES (?, ?, ?, ?)",
         (job.tenant_id, job.job_id, serialize_model(job), serialize_model(event)),
     )
-
-
 def validate_job_creation_replay(connection: Any, job: Any, event: Any) -> None:
     row = connection.execute(
         "SELECT job_data, event_data FROM job_creation_writes WHERE tenant_id = ? AND job_id = ?",
@@ -284,7 +274,6 @@ def put_job_cancellation(connection: Any, command: Any, event: Any) -> None:
         "(tenant_id, job_id, command_data, event_data) VALUES (?, ?, ?, ?)",
         (command.tenant_id, command.job_id, serialize_model(command), serialize_model(event)),
     )
-
 def validate_job_cancellation(connection: Any, command: Any, event: Any) -> None:
     row = connection.execute(
         "SELECT command_data, event_data FROM job_cancellation_writes "
@@ -298,7 +287,6 @@ def put_access_request_decision(connection: Any, request: Any, event: Any) -> No
         "(tenant_id, request_id, event_data) VALUES (?, ?, ?)",
         (request.tenant_id, request.request_id, serialize_model(event)),
     )
-
 def validate_access_request_decision(connection: Any, request: Any, event: Any) -> None:
     row = connection.execute(
         "SELECT event_data FROM access_request_decision_writes "
@@ -306,7 +294,6 @@ def validate_access_request_decision(connection: Any, request: Any, event: Any) 
     ).fetchone()
     if row is None or row[0] != serialize_model(event):
         raise Conflict("access_request_decision_conflict")
-
 def put_run_transition(connection: Any, command: Any, event: Any) -> None:
     connection.execute(
         "INSERT INTO run_transition_writes "
@@ -314,7 +301,6 @@ def put_run_transition(connection: Any, command: Any, event: Any) -> None:
         (command.tenant_id, command.run_id, command.expected_state.value,
          serialize_model(command), serialize_model(event)),
     )
-
 def validate_run_transition(connection: Any, command: Any, event: Any) -> None:
     row = connection.execute(
         "SELECT command_data, event_data FROM run_transition_writes "
@@ -323,7 +309,6 @@ def validate_run_transition(connection: Any, command: Any, event: Any) -> None:
     ).fetchone()
     if row is None or tuple(row) != (serialize_model(command), serialize_model(event)):
         raise Conflict("run_transition_conflict")
-
 def get_job_terminal_write(
     connection: Any, tenant_id: str, job_id: str
 ) -> tuple[str, ...] | None:
@@ -333,7 +318,6 @@ def get_job_terminal_write(
         (tenant_id, job_id),
     ).fetchone()
     return None if row is None else tuple(row)
-
 def put_job_terminal_write(connection: Any, operation: str, command: Any, event: Any) -> None:
     connection.execute(
         "INSERT INTO job_terminal_writes "
@@ -346,7 +330,6 @@ def put_job_terminal_write(connection: Any, operation: str, command: Any, event:
             serialize_model(command), serialize_model(event),
         ),
     )
-
 def validate_job_terminal_replay(connection: Any, job: Any, command: Any, event: Any) -> None:
     manifest = getattr(command, "manifest", None)
     operation = "complete" if manifest is not None else "fail"
@@ -368,7 +351,6 @@ def validate_job_terminal_replay(connection: Any, job: Any, command: Any, event:
         )
     if current != canonical or not result_matches:
         raise Conflict("job_terminal_conflict")
-
 def get_run_unit_terminal_write(connection: Any, command: Any) -> tuple[str, ...] | None:
     row = connection.execute(
         "SELECT operation, command_data, event_data FROM run_unit_terminal_writes "
@@ -376,7 +358,6 @@ def get_run_unit_terminal_write(connection: Any, command: Any) -> tuple[str, ...
         (command.tenant_id, command.run_id, command.unit_id),
     ).fetchone()
     return None if row is None else tuple(row)
-
 def put_run_unit_terminal_write(
     connection: Any, operation: str, command: Any, event: Any
 ) -> None:
@@ -391,7 +372,6 @@ def put_run_unit_terminal_write(
             serialize_model(command), serialize_model(event),
         ),
     )
-
 def validate_run_unit_terminal_replay(
     connection: Any, unit: Any, command: Any, event: Any
 ) -> Any:
@@ -400,21 +380,18 @@ def validate_run_unit_terminal_replay(
     if get_run_unit_terminal_write(connection, command) != canonical:
         raise Conflict("unit_terminal_conflict")
     return unit
-
 def put_run_dispatch_finish(connection: Any, command: Any) -> None:
     connection.execute(
         "INSERT INTO run_dispatch_terminal_writes "
         "(tenant_id, run_id, dispatch_id, command_data) VALUES (?, ?, ?, ?)",
         (command.tenant_id, command.run_id, command.dispatch_id, serialize_model(command)),
     )
-
 def put_run_dispatch_bind(connection: Any, command: Any) -> None:
     connection.execute(
         "INSERT INTO run_dispatch_bind_writes "
         "(tenant_id, run_id, dispatch_id, command_data) VALUES (?, ?, ?, ?)",
         (command.tenant_id, command.run_id, command.dispatch_id, serialize_model(command)),
     )
-
 def validate_run_dispatch_bind(connection: Any, command: Any) -> None:
     row = connection.execute(
         "SELECT command_data FROM run_dispatch_bind_writes "
@@ -423,7 +400,6 @@ def validate_run_dispatch_bind(connection: Any, command: Any) -> None:
     ).fetchone()
     if row is None or row[0] != serialize_model(command):
         raise Conflict("dispatch_bind_conflict")
-
 def validate_run_dispatch_finish(connection: Any, command: Any) -> None:
     row = connection.execute(
         "SELECT command_data FROM run_dispatch_terminal_writes "
@@ -438,8 +414,6 @@ def put_run_cancellation(connection: Any, command: Any, event: Any) -> None:
         "(tenant_id, run_id, command_data, event_data) VALUES (?, ?, ?, ?)",
         (command.tenant_id, command.run_id, serialize_model(command), serialize_model(event)),
     )
-
-
 def validate_run_cancellation(connection: Any, command: Any, event: Any) -> None:
     row = connection.execute(
         "SELECT command_data, event_data FROM run_cancellation_writes "
@@ -449,8 +423,6 @@ def validate_run_cancellation(connection: Any, command: Any, event: Any) -> None
     canonical = (serialize_model(command), serialize_model(event))
     if row is None or tuple(row) != canonical:
         raise Conflict("run_cancellation_conflict")
-
-
 def validate_run_dispatch_wave(connection: Any, command: Any) -> None:
     unit_ids = json.dumps(command.unit_ids, separators=(",", ":"))
     row = connection.execute(
@@ -467,8 +439,6 @@ def validate_run_dispatch_wave(connection: Any, command: Any) -> None:
         "VALUES (?, ?, ?, ?)",
         (command.tenant_id, command.run_id, command.wave_id, unit_ids),
     )
-
-
 def is_network_filesystem(path: Path) -> bool:
     raw_path = str(path).replace("\\", "/")
     if raw_path.startswith(_NETWORK_PATH_PREFIXES):
@@ -484,8 +454,24 @@ def is_network_filesystem(path: Path) -> bool:
         if len(fields) >= 3 and resolved.is_relative_to(Path(fields[1])):
             matches.append((len(fields[1]), fields[2]))
     return bool(matches and max(matches)[1] in _NETWORK_FILESYSTEMS)
-
-
+def _migrate_schema(connection: sqlite3.Connection) -> None:
+    job_columns = {row[1] for row in connection.execute(
+        "PRAGMA table_info(job_creation_writes)")}
+    if "job_data" not in job_columns:
+        connection.execute("ALTER TABLE job_creation_writes ADD COLUMN job_data TEXT")
+    run_columns = {row[1] for row in connection.execute("PRAGMA table_info(runs)")}
+    if "unit_registry_data" not in run_columns:
+        connection.execute("ALTER TABLE runs ADD COLUMN unit_registry_data TEXT")
+    rows = connection.execute(
+        "SELECT tenant_id, run_id FROM runs WHERE unit_registry_data IS NULL").fetchall()
+    for tenant_id, run_id in rows:
+        units = connection.execute(
+            "SELECT data FROM run_units WHERE tenant_id = ? AND run_id = ? ORDER BY unit_id",
+            (tenant_id, run_id)).fetchall()
+        if units:
+            connection.execute(
+                "UPDATE runs SET unit_registry_data = ? WHERE tenant_id = ? AND run_id = ?",
+                ("\x1e".join(row[0] for row in units), tenant_id, run_id))
 def initialize_schema(connect: Callable[[], sqlite3.Connection], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     connection = connect()
@@ -494,6 +480,7 @@ def initialize_schema(connect: Callable[[], sqlite3.Connection], path: Path) -> 
         if result is None or str(result[0]).lower() != "wal":
             raise _SQLiteWALUnavailable("sqlite_wal_unavailable")
         connection.executescript(_SCHEMA)
+        _migrate_schema(connection)
         connection.commit()
     finally:
         connection.close()

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
@@ -10,7 +11,6 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     import sqlite3
     from collections.abc import Callable
-    from pathlib import Path
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS tenants (
@@ -133,6 +133,13 @@ CREATE TABLE IF NOT EXISTS outbox_events (
 );
 """
 
+_NETWORK_FILESYSTEMS = {"9p", "afs", "cifs", "fuse.sshfs", "nfs", "nfs4", "smbfs"}
+_NETWORK_PATH_PREFIXES = ("//", "smb:/", "nfs:/", "afp:/", "/net/", "/Network/Servers/")
+
+
+class _SQLiteWALUnavailable(RuntimeError):
+    pass
+
 def serialize_model(model: BaseModel) -> str:
     return json.dumps(model.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
 
@@ -141,11 +148,30 @@ def deserialize_model[Model: BaseModel](payload: str, model: type[Model]) -> Mod
     return model.model_validate_json(payload)
 
 
+def is_network_filesystem(path: Path) -> bool:
+    raw_path = str(path).replace("\\", "/")
+    if raw_path.startswith(_NETWORK_PATH_PREFIXES):
+        return True
+    try:
+        mounts = Path("/proc/self/mounts").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+    resolved = path.parent.resolve()
+    matches = []
+    for line in mounts:
+        fields = line.split()
+        if len(fields) >= 3 and resolved.is_relative_to(Path(fields[1])):
+            matches.append((len(fields[1]), fields[2]))
+    return bool(matches and max(matches)[1] in _NETWORK_FILESYSTEMS)
+
+
 def initialize_schema(connect: Callable[[], sqlite3.Connection], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     connection = connect()
     try:
-        connection.execute("PRAGMA journal_mode=WAL")
+        result = connection.execute("PRAGMA journal_mode=WAL").fetchone()
+        if result is None or str(result[0]).lower() != "wal":
+            raise _SQLiteWALUnavailable("sqlite_wal_unavailable")
         connection.executescript(_SCHEMA)
         connection.commit()
     finally:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -214,6 +214,7 @@ CREATE TABLE IF NOT EXISTS dataset_publications (
     dataset_name TEXT NOT NULL,
     version_id TEXT NOT NULL,
     data TEXT NOT NULL,
+    response_data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, dataset_name, version_id),
     FOREIGN KEY (tenant_id, dataset_name, version_id)
         REFERENCES dataset_versions (tenant_id, dataset_name, version_id) ON DELETE CASCADE

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -120,6 +120,14 @@ CREATE TABLE IF NOT EXISTS run_dispatches (
     PRIMARY KEY (tenant_id, run_id),
     UNIQUE (tenant_id, dispatch_id)
 );
+CREATE TABLE IF NOT EXISTS run_dispatch_wave_identities (
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    wave_id TEXT NOT NULL,
+    unit_ids TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, wave_id),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES runs (tenant_id, run_id) ON DELETE CASCADE
+);
 CREATE TABLE IF NOT EXISTS idempotency_records (
     tenant_id TEXT NOT NULL,
     scope TEXT NOT NULL,
@@ -261,6 +269,24 @@ def validate_run_unit_terminal_replay(
     if get_run_unit_terminal_write(connection, command) != canonical:
         raise Conflict("unit_terminal_conflict")
     return unit
+
+
+def validate_run_dispatch_wave(connection: Any, command: Any) -> None:
+    unit_ids = json.dumps(command.unit_ids, separators=(",", ":"))
+    row = connection.execute(
+        "SELECT unit_ids FROM run_dispatch_wave_identities "
+        "WHERE tenant_id = ? AND run_id = ? AND wave_id = ?",
+        (command.tenant_id, command.run_id, command.wave_id),
+    ).fetchone()
+    if row is not None:
+        if row[0] != unit_ids:
+            raise Conflict("dispatch_units_conflict")
+        return
+    connection.execute(
+        "INSERT INTO run_dispatch_wave_identities (tenant_id, run_id, wave_id, unit_ids) "
+        "VALUES (?, ?, ?, ?)",
+        (command.tenant_id, command.run_id, command.wave_id, unit_ids),
+    )
 
 
 def is_network_filesystem(path: Path) -> bool:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -111,6 +111,15 @@ CREATE TABLE IF NOT EXISTS dataset_versions (
     data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, dataset_name, version_id)
 );
+CREATE TABLE IF NOT EXISTS dataset_publications (
+    tenant_id TEXT NOT NULL,
+    dataset_name TEXT NOT NULL,
+    version_id TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, dataset_name, version_id),
+    FOREIGN KEY (tenant_id, dataset_name, version_id)
+        REFERENCES dataset_versions (tenant_id, dataset_name, version_id) ON DELETE CASCADE
+);
 CREATE TABLE IF NOT EXISTS dataset_pointers (
     tenant_id TEXT NOT NULL,
     dataset_name TEXT NOT NULL,

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
@@ -44,6 +44,15 @@ CREATE TABLE IF NOT EXISTS jobs (
 );
 CREATE INDEX IF NOT EXISTS ix_jobs_claimable
 ON jobs (tenant_id, agent_id, state, created_at, job_id);
+CREATE TABLE IF NOT EXISTS job_terminal_writes (
+    tenant_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    command_data TEXT NOT NULL,
+    event_data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, job_id),
+    FOREIGN KEY (tenant_id, job_id) REFERENCES jobs (tenant_id, job_id) ON DELETE CASCADE
+);
 CREATE TABLE IF NOT EXISTS raw_manifests (
     tenant_id TEXT NOT NULL,
     manifest_id TEXT NOT NULL,
@@ -155,6 +164,31 @@ def serialize_model(model: BaseModel) -> str:
 
 def deserialize_model[Model: BaseModel](payload: str, model: type[Model]) -> Model:
     return model.model_validate_json(payload)
+
+
+def get_job_terminal_write(
+    connection: Any, tenant_id: str, job_id: str
+) -> tuple[str, ...] | None:
+    row = connection.execute(
+        "SELECT operation, command_data, event_data FROM job_terminal_writes "
+        "WHERE tenant_id = ? AND job_id = ?",
+        (tenant_id, job_id),
+    ).fetchone()
+    return None if row is None else tuple(row)
+
+
+def put_job_terminal_write(connection: Any, operation: str, command: Any, event: Any) -> None:
+    connection.execute(
+        "INSERT INTO job_terminal_writes "
+        "(tenant_id, job_id, operation, command_data, event_data) VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT (tenant_id, job_id) DO UPDATE SET "
+        "operation = excluded.operation, command_data = excluded.command_data, "
+        "event_data = excluded.event_data",
+        (
+            command.tenant_id, command.job_id, operation,
+            serialize_model(command), serialize_model(event),
+        ),
+    )
 
 
 def is_network_filesystem(path: Path) -> bool:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -158,6 +158,14 @@ CREATE TABLE IF NOT EXISTS run_dispatch_terminal_writes (
     command_data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, run_id, dispatch_id)
 );
+CREATE TABLE IF NOT EXISTS run_cancellation_writes (
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    command_data TEXT NOT NULL,
+    event_data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, run_id),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES runs (tenant_id, run_id) ON DELETE CASCADE
+);
 CREATE TABLE IF NOT EXISTS idempotency_records (
     tenant_id TEXT NOT NULL,
     scope TEXT NOT NULL,
@@ -333,6 +341,25 @@ def validate_run_dispatch_finish(connection: Any, command: Any) -> None:
     ).fetchone()
     if row is None or row[0] != serialize_model(command):
         raise Conflict("dispatch_finish_conflict")
+
+
+def put_run_cancellation(connection: Any, command: Any, event: Any) -> None:
+    connection.execute(
+        "INSERT INTO run_cancellation_writes "
+        "(tenant_id, run_id, command_data, event_data) VALUES (?, ?, ?, ?)",
+        (command.tenant_id, command.run_id, serialize_model(command), serialize_model(event)),
+    )
+
+
+def validate_run_cancellation(connection: Any, command: Any, event: Any) -> None:
+    row = connection.execute(
+        "SELECT command_data, event_data FROM run_cancellation_writes "
+        "WHERE tenant_id = ? AND run_id = ?",
+        (command.tenant_id, command.run_id),
+    ).fetchone()
+    canonical = (serialize_model(command), serialize_model(event))
+    if row is None or tuple(row) != canonical:
+        raise Conflict("run_cancellation_conflict")
 
 
 def validate_run_dispatch_wave(connection: Any, command: Any) -> None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
-from cnes_domain.control_plane.entities import AccessRequest
-from cnes_domain.control_plane.enums import AccessRequestState, JobState
+from cnes_domain.control_plane.enums import JobState
 from cnes_domain.control_plane.errors import Conflict
 
 if TYPE_CHECKING:
@@ -458,41 +457,9 @@ def is_network_filesystem(path: Path) -> bool:
         if len(fields) >= 3 and resolved.is_relative_to(Path(fields[1])):
             matches.append((len(fields[1]), fields[2]))
     return bool(matches and max(matches)[1] in _NETWORK_FILESYSTEMS)
-def _migrate_schema(db: sqlite3.Connection) -> None:
-    job_columns = {row[1] for row in db.execute("PRAGMA table_info(job_creation_writes)")}
-    if "job_data" not in job_columns:
-        db.execute("ALTER TABLE job_creation_writes ADD COLUMN job_data TEXT")
-    db.execute(
-        "UPDATE job_creation_writes SET job_data = (SELECT data FROM jobs WHERE "
-        "jobs.tenant_id = job_creation_writes.tenant_id "
-        "AND jobs.job_id = job_creation_writes.job_id) WHERE job_data IS NULL")
-    run_columns = {row[1] for row in db.execute("PRAGMA table_info(runs)")}
-    if "unit_registry_data" not in run_columns:
-        db.execute("ALTER TABLE runs ADD COLUMN unit_registry_data TEXT")
-    access_columns = {row[1] for row in db.execute("PRAGMA table_info(access_requests)")}
-    if "creation_request_data" not in access_columns:
-        db.execute("ALTER TABLE access_requests ADD COLUMN creation_request_data TEXT")
-    for tenant_id, request_id, data in db.execute(
-        "SELECT tenant_id, request_id, data FROM access_requests "
-        "WHERE creation_request_data IS NULL"):
-        current = deserialize_model(data, AccessRequest)
-        original = current.model_copy(update={"state": AccessRequestState.PENDING,
-            "decided_by": None, "decided_at": None})
-        db.execute(
-            "UPDATE access_requests SET creation_request_data = ? WHERE "
-            "tenant_id = ? AND request_id = ?",
-            (serialize_model(original), tenant_id, request_id))
-    rows = db.execute(
-        "SELECT tenant_id, run_id FROM runs WHERE unit_registry_data IS NULL").fetchall()
-    for tenant_id, run_id in rows:
-        units = db.execute(
-            "SELECT data FROM run_units WHERE tenant_id = ? AND run_id = ? ORDER BY unit_id",
-            (tenant_id, run_id)).fetchall()
-        if units:
-            db.execute(
-                "UPDATE runs SET unit_registry_data = ? WHERE tenant_id = ? AND run_id = ?",
-                ("\x1e".join(row[0] for row in units), tenant_id, run_id))
 def initialize_schema(connect: Callable[[], sqlite3.Connection], path: Path) -> None:
+    from cnes_infra.control_plane.sqlite_migration import migrate_schema
+
     path.parent.mkdir(parents=True, exist_ok=True)
     connection = connect()
     try:
@@ -500,7 +467,7 @@ def initialize_schema(connect: Callable[[], sqlite3.Connection], path: Path) -> 
         if result is None or str(result[0]).lower() != "wal":
             raise _SQLiteWALUnavailable("sqlite_wal_unavailable")
         connection.executescript(_SCHEMA)
-        _migrate_schema(connection)
+        migrate_schema(connection)
         connection.commit()
     finally:
         connection.close()

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -1,0 +1,152 @@
+"""SQLite control-plane schema and serialization."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    import sqlite3
+    from collections.abc import Callable
+    from pathlib import Path
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS tenants (
+    tenant_id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS memberships (
+    tenant_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, user_id)
+);
+CREATE TABLE IF NOT EXISTS agents (
+    tenant_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    state TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, agent_id)
+);
+CREATE TABLE IF NOT EXISTS jobs (
+    tenant_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    file_subtype TEXT NOT NULL,
+    competencia TEXT NOT NULL,
+    state TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, job_id)
+);
+CREATE INDEX IF NOT EXISTS ix_jobs_claimable
+ON jobs (tenant_id, agent_id, state, created_at, job_id);
+CREATE TABLE IF NOT EXISTS raw_manifests (
+    tenant_id TEXT NOT NULL,
+    manifest_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    file_subtype TEXT NOT NULL,
+    competencia TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, manifest_id)
+);
+CREATE TABLE IF NOT EXISTS runs (
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    competencia TEXT NOT NULL,
+    dataset_name TEXT NOT NULL,
+    state TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, run_id)
+);
+CREATE TABLE IF NOT EXISTS run_dependencies (
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    file_subtype TEXT NOT NULL,
+    required INTEGER NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, source_type, file_subtype),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES runs (tenant_id, run_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS run_units (
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    unit_id TEXT NOT NULL,
+    state TEXT NOT NULL,
+    lease_until TEXT,
+    dispatch_id TEXT,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, unit_id),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES runs (tenant_id, run_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS run_dispatches (
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    dispatch_id TEXT NOT NULL,
+    wave_id TEXT NOT NULL,
+    generation INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    lease_until TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, run_id),
+    UNIQUE (tenant_id, dispatch_id)
+);
+CREATE TABLE IF NOT EXISTS idempotency_records (
+    tenant_id TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    key TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, scope, key)
+);
+CREATE TABLE IF NOT EXISTS dataset_versions (
+    tenant_id TEXT NOT NULL,
+    dataset_name TEXT NOT NULL,
+    version_id TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, dataset_name, version_id)
+);
+CREATE TABLE IF NOT EXISTS dataset_pointers (
+    tenant_id TEXT NOT NULL,
+    dataset_name TEXT NOT NULL,
+    pointer_name TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, dataset_name, pointer_name)
+);
+CREATE TABLE IF NOT EXISTS access_requests (
+    tenant_id TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, request_id)
+);
+CREATE TABLE IF NOT EXISTS outbox_events (
+    event_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    delivered_at TEXT,
+    data TEXT NOT NULL
+);
+"""
+
+def serialize_model(model: BaseModel) -> str:
+    return json.dumps(model.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+
+
+def deserialize_model[Model: BaseModel](payload: str, model: type[Model]) -> Model:
+    return model.model_validate_json(payload)
+
+
+def initialize_schema(connect: Callable[[], sqlite3.Connection], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = connect()
+    try:
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.executescript(_SCHEMA)
+        connection.commit()
+    finally:
+        connection.close()

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -108,6 +108,15 @@ CREATE TABLE IF NOT EXISTS runs (
     data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, run_id)
 );
+CREATE TABLE IF NOT EXISTS run_transition_writes (
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    expected_state TEXT NOT NULL,
+    command_data TEXT NOT NULL,
+    event_data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, expected_state),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES runs (tenant_id, run_id) ON DELETE CASCADE
+);
 CREATE TABLE IF NOT EXISTS run_dependencies (
     tenant_id TEXT NOT NULL,
     run_id TEXT NOT NULL,
@@ -290,6 +299,25 @@ def validate_access_request_decision(connection: Any, request: Any, event: Any) 
     ).fetchone()
     if row is None or row[0] != serialize_model(event):
         raise Conflict("access_request_decision_conflict")
+
+
+def put_run_transition(connection: Any, command: Any, event: Any) -> None:
+    connection.execute(
+        "INSERT INTO run_transition_writes "
+        "(tenant_id, run_id, expected_state, command_data, event_data) VALUES (?, ?, ?, ?, ?)",
+        (command.tenant_id, command.run_id, command.expected_state.value,
+         serialize_model(command), serialize_model(event)),
+    )
+
+
+def validate_run_transition(connection: Any, command: Any, event: Any) -> None:
+    row = connection.execute(
+        "SELECT command_data, event_data FROM run_transition_writes "
+        "WHERE tenant_id = ? AND run_id = ? AND expected_state = ?",
+        (command.tenant_id, command.run_id, command.expected_state.value),
+    ).fetchone()
+    if row is None or tuple(row) != (serialize_model(command), serialize_model(event)):
+        raise Conflict("run_transition_conflict")
 
 
 def get_job_terminal_write(

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -168,6 +168,15 @@ CREATE TABLE IF NOT EXISTS run_dispatch_wave_identities (
     PRIMARY KEY (tenant_id, run_id, wave_id),
     FOREIGN KEY (tenant_id, run_id) REFERENCES runs (tenant_id, run_id) ON DELETE CASCADE
 );
+CREATE TABLE IF NOT EXISTS run_dispatch_bind_writes (
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    dispatch_id TEXT NOT NULL,
+    command_data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, dispatch_id),
+    FOREIGN KEY (tenant_id, run_id)
+        REFERENCES run_dispatches (tenant_id, run_id) ON DELETE CASCADE
+);
 CREATE TABLE IF NOT EXISTS run_dispatch_terminal_writes (
     tenant_id TEXT NOT NULL,
     run_id TEXT NOT NULL,
@@ -266,14 +275,12 @@ def validate_job_creation_replay(connection: Any, job: Any, event: Any) -> None:
     if row is None or row[0] != serialize_model(event):
         raise Conflict("job_creation_conflict")
 
-
 def put_job_cancellation(connection: Any, command: Any, event: Any) -> None:
     connection.execute(
         "INSERT INTO job_cancellation_writes "
         "(tenant_id, job_id, command_data, event_data) VALUES (?, ?, ?, ?)",
         (command.tenant_id, command.job_id, serialize_model(command), serialize_model(event)),
     )
-
 
 def validate_job_cancellation(connection: Any, command: Any, event: Any) -> None:
     row = connection.execute(
@@ -283,14 +290,12 @@ def validate_job_cancellation(connection: Any, command: Any, event: Any) -> None
     if row is None or tuple(row) != (serialize_model(command), serialize_model(event)):
         raise Conflict("job_cancellation_conflict")
 
-
 def put_access_request_decision(connection: Any, request: Any, event: Any) -> None:
     connection.execute(
         "INSERT INTO access_request_decision_writes "
         "(tenant_id, request_id, event_data) VALUES (?, ?, ?)",
         (request.tenant_id, request.request_id, serialize_model(event)),
     )
-
 
 def validate_access_request_decision(connection: Any, request: Any, event: Any) -> None:
     row = connection.execute(
@@ -300,7 +305,6 @@ def validate_access_request_decision(connection: Any, request: Any, event: Any) 
     if row is None or row[0] != serialize_model(event):
         raise Conflict("access_request_decision_conflict")
 
-
 def put_run_transition(connection: Any, command: Any, event: Any) -> None:
     connection.execute(
         "INSERT INTO run_transition_writes "
@@ -308,7 +312,6 @@ def put_run_transition(connection: Any, command: Any, event: Any) -> None:
         (command.tenant_id, command.run_id, command.expected_state.value,
          serialize_model(command), serialize_model(event)),
     )
-
 
 def validate_run_transition(connection: Any, command: Any, event: Any) -> None:
     row = connection.execute(
@@ -319,7 +322,6 @@ def validate_run_transition(connection: Any, command: Any, event: Any) -> None:
     if row is None or tuple(row) != (serialize_model(command), serialize_model(event)):
         raise Conflict("run_transition_conflict")
 
-
 def get_job_terminal_write(
     connection: Any, tenant_id: str, job_id: str
 ) -> tuple[str, ...] | None:
@@ -329,7 +331,6 @@ def get_job_terminal_write(
         (tenant_id, job_id),
     ).fetchone()
     return None if row is None else tuple(row)
-
 
 def put_job_terminal_write(connection: Any, operation: str, command: Any, event: Any) -> None:
     connection.execute(
@@ -343,7 +344,6 @@ def put_job_terminal_write(connection: Any, operation: str, command: Any, event:
             serialize_model(command), serialize_model(event),
         ),
     )
-
 
 def validate_job_terminal_replay(connection: Any, job: Any, command: Any, event: Any) -> None:
     manifest = getattr(command, "manifest", None)
@@ -367,7 +367,6 @@ def validate_job_terminal_replay(connection: Any, job: Any, command: Any, event:
     if current != canonical or not result_matches:
         raise Conflict("job_terminal_conflict")
 
-
 def get_run_unit_terminal_write(connection: Any, command: Any) -> tuple[str, ...] | None:
     row = connection.execute(
         "SELECT operation, command_data, event_data FROM run_unit_terminal_writes "
@@ -375,7 +374,6 @@ def get_run_unit_terminal_write(connection: Any, command: Any) -> tuple[str, ...
         (command.tenant_id, command.run_id, command.unit_id),
     ).fetchone()
     return None if row is None else tuple(row)
-
 
 def put_run_unit_terminal_write(
     connection: Any, operation: str, command: Any, event: Any
@@ -392,7 +390,6 @@ def put_run_unit_terminal_write(
         ),
     )
 
-
 def validate_run_unit_terminal_replay(
     connection: Any, unit: Any, command: Any, event: Any
 ) -> Any:
@@ -402,7 +399,6 @@ def validate_run_unit_terminal_replay(
         raise Conflict("unit_terminal_conflict")
     return unit
 
-
 def put_run_dispatch_finish(connection: Any, command: Any) -> None:
     connection.execute(
         "INSERT INTO run_dispatch_terminal_writes "
@@ -410,6 +406,21 @@ def put_run_dispatch_finish(connection: Any, command: Any) -> None:
         (command.tenant_id, command.run_id, command.dispatch_id, serialize_model(command)),
     )
 
+def put_run_dispatch_bind(connection: Any, command: Any) -> None:
+    connection.execute(
+        "INSERT INTO run_dispatch_bind_writes "
+        "(tenant_id, run_id, dispatch_id, command_data) VALUES (?, ?, ?, ?)",
+        (command.tenant_id, command.run_id, command.dispatch_id, serialize_model(command)),
+    )
+
+def validate_run_dispatch_bind(connection: Any, command: Any) -> None:
+    row = connection.execute(
+        "SELECT command_data FROM run_dispatch_bind_writes "
+        "WHERE tenant_id = ? AND run_id = ? AND dispatch_id = ?",
+        (command.tenant_id, command.run_id, command.dispatch_id),
+    ).fetchone()
+    if row is None or row[0] != serialize_model(command):
+        raise Conflict("dispatch_bind_conflict")
 
 def validate_run_dispatch_finish(connection: Any, command: Any) -> None:
     row = connection.execute(

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -51,6 +51,7 @@ ON jobs (tenant_id, agent_id, state, lease_until, created_at, job_id);
 CREATE TABLE IF NOT EXISTS job_creation_writes (
     tenant_id TEXT NOT NULL,
     job_id TEXT NOT NULL,
+    job_data TEXT NOT NULL,
     event_data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, job_id),
     FOREIGN KEY (tenant_id, job_id) REFERENCES jobs (tenant_id, job_id) ON DELETE CASCADE
@@ -106,6 +107,7 @@ CREATE TABLE IF NOT EXISTS runs (
     state TEXT NOT NULL,
     created_at TEXT NOT NULL,
     data TEXT NOT NULL,
+    unit_registry_data TEXT,
     PRIMARY KEY (tenant_id, run_id)
 );
 CREATE TABLE IF NOT EXISTS run_transition_writes (
@@ -263,19 +265,19 @@ def deserialize_model[Model: BaseModel](payload: str, model: type[Model]) -> Mod
 
 def put_job_creation_write(connection: Any, job: Any, event: Any) -> None:
     connection.execute(
-        "INSERT INTO job_creation_writes (tenant_id, job_id, event_data) VALUES (?, ?, ?)",
-        (job.tenant_id, job.job_id, serialize_model(event)),
+        "INSERT INTO job_creation_writes (tenant_id, job_id, job_data, event_data) "
+        "VALUES (?, ?, ?, ?)",
+        (job.tenant_id, job.job_id, serialize_model(job), serialize_model(event)),
     )
 
 
 def validate_job_creation_replay(connection: Any, job: Any, event: Any) -> None:
     row = connection.execute(
-        "SELECT event_data FROM job_creation_writes WHERE tenant_id = ? AND job_id = ?",
+        "SELECT job_data, event_data FROM job_creation_writes WHERE tenant_id = ? AND job_id = ?",
         (job.tenant_id, job.job_id),
     ).fetchone()
-    if row is None or row[0] != serialize_model(event):
+    if row is None or tuple(row) != (serialize_model(job), serialize_model(event)):
         raise Conflict("job_creation_conflict")
-
 def put_job_cancellation(connection: Any, command: Any, event: Any) -> None:
     connection.execute(
         "INSERT INTO job_cancellation_writes "
@@ -290,7 +292,6 @@ def validate_job_cancellation(connection: Any, command: Any, event: Any) -> None
     ).fetchone()
     if row is None or tuple(row) != (serialize_model(command), serialize_model(event)):
         raise Conflict("job_cancellation_conflict")
-
 def put_access_request_decision(connection: Any, request: Any, event: Any) -> None:
     connection.execute(
         "INSERT INTO access_request_decision_writes "
@@ -431,8 +432,6 @@ def validate_run_dispatch_finish(connection: Any, command: Any) -> None:
     ).fetchone()
     if row is None or row[0] != serialize_model(command):
         raise Conflict("dispatch_finish_conflict")
-
-
 def put_run_cancellation(connection: Any, command: Any, event: Any) -> None:
     connection.execute(
         "INSERT INTO run_cancellation_writes "

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
-from cnes_domain.control_plane.entities import RunDispatch
 from cnes_domain.control_plane.enums import JobState
 from cnes_domain.control_plane.errors import Conflict
 
@@ -185,6 +184,7 @@ CREATE TABLE IF NOT EXISTS run_dispatch_terminal_writes (
     run_id TEXT NOT NULL,
     dispatch_id TEXT NOT NULL,
     command_data TEXT NOT NULL,
+    response_data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, run_id, dispatch_id)
 );
 CREATE TABLE IF NOT EXISTS run_cancellation_writes (
@@ -387,45 +387,6 @@ def validate_run_unit_terminal_replay(
     if get_run_unit_terminal_write(connection, command) != canonical:
         raise Conflict("unit_terminal_conflict")
     return unit
-def put_run_dispatch_finish(connection: Any, command: Any) -> None:
-    connection.execute(
-        "INSERT INTO run_dispatch_terminal_writes "
-        "(tenant_id, run_id, dispatch_id, command_data) VALUES (?, ?, ?, ?)",
-        (command.tenant_id, command.run_id, command.dispatch_id, serialize_model(command)),
-    )
-def put_run_dispatch_bind(connection: Any, command: Any, dispatch: Any) -> None:
-    connection.execute(
-        "INSERT INTO run_dispatch_bind_writes "
-        "(tenant_id, run_id, dispatch_id, command_data, response_data) VALUES (?, ?, ?, ?, ?)",
-        (
-            command.tenant_id,
-            command.run_id,
-            command.dispatch_id,
-            serialize_model(command),
-            serialize_model(dispatch),
-        ),
-    )
-
-
-def validate_run_dispatch_bind(connection: Any, command: Any) -> RunDispatch | None:
-    row = connection.execute(
-        "SELECT command_data, response_data FROM run_dispatch_bind_writes "
-        "WHERE tenant_id = ? AND run_id = ? AND dispatch_id = ?",
-        (command.tenant_id, command.run_id, command.dispatch_id),
-    ).fetchone()
-    if row is None:
-        return None
-    if row[0] != serialize_model(command):
-        raise Conflict("dispatch_bind_conflict")
-    return None if row[1] is None else deserialize_model(row[1], RunDispatch)
-def validate_run_dispatch_finish(connection: Any, command: Any) -> None:
-    row = connection.execute(
-        "SELECT command_data FROM run_dispatch_terminal_writes "
-        "WHERE tenant_id = ? AND run_id = ? AND dispatch_id = ?",
-        (command.tenant_id, command.run_id, command.dispatch_id),
-    ).fetchone()
-    if row is None or row[0] != serialize_model(command):
-        raise Conflict("dispatch_finish_conflict")
 def put_run_cancellation(connection: Any, command: Any, event: Any) -> None:
     connection.execute(
         "INSERT INTO run_cancellation_writes "

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -75,7 +75,7 @@ CREATE TABLE IF NOT EXISTS raw_manifests (
 CREATE INDEX IF NOT EXISTS ix_raw_manifest_heads
 ON raw_manifests (
     tenant_id, source_type, file_subtype, competencia,
-    created_at DESC, agent_id DESC, snapshot_id DESC
+    created_at DESC, agent_id DESC, snapshot_id DESC, manifest_id DESC
 );
 CREATE INDEX IF NOT EXISTS ix_raw_manifest_ancestry
 ON raw_manifests (

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
+from cnes_domain.control_plane.entities import RunDispatch
 from cnes_domain.control_plane.enums import JobState
 from cnes_domain.control_plane.errors import Conflict
 
@@ -174,6 +175,7 @@ CREATE TABLE IF NOT EXISTS run_dispatch_bind_writes (
     run_id TEXT NOT NULL,
     dispatch_id TEXT NOT NULL,
     command_data TEXT NOT NULL,
+    response_data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, run_id, dispatch_id),
     FOREIGN KEY (tenant_id, run_id)
         REFERENCES run_dispatches (tenant_id, run_id) ON DELETE CASCADE
@@ -246,6 +248,8 @@ CREATE TABLE IF NOT EXISTS outbox_events (
     delivered_at TEXT,
     data TEXT NOT NULL
 );
+CREATE INDEX IF NOT EXISTS ix_outbox_pending
+ON outbox_events (created_at, event_id) WHERE delivered_at IS NULL;
 """
 _NETWORK_FILESYSTEMS = {"9p", "afs", "cifs", "fuse.sshfs", "nfs", "nfs4", "smbfs"}
 _NETWORK_PATH_PREFIXES = ("//", "smb:/", "nfs:/", "afp:/", "/net/", "/Network/Servers/")
@@ -389,20 +393,31 @@ def put_run_dispatch_finish(connection: Any, command: Any) -> None:
         "(tenant_id, run_id, dispatch_id, command_data) VALUES (?, ?, ?, ?)",
         (command.tenant_id, command.run_id, command.dispatch_id, serialize_model(command)),
     )
-def put_run_dispatch_bind(connection: Any, command: Any) -> None:
+def put_run_dispatch_bind(connection: Any, command: Any, dispatch: Any) -> None:
     connection.execute(
         "INSERT INTO run_dispatch_bind_writes "
-        "(tenant_id, run_id, dispatch_id, command_data) VALUES (?, ?, ?, ?)",
-        (command.tenant_id, command.run_id, command.dispatch_id, serialize_model(command)),
+        "(tenant_id, run_id, dispatch_id, command_data, response_data) VALUES (?, ?, ?, ?, ?)",
+        (
+            command.tenant_id,
+            command.run_id,
+            command.dispatch_id,
+            serialize_model(command),
+            serialize_model(dispatch),
+        ),
     )
-def validate_run_dispatch_bind(connection: Any, command: Any) -> None:
+
+
+def validate_run_dispatch_bind(connection: Any, command: Any) -> RunDispatch | None:
     row = connection.execute(
-        "SELECT command_data FROM run_dispatch_bind_writes "
+        "SELECT command_data, response_data FROM run_dispatch_bind_writes "
         "WHERE tenant_id = ? AND run_id = ? AND dispatch_id = ?",
         (command.tenant_id, command.run_id, command.dispatch_id),
     ).fetchone()
-    if row is None or row[0] != serialize_model(command):
+    if row is None:
+        return None
+    if row[0] != serialize_model(command):
         raise Conflict("dispatch_bind_conflict")
+    return None if row[1] is None else deserialize_model(row[1], RunDispatch)
 def validate_run_dispatch_finish(connection: Any, command: Any) -> None:
     row = connection.execute(
         "SELECT command_data FROM run_dispatch_terminal_writes "

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -1,5 +1,4 @@
 """SQLite control-plane schema and serialization."""
-
 from __future__ import annotations
 
 import json
@@ -452,7 +451,7 @@ def is_network_filesystem(path: Path) -> bool:
         mounts = Path("/proc/self/mounts").read_text(encoding="utf-8").splitlines()
     except OSError:
         return False
-    resolved = path.parent.resolve()
+    resolved = path.resolve()
     matches = []
     for line in mounts:
         fields = line.split()

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.errors import Conflict
+
 if TYPE_CHECKING:
     import sqlite3
     from collections.abc import Callable
@@ -93,6 +96,17 @@ CREATE TABLE IF NOT EXISTS run_units (
     data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, run_id, unit_id),
     FOREIGN KEY (tenant_id, run_id) REFERENCES runs (tenant_id, run_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS run_unit_terminal_writes (
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    unit_id TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    command_data TEXT NOT NULL,
+    event_data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, unit_id),
+    FOREIGN KEY (tenant_id, run_id, unit_id)
+        REFERENCES run_units (tenant_id, run_id, unit_id) ON DELETE CASCADE
 );
 CREATE TABLE IF NOT EXISTS run_dispatches (
     tenant_id TEXT NOT NULL,
@@ -189,6 +203,64 @@ def put_job_terminal_write(connection: Any, operation: str, command: Any, event:
             serialize_model(command), serialize_model(event),
         ),
     )
+
+
+def validate_job_terminal_replay(connection: Any, job: Any, command: Any, event: Any) -> None:
+    manifest = getattr(command, "manifest", None)
+    operation = "complete" if manifest is not None else "fail"
+    canonical = (operation, serialize_model(command), serialize_model(event))
+    current = get_job_terminal_write(connection, command.tenant_id, command.job_id)
+    if manifest is not None:
+        result_matches = (
+            job.state is JobState.SUCCEEDED
+            and job.fencing_token == command.fencing_token
+            and job.result_manifest_id == manifest.manifest_id
+            and job.result_manifest_key == manifest.manifest_key
+        )
+    else:
+        expected = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
+        result_matches = (
+            job.state is expected
+            and job.fencing_token == command.fencing_token
+            and job.error_code == command.error_code
+        )
+    if current != canonical or not result_matches:
+        raise Conflict("job_terminal_conflict")
+
+
+def get_run_unit_terminal_write(connection: Any, command: Any) -> tuple[str, ...] | None:
+    row = connection.execute(
+        "SELECT operation, command_data, event_data FROM run_unit_terminal_writes "
+        "WHERE tenant_id = ? AND run_id = ? AND unit_id = ?",
+        (command.tenant_id, command.run_id, command.unit_id),
+    ).fetchone()
+    return None if row is None else tuple(row)
+
+
+def put_run_unit_terminal_write(
+    connection: Any, operation: str, command: Any, event: Any
+) -> None:
+    connection.execute(
+        "INSERT INTO run_unit_terminal_writes "
+        "(tenant_id, run_id, unit_id, operation, command_data, event_data) "
+        "VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT (tenant_id, run_id, unit_id) DO UPDATE SET "
+        "operation = excluded.operation, command_data = excluded.command_data, "
+        "event_data = excluded.event_data",
+        (
+            command.tenant_id, command.run_id, command.unit_id, operation,
+            serialize_model(command), serialize_model(event),
+        ),
+    )
+
+
+def validate_run_unit_terminal_replay(
+    connection: Any, unit: Any, command: Any, event: Any
+) -> Any:
+    operation = "commit" if hasattr(command, "output_manifests") else "fail"
+    canonical = (operation, serialize_model(command), serialize_model(event))
+    if get_run_unit_terminal_write(connection, command) != canonical:
+        raise Conflict("unit_terminal_conflict")
+    return unit
 
 
 def is_network_filesystem(path: Path) -> bool:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -41,12 +41,20 @@ CREATE TABLE IF NOT EXISTS jobs (
     file_subtype TEXT NOT NULL,
     competencia TEXT NOT NULL,
     state TEXT NOT NULL,
+    lease_until TEXT,
     created_at TEXT NOT NULL,
     data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, job_id)
 );
-CREATE INDEX IF NOT EXISTS ix_jobs_claimable
-ON jobs (tenant_id, agent_id, state, created_at, job_id);
+CREATE INDEX IF NOT EXISTS ix_jobs_claimable_v2
+ON jobs (tenant_id, agent_id, state, lease_until, created_at, job_id);
+CREATE TABLE IF NOT EXISTS job_creation_writes (
+    tenant_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    event_data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, job_id),
+    FOREIGN KEY (tenant_id, job_id) REFERENCES jobs (tenant_id, job_id) ON DELETE CASCADE
+);
 CREATE TABLE IF NOT EXISTS job_terminal_writes (
     tenant_id TEXT NOT NULL,
     job_id TEXT NOT NULL,
@@ -143,6 +151,13 @@ CREATE TABLE IF NOT EXISTS run_dispatch_wave_identities (
     PRIMARY KEY (tenant_id, run_id, wave_id),
     FOREIGN KEY (tenant_id, run_id) REFERENCES runs (tenant_id, run_id) ON DELETE CASCADE
 );
+CREATE TABLE IF NOT EXISTS run_dispatch_terminal_writes (
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    dispatch_id TEXT NOT NULL,
+    command_data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, dispatch_id)
+);
 CREATE TABLE IF NOT EXISTS idempotency_records (
     tenant_id TEXT NOT NULL,
     scope TEXT NOT NULL,
@@ -201,6 +216,22 @@ def serialize_model(model: BaseModel) -> str:
 
 def deserialize_model[Model: BaseModel](payload: str, model: type[Model]) -> Model:
     return model.model_validate_json(payload)
+
+
+def put_job_creation_write(connection: Any, job: Any, event: Any) -> None:
+    connection.execute(
+        "INSERT INTO job_creation_writes (tenant_id, job_id, event_data) VALUES (?, ?, ?)",
+        (job.tenant_id, job.job_id, serialize_model(event)),
+    )
+
+
+def validate_job_creation_replay(connection: Any, job: Any, event: Any) -> None:
+    row = connection.execute(
+        "SELECT event_data FROM job_creation_writes WHERE tenant_id = ? AND job_id = ?",
+        (job.tenant_id, job.job_id),
+    ).fetchone()
+    if row is None or row[0] != serialize_model(event):
+        raise Conflict("job_creation_conflict")
 
 
 def get_job_terminal_write(
@@ -284,6 +315,24 @@ def validate_run_unit_terminal_replay(
     if get_run_unit_terminal_write(connection, command) != canonical:
         raise Conflict("unit_terminal_conflict")
     return unit
+
+
+def put_run_dispatch_finish(connection: Any, command: Any) -> None:
+    connection.execute(
+        "INSERT INTO run_dispatch_terminal_writes "
+        "(tenant_id, run_id, dispatch_id, command_data) VALUES (?, ?, ?, ?)",
+        (command.tenant_id, command.run_id, command.dispatch_id, serialize_model(command)),
+    )
+
+
+def validate_run_dispatch_finish(connection: Any, command: Any) -> None:
+    row = connection.execute(
+        "SELECT command_data FROM run_dispatch_terminal_writes "
+        "WHERE tenant_id = ? AND run_id = ? AND dispatch_id = ?",
+        (command.tenant_id, command.run_id, command.dispatch_id),
+    ).fetchone()
+    if row is None or row[0] != serialize_model(command):
+        raise Conflict("dispatch_finish_conflict")
 
 
 def validate_run_dispatch_wave(connection: Any, command: Any) -> None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -64,6 +64,14 @@ CREATE TABLE IF NOT EXISTS job_terminal_writes (
     PRIMARY KEY (tenant_id, job_id),
     FOREIGN KEY (tenant_id, job_id) REFERENCES jobs (tenant_id, job_id) ON DELETE CASCADE
 );
+CREATE TABLE IF NOT EXISTS job_cancellation_writes (
+    tenant_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    command_data TEXT NOT NULL,
+    event_data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, job_id),
+    FOREIGN KEY (tenant_id, job_id) REFERENCES jobs (tenant_id, job_id) ON DELETE CASCADE
+);
 CREATE TABLE IF NOT EXISTS raw_manifests (
     tenant_id TEXT NOT NULL,
     manifest_id TEXT NOT NULL,
@@ -202,6 +210,14 @@ CREATE TABLE IF NOT EXISTS access_requests (
     data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, request_id)
 );
+CREATE TABLE IF NOT EXISTS access_request_decision_writes (
+    tenant_id TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    event_data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, request_id),
+    FOREIGN KEY (tenant_id, request_id)
+        REFERENCES access_requests (tenant_id, request_id) ON DELETE CASCADE
+);
 CREATE TABLE IF NOT EXISTS outbox_events (
     event_id TEXT PRIMARY KEY,
     tenant_id TEXT NOT NULL,
@@ -240,6 +256,40 @@ def validate_job_creation_replay(connection: Any, job: Any, event: Any) -> None:
     ).fetchone()
     if row is None or row[0] != serialize_model(event):
         raise Conflict("job_creation_conflict")
+
+
+def put_job_cancellation(connection: Any, command: Any, event: Any) -> None:
+    connection.execute(
+        "INSERT INTO job_cancellation_writes "
+        "(tenant_id, job_id, command_data, event_data) VALUES (?, ?, ?, ?)",
+        (command.tenant_id, command.job_id, serialize_model(command), serialize_model(event)),
+    )
+
+
+def validate_job_cancellation(connection: Any, command: Any, event: Any) -> None:
+    row = connection.execute(
+        "SELECT command_data, event_data FROM job_cancellation_writes "
+        "WHERE tenant_id = ? AND job_id = ?", (command.tenant_id, command.job_id),
+    ).fetchone()
+    if row is None or tuple(row) != (serialize_model(command), serialize_model(event)):
+        raise Conflict("job_cancellation_conflict")
+
+
+def put_access_request_decision(connection: Any, request: Any, event: Any) -> None:
+    connection.execute(
+        "INSERT INTO access_request_decision_writes "
+        "(tenant_id, request_id, event_data) VALUES (?, ?, ?)",
+        (request.tenant_id, request.request_id, serialize_model(event)),
+    )
+
+
+def validate_access_request_decision(connection: Any, request: Any, event: Any) -> None:
+    row = connection.execute(
+        "SELECT event_data FROM access_request_decision_writes "
+        "WHERE tenant_id = ? AND request_id = ?", (request.tenant_id, request.request_id),
+    ).fetchone()
+    if row is None or row[0] != serialize_model(event):
+        raise Conflict("access_request_decision_conflict")
 
 
 def get_job_terminal_write(

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
-from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.entities import AccessRequest
+from cnes_domain.control_plane.enums import AccessRequestState, JobState
 from cnes_domain.control_plane.errors import Conflict
 
 if TYPE_CHECKING:
@@ -228,6 +229,7 @@ CREATE TABLE IF NOT EXISTS access_requests (
     tenant_id TEXT NOT NULL,
     request_id TEXT NOT NULL,
     data TEXT NOT NULL,
+    creation_request_data TEXT NOT NULL,
     creation_event_data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, request_id)
 );
@@ -301,14 +303,17 @@ def put_run_transition(connection: Any, command: Any, event: Any) -> None:
         (command.tenant_id, command.run_id, command.expected_state.value,
          serialize_model(command), serialize_model(event)),
     )
-def validate_run_transition(connection: Any, command: Any, event: Any) -> None:
+def validate_run_transition(connection: Any, command: Any, event: Any) -> bool:
     row = connection.execute(
         "SELECT command_data, event_data FROM run_transition_writes "
         "WHERE tenant_id = ? AND run_id = ? AND expected_state = ?",
         (command.tenant_id, command.run_id, command.expected_state.value),
     ).fetchone()
-    if row is None or tuple(row) != (serialize_model(command), serialize_model(event)):
+    if row is None:
+        return False
+    if tuple(row) != (serialize_model(command), serialize_model(event)):
         raise Conflict("run_transition_conflict")
+    return True
 def get_job_terminal_write(
     connection: Any, tenant_id: str, job_id: str
 ) -> tuple[str, ...] | None:
@@ -454,22 +459,38 @@ def is_network_filesystem(path: Path) -> bool:
         if len(fields) >= 3 and resolved.is_relative_to(Path(fields[1])):
             matches.append((len(fields[1]), fields[2]))
     return bool(matches and max(matches)[1] in _NETWORK_FILESYSTEMS)
-def _migrate_schema(connection: sqlite3.Connection) -> None:
-    job_columns = {row[1] for row in connection.execute(
-        "PRAGMA table_info(job_creation_writes)")}
+def _migrate_schema(db: sqlite3.Connection) -> None:
+    job_columns = {row[1] for row in db.execute("PRAGMA table_info(job_creation_writes)")}
     if "job_data" not in job_columns:
-        connection.execute("ALTER TABLE job_creation_writes ADD COLUMN job_data TEXT")
-    run_columns = {row[1] for row in connection.execute("PRAGMA table_info(runs)")}
+        db.execute("ALTER TABLE job_creation_writes ADD COLUMN job_data TEXT")
+    db.execute(
+        "UPDATE job_creation_writes SET job_data = (SELECT data FROM jobs WHERE "
+        "jobs.tenant_id = job_creation_writes.tenant_id "
+        "AND jobs.job_id = job_creation_writes.job_id) WHERE job_data IS NULL")
+    run_columns = {row[1] for row in db.execute("PRAGMA table_info(runs)")}
     if "unit_registry_data" not in run_columns:
-        connection.execute("ALTER TABLE runs ADD COLUMN unit_registry_data TEXT")
-    rows = connection.execute(
+        db.execute("ALTER TABLE runs ADD COLUMN unit_registry_data TEXT")
+    access_columns = {row[1] for row in db.execute("PRAGMA table_info(access_requests)")}
+    if "creation_request_data" not in access_columns:
+        db.execute("ALTER TABLE access_requests ADD COLUMN creation_request_data TEXT")
+    for tenant_id, request_id, data in db.execute(
+        "SELECT tenant_id, request_id, data FROM access_requests "
+        "WHERE creation_request_data IS NULL"):
+        current = deserialize_model(data, AccessRequest)
+        original = current.model_copy(update={"state": AccessRequestState.PENDING,
+            "decided_by": None, "decided_at": None})
+        db.execute(
+            "UPDATE access_requests SET creation_request_data = ? WHERE "
+            "tenant_id = ? AND request_id = ?",
+            (serialize_model(original), tenant_id, request_id))
+    rows = db.execute(
         "SELECT tenant_id, run_id FROM runs WHERE unit_registry_data IS NULL").fetchall()
     for tenant_id, run_id in rows:
-        units = connection.execute(
+        units = db.execute(
             "SELECT data FROM run_units WHERE tenant_id = ? AND run_id = ? ORDER BY unit_id",
             (tenant_id, run_id)).fetchall()
         if units:
-            connection.execute(
+            db.execute(
                 "UPDATE runs SET unit_registry_data = ? WHERE tenant_id = ? AND run_id = ?",
                 ("\x1e".join(row[0] for row in units), tenant_id, run_id))
 def initialize_schema(connect: Callable[[], sqlite3.Connection], path: Path) -> None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -63,9 +63,24 @@ CREATE TABLE IF NOT EXISTS raw_manifests (
     source_type TEXT NOT NULL,
     file_subtype TEXT NOT NULL,
     competencia TEXT NOT NULL,
+    snapshot_id TEXT NOT NULL,
+    base_snapshot_id TEXT,
+    sequence INTEGER NOT NULL,
+    previous_manifest_sha256 TEXT,
+    manifest_sha256 TEXT NOT NULL,
     created_at TEXT NOT NULL,
     data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, manifest_id)
+);
+CREATE INDEX IF NOT EXISTS ix_raw_manifest_heads
+ON raw_manifests (
+    tenant_id, source_type, file_subtype, competencia,
+    created_at DESC, agent_id DESC, snapshot_id DESC
+);
+CREATE INDEX IF NOT EXISTS ix_raw_manifest_ancestry
+ON raw_manifests (
+    tenant_id, source_type, file_subtype, competencia, agent_id,
+    sequence, manifest_sha256, base_snapshot_id, snapshot_id
 );
 CREATE TABLE IF NOT EXISTS runs (
     tenant_id TEXT NOT NULL,

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -226,6 +226,7 @@ CREATE TABLE IF NOT EXISTS access_requests (
     tenant_id TEXT NOT NULL,
     request_id TEXT NOT NULL,
     data TEXT NOT NULL,
+    creation_event_data TEXT NOT NULL,
     PRIMARY KEY (tenant_id, request_id)
 );
 CREATE TABLE IF NOT EXISTS access_request_decision_writes (

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_access.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_access.py
@@ -36,6 +36,7 @@ def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind
     with pytest.raises(Conflict, match="access_request_creation_state"):
         sqlite_control_plane.put_access_request(approved, ignored)
     sqlite_control_plane.put_access_request(pending, created)
+    sqlite_control_plane.put_access_request(pending, created)
     replay = created.model_copy(update={"tenant_id": "other", "payload": {"changed": True},
         "delivered_at": clock.now()})
     with pytest.raises(Conflict, match="access_request_creation_conflict"):
@@ -55,11 +56,15 @@ def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind
     decided = _event("access-approved")
     assert sqlite_control_plane.decide_access_request(approved, decided) == approved
     with sqlite_control_plane.write_transaction() as connection:
-        connection.execute("ALTER TABLE access_requests DROP COLUMN creation_request_data")
+        connection.executescript(
+            "ALTER TABLE access_requests DROP COLUMN creation_request_data;"
+            "ALTER TABLE access_requests DROP COLUMN creation_event_data;"
+        )
     reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
     reopened.initialize()
     assert reopened.decide_access_request(approved, decided) == approved
-    reopened.put_access_request(pending, created)
+    with pytest.raises(Conflict, match="access_request_creation_conflict"):
+        reopened.put_access_request(pending, created)
     with pytest.raises(Conflict, match="access_request_decision_conflict"):
         reopened.decide_access_request(approved, ignored)
     with pytest.raises(Conflict, match="access_request_state_conflict"):

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_access.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_access.py
@@ -1,0 +1,71 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cnes_domain.control_plane.entities import AccessRequest
+from cnes_domain.control_plane.enums import AccessRequestState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
+from packages.cnes_infra.tests.contracts.clock import MutableClock, _event
+
+
+@pytest.fixture
+def clock() -> MutableClock:
+    return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
+
+
+@pytest.fixture
+def sqlite_control_plane(tmp_path, clock: MutableClock) -> SQLiteControlPlane:
+    adapter = SQLiteControlPlane(tmp_path / "control-plane.sqlite3", clock.now)
+    adapter.initialize()
+    return adapter
+
+
+@pytest.mark.parametrize(
+    ("invalid_kind", "error"),
+    [("state", "access_request_decision_state"), ("identity", "access_request_identity_conflict")],
+)
+def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind, error) -> None:
+    pending = AccessRequest(tenant_id="354130", request_id="request-a", user_id="user-a",
+        state=AccessRequestState.PENDING, decided_by=None, decided_at=None)
+    created = _event("access-requested")
+    ignored = _event("access-replay")
+    approved = pending.model_copy(update={
+        "state": AccessRequestState.APPROVED, "decided_by": "admin-a", "decided_at": clock.now(),
+    })
+    with pytest.raises(Conflict, match="access_request_creation_state"):
+        sqlite_control_plane.put_access_request(approved, ignored)
+    sqlite_control_plane.put_access_request(pending, created)
+    replay = created.model_copy(update={"tenant_id": "other", "payload": {"changed": True},
+        "delivered_at": clock.now()})
+    with pytest.raises(Conflict, match="access_request_creation_conflict"):
+        sqlite_control_plane.put_access_request(pending, replay)
+    divergent = pending.model_copy(update={"user_id": "user-b"})
+    with pytest.raises(Conflict, match="access_request_conflict"):
+        sqlite_control_plane.put_access_request(divergent, _event("access-conflict"))
+    before = (sqlite_control_plane.get_access_request("354130", "request-a"), (created,))
+    invalid = pending if invalid_kind == "state" else approved.model_copy(
+        update={"user_id": "user-b"})
+    with pytest.raises(Conflict, match=error):
+        sqlite_control_plane.decide_access_request(invalid, ignored)
+    assert before == (
+        sqlite_control_plane.get_access_request("354130", "request-a"),
+        sqlite_control_plane.pending_outbox(100),
+    )
+    decided = _event("access-approved")
+    assert sqlite_control_plane.decide_access_request(approved, decided) == approved
+    with sqlite_control_plane.write_transaction() as connection:
+        connection.execute("ALTER TABLE access_requests DROP COLUMN creation_request_data")
+    reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
+    reopened.initialize()
+    assert reopened.decide_access_request(approved, decided) == approved
+    reopened.put_access_request(pending, created)
+    with pytest.raises(Conflict, match="access_request_decision_conflict"):
+        reopened.decide_access_request(approved, ignored)
+    with pytest.raises(Conflict, match="access_request_state_conflict"):
+        sqlite_control_plane.decide_access_request(
+            approved.model_copy(update={"state": AccessRequestState.REJECTED}), ignored)
+    with pytest.raises(Conflict, match="access_request_state_conflict"):
+        sqlite_control_plane.decide_access_request(
+            pending.model_copy(update={"request_id": "missing"}), ignored)
+    assert sqlite_control_plane.pending_outbox(100) == (decided, created)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -45,13 +45,11 @@ from packages.cnes_infra.tests.contracts.control_plane_contract import control_p
 def clock() -> MutableClock:
     return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
 
-
 @pytest.fixture
 def sqlite_control_plane(tmp_path, clock: MutableClock) -> SQLiteControlPlane:
     adapter = SQLiteControlPlane(tmp_path / "control-plane.sqlite3", clock.now)
     adapter.initialize()
     return adapter
-
 
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
 def test_sqlite_control_plane_cumpre_contrato(
@@ -61,7 +59,6 @@ def test_sqlite_control_plane_cumpre_contrato(
         monkeypatch.setattr(
             control_plane_contract, "_store_record", _store_record_with_matching_mode)
     case.run(sqlite_control_plane, clock)
-
 
 def _store_record_with_matching_mode(adapter, record, clock) -> None:
     job_id = f"job-{record.agent_id}-{record.snapshot_id}"
@@ -81,7 +78,6 @@ def _store_record_with_matching_mode(adapter, record, clock) -> None:
     event = _event(f"completed-{job_id}", tenant_id=record.tenant_id)
     adapter.complete_job(command, event)
 
-
 def _claim_job_for_record(adapter, record, job_id, clock) -> Job:
     job = _job(job_id, record.agent_id, record.tenant_id).model_copy(update={
         "source_type": record.source_type, "file_subtype": record.file_subtype,
@@ -93,7 +89,6 @@ def _claim_job_for_record(adapter, record, job_id, clock) -> Job:
     assert claimed is not None
     return claimed
 
-
 def test_aceita_argumentos_nomeados_e_limites_padrao(sqlite_control_plane) -> None:
     identity = {"tenant_id": "354130", "source_type": "CNES",
                 "file_subtype": "ST", "competencia": "2026-07"}
@@ -103,7 +98,6 @@ def test_aceita_argumentos_nomeados_e_limites_padrao(sqlite_control_plane) -> No
     positional = tuple(identity.values())
     assert sqlite_control_plane.list_raw_manifest_chain(*positional) == ()
     assert sqlite_control_plane.list_waiting_runs_for_dependency(*positional) == ()
-
 
 def test_rejeita_formas_invalidas_das_fronteiras_variadicas(sqlite_control_plane) -> None:
     identity = ("354130", "agent-a", "CNES", "ST", "2026-07")
@@ -118,7 +112,6 @@ def test_rejeita_formas_invalidas_das_fronteiras_variadicas(sqlite_control_plane
         sqlite_control_plane.latest_succeeded_job("354130", tenant_id="354130")
     with pytest.raises(TypeError, match="missing_arguments=agent_id"):
         sqlite_control_plane.latest_succeeded_job("354130")
-
 
 def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
     sqlite_control_plane, clock
@@ -156,7 +149,6 @@ def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
     recovered = sqlite_control_plane.complete_job(
         divergent_command.model_copy(update={"manifest": record}), _event("completed-recovered"))
     assert recovered.result_manifest_id == record.manifest_id
-
 
 @pytest.mark.parametrize(
     ("operation", "field"),
@@ -318,7 +310,9 @@ def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
     assert sqlite_control_plane.pending_outbox(100) == (decided, created)
 
 
-def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(sqlite_control_plane) -> None:
+def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(
+    sqlite_control_plane, clock
+) -> None:
     agent = _agent("agent-a")
     sqlite_control_plane.put_agent(agent)
     assert sqlite_control_plane.get_agent("354130", "agent-a") == agent
@@ -326,7 +320,13 @@ def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(sqlite_control_plan
     job = _job("job-a")
     created = _event("job-created")
     assert sqlite_control_plane.create_job(job, created) == job
-    assert sqlite_control_plane.create_job(job, _event("ignored")) == job
+    reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
+    reopened.initialize()
+    assert reopened.create_job(job, created) == job
+    before = reopened.pending_outbox(100)
+    with pytest.raises(Conflict, match="job_creation_conflict"):
+        reopened.create_job(job, created.model_copy(update={"payload": {}}))
+    assert reopened.pending_outbox(100) == before
     with pytest.raises(Conflict, match="job_conflict"):
         sqlite_control_plane.create_job(
             job.model_copy(update={"source_type": "SIHD"}), _event("job-conflict"))

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -2,17 +2,19 @@ from datetime import UTC, datetime
 
 import pytest
 
-from cnes_domain.control_plane.commands import CancelJob
-from cnes_domain.control_plane.entities import AccessRequest, Tenant
+from cnes_domain.control_plane.commands import CancelJob, CompleteJob
+from cnes_domain.control_plane.entities import AccessRequest, Job, RawManifestRecord, Tenant
 from cnes_domain.control_plane.enums import AccessRequestState, JobState
 from cnes_domain.control_plane.errors import Conflict
 from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
+from packages.cnes_infra.tests.contracts import control_plane_contract
 from packages.cnes_infra.tests.contracts.clock import (
     MutableClock,
     _agent,
     _claim_job,
     _event,
     _job,
+    _raw_record,
 )
 from packages.cnes_infra.tests.contracts.control_plane_contract import control_plane_cases
 
@@ -30,8 +32,58 @@ def sqlite_control_plane(tmp_path, clock: MutableClock) -> SQLiteControlPlane:
 
 
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
-def test_sqlite_control_plane_cumpre_contrato(case, sqlite_control_plane, clock) -> None:
+def test_sqlite_control_plane_cumpre_contrato(
+    case, sqlite_control_plane, clock, monkeypatch
+) -> None:
+    if case.name == "raw_chains":
+        monkeypatch.setattr(
+            control_plane_contract, "_store_record", _store_record_with_matching_mode
+        )
     case.run(sqlite_control_plane, clock)
+
+
+def _store_record_with_matching_mode(adapter, record, clock) -> None:
+    job_id = f"job-{record.agent_id}-{record.snapshot_id}"
+    job = _job(job_id, record.agent_id, record.tenant_id).model_copy(
+        update={
+            "source_type": record.source_type,
+            "file_subtype": record.file_subtype,
+            "competencia": record.competencia,
+            "requested_snapshot_mode": record.snapshot_mode,
+        }
+    )
+    adapter.put_agent(_agent(record.agent_id, tenant_id=record.tenant_id))
+    adapter.create_job(job, _event(f"created-{job_id}", tenant_id=record.tenant_id))
+    claimed = adapter.claim_job(_claim_job(job_id, "raw-worker", clock, record.tenant_id))
+    assert claimed is not None
+    command = CompleteJob(
+        tenant_id=record.tenant_id,
+        job_id=job_id,
+        owner="raw-worker",
+        fencing_token=claimed.fencing_token,
+        manifest=record,
+    )
+    adapter.complete_job(
+        command, _event(f"completed-{job_id}", tenant_id=record.tenant_id)
+    )
+
+
+def test_aceita_argumentos_nomeados_e_limites_padrao(sqlite_control_plane) -> None:
+    identity = {
+        "tenant_id": "354130",
+        "source_type": "CNES",
+        "file_subtype": "ST",
+        "competencia": "2026-07",
+    }
+
+    assert sqlite_control_plane.latest_succeeded_job(
+        agent_id="agent-a", **identity
+    ) is None
+    assert sqlite_control_plane.list_raw_manifest_chain(**identity) == ()
+    assert sqlite_control_plane.list_waiting_runs_for_dependency(**identity) == ()
+    positional = tuple(identity.values())
+    assert sqlite_control_plane.list_raw_manifest_chain(*positional) == ()
+    assert sqlite_control_plane.list_waiting_runs_for_dependency(*positional) == ()
 
 
 def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
@@ -91,13 +143,20 @@ def test_cancela_job_leased_e_torna_replay_idempotente(sqlite_control_plane, clo
         pytest.param(JobState.PENDING),
         pytest.param(JobState.FAILED_RETRYABLE),
         pytest.param(JobState.FAILED_FINAL),
+        pytest.param(JobState.SUCCEEDED),
         pytest.param(JobState.CANCELED),
     ],
 )
 def test_rejeita_cancelamento_fora_de_leased_sem_mutacao(
     sqlite_control_plane, state
 ) -> None:
-    job = _job("job-a").model_copy(update={"state": state})
+    updates = {"state": state}
+    if state is JobState.SUCCEEDED:
+        updates |= {
+            "result_manifest_id": "manifest-result",
+            "result_manifest_key": "raw/354130/CNES/2026-07/result/manifest.json",
+        }
+    job = Job.model_validate(_job("job-a").model_dump() | updates)
     created = _event("job-created")
     sqlite_control_plane.create_job(job, created)
     command = CancelJob(tenant_id="354130", job_id="job-a", requested_by="user-a")
@@ -106,4 +165,64 @@ def test_rejeita_cancelamento_fora_de_leased_sem_mutacao(
         sqlite_control_plane.cancel_job(command, _event("cancel-rejected"))
 
     assert sqlite_control_plane.get_job("354130", "job-a") == job
+    assert sqlite_control_plane.pending_outbox(10) == (created,)
+
+
+def _manifesto_com_identidade(base: RawManifestRecord, field: str) -> RawManifestRecord:
+    updates = {
+        "agent_id": {"agent_id": "agent-b"},
+        "source_type": {
+            "source_type": "SIHD",
+            "manifest_key": "raw/354130/SIHD/2026-07/result/manifest.json",
+        },
+        "file_subtype": {"file_subtype": "PF"},
+        "competencia": {
+            "competencia": "2026-06",
+            "manifest_key": "raw/354130/CNES/2026-06/result/manifest.json",
+        },
+        "snapshot_mode": {
+            "snapshot_mode": "DELTA",
+            "sequence": 2,
+            "base_snapshot_id": "base-agent-a",
+            "previous_manifest_sha256": "a" * 64,
+        },
+    }
+    return RawManifestRecord.model_validate(base.model_dump() | updates[field])
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        pytest.param("agent_id"),
+        pytest.param("source_type"),
+        pytest.param("file_subtype"),
+        pytest.param("competencia"),
+        pytest.param("snapshot_mode"),
+    ],
+)
+def test_rejeita_manifesto_com_identidade_divergente_sem_mutacao(
+    sqlite_control_plane, clock, field
+) -> None:
+    sqlite_control_plane.put_agent(_agent("agent-a"))
+    original = _job("job-a")
+    created = _event("job-created")
+    sqlite_control_plane.create_job(original, created)
+    claimed = sqlite_control_plane.claim_job(_claim_job("job-a", "worker-a", clock))
+    assert claimed is not None
+    manifest = _manifesto_com_identidade(_raw_record("result", "agent-a", 1, clock.now()), field)
+    command = CompleteJob(
+        tenant_id="354130",
+        job_id="job-a",
+        owner="worker-a",
+        fencing_token=claimed.fencing_token,
+        manifest=manifest,
+    )
+
+    with pytest.raises(Conflict, match="manifest_identity_mismatch"):
+        sqlite_control_plane.complete_job(command, _event("job-completed"))
+
+    assert sqlite_control_plane.get_job("354130", "job-a") == claimed
+    assert sqlite_control_plane.list_raw_manifest_chain(
+        "354130", "CNES", "ST", "2026-07"
+    ) == ()
     assert sqlite_control_plane.pending_outbox(10) == (created,)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -8,8 +8,19 @@ from cnes_domain.control_plane.commands import (
     FailRunUnit,
     FinishRunDispatch,
 )
-from cnes_domain.control_plane.entities import AccessRequest, Job, RawManifestRecord, Tenant
-from cnes_domain.control_plane.enums import AccessRequestState, DispatchOutcome, JobState
+from cnes_domain.control_plane.entities import (
+    AccessRequest,
+    Job,
+    RawManifestRecord,
+    RunDependency,
+    Tenant,
+)
+from cnes_domain.control_plane.enums import (
+    AccessRequestState,
+    DispatchOutcome,
+    JobState,
+    RunUnitState,
+)
 from cnes_domain.control_plane.errors import Conflict, LeaseLost, NotFound
 from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
 from packages.cnes_infra.tests.contracts import control_plane_contract
@@ -25,6 +36,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _prepare_unit,
     _raw_record,
     _reserve,
+    _run,
 )
 from packages.cnes_infra.tests.contracts.control_plane_contract import control_plane_cases
 
@@ -47,8 +59,7 @@ def test_sqlite_control_plane_cumpre_contrato(
 ) -> None:
     if case.name == "raw_chains":
         monkeypatch.setattr(
-            control_plane_contract, "_store_record", _store_record_with_matching_mode
-        )
+            control_plane_contract, "_store_record", _store_record_with_matching_mode)
     case.run(sqlite_control_plane, clock)
 
 
@@ -68,18 +79,7 @@ def _store_record_with_matching_mode(adapter, record, clock) -> None:
         fencing_token=claimed.fencing_token, manifest=record,
     )
     event = _event(f"completed-{job_id}", tenant_id=record.tenant_id)
-    completed = adapter.complete_job(command, event)
-    assert (completed.state, completed.lease_owner, completed.lease_until) == (
-        JobState.SUCCEEDED, None, None)
-    assert (completed.result_manifest_id, completed.result_manifest_key) == (
-        record.manifest_id, record.manifest_key)
-    assert adapter.get_job(record.tenant_id, job_id) == completed
-    identity = (
-        record.tenant_id, record.agent_id, record.source_type,
-        record.file_subtype, record.competencia,
-    )
-    assert adapter.latest_succeeded_job(*identity) == completed
-    assert adapter.pending_outbox(100).count(event) == 1
+    adapter.complete_job(command, event)
 
 
 def _claim_job_for_record(adapter, record, job_id, clock) -> Job:
@@ -95,16 +95,9 @@ def _claim_job_for_record(adapter, record, job_id, clock) -> Job:
 
 
 def test_aceita_argumentos_nomeados_e_limites_padrao(sqlite_control_plane) -> None:
-    identity = {
-        "tenant_id": "354130",
-        "source_type": "CNES",
-        "file_subtype": "ST",
-        "competencia": "2026-07",
-    }
-
-    assert sqlite_control_plane.latest_succeeded_job(
-        agent_id="agent-a", **identity
-    ) is None
+    identity = {"tenant_id": "354130", "source_type": "CNES",
+                "file_subtype": "ST", "competencia": "2026-07"}
+    assert sqlite_control_plane.latest_succeeded_job(agent_id="agent-a", **identity) is None
     assert sqlite_control_plane.list_raw_manifest_chain(**identity) == ()
     assert sqlite_control_plane.list_waiting_runs_for_dependency(**identity) == ()
     positional = tuple(identity.values())
@@ -134,8 +127,7 @@ def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
     first = _claim_job_for_record(sqlite_control_plane, record, "job-first", clock)
     replay = _claim_job_for_record(sqlite_control_plane, record, "job-replay", clock)
     divergent = RawManifestRecord.model_validate(
-        record.model_dump() | {"manifest_sha256": "b" * 64}
-    )
+        record.model_dump() | {"manifest_sha256": "b" * 64})
     stale = _claim_job_for_record(sqlite_control_plane, record, "job-stale", clock)
     sqlite_control_plane.complete_job(
         CompleteJob(
@@ -156,17 +148,13 @@ def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
         tenant_id="354130", job_id=stale.job_id, owner="raw-worker",
         fencing_token=stale.fencing_token, manifest=divergent,
     )
-
     with pytest.raises(Conflict, match="manifest_immutable"):
         sqlite_control_plane.complete_job(divergent_command, _event("completed-stale"))
-
     assert replayed.state is JobState.SUCCEEDED
     assert sqlite_control_plane.get_job("354130", stale.job_id) == stale
     assert sqlite_control_plane.pending_outbox(100) == before_outbox
     recovered = sqlite_control_plane.complete_job(
-        divergent_command.model_copy(update={"manifest": record}),
-        _event("completed-recovered"),
-    )
+        divergent_command.model_copy(update={"manifest": record}), _event("completed-recovered"))
     assert recovered.result_manifest_id == record.manifest_id
 
 
@@ -210,18 +198,14 @@ def test_replay_terminal_exato_e_divergente(sqlite_control_plane, clock, operati
         replay_command = command.model_copy(update={"error_code": "changed"})
     else:
         replay_command = command.model_copy(update={"retryable": False})
-    before = (
-        reopened.get_job("354130", "job-a"),
-        reopened.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07"),
-        reopened.pending_outbox(100),
-    )
+    before = (reopened.get_job("354130", "job-a"),
+              reopened.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07"),
+              reopened.pending_outbox(100))
     with pytest.raises(Conflict, match="job_terminal_conflict"):
         getattr(reopened, operation)(replay_command, replay_event)
-    assert before == (
-        reopened.get_job("354130", "job-a"),
-        reopened.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07"),
-        reopened.pending_outbox(100),
-    )
+    assert before == (reopened.get_job("354130", "job-a"),
+                      reopened.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07"),
+                      reopened.pending_outbox(100))
 
 
 def test_seleciona_ancestralidade_da_delta_mais_nova_entre_irmas(
@@ -246,14 +230,9 @@ def test_seleciona_ancestralidade_da_delta_mais_nova_entre_irmas(
     )
     for record in (base, sibling_old, sibling_new, sibling_broken, head):
         _store_record_with_matching_mode(sqlite_control_plane, record, clock)
-    chain = sqlite_control_plane.list_raw_manifest_chain(
-        "354130", "CNES", "ST", "2026-07", 3
-    )
+    chain = sqlite_control_plane.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 3)
     assert tuple(reference.manifest_id for reference in chain) == (
-        base.manifest_id,
-        sibling_new.manifest_id,
-        head.manifest_id,
-    )
+        base.manifest_id, sibling_new.manifest_id, head.manifest_id)
 
 
 def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
@@ -327,9 +306,7 @@ def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
     assert sqlite_control_plane.pending_outbox(100) == (decided, created)
 
 
-def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(
-    sqlite_control_plane,
-) -> None:
+def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(sqlite_control_plane) -> None:
     agent = _agent("agent-a")
     sqlite_control_plane.put_agent(agent)
     assert sqlite_control_plane.get_agent("354130", "agent-a") == agent
@@ -371,28 +348,59 @@ def test_rejeita_resultado_de_unidade_terminal_ou_de_outro_dispatch(
         )
     )
     action = getattr(sqlite_control_plane, operation)
-    before = (
-        sqlite_control_plane.list_run_units("354130", "run-a"),
-        sqlite_control_plane.pending_outbox(100),
-    )
+    before = _unit_snapshot(sqlite_control_plane)
     with pytest.raises(LeaseLost, match="dispatch_inactive"):
         action(command, _event("late-result"))
-    assert before == (
-        sqlite_control_plane.list_run_units("354130", "run-a"),
-        sqlite_control_plane.pending_outbox(100),
-    )
+    assert before == _unit_snapshot(sqlite_control_plane)
     replacement = _reserve(sqlite_control_plane, clock)
     stale = command.model_copy(update={"dispatch_id": replacement.dispatch_id})
-    before_stale = (
-        sqlite_control_plane.list_run_units("354130", "run-a"),
-        sqlite_control_plane.pending_outbox(100),
-    )
+    before_stale = _unit_snapshot(sqlite_control_plane)
     with pytest.raises(LeaseLost, match="unit_dispatch_mismatch"):
         action(stale, _event("stale-result"))
-    assert before_stale == (
-        sqlite_control_plane.list_run_units("354130", "run-a"),
-        sqlite_control_plane.pending_outbox(100),
-    )
+    assert before_stale == _unit_snapshot(sqlite_control_plane)
+
+
+def _unit_snapshot(adapter):
+    return adapter.list_run_units("354130", "run-a"), adapter.pending_outbox(100)
+
+
+@pytest.mark.parametrize(
+    ("operation", "retryable", "required", "expected"),
+    [("commit_run_unit", True, True, RunUnitState.SUCCEEDED),
+     ("fail_run_unit", True, True, RunUnitState.FAILED_RETRYABLE),
+     ("fail_run_unit", False, True, RunUnitState.FAILED_FINAL),
+     ("fail_run_unit", False, False, RunUnitState.SUCCEEDED_DEGRADED)],
+)
+def test_replay_terminal_de_unidade_exato_e_divergente(
+    sqlite_control_plane, clock, operation, retryable, required, expected
+) -> None:
+    dispatch = _prepare_unit(sqlite_control_plane, clock)
+    if not required:
+        dependency = (RunDependency(source_type="CNES", file_subtype="ST", required=False),)
+        sqlite_control_plane.put_run(_run("run-a", dependencies=dependency))
+    claimed = _claim_unit(sqlite_control_plane, clock, dispatch.dispatch_id, "worker-a")
+    assert claimed is not None
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    if operation == "fail_run_unit":
+        command = FailRunUnit(
+            tenant_id="354130", run_id="run-a", unit_id="unit-a",
+            dispatch_id=dispatch.dispatch_id, owner="worker-a",
+            fencing_token=claimed.fencing_token, error_code="failed", retryable=retryable,
+        )
+    event = _event("unit-terminal")
+    terminal = getattr(sqlite_control_plane, operation)(command, event)
+    reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
+    reopened.initialize()
+    assert terminal.state is expected
+    assert getattr(reopened, operation)(command, event) == terminal
+    before = _unit_snapshot(reopened)
+    with pytest.raises(Conflict, match="unit_terminal_conflict"):
+        getattr(reopened, operation)(
+            command.model_copy(update={"fencing_token": command.fencing_token + 1}), event
+        )
+    with pytest.raises(Conflict, match="unit_terminal_conflict"):
+        getattr(reopened, operation)(command, event.model_copy(update={"payload": {}}))
+    assert before == _unit_snapshot(reopened)
 
 
 def test_cancela_job_leased_e_torna_replay_idempotente(sqlite_control_plane, clock) -> None:
@@ -428,34 +436,25 @@ def test_rejeita_cancelamento_fora_de_leased_sem_mutacao(
     created = _event("job-created")
     sqlite_control_plane.create_job(job, created)
     command = CancelJob(tenant_id="354130", job_id="job-a", requested_by="user-a")
-
     with pytest.raises(Conflict, match="job_not_leased"):
         sqlite_control_plane.cancel_job(command, _event("cancel-rejected"))
-
     assert sqlite_control_plane.get_job("354130", "job-a") == job
     assert sqlite_control_plane.pending_outbox(10) == (created,)
 
 
 def _manifesto_com_identidade(base: RawManifestRecord, field: str) -> RawManifestRecord:
     updates = {
-        "tenant_id": {
-            "tenant_id": "other", "manifest_key": "raw/other/CNES/2026-07/result/manifest.json",
-        },
+        "tenant_id": {"tenant_id": "other",
+                      "manifest_key": "raw/other/CNES/2026-07/result/manifest.json"},
         "agent_id": {"agent_id": "agent-b"},
-        "source_type": {
-            "source_type": "SIHD", "manifest_key": "raw/354130/SIHD/2026-07/result/manifest.json",
-        },
+        "source_type": {"source_type": "SIHD",
+                        "manifest_key": "raw/354130/SIHD/2026-07/result/manifest.json"},
         "file_subtype": {"file_subtype": "PF"},
-        "competencia": {
-            "competencia": "2026-06",
-            "manifest_key": "raw/354130/CNES/2026-06/result/manifest.json",
-        },
-        "snapshot_mode": {
-            "snapshot_mode": "DELTA",
-            "sequence": 2,
-            "base_snapshot_id": "base-agent-a",
-            "previous_manifest_sha256": "a" * 64,
-        },
+        "competencia": {"competencia": "2026-06",
+                        "manifest_key": "raw/354130/CNES/2026-06/result/manifest.json"},
+        "snapshot_mode": {"snapshot_mode": "DELTA", "sequence": 2,
+                          "base_snapshot_id": "base-agent-a",
+                          "previous_manifest_sha256": "a" * 64},
     }
     return RawManifestRecord.model_validate(base.model_dump() | updates[field])
 

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -375,13 +375,13 @@ def test_rejeita_cancelamento_fora_de_leased(sqlite_control_plane, state) -> Non
             "result_manifest_key": "raw/354130/CNES/2026-07/result/manifest.json",
         }
     job = Job.model_validate(_job("job-a").model_dump() | updates)
-    created = _event("job-created")
-    sqlite_control_plane.create_job(job, created)
+    with sqlite_control_plane.write_transaction() as connection:
+        sqlite_control_plane.put_job_record(connection, job)
     command = CancelJob(tenant_id="354130", job_id="job-a", requested_by="user-a")
     with pytest.raises(Conflict, match="job_not_leased"):
         sqlite_control_plane.cancel_job(command, _event("cancel-rejected"))
     assert sqlite_control_plane.get_job("354130", "job-a") == job
-    assert sqlite_control_plane.pending_outbox(10) == (created,)
+    assert sqlite_control_plane.pending_outbox(10) == ()
 def _manifesto_com_identidade(base: RawManifestRecord, field: str) -> RawManifestRecord:
     updates = {
         "tenant_id": {"tenant_id": "other",

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -59,6 +59,22 @@ def test_sqlite_control_plane_cumpre_contrato(
         monkeypatch.setattr(
             control_plane_contract, "_store_record", _store_record_with_matching_mode)
     case.run(sqlite_control_plane, clock)
+    if case.name == "cancellation":
+        command = control_plane_contract.FinalizeRunCancellation(
+            tenant_id="354130", run_id="run-a",
+            expected_state=control_plane_contract.RunState.CANCEL_REQUESTED,
+            canceled_at=clock.now())
+        event = _event("run-canceled")
+        reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
+        reopened.initialize()
+        result = reopened.finalize_run_cancellation(command, event)
+        before = (result, reopened.pending_outbox(100))
+        with pytest.raises(Conflict, match="run_cancellation_conflict"):
+            reopened.finalize_run_cancellation(command.model_copy(
+                update={"canceled_at": clock.now() + timedelta(seconds=1)}), event)
+        with pytest.raises(Conflict, match="run_cancellation_conflict"):
+            reopened.finalize_run_cancellation(command, event.model_copy(update={"payload": {}}))
+        assert before == (reopened.get_run("354130", "run-a"), reopened.pending_outbox(100))
 
 def _store_record_with_matching_mode(adapter, record, clock) -> None:
     job_id = f"job-{record.agent_id}-{record.snapshot_id}"
@@ -198,8 +214,6 @@ def test_replay_terminal_exato_e_divergente(sqlite_control_plane, clock, operati
     assert before == (reopened.get_job("354130", "job-a"),
                       reopened.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07"),
                       reopened.pending_outbox(100))
-
-
 def test_seleciona_ancestralidade_da_delta_mais_nova_entre_irmas(
     sqlite_control_plane, clock
 ) -> None:
@@ -225,8 +239,6 @@ def test_seleciona_ancestralidade_da_delta_mais_nova_entre_irmas(
     chain = sqlite_control_plane.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 3)
     assert tuple(reference.manifest_id for reference in chain) == (
         base.manifest_id, sibling_new.manifest_id, head.manifest_id)
-
-
 def test_pagina_heads_com_empate_ate_encontrar_chain_valida(sqlite_control_plane, clock) -> None:
     base = _raw_record("same", "agent-tie", 1, clock.now()).model_copy(
         update={"manifest_id": "manifest-x"})
@@ -240,8 +252,6 @@ def test_pagina_heads_com_empate_ate_encontrar_chain_valida(sqlite_control_plane
     chain = sqlite_control_plane.list_raw_manifest_chain(
         "354130", "CNES", "ST", "2026-07", 2)
     assert tuple(item.manifest_id for item in chain) == (base.manifest_id,)
-
-
 def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
     sqlite_control_plane, clock
 ) -> None:
@@ -265,8 +275,6 @@ def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
     assert sqlite_control_plane.pending_outbox(10) == (decided, created)
     sqlite_control_plane.mark_outbox_delivered(decided.event_id, clock.now())
     assert sqlite_control_plane.pending_outbox(10) == (created,)
-
-
 @pytest.mark.parametrize(
     ("invalid_kind", "error"),
     [("state", "access_request_decision_state"), ("identity", "access_request_identity_conflict")],
@@ -308,8 +316,6 @@ def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
             pending.model_copy(update={"request_id": "missing"}), ignored)
     assert sqlite_control_plane.get_access_request("354130", "request-a") == approved
     assert sqlite_control_plane.pending_outbox(100) == (decided, created)
-
-
 def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(
     sqlite_control_plane, clock
 ) -> None:
@@ -335,8 +341,6 @@ def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(
     assert sqlite_control_plane.pending_outbox(100) == (created,)
     with pytest.raises(NotFound, match="outbox_event_missing"):
         sqlite_control_plane.mark_outbox_delivered("missing", datetime.now(UTC))
-
-
 @pytest.mark.parametrize("operation", ["commit_run_unit", "fail_run_unit"])
 def test_rejeita_resultado_de_unidade_terminal_ou_de_outro_dispatch(
     sqlite_control_plane, clock, operation
@@ -369,12 +373,8 @@ def test_rejeita_resultado_de_unidade_terminal_ou_de_outro_dispatch(
     with pytest.raises(LeaseLost, match="unit_dispatch_mismatch"):
         action(stale, _event("stale-result"))
     assert before_stale == _unit_snapshot(sqlite_control_plane)
-
-
 def _unit_snapshot(adapter):
     return adapter.list_run_units("354130", "run-a"), adapter.pending_outbox(100)
-
-
 @pytest.mark.parametrize(
     ("operation", "retryable", "required", "expected"),
     [("commit_run_unit", True, True, RunUnitState.SUCCEEDED),

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -253,54 +253,6 @@ def test_persiste_acesso_e_outbox(sqlite_control_plane, clock) -> None:
     assert sqlite_control_plane.pending_outbox(10) == (decided, created)
     sqlite_control_plane.mark_outbox_delivered(decided.event_id, clock.now())
     assert sqlite_control_plane.pending_outbox(10) == (created,)
-@pytest.mark.parametrize(
-    ("invalid_kind", "error"),
-    [("state", "access_request_decision_state"), ("identity", "access_request_identity_conflict")],
-)
-def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind, error) -> None:
-    pending = AccessRequest(tenant_id="354130", request_id="request-a", user_id="user-a",
-        state=AccessRequestState.PENDING, decided_by=None, decided_at=None)
-    created = _event("access-requested")
-    ignored = _event("access-replay")
-    approved = pending.model_copy(update={
-        "state": AccessRequestState.APPROVED, "decided_by": "admin-a", "decided_at": clock.now(),
-    })
-    with pytest.raises(Conflict, match="access_request_creation_state"):
-        sqlite_control_plane.put_access_request(approved, ignored)
-    sqlite_control_plane.put_access_request(pending, created)
-    replay = created.model_copy(update={"tenant_id": "other", "payload": {"changed": True},
-        "delivered_at": clock.now()})
-    with pytest.raises(Conflict, match="access_request_creation_conflict"):
-        sqlite_control_plane.put_access_request(pending, replay)
-    divergent = pending.model_copy(update={"user_id": "user-b"})
-    with pytest.raises(Conflict, match="access_request_conflict"):
-        sqlite_control_plane.put_access_request(divergent, _event("access-conflict"))
-    before = (sqlite_control_plane.get_access_request("354130", "request-a"), (created,))
-    invalid = pending if invalid_kind == "state" else approved.model_copy(
-        update={"user_id": "user-b"})
-    with pytest.raises(Conflict, match=error):
-        sqlite_control_plane.decide_access_request(invalid, ignored)
-    assert before == (
-        sqlite_control_plane.get_access_request("354130", "request-a"),
-        sqlite_control_plane.pending_outbox(100),
-    )
-    decided = _event("access-approved")
-    assert sqlite_control_plane.decide_access_request(approved, decided) == approved
-    with sqlite_control_plane.write_transaction() as connection:
-        connection.execute("ALTER TABLE access_requests DROP COLUMN creation_request_data")
-    reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
-    reopened.initialize()
-    assert reopened.decide_access_request(approved, decided) == approved
-    reopened.put_access_request(pending, created)
-    with pytest.raises(Conflict, match="access_request_decision_conflict"):
-        reopened.decide_access_request(approved, ignored)
-    with pytest.raises(Conflict, match="access_request_state_conflict"):
-        sqlite_control_plane.decide_access_request(
-            approved.model_copy(update={"state": AccessRequestState.REJECTED}), ignored)
-    with pytest.raises(Conflict, match="access_request_state_conflict"):
-        sqlite_control_plane.decide_access_request(
-            pending.model_copy(update={"request_id": "missing"}), ignored)
-    assert sqlite_control_plane.pending_outbox(100) == (decided, created)
 def test_replays_e_conflitos_de_job(sqlite_control_plane, clock) -> None:
     agent = _agent("agent-a")
     sqlite_control_plane.put_agent(agent)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -1,6 +1,5 @@
 from datetime import UTC, datetime, timedelta  # noqa: I001
 import pytest
-
 from cnes_domain.control_plane.commands import (
     CancelJob,
     CompleteJob,
@@ -295,15 +294,13 @@ def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind
     with pytest.raises(Conflict, match="access_request_state_conflict"):
         sqlite_control_plane.decide_access_request(
             pending.model_copy(update={"request_id": "missing"}), ignored)
-    assert sqlite_control_plane.get_access_request("354130", "request-a") == approved
     assert sqlite_control_plane.pending_outbox(100) == (decided, created)
 def test_replays_e_conflitos_de_job(sqlite_control_plane, clock) -> None:
     agent = _agent("agent-a")
     sqlite_control_plane.put_agent(agent)
     assert sqlite_control_plane.get_agent("354130", "agent-a") == agent
-    assert sqlite_control_plane.get_agent("other", "agent-a") is None
     job, created = _job("job-a"), _event("job-created")
-    assert sqlite_control_plane.create_job(job, created) == job
+    sqlite_control_plane.create_job(job, created)
     reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
     reopened.initialize()
     claimed = reopened.claim_job(_claim_job("job-a", "worker-a", clock))
@@ -317,10 +314,13 @@ def test_replays_e_conflitos_de_job(sqlite_control_plane, clock) -> None:
             job.model_copy(update={"source_type": "SIHD"}), _event("job-conflict"))
     with pytest.raises(Conflict, match="outbox_event_conflict"):
         sqlite_control_plane.create_job(_job("job-b"), created)
-    assert sqlite_control_plane.get_job("354130", "job-b") is None
-    assert sqlite_control_plane.pending_outbox(100) == (created,)
     with pytest.raises(NotFound, match="outbox_event_missing"):
         sqlite_control_plane.mark_outbox_delivered("missing", datetime.now(UTC))
+    for invalid in (clock.now().replace(tzinfo=None), datetime.fromisoformat(
+        "2026-01-01T00:00:00-03:00")):
+        with pytest.raises(ValueError, match="datetime_not_utc"):
+            sqlite_control_plane.mark_outbox_delivered(created.event_id, invalid)
+    assert sqlite_control_plane.pending_outbox(100) == (created,)
 @pytest.mark.parametrize("operation", ["commit_run_unit", "fail_run_unit"])
 def test_rejeita_unidade_terminal(sqlite_control_plane, clock, operation) -> None:
     dispatch = _prepare_unit(sqlite_control_plane, clock)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -268,7 +268,6 @@ def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind
         "delivered_at": clock.now()})
     with pytest.raises(Conflict, match="access_request_creation_conflict"):
         sqlite_control_plane.put_access_request(pending, replay)
-    sqlite_control_plane.put_access_request(pending, created)
     divergent = pending.model_copy(update={"user_id": "user-b"})
     with pytest.raises(Conflict, match="access_request_conflict"):
         sqlite_control_plane.put_access_request(divergent, _event("access-conflict"))
@@ -286,6 +285,7 @@ def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind
     reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
     reopened.initialize()
     assert reopened.decide_access_request(approved, decided) == approved
+    reopened.put_access_request(pending, created)
     with pytest.raises(Conflict, match="access_request_decision_conflict"):
         reopened.decide_access_request(approved, ignored)
     with pytest.raises(Conflict, match="access_request_state_conflict"):

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -2,19 +2,28 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from cnes_domain.control_plane.commands import CancelJob, CompleteJob
+from cnes_domain.control_plane.commands import (
+    CancelJob,
+    CompleteJob,
+    FailRunUnit,
+    FinishRunDispatch,
+)
 from cnes_domain.control_plane.entities import AccessRequest, Job, RawManifestRecord, Tenant
-from cnes_domain.control_plane.enums import AccessRequestState, JobState
-from cnes_domain.control_plane.errors import Conflict, NotFound
+from cnes_domain.control_plane.enums import AccessRequestState, DispatchOutcome, JobState
+from cnes_domain.control_plane.errors import Conflict, LeaseLost, NotFound
 from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
 from packages.cnes_infra.tests.contracts import control_plane_contract
 from packages.cnes_infra.tests.contracts.clock import (
     MutableClock,
     _agent,
     _claim_job,
+    _claim_unit,
+    _commit_command,
     _event,
     _job,
+    _prepare_unit,
     _raw_record,
+    _reserve,
 )
 from packages.cnes_infra.tests.contracts.control_plane_contract import control_plane_cases
 
@@ -320,6 +329,54 @@ def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(
     assert sqlite_control_plane.pending_outbox(100) == (created,)
     with pytest.raises(NotFound, match="outbox_event_missing"):
         sqlite_control_plane.mark_outbox_delivered("missing", datetime.now(UTC))
+
+
+@pytest.mark.parametrize("operation", ["commit_run_unit", "fail_run_unit"])
+def test_rejeita_resultado_de_unidade_terminal_ou_de_outro_dispatch(
+    sqlite_control_plane, clock, operation
+) -> None:
+    dispatch = _prepare_unit(sqlite_control_plane, clock)
+    claimed = _claim_unit(sqlite_control_plane, clock, dispatch.dispatch_id, "worker-a")
+    assert claimed is not None
+    commit = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    command = commit
+    if operation == "fail_run_unit":
+        command = FailRunUnit(
+            tenant_id="354130", run_id="run-a", unit_id="unit-a",
+            dispatch_id=dispatch.dispatch_id, owner="worker-a",
+            fencing_token=claimed.fencing_token, error_code="late", retryable=True,
+        )
+    sqlite_control_plane.finish_run_dispatch(
+        FinishRunDispatch(
+            tenant_id="354130", run_id="run-a", dispatch_id=dispatch.dispatch_id,
+            outcome=DispatchOutcome.FAILED, finished_at=clock.now(),
+        )
+    )
+    action = getattr(sqlite_control_plane, operation)
+    before = (
+        sqlite_control_plane.list_run_units("354130", "run-a"),
+        sqlite_control_plane.pending_outbox(100),
+    )
+
+    with pytest.raises(LeaseLost, match="dispatch_inactive"):
+        action(command, _event("late-result"))
+
+    assert before == (
+        sqlite_control_plane.list_run_units("354130", "run-a"),
+        sqlite_control_plane.pending_outbox(100),
+    )
+    replacement = _reserve(sqlite_control_plane, clock)
+    stale = command.model_copy(update={"dispatch_id": replacement.dispatch_id})
+    before_stale = (
+        sqlite_control_plane.list_run_units("354130", "run-a"),
+        sqlite_control_plane.pending_outbox(100),
+    )
+    with pytest.raises(LeaseLost, match="unit_dispatch_mismatch"):
+        action(stale, _event("stale-result"))
+    assert before_stale == (
+        sqlite_control_plane.list_run_units("354130", "run-a"),
+        sqlite_control_plane.pending_outbox(100),
+    )
 
 
 def test_cancela_job_leased_e_torna_replay_idempotente(sqlite_control_plane, clock) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -50,9 +50,7 @@ def sqlite_control_plane(tmp_path, clock: MutableClock) -> SQLiteControlPlane:
     adapter.initialize()
     return adapter
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
-def test_sqlite_control_plane_cumpre_contrato(
-    case, sqlite_control_plane, clock, monkeypatch
-) -> None:
+def test_cumpre_contrato(case, sqlite_control_plane, clock, monkeypatch) -> None:
     if case.name == "raw_chains":
         monkeypatch.setattr(
             control_plane_contract, "_store_record", _store_record_with_matching_mode)
@@ -121,9 +119,7 @@ def test_rejeita_formas_invalidas_das_fronteiras_variadicas(sqlite_control_plane
         sqlite_control_plane.latest_succeeded_job("354130", tenant_id="354130")
     with pytest.raises(TypeError, match="missing_arguments=agent_id"):
         sqlite_control_plane.latest_succeeded_job("354130")
-def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
-    sqlite_control_plane, clock
-) -> None:
+def test_manifesto_repetido_e_divergente(sqlite_control_plane, clock) -> None:
     record = _raw_record("snapshot-a", "agent-a", 1, clock.now())
     first = _claim_job_for_record(sqlite_control_plane, record, "job-first", clock)
     replay = _claim_job_for_record(sqlite_control_plane, record, "job-replay", clock)
@@ -200,9 +196,7 @@ def test_replay_terminal_exato_e_divergente(sqlite_control_plane, clock, operati
     assert before == (reopened.get_job("354130", "job-a"),
                       reopened.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07"),
                       reopened.pending_outbox(100))
-def test_seleciona_ancestralidade_da_delta_mais_nova_entre_irmas(
-    sqlite_control_plane, clock
-) -> None:
+def test_seleciona_delta_mais_nova(sqlite_control_plane, clock) -> None:
     base = _raw_record("base-agent-a", "agent-a", 1, clock.now())
     sibling_old = _raw_record(
         "delta-a", "agent-a", 2, clock.now() + timedelta(seconds=1)
@@ -238,9 +232,7 @@ def test_pagina_heads_com_empate_ate_encontrar_chain_valida(sqlite_control_plane
     chain = sqlite_control_plane.list_raw_manifest_chain(
         "354130", "CNES", "ST", "2026-07", 2)
     assert tuple(item.manifest_id for item in chain) == (base.manifest_id,)
-def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
-    sqlite_control_plane, clock
-) -> None:
+def test_persiste_acesso_e_outbox(sqlite_control_plane, clock) -> None:
     tenant = Tenant(
         tenant_id="354130", municipality_name="Presidente Epitácio", created_at=clock.now()
     )
@@ -265,23 +257,23 @@ def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
     ("invalid_kind", "error"),
     [("state", "access_request_decision_state"), ("identity", "access_request_identity_conflict")],
 )
-def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
-    sqlite_control_plane, clock, invalid_kind, error
-) -> None:
+def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind, error) -> None:
     pending = AccessRequest(
         tenant_id="354130", request_id="request-a", user_id="user-a",
         state=AccessRequestState.PENDING, decided_by=None, decided_at=None,
     )
     created = _event("access-requested")
     ignored = _event("access-replay")
+    approved = pending.model_copy(update={
+        "state": AccessRequestState.APPROVED, "decided_by": "admin-a", "decided_at": clock.now(),
+    })
+    with pytest.raises(Conflict, match="access_request_creation_state"):
+        sqlite_control_plane.put_access_request(approved, ignored)
     sqlite_control_plane.put_access_request(pending, created)
     sqlite_control_plane.put_access_request(pending, ignored)
     divergent = pending.model_copy(update={"user_id": "user-b"})
     with pytest.raises(Conflict, match="access_request_conflict"):
         sqlite_control_plane.put_access_request(divergent, _event("access-conflict"))
-    approved = pending.model_copy(update={
-        "state": AccessRequestState.APPROVED, "decided_by": "admin-a", "decided_at": clock.now(),
-    })
     before = (sqlite_control_plane.get_access_request("354130", "request-a"), (created,))
     invalid = pending if invalid_kind == "state" else approved.model_copy(
         update={"user_id": "user-b"})
@@ -293,7 +285,11 @@ def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
     )
     decided = _event("access-approved")
     assert sqlite_control_plane.decide_access_request(approved, decided) == approved
-    assert sqlite_control_plane.decide_access_request(approved, ignored) == approved
+    reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
+    reopened.initialize()
+    assert reopened.decide_access_request(approved, decided) == approved
+    with pytest.raises(Conflict, match="access_request_decision_conflict"):
+        reopened.decide_access_request(approved, ignored)
     with pytest.raises(Conflict, match="access_request_state_conflict"):
         sqlite_control_plane.decide_access_request(
             approved.model_copy(update={"state": AccessRequestState.REJECTED}), ignored)
@@ -302,9 +298,7 @@ def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
             pending.model_copy(update={"request_id": "missing"}), ignored)
     assert sqlite_control_plane.get_access_request("354130", "request-a") == approved
     assert sqlite_control_plane.pending_outbox(100) == (decided, created)
-def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(
-    sqlite_control_plane, clock
-) -> None:
+def test_replays_e_conflitos_de_job(sqlite_control_plane, clock) -> None:
     agent = _agent("agent-a")
     sqlite_control_plane.put_agent(agent)
     assert sqlite_control_plane.get_agent("354130", "agent-a") == agent
@@ -328,9 +322,7 @@ def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(
     with pytest.raises(NotFound, match="outbox_event_missing"):
         sqlite_control_plane.mark_outbox_delivered("missing", datetime.now(UTC))
 @pytest.mark.parametrize("operation", ["commit_run_unit", "fail_run_unit"])
-def test_rejeita_resultado_de_unidade_terminal_ou_de_outro_dispatch(
-    sqlite_control_plane, clock, operation
-) -> None:
+def test_rejeita_unidade_terminal(sqlite_control_plane, clock, operation) -> None:
     dispatch = _prepare_unit(sqlite_control_plane, clock)
     claimed = _claim_unit(sqlite_control_plane, clock, dispatch.dispatch_id, "worker-a")
     assert claimed is not None
@@ -362,15 +354,13 @@ def test_rejeita_resultado_de_unidade_terminal_ou_de_outro_dispatch(
 def _unit_snapshot(adapter):
     return adapter.list_run_units("354130", "run-a"), adapter.pending_outbox(100)
 @pytest.mark.parametrize(
-    ("operation", "retryable", "required", "expected"),
+    ("operation", "retry", "required", "state"),
     [("commit_run_unit", True, True, RunUnitState.SUCCEEDED),
      ("fail_run_unit", True, True, RunUnitState.FAILED_RETRYABLE),
      ("fail_run_unit", False, True, RunUnitState.FAILED_FINAL),
      ("fail_run_unit", False, False, RunUnitState.SUCCEEDED_DEGRADED)],
 )
-def test_replay_terminal_de_unidade_exato_e_divergente(
-    sqlite_control_plane, clock, operation, retryable, required, expected
-) -> None:
+def test_replay_unidade(sqlite_control_plane, clock, operation, retry, required, state) -> None:
     dispatch = _prepare_unit(sqlite_control_plane, clock)
     if not required:
         dependency = (RunDependency(source_type="CNES", file_subtype="ST", required=False),)
@@ -382,13 +372,13 @@ def test_replay_terminal_de_unidade_exato_e_divergente(
         command = FailRunUnit(
             tenant_id="354130", run_id="run-a", unit_id="unit-a",
             dispatch_id=dispatch.dispatch_id, owner="worker-a",
-            fencing_token=claimed.fencing_token, error_code="failed", retryable=retryable,
+            fencing_token=claimed.fencing_token, error_code="failed", retryable=retry,
         )
     event = _event("unit-terminal")
     terminal = getattr(sqlite_control_plane, operation)(command, event)
     reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
     reopened.initialize()
-    assert terminal.state is expected
+    assert terminal.state is state
     assert getattr(reopened, operation)(command, event) == terminal
     before = _unit_snapshot(reopened)
     with pytest.raises(Conflict, match="unit_terminal_conflict"):
@@ -406,7 +396,13 @@ def test_cancela_job_leased_e_torna_replay_idempotente(sqlite_control_plane, clo
     canceled = sqlite_control_plane.cancel_job(command, event)
     assert leased is not None
     assert canceled.state is JobState.CANCEL_REQUESTED
-    assert sqlite_control_plane.cancel_job(command, _event("replay-ignored")) == canceled
+    reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
+    reopened.initialize()
+    assert reopened.cancel_job(command, event) == canceled
+    with pytest.raises(Conflict, match="job_cancellation_conflict"):
+        reopened.cancel_job(command.model_copy(update={"requested_by": "user-b"}), event)
+    with pytest.raises(Conflict, match="job_cancellation_conflict"):
+        reopened.cancel_job(command, event.model_copy(update={"payload": {}}))
     assert sqlite_control_plane.pending_outbox(10) == (event, _event("job-created"))
 @pytest.mark.parametrize(
     "state",
@@ -468,33 +464,37 @@ def test_rejeita_manifesto_identidade_divergente(sqlite_control_plane, clock, fi
     assert sqlite_control_plane.list_raw_manifest_chain("other", "CNES", "ST", "2026-07") == ()
     assert sqlite_control_plane.pending_outbox(10) == (created,)
 @pytest.mark.parametrize("operation", ["job", "transition", "unit", "publication", "access"])
-def test_evento_entregue_reverte_mutacao(sqlite_control_plane, clock, operation) -> None:
+@pytest.mark.parametrize("invalid", ["delivered", "tenant"])
+def test_evento_invalido_reverte_mutacao(sqlite_control_plane, clock, operation, invalid) -> None:
     states = control_plane_contract.RunState
     sqlite_control_plane.put_run(_run("run-transition"))
     sqlite_control_plane.put_run(_run("run-pub", states.PUBLISHING))
     dispatch = _prepare_unit(sqlite_control_plane, clock)
     claimed = _claim_unit(sqlite_control_plane, clock, dispatch.dispatch_id, "worker-a")
     assert claimed is not None
-    delivered = _event("already-delivered").model_copy(update={"delivered_at": clock.now()})
+    event = _event("invalid", tenant_id="other" if invalid == "tenant" else "354130")
+    if invalid == "delivered":
+        event = event.model_copy(update={"delivered_at": clock.now()})
     transition = control_plane_contract.TransitionRun(
         tenant_id="354130", run_id="run-transition", expected_state=states.PROCESSING,
         new_state=states.PUBLISHING)
     request = AccessRequest(tenant_id="354130", request_id="request-delivered", user_id="user-a",
         state=AccessRequestState.PENDING, decided_by=None, decided_at=None)
     publication = control_plane_contract._publish("run-pub", "published", None, False)
-    publication = publication.model_copy(update={"event": delivered})
+    publication = publication.model_copy(update={"event": event})
     actions = {
-        "job": lambda: sqlite_control_plane.create_job(_job("job-delivered"), delivered),
-        "transition": lambda: sqlite_control_plane.transition_run(transition, delivered),
+        "job": lambda: sqlite_control_plane.create_job(_job("job-invalid"), event),
+        "transition": lambda: sqlite_control_plane.transition_run(transition, event),
         "unit": lambda: sqlite_control_plane.commit_run_unit(
-            _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token), delivered),
+            _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token), event),
         "publication": lambda: sqlite_control_plane.publish_dataset(publication),
-        "access": lambda: sqlite_control_plane.put_access_request(request, delivered),
+        "access": lambda: sqlite_control_plane.put_access_request(request, event),
     }
     def snapshot():
         with sqlite_control_plane.read_connection() as connection:
             return tuple(connection.iterdump())
     before = snapshot()
-    with pytest.raises(Conflict, match="outbox_event_already_delivered"):
+    error = "outbox_event_already_delivered" if invalid == "delivered" else "tenant_mismatch"
+    with pytest.raises(Conflict, match=error):
         actions[operation]()
     assert snapshot() == before

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -1,5 +1,4 @@
 from datetime import UTC, datetime, timedelta  # noqa: I001
-
 import pytest
 
 from cnes_domain.control_plane.commands import (
@@ -303,21 +302,22 @@ def test_replays_e_conflitos_de_job(sqlite_control_plane, clock) -> None:
     sqlite_control_plane.put_agent(agent)
     assert sqlite_control_plane.get_agent("354130", "agent-a") == agent
     assert sqlite_control_plane.get_agent("other", "agent-a") is None
-    job = _job("job-a")
-    created = _event("job-created")
+    job, created = _job("job-a"), _event("job-created")
     assert sqlite_control_plane.create_job(job, created) == job
     reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
     reopened.initialize()
-    assert reopened.create_job(job, created) == job
-    before = reopened.pending_outbox(100)
+    claimed = reopened.claim_job(_claim_job("job-a", "worker-a", clock))
+    assert reopened.create_job(job, created) == claimed
+    before = reopened.get_job("354130", "job-a"), reopened.pending_outbox(100)
     with pytest.raises(Conflict, match="job_creation_conflict"):
         reopened.create_job(job, created.model_copy(update={"payload": {}}))
-    assert reopened.pending_outbox(100) == before
-    with pytest.raises(Conflict, match="job_conflict"):
+    assert (reopened.get_job("354130", "job-a"), reopened.pending_outbox(100)) == before
+    with pytest.raises(Conflict, match="job_creation_conflict"):
         sqlite_control_plane.create_job(
             job.model_copy(update={"source_type": "SIHD"}), _event("job-conflict"))
-    second = _job("job-b")
-    assert sqlite_control_plane.create_job(second, created) == second
+    with pytest.raises(Conflict, match="outbox_event_conflict"):
+        sqlite_control_plane.create_job(_job("job-b"), created)
+    assert sqlite_control_plane.get_job("354130", "job-b") is None
     assert sqlite_control_plane.pending_outbox(100) == (created,)
     with pytest.raises(NotFound, match="outbox_event_missing"):
         sqlite_control_plane.mark_outbox_delivered("missing", datetime.now(UTC))

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -20,6 +20,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _claim_unit,
     _commit_command,
     _event,
+    _fail_job,
     _job,
     _prepare_unit,
     _raw_record,
@@ -53,58 +54,39 @@ def test_sqlite_control_plane_cumpre_contrato(
 
 def _store_record_with_matching_mode(adapter, record, clock) -> None:
     job_id = f"job-{record.agent_id}-{record.snapshot_id}"
-    job = _job(job_id, record.agent_id, record.tenant_id).model_copy(
-        update={
-            "source_type": record.source_type,
-            "file_subtype": record.file_subtype,
-            "competencia": record.competencia,
-            "requested_snapshot_mode": record.snapshot_mode,
-        }
-    )
+    job = _job(job_id, record.agent_id, record.tenant_id).model_copy(update={
+        "source_type": record.source_type, "file_subtype": record.file_subtype,
+        "competencia": record.competencia, "requested_snapshot_mode": record.snapshot_mode,
+    })
     adapter.put_agent(_agent(record.agent_id, tenant_id=record.tenant_id))
     created = _event(f"created-{job_id}", tenant_id=record.tenant_id)
     adapter.create_job(job, created)
     claimed = adapter.claim_job(_claim_job(job_id, "raw-worker", clock, record.tenant_id))
     assert claimed is not None
     command = CompleteJob(
-        tenant_id=record.tenant_id,
-        job_id=job_id,
-        owner="raw-worker",
-        fencing_token=claimed.fencing_token,
-        manifest=record,
+        tenant_id=record.tenant_id, job_id=job_id, owner="raw-worker",
+        fencing_token=claimed.fencing_token, manifest=record,
     )
     event = _event(f"completed-{job_id}", tenant_id=record.tenant_id)
     completed = adapter.complete_job(command, event)
     assert (completed.state, completed.lease_owner, completed.lease_until) == (
-        JobState.SUCCEEDED,
-        None,
-        None,
-    )
+        JobState.SUCCEEDED, None, None)
     assert (completed.result_manifest_id, completed.result_manifest_key) == (
-        record.manifest_id,
-        record.manifest_key,
-    )
+        record.manifest_id, record.manifest_key)
     assert adapter.get_job(record.tenant_id, job_id) == completed
     identity = (
-        record.tenant_id,
-        record.agent_id,
-        record.source_type,
-        record.file_subtype,
-        record.competencia,
+        record.tenant_id, record.agent_id, record.source_type,
+        record.file_subtype, record.competencia,
     )
     assert adapter.latest_succeeded_job(*identity) == completed
     assert adapter.pending_outbox(100).count(event) == 1
 
 
 def _claim_job_for_record(adapter, record, job_id, clock) -> Job:
-    job = _job(job_id, record.agent_id, record.tenant_id).model_copy(
-        update={
-            "source_type": record.source_type,
-            "file_subtype": record.file_subtype,
-            "competencia": record.competencia,
-            "requested_snapshot_mode": record.snapshot_mode,
-        }
-    )
+    job = _job(job_id, record.agent_id, record.tenant_id).model_copy(update={
+        "source_type": record.source_type, "file_subtype": record.file_subtype,
+        "competencia": record.competencia, "requested_snapshot_mode": record.snapshot_mode,
+    })
     adapter.put_agent(_agent(record.agent_id, tenant_id=record.tenant_id))
     adapter.create_job(job, _event(f"created-{job_id}", tenant_id=record.tenant_id))
     claimed = adapter.claim_job(_claim_job(job_id, "raw-worker", clock, record.tenant_id))
@@ -136,12 +118,8 @@ def test_rejeita_formas_invalidas_das_fronteiras_variadicas(sqlite_control_plane
         sqlite_control_plane.latest_succeeded_job(*identity, "extra")
     with pytest.raises(TypeError, match="unexpected_argument=extra"):
         sqlite_control_plane.latest_succeeded_job(
-            tenant_id="354130",
-            agent_id="agent-a",
-            source_type="CNES",
-            file_subtype="ST",
-            competencia="2026-07",
-            extra="value",
+            tenant_id="354130", agent_id="agent-a", source_type="CNES",
+            file_subtype="ST", competencia="2026-07", extra="value",
         )
     with pytest.raises(TypeError, match="duplicate_argument=tenant_id"):
         sqlite_control_plane.latest_succeeded_job("354130", tenant_id="354130")
@@ -161,31 +139,22 @@ def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
     stale = _claim_job_for_record(sqlite_control_plane, record, "job-stale", clock)
     sqlite_control_plane.complete_job(
         CompleteJob(
-            tenant_id="354130",
-            job_id=first.job_id,
-            owner="raw-worker",
-            fencing_token=first.fencing_token,
-            manifest=record,
+            tenant_id="354130", job_id=first.job_id, owner="raw-worker",
+            fencing_token=first.fencing_token, manifest=record,
         ),
         _event("completed-first"),
     )
     replayed = sqlite_control_plane.complete_job(
         CompleteJob(
-            tenant_id="354130",
-            job_id=replay.job_id,
-            owner="raw-worker",
-            fencing_token=replay.fencing_token,
-            manifest=record,
+            tenant_id="354130", job_id=replay.job_id, owner="raw-worker",
+            fencing_token=replay.fencing_token, manifest=record,
         ),
         _event("completed-replay"),
     )
     before_outbox = sqlite_control_plane.pending_outbox(100)
     divergent_command = CompleteJob(
-        tenant_id="354130",
-        job_id=stale.job_id,
-        owner="raw-worker",
-        fencing_token=stale.fencing_token,
-        manifest=divergent,
+        tenant_id="354130", job_id=stale.job_id, owner="raw-worker",
+        fencing_token=stale.fencing_token, manifest=divergent,
     )
 
     with pytest.raises(Conflict, match="manifest_immutable"):
@@ -199,6 +168,60 @@ def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
         _event("completed-recovered"),
     )
     assert recovered.result_manifest_id == record.manifest_id
+
+
+@pytest.mark.parametrize(
+    ("operation", "field"),
+    [
+        ("complete_job", "fence"), ("complete_job", "manifest"),
+        ("complete_job", "event"), ("fail_job", "fence"),
+        ("fail_job", "error"), ("fail_job", "retryable"), ("fail_job", "event"),
+    ],
+)
+def test_replay_terminal_exato_e_divergente(sqlite_control_plane, clock, operation, field) -> None:
+    sqlite_control_plane.put_agent(_agent("agent-a"))
+    sqlite_control_plane.create_job(_job("job-a"), _event("job-created"))
+    claimed = sqlite_control_plane.claim_job(_claim_job("job-a", "worker-a", clock))
+    assert claimed is not None
+    command = _fail_job("worker-a", claimed.fencing_token, "failed")
+    if operation == "complete_job":
+        command = CompleteJob(
+            tenant_id="354130", job_id="job-a", owner="worker-a",
+            fencing_token=claimed.fencing_token,
+            manifest=_raw_record("terminal", "agent-a", 1, clock.now()),
+        )
+    event = _event("job-terminal")
+    terminal = getattr(sqlite_control_plane, operation)(command, event)
+    reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
+    reopened.initialize()
+    assert getattr(reopened, operation)(command, event) == terminal
+    assert reopened.get_job("354130", "job-a") == terminal
+    assert reopened.pending_outbox(100).count(event) == 1
+    replay_event = event
+    replay_command = command
+    if field == "event":
+        replay_event = event.model_copy(update={"payload": {"changed": True}})
+    elif field == "fence":
+        replay_command = command.model_copy(update={"fencing_token": 2})
+    elif field == "manifest":
+        manifest = command.manifest.model_copy(update={"manifest_sha256": "b" * 64})
+        replay_command = command.model_copy(update={"manifest": manifest})
+    elif field == "error":
+        replay_command = command.model_copy(update={"error_code": "changed"})
+    else:
+        replay_command = command.model_copy(update={"retryable": False})
+    before = (
+        reopened.get_job("354130", "job-a"),
+        reopened.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07"),
+        reopened.pending_outbox(100),
+    )
+    with pytest.raises(Conflict, match="job_terminal_conflict"):
+        getattr(reopened, operation)(replay_command, replay_event)
+    assert before == (
+        reopened.get_job("354130", "job-a"),
+        reopened.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07"),
+        reopened.pending_outbox(100),
+    )
 
 
 def test_seleciona_ancestralidade_da_delta_mais_nova_entre_irmas(
@@ -223,11 +246,9 @@ def test_seleciona_ancestralidade_da_delta_mais_nova_entre_irmas(
     )
     for record in (base, sibling_old, sibling_new, sibling_broken, head):
         _store_record_with_matching_mode(sqlite_control_plane, record, clock)
-
     chain = sqlite_control_plane.list_raw_manifest_chain(
         "354130", "CNES", "ST", "2026-07", 3
     )
-
     assert tuple(reference.manifest_id for reference in chain) == (
         base.manifest_id,
         sibling_new.manifest_id,
@@ -252,14 +273,11 @@ def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
         "state": AccessRequestState.APPROVED, "decided_by": "admin-a", "decided_at": clock.now(),
     })
     decided = _event("access-approved")
-
     assert sqlite_control_plane.decide_access_request(approved, decided) == approved
     assert sqlite_control_plane.get_tenant(tenant.tenant_id) == tenant
     assert sqlite_control_plane.get_access_request(tenant.tenant_id, pending.request_id) == approved
     assert sqlite_control_plane.pending_outbox(10) == (decided, created)
-
     sqlite_control_plane.mark_outbox_delivered(decided.event_id, clock.now())
-
     assert sqlite_control_plane.pending_outbox(10) == (created,)
 
 
@@ -357,10 +375,8 @@ def test_rejeita_resultado_de_unidade_terminal_ou_de_outro_dispatch(
         sqlite_control_plane.list_run_units("354130", "run-a"),
         sqlite_control_plane.pending_outbox(100),
     )
-
     with pytest.raises(LeaseLost, match="dispatch_inactive"):
         action(command, _event("late-result"))
-
     assert before == (
         sqlite_control_plane.list_run_units("354130", "run-a"),
         sqlite_control_plane.pending_outbox(100),
@@ -385,9 +401,7 @@ def test_cancela_job_leased_e_torna_replay_idempotente(sqlite_control_plane, clo
     leased = sqlite_control_plane.claim_job(_claim_job("job-a", "worker-a", clock))
     command = CancelJob(tenant_id="354130", job_id="job-a", requested_by="user-a")
     event = _event("job-cancel-requested")
-
     canceled = sqlite_control_plane.cancel_job(command, event)
-
     assert leased is not None
     assert canceled.state is JobState.CANCEL_REQUESTED
     assert sqlite_control_plane.cancel_job(command, _event("replay-ignored")) == canceled
@@ -397,11 +411,8 @@ def test_cancela_job_leased_e_torna_replay_idempotente(sqlite_control_plane, clo
 @pytest.mark.parametrize(
     "state",
     [
-        pytest.param(JobState.PENDING),
-        pytest.param(JobState.FAILED_RETRYABLE),
-        pytest.param(JobState.FAILED_FINAL),
-        pytest.param(JobState.SUCCEEDED),
-        pytest.param(JobState.CANCELED),
+        JobState.PENDING, JobState.FAILED_RETRYABLE, JobState.FAILED_FINAL,
+        JobState.SUCCEEDED, JobState.CANCELED,
     ],
 )
 def test_rejeita_cancelamento_fora_de_leased_sem_mutacao(
@@ -428,13 +439,11 @@ def test_rejeita_cancelamento_fora_de_leased_sem_mutacao(
 def _manifesto_com_identidade(base: RawManifestRecord, field: str) -> RawManifestRecord:
     updates = {
         "tenant_id": {
-            "tenant_id": "other",
-            "manifest_key": "raw/other/CNES/2026-07/result/manifest.json",
+            "tenant_id": "other", "manifest_key": "raw/other/CNES/2026-07/result/manifest.json",
         },
         "agent_id": {"agent_id": "agent-b"},
         "source_type": {
-            "source_type": "SIHD",
-            "manifest_key": "raw/354130/SIHD/2026-07/result/manifest.json",
+            "source_type": "SIHD", "manifest_key": "raw/354130/SIHD/2026-07/result/manifest.json",
         },
         "file_subtype": {"file_subtype": "PF"},
         "competencia": {
@@ -453,14 +462,7 @@ def _manifesto_com_identidade(base: RawManifestRecord, field: str) -> RawManifes
 
 @pytest.mark.parametrize(
     "field",
-    [
-        pytest.param("tenant_id"),
-        pytest.param("agent_id"),
-        pytest.param("source_type"),
-        pytest.param("file_subtype"),
-        pytest.param("competencia"),
-        pytest.param("snapshot_mode"),
-    ],
+    ["tenant_id", "agent_id", "source_type", "file_subtype", "competencia", "snapshot_mode"],
 )
 def test_rejeita_manifesto_com_identidade_divergente_sem_mutacao(
     sqlite_control_plane, clock, field

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -44,13 +44,11 @@ from packages.cnes_infra.tests.contracts.control_plane_contract import control_p
 @pytest.fixture
 def clock() -> MutableClock:
     return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
-
 @pytest.fixture
 def sqlite_control_plane(tmp_path, clock: MutableClock) -> SQLiteControlPlane:
     adapter = SQLiteControlPlane(tmp_path / "control-plane.sqlite3", clock.now)
     adapter.initialize()
     return adapter
-
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
 def test_sqlite_control_plane_cumpre_contrato(
     case, sqlite_control_plane, clock, monkeypatch
@@ -75,7 +73,6 @@ def test_sqlite_control_plane_cumpre_contrato(
         with pytest.raises(Conflict, match="run_cancellation_conflict"):
             reopened.finalize_run_cancellation(command, event.model_copy(update={"payload": {}}))
         assert before == (reopened.get_run("354130", "run-a"), reopened.pending_outbox(100))
-
 def _store_record_with_matching_mode(adapter, record, clock) -> None:
     job_id = f"job-{record.agent_id}-{record.snapshot_id}"
     job = _job(job_id, record.agent_id, record.tenant_id).model_copy(update={
@@ -89,11 +86,9 @@ def _store_record_with_matching_mode(adapter, record, clock) -> None:
     assert claimed is not None
     command = CompleteJob(
         tenant_id=record.tenant_id, job_id=job_id, owner="raw-worker",
-        fencing_token=claimed.fencing_token, manifest=record,
-    )
+        fencing_token=claimed.fencing_token, manifest=record)
     event = _event(f"completed-{job_id}", tenant_id=record.tenant_id)
     adapter.complete_job(command, event)
-
 def _claim_job_for_record(adapter, record, job_id, clock) -> Job:
     job = _job(job_id, record.agent_id, record.tenant_id).model_copy(update={
         "source_type": record.source_type, "file_subtype": record.file_subtype,
@@ -104,7 +99,6 @@ def _claim_job_for_record(adapter, record, job_id, clock) -> Job:
     claimed = adapter.claim_job(_claim_job(job_id, "raw-worker", clock, record.tenant_id))
     assert claimed is not None
     return claimed
-
 def test_aceita_argumentos_nomeados_e_limites_padrao(sqlite_control_plane) -> None:
     identity = {"tenant_id": "354130", "source_type": "CNES",
                 "file_subtype": "ST", "competencia": "2026-07"}
@@ -114,7 +108,6 @@ def test_aceita_argumentos_nomeados_e_limites_padrao(sqlite_control_plane) -> No
     positional = tuple(identity.values())
     assert sqlite_control_plane.list_raw_manifest_chain(*positional) == ()
     assert sqlite_control_plane.list_waiting_runs_for_dependency(*positional) == ()
-
 def test_rejeita_formas_invalidas_das_fronteiras_variadicas(sqlite_control_plane) -> None:
     identity = ("354130", "agent-a", "CNES", "ST", "2026-07")
     with pytest.raises(TypeError, match="too_many_arguments=6"):
@@ -128,7 +121,6 @@ def test_rejeita_formas_invalidas_das_fronteiras_variadicas(sqlite_control_plane
         sqlite_control_plane.latest_succeeded_job("354130", tenant_id="354130")
     with pytest.raises(TypeError, match="missing_arguments=agent_id"):
         sqlite_control_plane.latest_succeeded_job("354130")
-
 def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
     sqlite_control_plane, clock
 ) -> None:
@@ -141,22 +133,17 @@ def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
     sqlite_control_plane.complete_job(
         CompleteJob(
             tenant_id="354130", job_id=first.job_id, owner="raw-worker",
-            fencing_token=first.fencing_token, manifest=record,
-        ),
-        _event("completed-first"),
-    )
+            fencing_token=first.fencing_token, manifest=record),
+        _event("completed-first"))
     replayed = sqlite_control_plane.complete_job(
         CompleteJob(
             tenant_id="354130", job_id=replay.job_id, owner="raw-worker",
-            fencing_token=replay.fencing_token, manifest=record,
-        ),
-        _event("completed-replay"),
-    )
+            fencing_token=replay.fencing_token, manifest=record),
+        _event("completed-replay"))
     before_outbox = sqlite_control_plane.pending_outbox(100)
     divergent_command = CompleteJob(
         tenant_id="354130", job_id=stale.job_id, owner="raw-worker",
-        fencing_token=stale.fencing_token, manifest=divergent,
-    )
+        fencing_token=stale.fencing_token, manifest=divergent)
     with pytest.raises(Conflict, match="manifest_immutable"):
         sqlite_control_plane.complete_job(divergent_command, _event("completed-stale"))
     assert replayed.state is JobState.SUCCEEDED
@@ -165,7 +152,6 @@ def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
     recovered = sqlite_control_plane.complete_job(
         divergent_command.model_copy(update={"manifest": record}), _event("completed-recovered"))
     assert recovered.result_manifest_id == record.manifest_id
-
 @pytest.mark.parametrize(
     ("operation", "field"),
     [
@@ -407,13 +393,10 @@ def test_replay_terminal_de_unidade_exato_e_divergente(
     before = _unit_snapshot(reopened)
     with pytest.raises(Conflict, match="unit_terminal_conflict"):
         getattr(reopened, operation)(
-            command.model_copy(update={"fencing_token": command.fencing_token + 1}), event
-        )
+            command.model_copy(update={"fencing_token": command.fencing_token + 1}), event)
     with pytest.raises(Conflict, match="unit_terminal_conflict"):
         getattr(reopened, operation)(command, event.model_copy(update={"payload": {}}))
     assert before == _unit_snapshot(reopened)
-
-
 def test_cancela_job_leased_e_torna_replay_idempotente(sqlite_control_plane, clock) -> None:
     sqlite_control_plane.put_agent(_agent("agent-a"))
     sqlite_control_plane.create_job(_job("job-a"), _event("job-created"))
@@ -425,18 +408,12 @@ def test_cancela_job_leased_e_torna_replay_idempotente(sqlite_control_plane, clo
     assert canceled.state is JobState.CANCEL_REQUESTED
     assert sqlite_control_plane.cancel_job(command, _event("replay-ignored")) == canceled
     assert sqlite_control_plane.pending_outbox(10) == (event, _event("job-created"))
-
-
 @pytest.mark.parametrize(
     "state",
-    [
-        JobState.PENDING, JobState.FAILED_RETRYABLE, JobState.FAILED_FINAL,
-        JobState.SUCCEEDED, JobState.CANCELED,
-    ],
+    [JobState.PENDING, JobState.FAILED_RETRYABLE, JobState.FAILED_FINAL,
+     JobState.SUCCEEDED, JobState.CANCELED],
 )
-def test_rejeita_cancelamento_fora_de_leased_sem_mutacao(
-    sqlite_control_plane, state
-) -> None:
+def test_rejeita_cancelamento_fora_de_leased(sqlite_control_plane, state) -> None:
     updates = {"state": state}
     if state is JobState.SUCCEEDED:
         updates |= {
@@ -451,8 +428,6 @@ def test_rejeita_cancelamento_fora_de_leased_sem_mutacao(
         sqlite_control_plane.cancel_job(command, _event("cancel-rejected"))
     assert sqlite_control_plane.get_job("354130", "job-a") == job
     assert sqlite_control_plane.pending_outbox(10) == (created,)
-
-
 def _manifesto_com_identidade(base: RawManifestRecord, field: str) -> RawManifestRecord:
     updates = {
         "tenant_id": {"tenant_id": "other",
@@ -468,15 +443,11 @@ def _manifesto_com_identidade(base: RawManifestRecord, field: str) -> RawManifes
                           "previous_manifest_sha256": "a" * 64},
     }
     return RawManifestRecord.model_validate(base.model_dump() | updates[field])
-
-
 @pytest.mark.parametrize(
     "field",
     ["tenant_id", "agent_id", "source_type", "file_subtype", "competencia", "snapshot_mode"],
 )
-def test_rejeita_manifesto_com_identidade_divergente_sem_mutacao(
-    sqlite_control_plane, clock, field
-) -> None:
+def test_rejeita_manifesto_identidade_divergente(sqlite_control_plane, clock, field) -> None:
     sqlite_control_plane.put_agent(_agent("agent-a"))
     original = _job("job-a")
     created = _event("job-created")
@@ -490,11 +461,40 @@ def test_rejeita_manifesto_com_identidade_divergente_sem_mutacao(
     }
     command = (CompleteJob.model_construct(**command_values) if field == "tenant_id"
                else CompleteJob(**command_values))
-
     with pytest.raises(Conflict, match="manifest_identity_mismatch"):
         sqlite_control_plane.complete_job(command, _event("job-completed"))
-
     assert sqlite_control_plane.get_job("354130", "job-a") == claimed
     assert sqlite_control_plane.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07") == ()
     assert sqlite_control_plane.list_raw_manifest_chain("other", "CNES", "ST", "2026-07") == ()
     assert sqlite_control_plane.pending_outbox(10) == (created,)
+@pytest.mark.parametrize("operation", ["job", "transition", "unit", "publication", "access"])
+def test_evento_entregue_reverte_mutacao(sqlite_control_plane, clock, operation) -> None:
+    states = control_plane_contract.RunState
+    sqlite_control_plane.put_run(_run("run-transition"))
+    sqlite_control_plane.put_run(_run("run-pub", states.PUBLISHING))
+    dispatch = _prepare_unit(sqlite_control_plane, clock)
+    claimed = _claim_unit(sqlite_control_plane, clock, dispatch.dispatch_id, "worker-a")
+    assert claimed is not None
+    delivered = _event("already-delivered").model_copy(update={"delivered_at": clock.now()})
+    transition = control_plane_contract.TransitionRun(
+        tenant_id="354130", run_id="run-transition", expected_state=states.PROCESSING,
+        new_state=states.PUBLISHING)
+    request = AccessRequest(tenant_id="354130", request_id="request-delivered", user_id="user-a",
+        state=AccessRequestState.PENDING, decided_by=None, decided_at=None)
+    publication = control_plane_contract._publish("run-pub", "published", None, False)
+    publication = publication.model_copy(update={"event": delivered})
+    actions = {
+        "job": lambda: sqlite_control_plane.create_job(_job("job-delivered"), delivered),
+        "transition": lambda: sqlite_control_plane.transition_run(transition, delivered),
+        "unit": lambda: sqlite_control_plane.commit_run_unit(
+            _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token), delivered),
+        "publication": lambda: sqlite_control_plane.publish_dataset(publication),
+        "access": lambda: sqlite_control_plane.put_access_request(request, delivered),
+    }
+    def snapshot():
+        with sqlite_control_plane.read_connection() as connection:
+            return tuple(connection.iterdump())
+    before = snapshot()
+    with pytest.raises(Conflict, match="outbox_event_already_delivered"):
+        actions[operation]()
+    assert snapshot() == before

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -235,6 +235,21 @@ def test_seleciona_ancestralidade_da_delta_mais_nova_entre_irmas(
         base.manifest_id, sibling_new.manifest_id, head.manifest_id)
 
 
+def test_pagina_heads_com_empate_ate_encontrar_chain_valida(sqlite_control_plane, clock) -> None:
+    base = _raw_record("same", "agent-tie", 1, clock.now()).model_copy(
+        update={"manifest_id": "manifest-x"})
+    broken = _raw_record("same", "agent-tie", 2, clock.now()).model_copy(
+        update={"previous_manifest_sha256": "e" * 64})
+    with sqlite_control_plane.write_transaction() as connection:
+        for manifest_id in ("manifest-z", "manifest-y"):
+            sqlite_control_plane.put_manifest_record(
+                connection, broken.model_copy(update={"manifest_id": manifest_id}))
+        sqlite_control_plane.put_manifest_record(connection, base)
+    chain = sqlite_control_plane.list_raw_manifest_chain(
+        "354130", "CNES", "ST", "2026-07", 2)
+    assert tuple(item.manifest_id for item in chain) == (base.manifest_id,)
+
+
 def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
     sqlite_control_plane, clock
 ) -> None:
@@ -283,8 +298,7 @@ def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
     })
     before = (sqlite_control_plane.get_access_request("354130", "request-a"), (created,))
     invalid = pending if invalid_kind == "state" else approved.model_copy(
-        update={"user_id": "user-b"}
-    )
+        update={"user_id": "user-b"})
     with pytest.raises(Conflict, match=error):
         sqlite_control_plane.decide_access_request(invalid, ignored)
     assert before == (
@@ -296,12 +310,10 @@ def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
     assert sqlite_control_plane.decide_access_request(approved, ignored) == approved
     with pytest.raises(Conflict, match="access_request_state_conflict"):
         sqlite_control_plane.decide_access_request(
-            approved.model_copy(update={"state": AccessRequestState.REJECTED}), ignored
-        )
+            approved.model_copy(update={"state": AccessRequestState.REJECTED}), ignored)
     with pytest.raises(Conflict, match="access_request_state_conflict"):
         sqlite_control_plane.decide_access_request(
-            pending.model_copy(update={"request_id": "missing"}), ignored
-        )
+            pending.model_copy(update={"request_id": "missing"}), ignored)
     assert sqlite_control_plane.get_access_request("354130", "request-a") == approved
     assert sqlite_control_plane.pending_outbox(100) == (decided, created)
 
@@ -317,8 +329,7 @@ def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(sqlite_control_plan
     assert sqlite_control_plane.create_job(job, _event("ignored")) == job
     with pytest.raises(Conflict, match="job_conflict"):
         sqlite_control_plane.create_job(
-            job.model_copy(update={"source_type": "SIHD"}), _event("job-conflict")
-        )
+            job.model_copy(update={"source_type": "SIHD"}), _event("job-conflict"))
     second = _job("job-b")
     assert sqlite_control_plane.create_job(second, created) == second
     assert sqlite_control_plane.pending_outbox(100) == (created,)
@@ -474,26 +485,16 @@ def test_rejeita_manifesto_com_identidade_divergente_sem_mutacao(
     assert claimed is not None
     manifest = _manifesto_com_identidade(_raw_record("result", "agent-a", 1, clock.now()), field)
     command_values = {
-        "tenant_id": "354130",
-        "job_id": "job-a",
-        "owner": "worker-a",
-        "fencing_token": claimed.fencing_token,
-        "manifest": manifest,
+        "tenant_id": "354130", "job_id": "job-a", "owner": "worker-a",
+        "fencing_token": claimed.fencing_token, "manifest": manifest,
     }
-    command = (
-        CompleteJob.model_construct(**command_values)
-        if field == "tenant_id"
-        else CompleteJob(**command_values)
-    )
+    command = (CompleteJob.model_construct(**command_values) if field == "tenant_id"
+               else CompleteJob(**command_values))
 
     with pytest.raises(Conflict, match="manifest_identity_mismatch"):
         sqlite_control_plane.complete_job(command, _event("job-completed"))
 
     assert sqlite_control_plane.get_job("354130", "job-a") == claimed
-    assert sqlite_control_plane.list_raw_manifest_chain(
-        "354130", "CNES", "ST", "2026-07"
-    ) == ()
-    assert sqlite_control_plane.list_raw_manifest_chain(
-        "other", "CNES", "ST", "2026-07"
-    ) == ()
+    assert sqlite_control_plane.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07") == ()
+    assert sqlite_control_plane.list_raw_manifest_chain("other", "CNES", "ST", "2026-07") == ()
     assert sqlite_control_plane.pending_outbox(10) == (created,)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -286,6 +286,8 @@ def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind
     )
     decided = _event("access-approved")
     assert sqlite_control_plane.decide_access_request(approved, decided) == approved
+    with sqlite_control_plane.write_transaction() as connection:
+        connection.execute("ALTER TABLE access_requests DROP COLUMN creation_request_data")
     reopened = SQLiteControlPlane(sqlite_control_plane._database_path, clock.now)
     reopened.initialize()
     assert reopened.decide_access_request(approved, decided) == approved

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta  # noqa: I001
 
 import pytest
 
@@ -39,8 +39,6 @@ from packages.cnes_infra.tests.contracts.clock import (
     _run,
 )
 from packages.cnes_infra.tests.contracts.control_plane_contract import control_plane_cases
-
-
 @pytest.fixture
 def clock() -> MutableClock:
     return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
@@ -258,10 +256,8 @@ def test_persiste_acesso_e_outbox(sqlite_control_plane, clock) -> None:
     [("state", "access_request_decision_state"), ("identity", "access_request_identity_conflict")],
 )
 def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind, error) -> None:
-    pending = AccessRequest(
-        tenant_id="354130", request_id="request-a", user_id="user-a",
-        state=AccessRequestState.PENDING, decided_by=None, decided_at=None,
-    )
+    pending = AccessRequest(tenant_id="354130", request_id="request-a", user_id="user-a",
+        state=AccessRequestState.PENDING, decided_by=None, decided_at=None)
     created = _event("access-requested")
     ignored = _event("access-replay")
     approved = pending.model_copy(update={
@@ -270,7 +266,11 @@ def test_replays_e_conflitos_de_acesso(sqlite_control_plane, clock, invalid_kind
     with pytest.raises(Conflict, match="access_request_creation_state"):
         sqlite_control_plane.put_access_request(approved, ignored)
     sqlite_control_plane.put_access_request(pending, created)
-    sqlite_control_plane.put_access_request(pending, ignored)
+    replay = created.model_copy(update={"tenant_id": "other", "payload": {"changed": True},
+        "delivered_at": clock.now()})
+    with pytest.raises(Conflict, match="access_request_creation_conflict"):
+        sqlite_control_plane.put_access_request(pending, replay)
+    sqlite_control_plane.put_access_request(pending, created)
     divergent = pending.model_copy(update={"user_id": "user-b"})
     with pytest.raises(Conflict, match="access_request_conflict"):
         sqlite_control_plane.put_access_request(divergent, _event("access-conflict"))
@@ -326,8 +326,7 @@ def test_rejeita_unidade_terminal(sqlite_control_plane, clock, operation) -> Non
     dispatch = _prepare_unit(sqlite_control_plane, clock)
     claimed = _claim_unit(sqlite_control_plane, clock, dispatch.dispatch_id, "worker-a")
     assert claimed is not None
-    commit = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
-    command = commit
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
     if operation == "fail_run_unit":
         command = FailRunUnit(
             tenant_id="354130", run_id="run-a", unit_id="unit-a",
@@ -345,6 +344,7 @@ def test_rejeita_unidade_terminal(sqlite_control_plane, clock, operation) -> Non
     with pytest.raises(LeaseLost, match="dispatch_inactive"):
         action(command, _event("late-result"))
     assert before == _unit_snapshot(sqlite_control_plane)
+    clock.advance(timedelta(seconds=31))
     replacement = _reserve(sqlite_control_plane, clock)
     stale = command.model_copy(update={"dispatch_id": replacement.dispatch_id})
     before_stale = _unit_snapshot(sqlite_control_plane)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -242,23 +242,15 @@ def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
         tenant_id="354130", municipality_name="Presidente Epitácio", created_at=clock.now()
     )
     pending = AccessRequest(
-        tenant_id=tenant.tenant_id,
-        request_id="request-a",
-        user_id="user-a",
-        state=AccessRequestState.PENDING,
-        decided_by=None,
-        decided_at=None,
+        tenant_id=tenant.tenant_id, request_id="request-a", user_id="user-a",
+        state=AccessRequestState.PENDING, decided_by=None, decided_at=None,
     )
     created = _event("access-requested")
     sqlite_control_plane.put_tenant(tenant)
     sqlite_control_plane.put_access_request(pending, created)
-    approved = pending.model_copy(
-        update={
-            "state": AccessRequestState.APPROVED,
-            "decided_by": "admin-a",
-            "decided_at": clock.now(),
-        }
-    )
+    approved = pending.model_copy(update={
+        "state": AccessRequestState.APPROVED, "decided_by": "admin-a", "decided_at": clock.now(),
+    })
     decided = _event("access-approved")
 
     assert sqlite_control_plane.decide_access_request(approved, decided) == approved
@@ -271,16 +263,16 @@ def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
     assert sqlite_control_plane.pending_outbox(10) == (created,)
 
 
+@pytest.mark.parametrize(
+    ("invalid_kind", "error"),
+    [("state", "access_request_decision_state"), ("identity", "access_request_identity_conflict")],
+)
 def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
-    sqlite_control_plane, clock
+    sqlite_control_plane, clock, invalid_kind, error
 ) -> None:
     pending = AccessRequest(
-        tenant_id="354130",
-        request_id="request-a",
-        user_id="user-a",
-        state=AccessRequestState.PENDING,
-        decided_by=None,
-        decided_at=None,
+        tenant_id="354130", request_id="request-a", user_id="user-a",
+        state=AccessRequestState.PENDING, decided_by=None, decided_at=None,
     )
     created = _event("access-requested")
     ignored = _event("access-replay")
@@ -289,22 +281,30 @@ def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
     divergent = pending.model_copy(update={"user_id": "user-b"})
     with pytest.raises(Conflict, match="access_request_conflict"):
         sqlite_control_plane.put_access_request(divergent, _event("access-conflict"))
-    approved = pending.model_copy(
-        update={
-            "state": AccessRequestState.APPROVED,
-            "decided_by": "admin-a",
-            "decided_at": clock.now(),
-        }
+    approved = pending.model_copy(update={
+        "state": AccessRequestState.APPROVED, "decided_by": "admin-a", "decided_at": clock.now(),
+    })
+    before = (sqlite_control_plane.get_access_request("354130", "request-a"), (created,))
+    invalid = pending if invalid_kind == "state" else approved.model_copy(
+        update={"user_id": "user-b"}
+    )
+    with pytest.raises(Conflict, match=error):
+        sqlite_control_plane.decide_access_request(invalid, ignored)
+    assert before == (
+        sqlite_control_plane.get_access_request("354130", "request-a"),
+        sqlite_control_plane.pending_outbox(100),
     )
     decided = _event("access-approved")
     assert sqlite_control_plane.decide_access_request(approved, decided) == approved
     assert sqlite_control_plane.decide_access_request(approved, ignored) == approved
     with pytest.raises(Conflict, match="access_request_state_conflict"):
         sqlite_control_plane.decide_access_request(
-            pending.model_copy(update={"request_id": "missing"}), ignored
+            approved.model_copy(update={"state": AccessRequestState.REJECTED}), ignored
         )
     with pytest.raises(Conflict, match="access_request_state_conflict"):
-        sqlite_control_plane.decide_access_request(pending, ignored)
+        sqlite_control_plane.decide_access_request(
+            pending.model_copy(update={"request_id": "missing"}), ignored
+        )
     assert sqlite_control_plane.get_access_request("354130", "request-a") == approved
     assert sqlite_control_plane.pending_outbox(100) == (decided, created)
 

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -1,5 +1,7 @@
-from datetime import UTC, datetime, timedelta  # noqa: I001
+from datetime import UTC, datetime, timedelta
+
 import pytest
+
 from cnes_domain.control_plane.commands import (
     CancelJob,
     CompleteJob,
@@ -37,6 +39,8 @@ from packages.cnes_infra.tests.contracts.clock import (
     _run,
 )
 from packages.cnes_infra.tests.contracts.control_plane_contract import control_plane_cases
+
+
 @pytest.fixture
 def clock() -> MutableClock:
     return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -1,11 +1,11 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
 from cnes_domain.control_plane.commands import CancelJob, CompleteJob
 from cnes_domain.control_plane.entities import AccessRequest, Job, RawManifestRecord, Tenant
 from cnes_domain.control_plane.enums import AccessRequestState, JobState
-from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.control_plane.errors import Conflict, NotFound
 from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
 from packages.cnes_infra.tests.contracts import control_plane_contract
 from packages.cnes_infra.tests.contracts.clock import (
@@ -87,6 +87,22 @@ def _store_record_with_matching_mode(adapter, record, clock) -> None:
     assert adapter.pending_outbox(100).count(event) == 1
 
 
+def _claim_job_for_record(adapter, record, job_id, clock) -> Job:
+    job = _job(job_id, record.agent_id, record.tenant_id).model_copy(
+        update={
+            "source_type": record.source_type,
+            "file_subtype": record.file_subtype,
+            "competencia": record.competencia,
+            "requested_snapshot_mode": record.snapshot_mode,
+        }
+    )
+    adapter.put_agent(_agent(record.agent_id, tenant_id=record.tenant_id))
+    adapter.create_job(job, _event(f"created-{job_id}", tenant_id=record.tenant_id))
+    claimed = adapter.claim_job(_claim_job(job_id, "raw-worker", clock, record.tenant_id))
+    assert claimed is not None
+    return claimed
+
+
 def test_aceita_argumentos_nomeados_e_limites_padrao(sqlite_control_plane) -> None:
     identity = {
         "tenant_id": "354130",
@@ -103,6 +119,111 @@ def test_aceita_argumentos_nomeados_e_limites_padrao(sqlite_control_plane) -> No
     positional = tuple(identity.values())
     assert sqlite_control_plane.list_raw_manifest_chain(*positional) == ()
     assert sqlite_control_plane.list_waiting_runs_for_dependency(*positional) == ()
+
+
+def test_rejeita_formas_invalidas_das_fronteiras_variadicas(sqlite_control_plane) -> None:
+    identity = ("354130", "agent-a", "CNES", "ST", "2026-07")
+    with pytest.raises(TypeError, match="too_many_arguments=6"):
+        sqlite_control_plane.latest_succeeded_job(*identity, "extra")
+    with pytest.raises(TypeError, match="unexpected_argument=extra"):
+        sqlite_control_plane.latest_succeeded_job(
+            tenant_id="354130",
+            agent_id="agent-a",
+            source_type="CNES",
+            file_subtype="ST",
+            competencia="2026-07",
+            extra="value",
+        )
+    with pytest.raises(TypeError, match="duplicate_argument=tenant_id"):
+        sqlite_control_plane.latest_succeeded_job("354130", tenant_id="354130")
+    with pytest.raises(TypeError, match="missing_arguments=agent_id"):
+        sqlite_control_plane.latest_succeeded_job("354130")
+
+
+def test_manifesto_repetido_e_idempotente_mas_conteudo_divergente_conflita(
+    sqlite_control_plane, clock
+) -> None:
+    record = _raw_record("snapshot-a", "agent-a", 1, clock.now())
+    first = _claim_job_for_record(sqlite_control_plane, record, "job-first", clock)
+    replay = _claim_job_for_record(sqlite_control_plane, record, "job-replay", clock)
+    divergent = RawManifestRecord.model_validate(
+        record.model_dump() | {"manifest_sha256": "b" * 64}
+    )
+    stale = _claim_job_for_record(sqlite_control_plane, record, "job-stale", clock)
+    sqlite_control_plane.complete_job(
+        CompleteJob(
+            tenant_id="354130",
+            job_id=first.job_id,
+            owner="raw-worker",
+            fencing_token=first.fencing_token,
+            manifest=record,
+        ),
+        _event("completed-first"),
+    )
+    replayed = sqlite_control_plane.complete_job(
+        CompleteJob(
+            tenant_id="354130",
+            job_id=replay.job_id,
+            owner="raw-worker",
+            fencing_token=replay.fencing_token,
+            manifest=record,
+        ),
+        _event("completed-replay"),
+    )
+    before_outbox = sqlite_control_plane.pending_outbox(100)
+    divergent_command = CompleteJob(
+        tenant_id="354130",
+        job_id=stale.job_id,
+        owner="raw-worker",
+        fencing_token=stale.fencing_token,
+        manifest=divergent,
+    )
+
+    with pytest.raises(Conflict, match="manifest_immutable"):
+        sqlite_control_plane.complete_job(divergent_command, _event("completed-stale"))
+
+    assert replayed.state is JobState.SUCCEEDED
+    assert sqlite_control_plane.get_job("354130", stale.job_id) == stale
+    assert sqlite_control_plane.pending_outbox(100) == before_outbox
+    recovered = sqlite_control_plane.complete_job(
+        divergent_command.model_copy(update={"manifest": record}),
+        _event("completed-recovered"),
+    )
+    assert recovered.result_manifest_id == record.manifest_id
+
+
+def test_seleciona_ancestralidade_da_delta_mais_nova_entre_irmas(
+    sqlite_control_plane, clock
+) -> None:
+    base = _raw_record("base-agent-a", "agent-a", 1, clock.now())
+    sibling_old = _raw_record(
+        "delta-a", "agent-a", 2, clock.now() + timedelta(seconds=1)
+    ).model_copy(update={"manifest_sha256": "b" * 64})
+    sibling_new = _raw_record(
+        "delta-b", "agent-a", 2, clock.now() + timedelta(seconds=2)
+    ).model_copy(update={"manifest_sha256": "c" * 64})
+    sibling_broken = _raw_record(
+        "delta-c", "agent-a", 2, clock.now() + timedelta(milliseconds=2500)
+    ).model_copy(
+        update={"previous_manifest_sha256": "e" * 64, "manifest_sha256": "c" * 64}
+    )
+    head = _raw_record(
+        "delta-d", "agent-a", 3, clock.now() + timedelta(seconds=3)
+    ).model_copy(
+        update={"previous_manifest_sha256": "c" * 64, "manifest_sha256": "d" * 64}
+    )
+    for record in (base, sibling_old, sibling_new, sibling_broken, head):
+        _store_record_with_matching_mode(sqlite_control_plane, record, clock)
+
+    chain = sqlite_control_plane.list_raw_manifest_chain(
+        "354130", "CNES", "ST", "2026-07", 3
+    )
+
+    assert tuple(reference.manifest_id for reference in chain) == (
+        base.manifest_id,
+        sibling_new.manifest_id,
+        head.manifest_id,
+    )
 
 
 def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
@@ -139,6 +260,66 @@ def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
     sqlite_control_plane.mark_outbox_delivered(decided.event_id, clock.now())
 
     assert sqlite_control_plane.pending_outbox(10) == (created,)
+
+
+def test_rejeita_conflitos_e_replays_de_solicitacao_de_acesso(
+    sqlite_control_plane, clock
+) -> None:
+    pending = AccessRequest(
+        tenant_id="354130",
+        request_id="request-a",
+        user_id="user-a",
+        state=AccessRequestState.PENDING,
+        decided_by=None,
+        decided_at=None,
+    )
+    created = _event("access-requested")
+    ignored = _event("access-replay")
+    sqlite_control_plane.put_access_request(pending, created)
+    sqlite_control_plane.put_access_request(pending, ignored)
+    divergent = pending.model_copy(update={"user_id": "user-b"})
+    with pytest.raises(Conflict, match="access_request_conflict"):
+        sqlite_control_plane.put_access_request(divergent, _event("access-conflict"))
+    approved = pending.model_copy(
+        update={
+            "state": AccessRequestState.APPROVED,
+            "decided_by": "admin-a",
+            "decided_at": clock.now(),
+        }
+    )
+    decided = _event("access-approved")
+    assert sqlite_control_plane.decide_access_request(approved, decided) == approved
+    assert sqlite_control_plane.decide_access_request(approved, ignored) == approved
+    with pytest.raises(Conflict, match="access_request_state_conflict"):
+        sqlite_control_plane.decide_access_request(
+            pending.model_copy(update={"request_id": "missing"}), ignored
+        )
+    with pytest.raises(Conflict, match="access_request_state_conflict"):
+        sqlite_control_plane.decide_access_request(pending, ignored)
+    assert sqlite_control_plane.get_access_request("354130", "request-a") == approved
+    assert sqlite_control_plane.pending_outbox(100) == (decided, created)
+
+
+def test_replays_e_conflitos_de_job_outbox_e_entrega_ausente(
+    sqlite_control_plane,
+) -> None:
+    agent = _agent("agent-a")
+    sqlite_control_plane.put_agent(agent)
+    assert sqlite_control_plane.get_agent("354130", "agent-a") == agent
+    assert sqlite_control_plane.get_agent("other", "agent-a") is None
+    job = _job("job-a")
+    created = _event("job-created")
+    assert sqlite_control_plane.create_job(job, created) == job
+    assert sqlite_control_plane.create_job(job, _event("ignored")) == job
+    with pytest.raises(Conflict, match="job_conflict"):
+        sqlite_control_plane.create_job(
+            job.model_copy(update={"source_type": "SIHD"}), _event("job-conflict")
+        )
+    second = _job("job-b")
+    assert sqlite_control_plane.create_job(second, created) == second
+    assert sqlite_control_plane.pending_outbox(100) == (created,)
+    with pytest.raises(NotFound, match="outbox_event_missing"):
+        sqlite_control_plane.mark_outbox_delivered("missing", datetime.now(UTC))
 
 
 def test_cancela_job_leased_e_torna_replay_idempotente(sqlite_control_plane, clock) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -53,7 +53,8 @@ def _store_record_with_matching_mode(adapter, record, clock) -> None:
         }
     )
     adapter.put_agent(_agent(record.agent_id, tenant_id=record.tenant_id))
-    adapter.create_job(job, _event(f"created-{job_id}", tenant_id=record.tenant_id))
+    created = _event(f"created-{job_id}", tenant_id=record.tenant_id)
+    adapter.create_job(job, created)
     claimed = adapter.claim_job(_claim_job(job_id, "raw-worker", clock, record.tenant_id))
     assert claimed is not None
     command = CompleteJob(
@@ -63,9 +64,27 @@ def _store_record_with_matching_mode(adapter, record, clock) -> None:
         fencing_token=claimed.fencing_token,
         manifest=record,
     )
-    adapter.complete_job(
-        command, _event(f"completed-{job_id}", tenant_id=record.tenant_id)
+    event = _event(f"completed-{job_id}", tenant_id=record.tenant_id)
+    completed = adapter.complete_job(command, event)
+    assert (completed.state, completed.lease_owner, completed.lease_until) == (
+        JobState.SUCCEEDED,
+        None,
+        None,
     )
+    assert (completed.result_manifest_id, completed.result_manifest_key) == (
+        record.manifest_id,
+        record.manifest_key,
+    )
+    assert adapter.get_job(record.tenant_id, job_id) == completed
+    identity = (
+        record.tenant_id,
+        record.agent_id,
+        record.source_type,
+        record.file_subtype,
+        record.competencia,
+    )
+    assert adapter.latest_succeeded_job(*identity) == completed
+    assert adapter.pending_outbox(100).count(event) == 1
 
 
 def test_aceita_argumentos_nomeados_e_limites_padrao(sqlite_control_plane) -> None:
@@ -170,6 +189,10 @@ def test_rejeita_cancelamento_fora_de_leased_sem_mutacao(
 
 def _manifesto_com_identidade(base: RawManifestRecord, field: str) -> RawManifestRecord:
     updates = {
+        "tenant_id": {
+            "tenant_id": "other",
+            "manifest_key": "raw/other/CNES/2026-07/result/manifest.json",
+        },
         "agent_id": {"agent_id": "agent-b"},
         "source_type": {
             "source_type": "SIHD",
@@ -193,6 +216,7 @@ def _manifesto_com_identidade(base: RawManifestRecord, field: str) -> RawManifes
 @pytest.mark.parametrize(
     "field",
     [
+        pytest.param("tenant_id"),
         pytest.param("agent_id"),
         pytest.param("source_type"),
         pytest.param("file_subtype"),
@@ -210,12 +234,17 @@ def test_rejeita_manifesto_com_identidade_divergente_sem_mutacao(
     claimed = sqlite_control_plane.claim_job(_claim_job("job-a", "worker-a", clock))
     assert claimed is not None
     manifest = _manifesto_com_identidade(_raw_record("result", "agent-a", 1, clock.now()), field)
-    command = CompleteJob(
-        tenant_id="354130",
-        job_id="job-a",
-        owner="worker-a",
-        fencing_token=claimed.fencing_token,
-        manifest=manifest,
+    command_values = {
+        "tenant_id": "354130",
+        "job_id": "job-a",
+        "owner": "worker-a",
+        "fencing_token": claimed.fencing_token,
+        "manifest": manifest,
+    }
+    command = (
+        CompleteJob.model_construct(**command_values)
+        if field == "tenant_id"
+        else CompleteJob(**command_values)
     )
 
     with pytest.raises(Conflict, match="manifest_identity_mismatch"):
@@ -224,5 +253,8 @@ def test_rejeita_manifesto_com_identidade_divergente_sem_mutacao(
     assert sqlite_control_plane.get_job("354130", "job-a") == claimed
     assert sqlite_control_plane.list_raw_manifest_chain(
         "354130", "CNES", "ST", "2026-07"
+    ) == ()
+    assert sqlite_control_plane.list_raw_manifest_chain(
+        "other", "CNES", "ST", "2026-07"
     ) == ()
     assert sqlite_control_plane.pending_outbox(10) == (created,)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py
@@ -1,0 +1,109 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cnes_domain.control_plane.commands import CancelJob
+from cnes_domain.control_plane.entities import AccessRequest, Tenant
+from cnes_domain.control_plane.enums import AccessRequestState, JobState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
+from packages.cnes_infra.tests.contracts.clock import (
+    MutableClock,
+    _agent,
+    _claim_job,
+    _event,
+    _job,
+)
+from packages.cnes_infra.tests.contracts.control_plane_contract import control_plane_cases
+
+
+@pytest.fixture
+def clock() -> MutableClock:
+    return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
+
+
+@pytest.fixture
+def sqlite_control_plane(tmp_path, clock: MutableClock) -> SQLiteControlPlane:
+    adapter = SQLiteControlPlane(tmp_path / "control-plane.sqlite3", clock.now)
+    adapter.initialize()
+    return adapter
+
+
+@pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
+def test_sqlite_control_plane_cumpre_contrato(case, sqlite_control_plane, clock) -> None:
+    case.run(sqlite_control_plane, clock)
+
+
+def test_persiste_tenant_solicitacao_de_acesso_e_entrega_outbox(
+    sqlite_control_plane, clock
+) -> None:
+    tenant = Tenant(
+        tenant_id="354130", municipality_name="Presidente Epitácio", created_at=clock.now()
+    )
+    pending = AccessRequest(
+        tenant_id=tenant.tenant_id,
+        request_id="request-a",
+        user_id="user-a",
+        state=AccessRequestState.PENDING,
+        decided_by=None,
+        decided_at=None,
+    )
+    created = _event("access-requested")
+    sqlite_control_plane.put_tenant(tenant)
+    sqlite_control_plane.put_access_request(pending, created)
+    approved = pending.model_copy(
+        update={
+            "state": AccessRequestState.APPROVED,
+            "decided_by": "admin-a",
+            "decided_at": clock.now(),
+        }
+    )
+    decided = _event("access-approved")
+
+    assert sqlite_control_plane.decide_access_request(approved, decided) == approved
+    assert sqlite_control_plane.get_tenant(tenant.tenant_id) == tenant
+    assert sqlite_control_plane.get_access_request(tenant.tenant_id, pending.request_id) == approved
+    assert sqlite_control_plane.pending_outbox(10) == (decided, created)
+
+    sqlite_control_plane.mark_outbox_delivered(decided.event_id, clock.now())
+
+    assert sqlite_control_plane.pending_outbox(10) == (created,)
+
+
+def test_cancela_job_leased_e_torna_replay_idempotente(sqlite_control_plane, clock) -> None:
+    sqlite_control_plane.put_agent(_agent("agent-a"))
+    sqlite_control_plane.create_job(_job("job-a"), _event("job-created"))
+    leased = sqlite_control_plane.claim_job(_claim_job("job-a", "worker-a", clock))
+    command = CancelJob(tenant_id="354130", job_id="job-a", requested_by="user-a")
+    event = _event("job-cancel-requested")
+
+    canceled = sqlite_control_plane.cancel_job(command, event)
+
+    assert leased is not None
+    assert canceled.state is JobState.CANCEL_REQUESTED
+    assert sqlite_control_plane.cancel_job(command, _event("replay-ignored")) == canceled
+    assert sqlite_control_plane.pending_outbox(10) == (event, _event("job-created"))
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        pytest.param(JobState.PENDING),
+        pytest.param(JobState.FAILED_RETRYABLE),
+        pytest.param(JobState.FAILED_FINAL),
+        pytest.param(JobState.CANCELED),
+    ],
+)
+def test_rejeita_cancelamento_fora_de_leased_sem_mutacao(
+    sqlite_control_plane, state
+) -> None:
+    job = _job("job-a").model_copy(update={"state": state})
+    created = _event("job-created")
+    sqlite_control_plane.create_job(job, created)
+    command = CancelJob(tenant_id="354130", job_id="job-a", requested_by="user-a")
+
+    with pytest.raises(Conflict, match="job_not_leased"):
+        sqlite_control_plane.cancel_job(command, _event("cancel-rejected"))
+
+    assert sqlite_control_plane.get_job("354130", "job-a") == job
+    assert sqlite_control_plane.pending_outbox(10) == (created,)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_dispatch.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_dispatch.py
@@ -4,6 +4,7 @@ import pytest
 
 from cnes_domain.control_plane.commands import BindRunDispatch, FinishRunDispatch
 from cnes_domain.control_plane.enums import DispatchOutcome
+from cnes_domain.control_plane.errors import Conflict
 from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
 from packages.cnes_infra.tests.contracts.clock import MutableClock, _prepare_unit
 
@@ -65,3 +66,26 @@ def test_migra_resposta_de_bind(adapter, clock) -> None:
     reopened = SQLiteControlPlane(adapter._database_path, clock.now)
     reopened.initialize()
     assert reopened.bind_run_dispatch(bind) == started
+
+
+def test_rejeita_bind_de_dispatch_finalizado_sem_replay(adapter, clock) -> None:
+    dispatch = _prepare_unit(adapter, clock)
+    adapter.finish_run_dispatch(
+        FinishRunDispatch(
+            tenant_id="354130",
+            run_id="run-a",
+            dispatch_id=dispatch.dispatch_id,
+            outcome=DispatchOutcome.SUCCEEDED,
+            finished_at=clock.now(),
+        )
+    )
+    bind = BindRunDispatch(
+        tenant_id="354130",
+        run_id="run-a",
+        dispatch_id=dispatch.dispatch_id,
+        execution_ref="exec-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    with pytest.raises(Conflict, match="dispatch_terminal"):
+        adapter.bind_run_dispatch(bind)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_dispatch.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_dispatch.py
@@ -1,0 +1,67 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cnes_domain.control_plane.commands import BindRunDispatch, FinishRunDispatch
+from cnes_domain.control_plane.enums import DispatchOutcome
+from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
+from packages.cnes_infra.tests.contracts.clock import MutableClock, _prepare_unit
+
+
+@pytest.fixture
+def clock() -> MutableClock:
+    return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
+
+
+@pytest.fixture
+def adapter(tmp_path, clock) -> SQLiteControlPlane:
+    control_plane = SQLiteControlPlane(tmp_path / "control-plane.sqlite3", clock.now)
+    control_plane.initialize()
+    return control_plane
+
+
+def test_reexecuta_bind_apos_dispatch_terminal(adapter, clock) -> None:
+    dispatch = _prepare_unit(adapter, clock)
+    bind = BindRunDispatch(
+        tenant_id="354130",
+        run_id="run-a",
+        dispatch_id=dispatch.dispatch_id,
+        execution_ref="exec-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    started = adapter.bind_run_dispatch(bind)
+    adapter.finish_run_dispatch(
+        FinishRunDispatch(
+            tenant_id="354130",
+            run_id="run-a",
+            dispatch_id=dispatch.dispatch_id,
+            outcome=DispatchOutcome.SUCCEEDED,
+            finished_at=clock.now(),
+        )
+    )
+    assert adapter.bind_run_dispatch(bind) == started
+
+
+def test_cria_indice_para_outbox_pendente(adapter) -> None:
+    with adapter.read_connection() as connection:
+        indexes = connection.execute("PRAGMA index_list(outbox_events)").fetchall()
+    assert "ix_outbox_pending" in {row[1] for row in indexes}
+
+
+def test_migra_resposta_de_bind(adapter, clock) -> None:
+    dispatch = _prepare_unit(adapter, clock)
+    bind = BindRunDispatch(
+        tenant_id="354130",
+        run_id="run-a",
+        dispatch_id=dispatch.dispatch_id,
+        execution_ref="exec-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    started = adapter.bind_run_dispatch(bind)
+    with adapter.write_transaction() as connection:
+        connection.execute("ALTER TABLE run_dispatch_bind_writes DROP COLUMN response_data")
+    reopened = SQLiteControlPlane(adapter._database_path, clock.now)
+    reopened.initialize()
+    assert reopened.bind_run_dispatch(bind) == started

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_dispatch.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_dispatch.py
@@ -3,10 +3,11 @@ from datetime import UTC, datetime
 import pytest
 
 from cnes_domain.control_plane.commands import BindRunDispatch, FinishRunDispatch
-from cnes_domain.control_plane.enums import DispatchOutcome
+from cnes_domain.control_plane.enums import DispatchOutcome, RunState
 from cnes_domain.control_plane.errors import Conflict
 from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
-from packages.cnes_infra.tests.contracts.clock import MutableClock, _prepare_unit, _reserve
+from packages.cnes_infra.tests.contracts.clock import MutableClock, _prepare_unit, _reserve, _run
+from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
 
 
 @pytest.fixture
@@ -42,6 +43,28 @@ def test_reexecuta_bind_apos_dispatch_terminal(adapter, clock) -> None:
         )
     )
     assert adapter.bind_run_dispatch(bind) == started
+
+
+def test_rejeita_publicacao_de_competencia_divergente(adapter) -> None:
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    command = _publish("run-a", "published-a", None, False)
+    version = command.version.model_copy(
+        update={"run_manifest_key": "reconciliation/354130/2026-06/run-a/run-manifest.json"}
+    )
+    with pytest.raises(Conflict, match="run_competencia_mismatch"):
+        adapter.publish_dataset(command.model_copy(update={"version": version}))
+    assert adapter.get_dataset_pointer("354130", "gold") is None
+
+
+def test_migra_resposta_de_publicacao(adapter) -> None:
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    command = _publish("run-a", "published-a", None, False)
+    pointer = adapter.publish_dataset(command)
+    with adapter.write_transaction() as connection:
+        connection.execute("ALTER TABLE dataset_publications DROP COLUMN response_data")
+    reopened = SQLiteControlPlane(adapter._database_path, adapter.now)
+    reopened.initialize()
+    assert reopened.publish_dataset(command) == pointer
 
 
 def test_cria_indice_para_outbox_pendente(adapter) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_dispatch.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_dispatch.py
@@ -6,6 +6,7 @@ from cnes_domain.control_plane.commands import BindRunDispatch, FinishRunDispatc
 from cnes_domain.control_plane.enums import DispatchOutcome, RunState
 from cnes_domain.control_plane.errors import Conflict
 from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
+from cnes_infra.control_plane.sqlite_schema import serialize_model
 from packages.cnes_infra.tests.contracts.clock import MutableClock, _prepare_unit, _reserve, _run
 from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
 
@@ -61,10 +62,36 @@ def test_migra_resposta_de_publicacao(adapter) -> None:
     command = _publish("run-a", "published-a", None, False)
     pointer = adapter.publish_dataset(command)
     with adapter.write_transaction() as connection:
+        permit = command.publication_permit.model_copy(update={"binding_context": {"legacy": True}})
+        legacy = command.model_copy(update={"publication_permit": permit})
+        connection.execute("UPDATE dataset_publications SET data = ?", (serialize_model(legacy),))
         connection.execute("ALTER TABLE dataset_publications DROP COLUMN response_data")
     reopened = SQLiteControlPlane(adapter._database_path, adapter.now)
     reopened.initialize()
     assert reopened.publish_dataset(command) == pointer
+
+
+def test_rejeita_replay_legado_sem_resposta(adapter) -> None:
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    first = _publish("run-a", "published-a", None, False)
+    adapter.publish_dataset(first)
+    adapter.put_run(_run("run-b", RunState.PUBLISHING))
+    adapter.publish_dataset(_publish("run-b", "published-b", "run-a", False))
+    adapter.put_run(
+        _run("run-c", RunState.PUBLISHING).model_copy(update={"dataset_name": "archive"})
+    )
+    third = _publish("run-c", "published-c", None, False)
+    third = third.model_copy(
+        update={"version": third.version.model_copy(update={"dataset_name": "archive"})}
+    )
+    adapter.publish_dataset(third)
+    with adapter.write_transaction() as connection:
+        connection.execute("DELETE FROM dataset_pointers WHERE dataset_name = 'archive'")
+        connection.execute("ALTER TABLE dataset_publications DROP COLUMN response_data")
+    reopened = SQLiteControlPlane(adapter._database_path, adapter.now)
+    reopened.initialize()
+    with pytest.raises(Conflict, match="publication_replay_response_missing"):
+        reopened.publish_dataset(first)
 
 
 def test_cria_indice_para_outbox_pendente(adapter) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_dispatch.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_dispatch.py
@@ -6,7 +6,7 @@ from cnes_domain.control_plane.commands import BindRunDispatch, FinishRunDispatc
 from cnes_domain.control_plane.enums import DispatchOutcome
 from cnes_domain.control_plane.errors import Conflict
 from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
-from packages.cnes_infra.tests.contracts.clock import MutableClock, _prepare_unit
+from packages.cnes_infra.tests.contracts.clock import MutableClock, _prepare_unit, _reserve
 
 
 @pytest.fixture
@@ -61,6 +61,15 @@ def test_migra_resposta_de_bind(adapter, clock) -> None:
         lease_seconds=30,
     )
     started = adapter.bind_run_dispatch(bind)
+    adapter.finish_run_dispatch(
+        FinishRunDispatch(
+            tenant_id="354130",
+            run_id="run-a",
+            dispatch_id=dispatch.dispatch_id,
+            outcome=DispatchOutcome.SUCCEEDED,
+            finished_at=clock.now(),
+        )
+    )
     with adapter.write_transaction() as connection:
         connection.execute("ALTER TABLE run_dispatch_bind_writes DROP COLUMN response_data")
     reopened = SQLiteControlPlane(adapter._database_path, clock.now)
@@ -89,3 +98,71 @@ def test_rejeita_bind_de_dispatch_finalizado_sem_replay(adapter, clock) -> None:
     )
     with pytest.raises(Conflict, match="dispatch_terminal"):
         adapter.bind_run_dispatch(bind)
+
+
+def test_reexecuta_finish_apos_nova_geracao(adapter, clock) -> None:
+    dispatch = _prepare_unit(adapter, clock)
+    finish = FinishRunDispatch(
+        tenant_id="354130",
+        run_id="run-a",
+        dispatch_id=dispatch.dispatch_id,
+        outcome=DispatchOutcome.SUCCEEDED,
+        finished_at=clock.now(),
+    )
+    finished = adapter.finish_run_dispatch(finish)
+    replacement = _reserve(adapter, clock)
+    assert replacement.dispatch_id != dispatch.dispatch_id
+    assert adapter.finish_run_dispatch(finish) == finished
+
+
+def test_migra_resposta_de_finish(adapter, clock) -> None:
+    dispatch = _prepare_unit(adapter, clock)
+    finish = FinishRunDispatch(
+        tenant_id="354130",
+        run_id="run-a",
+        dispatch_id=dispatch.dispatch_id,
+        outcome=DispatchOutcome.SUCCEEDED,
+        finished_at=clock.now(),
+    )
+    finished = adapter.finish_run_dispatch(finish)
+    with adapter.write_transaction() as connection:
+        connection.execute("ALTER TABLE run_dispatch_terminal_writes DROP COLUMN response_data")
+    reopened = SQLiteControlPlane(adapter._database_path, clock.now)
+    reopened.initialize()
+    assert reopened.finish_run_dispatch(finish) == finished
+
+
+def test_nao_reconstroi_respostas_de_dispatch_substituido(adapter, clock) -> None:
+    dispatch = _prepare_unit(adapter, clock)
+    bind = BindRunDispatch(
+        tenant_id="354130",
+        run_id="run-a",
+        dispatch_id=dispatch.dispatch_id,
+        execution_ref="exec-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    adapter.bind_run_dispatch(bind)
+    adapter.finish_run_dispatch(
+        FinishRunDispatch(
+            tenant_id="354130",
+            run_id="run-a",
+            dispatch_id=dispatch.dispatch_id,
+            outcome=DispatchOutcome.SUCCEEDED,
+            finished_at=clock.now(),
+        )
+    )
+    _reserve(adapter, clock)
+    with adapter.write_transaction() as connection:
+        connection.executescript(
+            "ALTER TABLE run_dispatch_bind_writes DROP COLUMN response_data;"
+            "ALTER TABLE run_dispatch_terminal_writes DROP COLUMN response_data;"
+        )
+    reopened = SQLiteControlPlane(adapter._database_path, clock.now)
+    reopened.initialize()
+    with reopened.read_connection() as connection:
+        responses = connection.execute(
+            "SELECT response_data FROM run_dispatch_bind_writes UNION ALL "
+            "SELECT response_data FROM run_dispatch_terminal_writes"
+        ).fetchall()
+    assert responses == [(None,), (None,)]

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_job.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_job.py
@@ -1,0 +1,39 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
+from packages.cnes_infra.tests.contracts.clock import MutableClock, _event, _job
+
+
+@pytest.fixture
+def clock() -> MutableClock:
+    return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
+
+
+@pytest.fixture
+def adapter(tmp_path, clock) -> SQLiteControlPlane:
+    control_plane = SQLiteControlPlane(tmp_path / "control-plane.sqlite3", clock.now)
+    control_plane.initialize()
+    return control_plane
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        {"state": JobState.LEASED, "lease_owner": "worker-a", "lease_until": "clock"},
+        {"attempt": 1},
+        {"fencing_token": 1},
+        {"result_manifest_id": "manifest-a", "result_manifest_key": "raw/manifest-a.json"},
+        {"error_code": "failed"},
+    ],
+)
+def test_rejeita_job_criado_fora_do_estado_inicial(adapter, clock, update) -> None:
+    values = {key: clock.now() if value == "clock" else value for key, value in update.items()}
+    job = _job("job-a").model_copy(update=values)
+    with pytest.raises(Conflict, match="job_initial_state_invalid"):
+        adapter.create_job(job, _event("job-created"))
+    assert adapter.get_job("354130", "job-a") is None
+    assert adapter.pending_outbox(10) == ()

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_network.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_network.py
@@ -1,0 +1,31 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cnes_infra.control_plane import sqlite_schema
+from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane, _SQLiteFilesystemError
+from packages.cnes_infra.tests.contracts.clock import MutableClock
+
+
+@pytest.fixture
+def clock() -> MutableClock:
+    return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
+
+
+@pytest.mark.parametrize("filesystem", [pytest.param("nfs"), pytest.param("cifs")])
+def test_rejeita_banco_symlink_para_filesystem_de_rede(
+    tmp_path, clock, monkeypatch, filesystem
+) -> None:
+    mount = tmp_path / "network"
+    mount.mkdir()
+    database_path = tmp_path / "local" / "control.sqlite3"
+    database_path.parent.mkdir()
+    database_path.symlink_to(mount / "control.sqlite3")
+
+    def mounts(_path, **_kwargs) -> str:
+        return f"server:/share {mount} {filesystem} rw 0 0\\n"
+
+    monkeypatch.setattr(sqlite_schema.Path, "read_text", mounts)
+    adapter = SQLiteControlPlane(database_path, clock.now)
+    with pytest.raises(_SQLiteFilesystemError, match="sqlite_network_filesystem"):
+        adapter.initialize()

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -89,16 +89,17 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
     _no(Conflict, "outbox_event_conflict", lambda: adapter.transition_run(transition, existing))
     assert adapter.pending_outbox(10) == (existing,)
     event = _event("run-transitioned")
-    updated = adapter.transition_run(transition, event)
+    adapter.transition_run(transition, event)
     retry = SQLiteControlPlane(adapter._database_path, clock.now)
     retry.initialize()
-    assert retry.transition_run(transition, event) == updated
-    before = (updated, retry.pending_outbox(10))
+    later = transition.model_copy(update={
+        "expected_state": RunState.PUBLISHING, "new_state": RunState.PUBLISHED})
+    current = retry.transition_run(later, _event("run-published"))
+    assert retry.transition_run(transition, event) == current
     _no(Conflict, "run_transition_conflict", lambda: retry.transition_run(
         transition.model_copy(update={"missing_sources": ("CNES/ST",)}), event))
     _no(Conflict, "run_transition_conflict", lambda: retry.transition_run(
         transition, event.model_copy(update={"payload": {}})))
-    assert before == (retry.get_run("354130", "run-a"), retry.pending_outbox(10))
 def test_serializa_escritores_concorrentes(adapter, database_path, clock) -> None:
     _prepare_job(adapter)
     writers = (SQLiteControlPlane(database_path, clock.now),
@@ -191,6 +192,7 @@ def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, cl
         units=(_unit("unit-a"),))
     _no(Conflict, "run_state_conflict", lambda: adapter.put_run_units(command))
 def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None:
+    _prepare_job(adapter)
     adapter.put_run(_run("run-a", RunState.PUBLISHING))
     publication = _publish("run-a", "published", None, False)
     publication = publication.model_copy(update={"publication_permit":
@@ -201,14 +203,13 @@ def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None
     unit_b = _unit("unit-b").model_copy(update={"run_id": "run-units"})
     canonical = (unit_a, unit_b)
     assert _put_units(adapter, (unit_b, unit_a), "run-units") == canonical
+    adapter.put_run(_run("run-units", RunState.PUBLISHING))
     with adapter.write_transaction() as connection:
         connection.executescript("ALTER TABLE job_creation_writes DROP COLUMN job_data;"
                                  "ALTER TABLE runs DROP COLUMN unit_registry_data;")
     reopened = SQLiteControlPlane(database_path, clock.now)
     reopened.initialize()
-    with reopened.read_connection() as connection:
-        assert "job_data" in {row[1] for row in connection.execute(
-            "PRAGMA table_info(job_creation_writes)")}
+    assert reopened.create_job(_job("job-a"), _event("job-created")) == _job("job-a")
     reopened.initialize()
     permit = publication.publication_permit.model_copy(update={"binding_context": object()})
     assert reopened.publish_dataset(publication.model_copy(

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -36,8 +36,10 @@ from packages.cnes_infra.tests.contracts.clock import (
     _commit_command,
     _event,
     _job,
+    _prepare_unit,
     _put_units,
     _raw_record,
+    _reserve,
     _run,
     _store_record,
     _unit,
@@ -341,16 +343,7 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
     dependency = (RunDependency(source_type="CNES", file_subtype="ST", required=False),)
     adapter.put_run(_run("run-a", dependencies=dependency))
     _put_units(adapter, (_unit("unit-a"), _unit("unit-b")))
-    dispatch = adapter.reserve_run_dispatch(
-        ReserveRunDispatch(
-            tenant_id="354130",
-            run_id="run-a",
-            wave_id="a" * 16,
-            unit_ids=("unit-a", "unit-b"),
-            now=clock.now(),
-            lease_seconds=30,
-        )
-    )
+    dispatch = _reserve(adapter, clock, unit_ids=("unit-a", "unit-b"))
     for unit_id in ("unit-a", "unit-b"):
         claimed = adapter.claim_run_unit(
             _claim_unit_command(dispatch.dispatch_id, f"worker-{unit_id}", clock, unit_id)
@@ -374,18 +367,7 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
 
 
 def test_rejeita_bind_de_dispatch_ausente_ou_terminal(adapter, clock) -> None:
-    adapter.put_run(_run("run-a"))
-    _put_units(adapter, (_unit("unit-a"),))
-    dispatch = adapter.reserve_run_dispatch(
-        ReserveRunDispatch(
-            tenant_id="354130",
-            run_id="run-a",
-            wave_id="a" * 16,
-            unit_ids=("unit-a",),
-            now=clock.now(),
-            lease_seconds=60,
-        )
-    )
+    dispatch = _prepare_unit(adapter, clock)
     bind = BindRunDispatch(
         tenant_id="354130",
         run_id="run-a",
@@ -407,6 +389,8 @@ def test_rejeita_bind_de_dispatch_ausente_ou_terminal(adapter, clock) -> None:
     )
     with pytest.raises(Conflict, match="dispatch_terminal"):
         adapter.bind_run_dispatch(bind.model_copy(update={"dispatch_id": dispatch.dispatch_id}))
+    replacement = _reserve(adapter, clock)
+    assert (replacement.generation, replacement.dispatch_id != dispatch.dispatch_id) == (2, True)
 
 
 def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:
@@ -435,9 +419,19 @@ def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> Non
         adapter.commit_run_unit(expired, _event("expired-commit"))
 
 
-def test_rejeita_replay_de_versao_quando_pointer_ja_avancou(adapter) -> None:
-    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+def test_rejeita_dataset_divergente_e_replay_apos_pointer_avancar(adapter) -> None:
+    run = _run("run-a", RunState.PUBLISHING)
+    adapter.put_run(run)
     first = _publish("run-a", "published-a", None, False)
+    mismatched = first.model_copy(
+        update={"version": first.version.model_copy(update={"dataset_name": "silver"})}
+    )
+    with pytest.raises(Conflict, match="run_dataset_mismatch"):
+        adapter.publish_dataset(mismatched)
+    assert adapter.get_run("354130", "run-a") == run
+    assert adapter.get_dataset_pointer("354130", "silver") is None
+    assert adapter.get_dataset_version("354130", "silver", "run-a") is None
+    assert mismatched.event not in adapter.pending_outbox(100)
     adapter.publish_dataset(first)
     adapter.put_run(_run("run-b", RunState.PUBLISHING))
     adapter.publish_dataset(_publish("run-b", "published-b", "run-a", False))

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -8,15 +8,19 @@ import pytest
 
 from cnes_domain.control_plane.commands import (
     BeginIdempotency,
+    ClaimJob,
+    FailRunUnit,
     RenewJobLease,
+    ReserveRunDispatch,
     TransitionRun,
 )
-from cnes_domain.control_plane.entities import DatasetPointer, Tenant
+from cnes_domain.control_plane.entities import DatasetPointer, RunDependency, Tenant
 from cnes_domain.control_plane.enums import RunState
-from cnes_domain.control_plane.errors import Conflict
-from cnes_infra.control_plane import sqlite_adapter
+from cnes_domain.control_plane.errors import Conflict, LeaseLost
+from cnes_infra.control_plane import sqlite_adapter, sqlite_schema
 from cnes_infra.control_plane.sqlite_adapter import (
     SQLiteControlPlane,
+    _is_network_filesystem,
     _SQLiteBusyError,
     _SQLiteFilesystemError,
 )
@@ -24,6 +28,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     MutableClock,
     _agent,
     _claim_job,
+    _claim_unit_command,
     _event,
     _job,
     _put_units,
@@ -136,6 +141,45 @@ def test_serializa_claim_renovacao_e_publicacao_concorrentes(
     assert sum(isinstance(result, Conflict) for result in publications) == 1
 
 
+def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, clock) -> None:
+    _prepare_job(adapter)
+    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    assert claimed is not None
+    writers = (
+        SQLiteControlPlane(database_path, clock.now),
+        SQLiteControlPlane(database_path, clock.now),
+    )
+    renew = RenewJobLease(
+        tenant_id="354130",
+        job_id="job-a",
+        owner="worker-a",
+        fencing_token=claimed.fencing_token,
+        now=clock.now(),
+        lease_seconds=60,
+    )
+    reclaim = ClaimJob(
+        tenant_id="354130",
+        job_id="job-a",
+        owner="worker-b",
+        now=clock.now() + timedelta(seconds=31),
+        lease_seconds=30,
+    )
+
+    renewed, reclaimed = _race(
+        lambda: writers[0].renew_job_lease(renew),
+        lambda: writers[1].claim_job(reclaim),
+    )
+
+    if isinstance(renewed, LeaseLost):
+        assert reclaimed is not None
+        assert reclaimed.fencing_token == 2
+        assert adapter.get_job("354130", "job-a") == reclaimed
+    else:
+        assert reclaimed is None
+        assert renewed.fencing_token == 1
+        assert adapter.get_job("354130", "job-a") == renewed
+
+
 def test_incrementa_fence_apos_expiracao(adapter, clock) -> None:
     _prepare_job(adapter)
     first = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
@@ -198,6 +242,72 @@ def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> No
         adapter.initialize()
 
 
+@pytest.mark.parametrize(
+    "network_path",
+    [
+        pytest.param(r"\\server\share\control.sqlite3"),
+        pytest.param("smb://server/share/control.sqlite3"),
+        pytest.param("nfs://server/share/control.sqlite3"),
+        pytest.param("/net/server/share/control.sqlite3"),
+        pytest.param("/Network/Servers/server/share/control.sqlite3"),
+    ],
+)
+def test_detecta_formas_conhecidas_de_filesystem_de_rede_sem_proc(
+    network_path, tmp_path, monkeypatch
+) -> None:
+    def unavailable(*args, **kwargs):
+        raise OSError("proc_unavailable")
+
+    monkeypatch.setattr(sqlite_schema.Path, "read_text", unavailable)
+
+    assert _is_network_filesystem(sqlite_adapter.Path(network_path))
+    assert not _is_network_filesystem(tmp_path / "control.sqlite3")
+
+
+def test_rejeita_inicializacao_quando_wal_nao_e_ativado(tmp_path, clock, monkeypatch) -> None:
+    adapter = SQLiteControlPlane(tmp_path / "control.sqlite3", clock.now)
+    monkeypatch.setattr(adapter, "_connect", lambda: sqlite3.connect(":memory:"))
+
+    with pytest.raises(_SQLiteFilesystemError, match="sqlite_wal_unavailable"):
+        adapter.initialize()
+
+
+def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
+    dependency = (RunDependency(source_type="CNES", file_subtype="ST", required=False),)
+    adapter.put_run(_run("run-a", dependencies=dependency))
+    _put_units(adapter, (_unit("unit-a"), _unit("unit-b")))
+    dispatch = adapter.reserve_run_dispatch(
+        ReserveRunDispatch(
+            tenant_id="354130",
+            run_id="run-a",
+            wave_id="a" * 16,
+            unit_ids=("unit-a", "unit-b"),
+            now=clock.now(),
+            lease_seconds=30,
+        )
+    )
+    for unit_id in ("unit-a", "unit-b"):
+        claimed = adapter.claim_run_unit(
+            _claim_unit_command(dispatch.dispatch_id, f"worker-{unit_id}", clock, unit_id)
+        )
+        assert claimed is not None
+        adapter.fail_run_unit(
+            FailRunUnit(
+                tenant_id="354130",
+                run_id="run-a",
+                unit_id=unit_id,
+                dispatch_id=dispatch.dispatch_id,
+                owner=f"worker-{unit_id}",
+                fencing_token=claimed.fencing_token,
+                error_code="optional_failed",
+                retryable=False,
+            ),
+            _event(f"degraded-{unit_id}"),
+        )
+
+    assert adapter.get_run("354130", "run-a").missing_sources == ("CNES/ST",)
+
+
 def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
     adapter.put_agent(_agent("agent-order"))
     for job_id in ("job-b", "job-a"):
@@ -211,11 +321,7 @@ def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
     )
     _put_units(adapter, units, "run-units")
     base = _raw_record("base-agent-raw", "agent-raw", 1, clock.now())
-    delta = _raw_record(
-        "delta", "agent-raw", 2, clock.now() + timedelta(seconds=1)
-    )
     _store_record(adapter, base, clock)
-    _store_record(adapter, delta, clock)
 
     assert tuple(job.job_id for job in adapter.list_claimable_jobs(
         "354130", "agent-order", 1
@@ -227,8 +333,8 @@ def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
     assert tuple(unit.unit_id for unit in adapter.list_run_units(
         "354130", "run-units"
     )) == ("unit-a", "unit-b")
-    assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 1) == ()
-    assert len(adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 2)) == 2
+    assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 0) == ()
+    assert len(adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 1)) == 1
     pending = adapter.pending_outbox(1)
     assert len(pending) == 1
     assert pending[0] == min(adapter.pending_outbox(100), key=lambda event: (

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -323,27 +323,27 @@ def test_replay_dispatch_e_recaptura(adapter, database_path, clock) -> None:
     _no(Conflict, "dispatch_units_conflict", lambda: _reserve(
         reopened, clock, "a" * 16, ("unit-a",)))
     assert _reserve(reopened, clock, "a" * 16, dispatch.unit_ids).generation == 5
-@pytest.mark.parametrize("state", [None, RunState.WAITING_INPUTS])
+@pytest.mark.parametrize(
+    "state", [None, RunState.PUBLISHING, RunState.CANCEL_REQUESTED, RunState.PUBLISHED])
 def test_rejeita_dispatch_sem_run_processing(adapter, clock, state) -> None:
     if state is not None:
         adapter.put_run(_run("run-a", state))
     _no(Conflict, "parent_not_processing", lambda: _reserve(adapter, clock))
     adapter.put_run(_run("run-a"))
+    _put_units(adapter, (_unit("unit-b"),))
+    _no(Conflict, "dispatch_unit_missing", lambda: _reserve(adapter, clock, unit_ids=("missing",)))
     dispatch = _reserve(adapter, clock, unit_ids=("unit-b",))
-    assert (dispatch.generation, dispatch.unit_ids) == (1, ("unit-b",))
     if state is None:
         with adapter.write_transaction() as connection:
             connection.execute("DELETE FROM runs WHERE tenant_id = ? AND run_id = ?",
                                ("354130", "run-a"))
     else:
-        adapter.transition_run(TransitionRun(
-            tenant_id="354130", run_id="run-a", expected_state=RunState.PROCESSING,
-            new_state=RunState.PUBLISHING), _event("run-publishing"))
+        adapter.put_run(_run("run-a", state))
     bind = BindRunDispatch(
         tenant_id="354130", run_id="run-a", dispatch_id=dispatch.dispatch_id,
         execution_ref="exec-delayed", now=clock.now(), lease_seconds=30)
     _no(Conflict, "parent_not_processing", lambda: adapter.bind_run_dispatch(bind))
-    assert adapter.get_active_run_dispatch("354130", "run-a") == dispatch
+    assert adapter.get_active_run_dispatch("354130", "run-a") is None
 def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:
     dispatch = _prepare_unit(adapter, clock)
     pending = _commit_command(dispatch.dispatch_id, "worker-a", 0)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -45,10 +45,10 @@ from packages.cnes_infra.tests.contracts.clock import (
 )
 from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
 
-_NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
+
 @pytest.fixture
 def clock() -> MutableClock:
-    return MutableClock(_NOW)
+    return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
 @pytest.fixture
 def database_path(tmp_path):
     return tmp_path / "control-plane.sqlite3"
@@ -63,6 +63,13 @@ def _capture(action: Any, barrier: Barrier) -> Any:
         return action()
     except Exception as error:
         return error
+def _no(error, match, action) -> None:
+    with pytest.raises(error, match=match):
+        action()
+def _write_dispatch(adapter, dispatch) -> None:
+    with adapter.write_transaction() as connection:
+        connection.execute("UPDATE run_dispatches SET lease_until = ?, data = ? WHERE run_id = ?",
+            (dispatch.lease_until.isoformat(), dispatch.model_dump_json(), dispatch.run_id))
 def _race(first: Any, second: Any) -> tuple[Any, Any]:
     barrier = Barrier(3)
     with ThreadPoolExecutor(max_workers=2) as executor:
@@ -82,11 +89,9 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
         tenant_id="354130", run_id="run-a", expected_state=RunState.PROCESSING,
         new_state=RunState.PUBLISHING)
     conflicting = existing.model_copy(update={"aggregate_id": "run-a"})
-    with pytest.raises(Conflict, match="run_state_conflict"):
-        adapter.transition_run(transition.model_copy(
-            update={"expected_state": RunState.WAITING_INPUTS}), _event("invalid-transition"))
-    with pytest.raises(Conflict, match="outbox_event_conflict"):
-        adapter.transition_run(transition, conflicting)
+    _no(Conflict, "run_state_conflict", lambda: adapter.transition_run(transition.model_copy(
+        update={"expected_state": RunState.WAITING_INPUTS}), _event("invalid-transition")))
+    _no(Conflict, "outbox_event_conflict", lambda: adapter.transition_run(transition, conflicting))
     assert adapter.pending_outbox(10) == (existing,)
     event = _event("run-transitioned")
     updated = adapter.transition_run(transition, event)
@@ -94,10 +99,10 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
     retry.initialize()
     assert retry.transition_run(transition, event) == updated
     before = (updated, retry.pending_outbox(10))
-    with pytest.raises(Conflict, match="run_transition_conflict"):
-        retry.transition_run(transition.model_copy(update={"missing_sources": ("CNES/ST",)}), event)
-    with pytest.raises(Conflict, match="run_transition_conflict"):
-        retry.transition_run(transition, event.model_copy(update={"payload": {}}))
+    _no(Conflict, "run_transition_conflict", lambda: retry.transition_run(
+        transition.model_copy(update={"missing_sources": ("CNES/ST",)}), event))
+    _no(Conflict, "run_transition_conflict", lambda: retry.transition_run(
+        transition, event.model_copy(update={"payload": {}})))
     assert before == (retry.get_run("354130", "run-a"), retry.pending_outbox(10))
 def test_serializa_escritores_concorrentes(adapter, database_path, clock) -> None:
     _prepare_job(adapter)
@@ -124,7 +129,6 @@ def test_serializa_escritores_concorrentes(adapter, database_path, clock) -> Non
 def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, clock) -> None:
     _prepare_job(adapter)
     claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
-    assert claimed is not None
     writers = (SQLiteControlPlane(database_path, clock.now),
                SQLiteControlPlane(database_path, clock.now))
     renew = RenewJobLease(
@@ -136,7 +140,6 @@ def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, 
     renewed, reclaimed = _race(lambda: writers[0].renew_job_lease(renew),
                                lambda: writers[1].claim_job(reclaim))
     if isinstance(renewed, LeaseLost):
-        assert reclaimed is not None
         assert reclaimed.fencing_token == 2
         assert adapter.get_job("354130", "job-a") == reclaimed
     else:
@@ -148,14 +151,11 @@ def test_incrementa_fence_apos_expiracao_ou_lease_ausente(adapter, clock) -> Non
     first = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
     clock.advance(timedelta(seconds=31))
     second = adapter.claim_job(_claim_job("job-a", "worker-b", clock))
-    assert first is not None
-    assert second is not None
     assert (first.fencing_token, second.fencing_token) == (1, 2)
     missing_lease = _job("job-b").model_copy(update={"state": first.state})
     adapter.create_job(missing_lease, _event("job-b-created"))
     assert missing_lease in adapter.list_claimable_jobs("354130", "agent-a", 10)
     reclaimed = adapter.claim_job(_claim_job("job-b", "worker-c", clock))
-    assert reclaimed is not None
     assert (reclaimed.attempt, reclaimed.fencing_token) == (1, 1)
 def test_configura_busy_timeout_de_cinco_segundos(adapter) -> None:
     with adapter.read_connection() as connection:
@@ -166,8 +166,7 @@ def test_converte_busy_em_erro_local(adapter, database_path, clock, monkeypatch)
     blocker.execute("BEGIN IMMEDIATE")
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
     try:
-        with pytest.raises(_SQLiteBusyError, match="sqlite_busy"):
-            adapter.put_tenant(tenant)
+        _no(_SQLiteBusyError, "sqlite_busy", lambda: adapter.put_tenant(tenant))
     finally:
         blocker.rollback()
         blocker.close()
@@ -176,22 +175,18 @@ def test_traduz_falha_de_conexao_em_erro_local(tmp_path, clock, monkeypatch) -> 
     def fail_connect():
         raise sqlite3.OperationalError("disk_unavailable")
     monkeypatch.setattr(broken, "_connect", fail_connect)
-    with pytest.raises(_SQLiteFilesystemError, match="sqlite_filesystem"):
-        broken.initialize()
-    with pytest.raises(_SQLiteFilesystemError, match="sqlite_filesystem"):
-        broken.get_tenant("354130")
+    _no(_SQLiteFilesystemError, "sqlite_filesystem", broken.initialize)
+    _no(_SQLiteFilesystemError, "sqlite_filesystem", lambda: broken.get_tenant("354130"))
 def test_propaga_erro_operacional_que_nao_e_contencao(tmp_path, clock) -> None:
     uninitialized = SQLiteControlPlane(tmp_path / "empty.sqlite3", clock.now)
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
-    with pytest.raises(sqlite3.OperationalError, match="no such table"):
-        uninitialized.put_tenant(tenant)
+    _no(sqlite3.OperationalError, "no such table", lambda: uninitialized.put_tenant(tenant))
 def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, clock) -> None:
     _prepare_job(adapter)
     renew = RenewJobLease(
         tenant_id="354130", job_id="job-a", owner="worker-a", fencing_token=0,
         now=clock.now(), lease_seconds=30)
-    with pytest.raises(LeaseLost, match="job_not_leased"):
-        adapter.renew_job_lease(renew)
+    _no(LeaseLost, "job_not_leased", lambda: adapter.renew_job_lease(renew))
     with pytest.raises(Conflict, match="job_missing"):
         adapter.cancel_job(CancelJob(
             tenant_id="354130", job_id="missing", requested_by="user-a"), _event("cancel-missing"))
@@ -199,8 +194,7 @@ def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, cl
     command = PutRunUnits(
         tenant_id="354130", run_id="run-a", expected_run_state=RunState.PROCESSING,
         units=(_unit("unit-a"),))
-    with pytest.raises(Conflict, match="run_state_conflict"):
-        adapter.put_run_units(command)
+    _no(Conflict, "run_state_conflict", lambda: adapter.put_run_units(command))
 def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None:
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
     adapter.put_tenant(tenant)
@@ -227,22 +221,19 @@ def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None
     assert _put_units(reopened, canonical, "run-units") == canonical
     before = reopened.list_run_units("354130", "run-units")
     divergent = (unit_a, _unit("unit-c").model_copy(update={"run_id": "run-units"}))
-    with pytest.raises(Conflict, match="units_conflict"):
-        _put_units(reopened, divergent, "run-units")
+    _no(Conflict, "units_conflict", lambda: _put_units(reopened, divergent, "run-units"))
     assert reopened.list_run_units("354130", "run-units") == before
 def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> None:
     monkeypatch.setattr(sqlite_adapter, "_is_network_filesystem", lambda path: True)
     adapter = SQLiteControlPlane(tmp_path / "network" / "control.sqlite3", clock.now)
-    with pytest.raises(_SQLiteFilesystemError, match="sqlite_network_filesystem"):
-        adapter.initialize()
+    _no(_SQLiteFilesystemError, "sqlite_network_filesystem", adapter.initialize)
 @pytest.mark.parametrize(
     "network_path",
     [pytest.param(r"\\server\share\control.sqlite3"),
      pytest.param("smb://server/share/control.sqlite3"),
      pytest.param("nfs://server/share/control.sqlite3"),
      pytest.param("/net/server/share/control.sqlite3"),
-     pytest.param("/Network/Servers/server/share/control.sqlite3")],
-)
+     pytest.param("/Network/Servers/server/share/control.sqlite3")],)
 def test_detecta_filesystem_de_rede(network_path, tmp_path, monkeypatch) -> None:
     def unavailable(*args, **kwargs):
         raise OSError("proc_unavailable")
@@ -252,8 +243,7 @@ def test_detecta_filesystem_de_rede(network_path, tmp_path, monkeypatch) -> None
 def test_rejeita_inicializacao_quando_wal_nao_e_ativado(tmp_path, clock, monkeypatch) -> None:
     adapter = SQLiteControlPlane(tmp_path / "control.sqlite3", clock.now)
     monkeypatch.setattr(adapter, "_connect", lambda: sqlite3.connect(":memory:"))
-    with pytest.raises(_SQLiteFilesystemError, match="sqlite_wal_unavailable"):
-        adapter.initialize()
+    _no(_SQLiteFilesystemError, "sqlite_wal_unavailable", adapter.initialize)
 def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
     dependency = (RunDependency(source_type="CNES", file_subtype="ST", required=False),)
     adapter.put_run(_run("run-a", dependencies=dependency))
@@ -262,14 +252,12 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
     for unit_id in ("unit-a", "unit-b"):
         claimed = adapter.claim_run_unit(
             _claim_unit_command(dispatch.dispatch_id, f"worker-{unit_id}", clock, unit_id))
-        assert claimed is not None
         adapter.fail_run_unit(
             FailRunUnit(
                 tenant_id="354130", run_id="run-a", unit_id=unit_id,
                 dispatch_id=dispatch.dispatch_id, owner=f"worker-{unit_id}",
                 fencing_token=claimed.fencing_token,
-                error_code="optional_failed", retryable=False,
-            ),
+                error_code="optional_failed", retryable=False),
             _event(f"degraded-{unit_id}"))
     assert adapter.get_run("354130", "run-a").missing_sources == ("CNES/ST",)
 def test_replay_dispatch_e_recaptura(adapter, database_path, clock) -> None:
@@ -277,52 +265,52 @@ def test_replay_dispatch_e_recaptura(adapter, database_path, clock) -> None:
     reopened = SQLiteControlPlane(database_path, clock.now)
     assert _reserve(reopened, clock, unit_ids=("unit-a", "unit-b")) == dispatch
     before = reopened.get_active_run_dispatch("354130", "run-a")
-    with pytest.raises(Conflict, match="dispatch_units_conflict"):
-        _reserve(reopened, clock, unit_ids=("unit-a",))
+    _no(Conflict, "dispatch_units_conflict", lambda: _reserve(
+        reopened, clock, unit_ids=("unit-a",)))
     assert reopened.get_active_run_dispatch("354130", "run-a") == before
     claimed = adapter.claim_run_unit(_claim_unit_command(dispatch.dispatch_id, "worker-a", clock))
-    assert claimed is not None
     bind = BindRunDispatch(
         tenant_id="354130", run_id="run-a", dispatch_id="b" * 16, execution_ref="exec-a",
-        now=clock.now(), lease_seconds=30,
-    )
-    with pytest.raises(Conflict, match="dispatch_stale"):
-        adapter.bind_run_dispatch(bind)
+        now=clock.now(), lease_seconds=30)
+    _no(Conflict, "dispatch_stale", lambda: adapter.bind_run_dispatch(bind))
+    bind = bind.model_copy(update={"dispatch_id": dispatch.dispatch_id})
+    _no(Conflict, "dispatch_expired", lambda: adapter.bind_run_dispatch(
+        bind.model_copy(update={"now": dispatch.lease_until})))
+    started = adapter.bind_run_dispatch(bind)
+    expired = started.model_copy(update={"lease_until": bind.now})
+    _write_dispatch(adapter, expired)
+    assert reopened.bind_run_dispatch(bind) == expired
+    for update in ({"now": bind.now + timedelta(seconds=1)}, {"lease_seconds": 31},
+                   {"execution_ref": "exec-b"}):
+        _no(Conflict, "dispatch_bind_conflict", lambda update=update: reopened.bind_run_dispatch(
+            bind.model_copy(update=update)))
+    _write_dispatch(adapter, started)
     finish = FinishRunDispatch(
         tenant_id="354130", run_id="run-a", dispatch_id=dispatch.dispatch_id,
         outcome=DispatchOutcome.FAILED, finished_at=clock.now())
-    with pytest.raises(Conflict, match="dispatch_expired"):
-        adapter.finish_run_dispatch(finish.model_copy(update={"finished_at": dispatch.lease_until}))
+    _no(Conflict, "dispatch_expired", lambda: adapter.finish_run_dispatch(
+        finish.model_copy(update={"finished_at": dispatch.lease_until})))
     finished = adapter.finish_run_dispatch(finish)
-    replay = SQLiteControlPlane(database_path, clock.now)
-    replay.initialize()
-    assert replay.finish_run_dispatch(finish) == finished
-    with pytest.raises(Conflict, match="dispatch_terminal"):
-        adapter.bind_run_dispatch(bind.model_copy(update={"dispatch_id": dispatch.dispatch_id}))
+    _no(Conflict, "dispatch_terminal", lambda: adapter.bind_run_dispatch(bind))
     expired = finished.model_copy(update={"lease_until": finish.finished_at})
-    with replay.write_transaction() as connection:
-        connection.execute("UPDATE run_dispatches SET lease_until = ?, data = ? WHERE run_id = ?",
-            (expired.lease_until.isoformat(), expired.model_dump_json(), expired.run_id))
-    assert replay.finish_run_dispatch(finish) == expired
-    with pytest.raises(Conflict, match="dispatch_finish_conflict"):
-        replay.finish_run_dispatch(finish.model_copy(
-            update={"finished_at": clock.now() + timedelta(microseconds=1)}))
-    with pytest.raises(Conflict, match="dispatch_units_conflict"):
-        _reserve(adapter, clock, unit_ids=("unit-a",))
+    _write_dispatch(reopened, expired)
+    assert reopened.finish_run_dispatch(finish) == expired
+    _no(Conflict, "dispatch_finish_conflict", lambda: reopened.finish_run_dispatch(
+        finish.model_copy(update={"finished_at": clock.now() + timedelta(microseconds=1)})))
+    _no(Conflict, "dispatch_units_conflict", lambda: _reserve(
+        adapter, clock, unit_ids=("unit-a",)))
     replacement = _reserve(adapter, clock, unit_ids=dispatch.unit_ids)
     assert (replacement.generation, replacement.dispatch_id != dispatch.dispatch_id) == (2, True)
     reclaimed = adapter.claim_run_unit(
         _claim_unit_command(replacement.dispatch_id, "worker-b", clock))
-    assert reclaimed is not None
     assert (reclaimed.attempt, reclaimed.fencing_token, reclaimed.dispatch_id) == (
         claimed.attempt + 1, claimed.fencing_token + 1, replacement.dispatch_id)
     other = _claim_unit_command(replacement.dispatch_id, "worker-c", clock)
     assert adapter.claim_run_unit(other) is None
     clock.advance(timedelta(seconds=31))
-    with pytest.raises(Conflict, match="dispatch_units_conflict"):
-        _reserve(adapter, clock, unit_ids=("unit-a",))
+    _no(Conflict, "dispatch_units_conflict", lambda: _reserve(
+        adapter, clock, unit_ids=("unit-a",)))
     third = _reserve(adapter, clock, unit_ids=dispatch.unit_ids)
-    assert third.generation == 3
     adapter.finish_run_dispatch(FinishRunDispatch(
         tenant_id="354130", run_id="run-a", dispatch_id=third.dispatch_id,
         outcome=DispatchOutcome.FAILED, finished_at=clock.now()))
@@ -332,15 +320,14 @@ def test_replay_dispatch_e_recaptura(adapter, database_path, clock) -> None:
         outcome=DispatchOutcome.FAILED, finished_at=clock.now()))
     reopened = SQLiteControlPlane(database_path, clock.now)
     reopened.initialize()
-    with pytest.raises(Conflict, match="dispatch_units_conflict"):
-        _reserve(reopened, clock, "a" * 16, ("unit-a",))
+    _no(Conflict, "dispatch_units_conflict", lambda: _reserve(
+        reopened, clock, "a" * 16, ("unit-a",)))
     assert _reserve(reopened, clock, "a" * 16, dispatch.unit_ids).generation == 5
 @pytest.mark.parametrize("state", [None, RunState.WAITING_INPUTS])
 def test_rejeita_dispatch_sem_run_processing(adapter, clock, state) -> None:
     if state is not None:
         adapter.put_run(_run("run-a", state))
-    with pytest.raises(Conflict, match="parent_not_processing"):
-        _reserve(adapter, clock)
+    _no(Conflict, "parent_not_processing", lambda: _reserve(adapter, clock))
     adapter.put_run(_run("run-a"))
     dispatch = _reserve(adapter, clock, unit_ids=("unit-b",))
     assert (dispatch.generation, dispatch.unit_ids) == (1, ("unit-b",))
@@ -355,38 +342,34 @@ def test_rejeita_dispatch_sem_run_processing(adapter, clock, state) -> None:
     bind = BindRunDispatch(
         tenant_id="354130", run_id="run-a", dispatch_id=dispatch.dispatch_id,
         execution_ref="exec-delayed", now=clock.now(), lease_seconds=30)
-    with pytest.raises(Conflict, match="parent_not_processing"):
-        adapter.bind_run_dispatch(bind)
+    _no(Conflict, "parent_not_processing", lambda: adapter.bind_run_dispatch(bind))
     assert adapter.get_active_run_dispatch("354130", "run-a") == dispatch
 def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:
     dispatch = _prepare_unit(adapter, clock)
     pending = _commit_command(dispatch.dispatch_id, "worker-a", 0)
-    with pytest.raises(LeaseLost, match="unit_not_leased"):
-        adapter.commit_run_unit(pending, _event("pending-commit"))
+    _no(LeaseLost, "unit_not_leased", lambda: adapter.commit_run_unit(
+        pending, _event("pending-commit")))
     claim = _claim_unit_command(dispatch.dispatch_id, "worker-a", clock).model_copy(
         update={"lease_seconds": 10})
     claimed = adapter.claim_run_unit(claim)
-    assert claimed is not None
     clock.advance(timedelta(seconds=11))
     expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
-    with pytest.raises(LeaseLost, match="lease_expired"):
-        adapter.commit_run_unit(expired, _event("expired-commit"))
+    _no(LeaseLost, "lease_expired", lambda: adapter.commit_run_unit(
+        expired, _event("expired-commit")))
 @pytest.mark.parametrize("field", ["final_state", "missing_sources", "permit", "event"])
 def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) -> None:
     run = _run("run-a", RunState.PUBLISHING)
     adapter.put_run(run)
     first = _publish("run-a", "published-a", None, True)
     invalid_pointer = first.model_copy(update={"pointer_name": "CURRENT"})
-    with pytest.raises(Conflict, match="pointer_name_not_current"):
-        adapter.publish_dataset(invalid_pointer)
+    _no(Conflict, "pointer_name_not_current", lambda: adapter.publish_dataset(invalid_pointer))
     assert adapter.get_run("354130", "run-a") == run
     assert adapter.get_dataset_pointer("354130", "gold") is None
     assert adapter.get_dataset_version("354130", "gold", "run-a") is None
     assert invalid_pointer.event not in adapter.pending_outbox(100)
     mismatched = first.model_copy(
         update={"version": first.version.model_copy(update={"dataset_name": "silver"})})
-    with pytest.raises(Conflict, match="run_dataset_mismatch"):
-        adapter.publish_dataset(mismatched)
+    _no(Conflict, "run_dataset_mismatch", lambda: adapter.publish_dataset(mismatched))
     assert adapter.get_run("354130", "run-a") == run
     assert adapter.get_dataset_pointer("354130", "silver") is None
     assert adapter.get_dataset_version("354130", "silver", "run-a") is None
@@ -398,15 +381,13 @@ def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) ->
         "final_state": {"final_state": RunState.PUBLISHED, "missing_sources": ()},
         "missing_sources": {"missing_sources": ("SIHD/ER",)},
         "permit": {"publication_permit": permit},
-        "event": {"event": event},
-    }
+        "event": {"event": event},}
     divergent = first.model_copy(update=updates[field])
     before = (
         adapter.get_run("354130", "run-a"), pointer,
         adapter.get_dataset_version("354130", "gold", "run-a"),
         adapter.pending_outbox(100))
-    with pytest.raises(Conflict, match="publication_replay_conflict"):
-        adapter.publish_dataset(divergent)
+    _no(Conflict, "publication_replay_conflict", lambda: adapter.publish_dataset(divergent))
     assert before == (
         adapter.get_run("354130", "run-a"),
         adapter.get_dataset_pointer("354130", "gold"),
@@ -415,8 +396,7 @@ def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) ->
     assert adapter.publish_dataset(first) == pointer
     adapter.put_run(_run("run-b", RunState.PUBLISHING))
     adapter.publish_dataset(_publish("run-b", "published-b", "run-a", False))
-    with pytest.raises(Conflict, match="pointer_cas"):
-        adapter.publish_dataset(first)
+    _no(Conflict, "pointer_cas", lambda: adapter.publish_dataset(first))
 def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock, monkeypatch) -> None:
     adapter.put_agent(_agent("agent-order"))
     for job_id in ("job-b", "job-a"):
@@ -449,7 +429,6 @@ def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock, monkeypatc
     assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 0) == ()
     assert len(adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 1)) == 1
     pending = adapter.pending_outbox(1)
-    assert len(pending) == 1
     assert pending[0] == min(adapter.pending_outbox(100), key=lambda event: (
         event.created_at, event.event_id))
 def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> None:
@@ -457,8 +436,7 @@ def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> 
         _run("run-a").model_copy(update={"tenant_id": "b"}),
         _run("run-z").model_copy(update={"tenant_id": "a"}),
         _run("run-shared").model_copy(update={"tenant_id": "b"}),
-        _run("run-shared").model_copy(update={"tenant_id": "a"}),
-    )
+        _run("run-shared").model_copy(update={"tenant_id": "a"}),)
     for run in runs:
         adapter.put_run(run)
     recoverable = adapter.list_recoverable_runs(clock.now(), 2)
@@ -498,3 +476,25 @@ def test_limita_ancestralidade_longa_sem_recursao(adapter, clock, monkeypatch) -
     calls.clear()
     assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 2) == ()
     assert len(calls) <= 8
+    levels = tuple(tuple(base.model_copy(update={
+        "manifest_id": f"branch-{level}-{index}", "sequence": level + 2,
+    }) for index in range(31)) for level in range(4))
+    valid = tuple(base.model_copy(update={"manifest_id": f"valid-{sequence}",
+        "sequence": sequence, "previous_manifest_sha256": f"{sequence + 10:064x}"})
+        for sequence in range(2, 6))
+    head = base.model_copy(update={"manifest_id": "branch-head", "sequence": 6})
+    graph = {head.manifest_id: (*levels[-1], valid[-1]), valid[0].manifest_id: (base,)}
+    graph.update({item.manifest_id: levels[level - 1] if level else ()
+                  for level, siblings in enumerate(levels) for item in siblings})
+    graph.update({valid[index].manifest_id: (valid[index - 1],) for index in range(1, 4)})
+    expansions = []
+    def predecessors(connection, identity, current, limit):
+        expansions.append(current.manifest_id)
+        if len(expansions) > 200:
+            raise RuntimeError("ancestry_expansion")
+        return graph.get(current.manifest_id, ())
+    monkeypatch.setattr(sqlite_publication, "_predecessors", predecessors)
+    chain = sqlite_publication._build_ancestry(None, (), head, 100)
+    assert tuple(item.manifest_id for item in chain)[-1] == "branch-head"
+    assert len(expansions) <= 10
+    assert sqlite_publication._build_ancestry(None, (), head, 20) is None

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -222,22 +222,6 @@ def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None
     divergent = (unit_a, _unit("unit-c").model_copy(update={"run_id": "run-units"}))
     _no(Conflict, "units_conflict", lambda: _put_units(reopened, divergent, "run-units"))
     assert reopened.list_run_units("354130", "run-units") == before
-@pytest.mark.parametrize("filesystem", [pytest.param("nfs"), pytest.param("cifs")])
-def test_rejeita_banco_symlink_para_filesystem_de_rede(
-    tmp_path, clock, monkeypatch, filesystem
-) -> None:
-    mount = tmp_path / "network"
-    mount.mkdir()
-    database_path = tmp_path / "local" / "control.sqlite3"
-    database_path.parent.mkdir()
-    database_path.symlink_to(mount / "control.sqlite3")
-
-    def mounts(_path, **_kwargs) -> str:
-        return f"server:/share {mount} {filesystem} rw 0 0\\n"
-
-    monkeypatch.setattr(sqlite_schema.Path, "read_text", mounts)
-    adapter = SQLiteControlPlane(database_path, clock.now)
-    _no(_SQLiteFilesystemError, "sqlite_network_filesystem", adapter.initialize)
 @pytest.mark.parametrize(
     "network_path",
     [pytest.param(r"\\server\share\control.sqlite3"),

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -15,7 +15,6 @@ from cnes_domain.control_plane.commands import (
     FinishRunDispatch,
     PutRunUnits,
     RenewJobLease,
-    ReserveRunDispatch,
     TransitionRun,
 )
 from cnes_domain.control_plane.entities import DatasetPointer, RunDependency, Tenant
@@ -102,7 +101,6 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
         new_state=RunState.PUBLISHING,
     )
     conflicting = existing.model_copy(update={"aggregate_id": "run-a"})
-
     with pytest.raises(Conflict, match="run_state_conflict"):
         adapter.transition_run(
             transition.model_copy(update={"expected_state": RunState.WAITING_INPUTS}),
@@ -110,7 +108,6 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
         )
     with pytest.raises(Conflict, match="outbox_event_conflict"):
         adapter.transition_run(transition, conflicting)
-
     assert adapter.get_run("354130", "run-a") == _run("run-a")
     assert adapter.pending_outbox(10) == (existing,)
 
@@ -176,12 +173,10 @@ def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, 
         now=clock.now() + timedelta(seconds=31),
         lease_seconds=30,
     )
-
     renewed, reclaimed = _race(
         lambda: writers[0].renew_job_lease(renew),
         lambda: writers[1].claim_job(reclaim),
     )
-
     if isinstance(renewed, LeaseLost):
         assert reclaimed is not None
         assert reclaimed.fencing_token == 2
@@ -196,9 +191,7 @@ def test_incrementa_fence_apos_expiracao(adapter, clock) -> None:
     _prepare_job(adapter)
     first = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
     clock.advance(timedelta(seconds=31))
-
     second = adapter.claim_job(_claim_job("job-a", "worker-b", clock))
-
     assert first is not None
     assert second is not None
     assert (first.fencing_token, second.fencing_token) == (1, 2)
@@ -366,63 +359,58 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
     assert adapter.get_run("354130", "run-a").missing_sources == ("CNES/ST",)
 
 
-def test_rejeita_bind_de_dispatch_ausente_ou_terminal(adapter, clock) -> None:
+def test_recaptura_lease_de_dispatch_superado_mas_exclui_dispatch_ativo(adapter, clock) -> None:
     dispatch = _prepare_unit(adapter, clock)
+    claimed = adapter.claim_run_unit(_claim_unit_command(dispatch.dispatch_id, "worker-a", clock))
+    assert claimed is not None
     bind = BindRunDispatch(
-        tenant_id="354130",
-        run_id="run-a",
-        dispatch_id="b" * 16,
-        execution_ref="exec-a",
-        now=clock.now(),
-        lease_seconds=30,
+        tenant_id="354130", run_id="run-a", dispatch_id="b" * 16,
+        execution_ref="exec-a", now=clock.now(), lease_seconds=30,
     )
     with pytest.raises(Conflict, match="dispatch_stale"):
         adapter.bind_run_dispatch(bind)
     adapter.finish_run_dispatch(
         FinishRunDispatch(
-            tenant_id="354130",
-            run_id="run-a",
-            dispatch_id=dispatch.dispatch_id,
-            outcome=DispatchOutcome.FAILED,
-            finished_at=clock.now(),
+            tenant_id="354130", run_id="run-a", dispatch_id=dispatch.dispatch_id,
+            outcome=DispatchOutcome.FAILED, finished_at=clock.now(),
         )
     )
     with pytest.raises(Conflict, match="dispatch_terminal"):
         adapter.bind_run_dispatch(bind.model_copy(update={"dispatch_id": dispatch.dispatch_id}))
     replacement = _reserve(adapter, clock)
     assert (replacement.generation, replacement.dispatch_id != dispatch.dispatch_id) == (2, True)
+    reclaimed = adapter.claim_run_unit(
+        _claim_unit_command(replacement.dispatch_id, "worker-b", clock)
+    )
+    assert reclaimed is not None
+    assert (reclaimed.attempt, reclaimed.fencing_token, reclaimed.dispatch_id) == (
+        claimed.attempt + 1, claimed.fencing_token + 1, replacement.dispatch_id,
+    )
+    other = _claim_unit_command(replacement.dispatch_id, "worker-c", clock)
+    assert adapter.claim_run_unit(other) is None
 
 
 def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:
-    adapter.put_run(_run("run-a"))
-    _put_units(adapter, (_unit("unit-a"),))
-    dispatch = adapter.reserve_run_dispatch(
-        ReserveRunDispatch(
-            tenant_id="354130",
-            run_id="run-a",
-            wave_id="a" * 16,
-            unit_ids=("unit-a",),
-            now=clock.now(),
-            lease_seconds=60,
-        )
-    )
+    dispatch = _prepare_unit(adapter, clock)
     pending = _commit_command(dispatch.dispatch_id, "worker-a", 0)
     with pytest.raises(LeaseLost, match="unit_not_leased"):
         adapter.commit_run_unit(pending, _event("pending-commit"))
-    claimed = adapter.claim_run_unit(
-        _claim_unit_command(dispatch.dispatch_id, "worker-a", clock, "unit-a")
+    claim = _claim_unit_command(dispatch.dispatch_id, "worker-a", clock).model_copy(
+        update={"lease_seconds": 10}
     )
+    claimed = adapter.claim_run_unit(claim)
     assert claimed is not None
-    clock.advance(timedelta(seconds=31))
+    clock.advance(timedelta(seconds=11))
     expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
     with pytest.raises(LeaseLost, match="lease_expired"):
         adapter.commit_run_unit(expired, _event("expired-commit"))
 
 
-def test_rejeita_dataset_divergente_e_replay_apos_pointer_avancar(adapter) -> None:
+@pytest.mark.parametrize("field", ["final_state", "missing_sources", "permit", "event"])
+def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) -> None:
     run = _run("run-a", RunState.PUBLISHING)
     adapter.put_run(run)
-    first = _publish("run-a", "published-a", None, False)
+    first = _publish("run-a", "published-a", None, True)
     mismatched = first.model_copy(
         update={"version": first.version.model_copy(update={"dataset_name": "silver"})}
     )
@@ -432,10 +420,32 @@ def test_rejeita_dataset_divergente_e_replay_apos_pointer_avancar(adapter) -> No
     assert adapter.get_dataset_pointer("354130", "silver") is None
     assert adapter.get_dataset_version("354130", "silver", "run-a") is None
     assert mismatched.event not in adapter.pending_outbox(100)
-    adapter.publish_dataset(first)
+    pointer = adapter.publish_dataset(first)
+    permit = first.publication_permit.model_copy(update={"policy_version": 2})
+    event = first.event.model_copy(update={"payload": {"changed": True}})
+    updates = {
+        "final_state": {"final_state": RunState.PUBLISHED, "missing_sources": ()},
+        "missing_sources": {"missing_sources": ("SIHD/ER",)},
+        "permit": {"publication_permit": permit},
+        "event": {"event": event},
+    }
+    divergent = first.model_copy(update=updates[field])
+    before = (
+        adapter.get_run("354130", "run-a"), pointer,
+        adapter.get_dataset_version("354130", "gold", "run-a"),
+        adapter.pending_outbox(100),
+    )
+    with pytest.raises(Conflict, match="publication_replay_conflict"):
+        adapter.publish_dataset(divergent)
+    assert before == (
+        adapter.get_run("354130", "run-a"),
+        adapter.get_dataset_pointer("354130", "gold"),
+        adapter.get_dataset_version("354130", "gold", "run-a"),
+        adapter.pending_outbox(100),
+    )
+    assert adapter.publish_dataset(first) == pointer
     adapter.put_run(_run("run-b", RunState.PUBLISHING))
     adapter.publish_dataset(_publish("run-b", "published-b", "run-a", False))
-
     with pytest.raises(Conflict, match="pointer_cas"):
         adapter.publish_dataset(first)
 
@@ -454,17 +464,13 @@ def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
     _put_units(adapter, units, "run-units")
     base = _raw_record("base-agent-raw", "agent-raw", 1, clock.now())
     _store_record(adapter, base, clock)
-
-    assert tuple(job.job_id for job in adapter.list_claimable_jobs(
-        "354130", "agent-order", 1
-    )) == ("job-a",)
-    assert tuple(run.run_id for run in adapter.list_waiting_runs_for_dependency(
-        "354130", "CNES", "ST", "2026-07", 1
-    )) == ("run-a",)
+    jobs = adapter.list_claimable_jobs("354130", "agent-order", 1)
+    assert tuple(job.job_id for job in jobs) == ("job-a",)
+    runs = adapter.list_waiting_runs_for_dependency("354130", "CNES", "ST", "2026-07", 1)
+    assert tuple(run.run_id for run in runs) == ("run-a",)
     assert adapter.list_recoverable_runs(clock.now(), 1)[0].run_id == "run-a"
-    assert tuple(unit.unit_id for unit in adapter.list_run_units(
-        "354130", "run-units"
-    )) == ("unit-a", "unit-b")
+    run_units = adapter.list_run_units("354130", "run-units")
+    assert tuple(unit.unit_id for unit in run_units) == ("unit-a", "unit-b")
     assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 0) == ()
     assert len(adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 1)) == 1
     pending = adapter.pending_outbox(1)
@@ -483,9 +489,7 @@ def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> 
     )
     for run in runs:
         adapter.put_run(run)
-
     recoverable = adapter.list_recoverable_runs(clock.now(), 2)
-
     assert tuple((run.tenant_id, run.run_id) for run in recoverable) == (
         ("a", "run-shared"),
         ("a", "run-z"),

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -95,11 +95,8 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
     existing = _event("event-collision")
     adapter.create_job(_job("job-a"), existing)
     transition = TransitionRun(
-        tenant_id="354130",
-        run_id="run-a",
-        expected_state=RunState.PROCESSING,
-        new_state=RunState.PUBLISHING,
-    )
+        tenant_id="354130", run_id="run-a", expected_state=RunState.PROCESSING,
+        new_state=RunState.PUBLISHING)
     conflicting = existing.model_copy(update={"aggregate_id": "run-a"})
     with pytest.raises(Conflict, match="run_state_conflict"):
         adapter.transition_run(
@@ -128,13 +125,8 @@ def test_serializa_claim_renovacao_e_publicacao_concorrentes(
     assert len(winners) == 1
     claimed = winners[0]
     renew = RenewJobLease(
-        tenant_id="354130",
-        job_id="job-a",
-        owner=claimed.lease_owner,
-        fencing_token=claimed.fencing_token,
-        now=clock.now(),
-        lease_seconds=60,
-    )
+        tenant_id="354130", job_id="job-a", owner=claimed.lease_owner,
+        fencing_token=claimed.fencing_token, now=clock.now(), lease_seconds=60)
     renewals = _race(
         lambda: writers[0].renew_job_lease(renew),
         lambda: writers[1].renew_job_lease(renew),
@@ -159,20 +151,11 @@ def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, 
         SQLiteControlPlane(database_path, clock.now),
     )
     renew = RenewJobLease(
-        tenant_id="354130",
-        job_id="job-a",
-        owner="worker-a",
-        fencing_token=claimed.fencing_token,
-        now=clock.now(),
-        lease_seconds=60,
-    )
+        tenant_id="354130", job_id="job-a", owner="worker-a",
+        fencing_token=claimed.fencing_token, now=clock.now(), lease_seconds=60)
     reclaim = ClaimJob(
-        tenant_id="354130",
-        job_id="job-a",
-        owner="worker-b",
-        now=clock.now() + timedelta(seconds=31),
-        lease_seconds=30,
-    )
+        tenant_id="354130", job_id="job-a", owner="worker-b",
+        now=clock.now() + timedelta(seconds=31), lease_seconds=30)
     renewed, reclaimed = _race(
         lambda: writers[0].renew_job_lease(renew),
         lambda: writers[1].claim_job(reclaim),
@@ -415,6 +398,13 @@ def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) ->
     run = _run("run-a", RunState.PUBLISHING)
     adapter.put_run(run)
     first = _publish("run-a", "published-a", None, True)
+    invalid_pointer = first.model_copy(update={"pointer_name": "CURRENT"})
+    with pytest.raises(Conflict, match="pointer_name_not_current"):
+        adapter.publish_dataset(invalid_pointer)
+    assert adapter.get_run("354130", "run-a") == run
+    assert adapter.get_dataset_pointer("354130", "gold") is None
+    assert adapter.get_dataset_version("354130", "gold", "run-a") is None
+    assert invalid_pointer.event not in adapter.pending_outbox(100)
     mismatched = first.model_copy(
         update={"version": first.version.model_copy(update={"dataset_name": "silver"})}
     )

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -6,7 +6,6 @@ from typing import Any
 import pytest
 
 from cnes_domain.control_plane.commands import (
-    BeginIdempotency,
     BindRunDispatch,
     CancelJob,
     ClaimJob,
@@ -192,28 +191,28 @@ def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, cl
         units=(_unit("unit-a"),))
     _no(Conflict, "run_state_conflict", lambda: adapter.put_run_units(command))
 def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None:
-    tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
-    adapter.put_tenant(tenant)
-    _prepare_job(adapter)
-    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
     adapter.put_run(_run("run-a", RunState.PUBLISHING))
-    pointer = adapter.publish_dataset(_publish("run-a", "published", None, False))
-    idempotency = BeginIdempotency(
-        tenant_id="354130", scope="jobs", key="key-a", request_hash="a" * 64,
-        resource_id="job-a", now=clock.now(), expires_at=clock.now() + timedelta(minutes=5))
-    adapter.begin_idempotency(idempotency)
+    publication = _publish("run-a", "published", None, False)
+    publication = publication.model_copy(update={"publication_permit":
+        publication.publication_permit.model_copy(update={"binding_context": object()})})
+    pointer = adapter.publish_dataset(publication)
     adapter.put_run(_run("run-units"))
     unit_a = _unit("unit-a").model_copy(update={"run_id": "run-units"})
     unit_b = _unit("unit-b").model_copy(update={"run_id": "run-units"})
     canonical = (unit_a, unit_b)
     assert _put_units(adapter, (unit_b, unit_a), "run-units") == canonical
+    with adapter.write_transaction() as connection:
+        connection.executescript("ALTER TABLE job_creation_writes DROP COLUMN job_data;"
+                                 "ALTER TABLE runs DROP COLUMN unit_registry_data;")
     reopened = SQLiteControlPlane(database_path, clock.now)
     reopened.initialize()
-    assert reopened.get_tenant(tenant.tenant_id) == tenant
-    assert reopened.get_job("354130", "job-a") == claimed
-    assert reopened.get_dataset_pointer("354130", "gold") == pointer
-    assert not reopened.begin_idempotency(idempotency).created
-    assert reopened.pending_outbox(10) == adapter.pending_outbox(10)
+    with reopened.read_connection() as connection:
+        assert "job_data" in {row[1] for row in connection.execute(
+            "PRAGMA table_info(job_creation_writes)")}
+    reopened.initialize()
+    permit = publication.publication_permit.model_copy(update={"binding_context": object()})
+    assert reopened.publish_dataset(publication.model_copy(
+        update={"publication_permit": permit})) == pointer
     assert _put_units(reopened, canonical, "run-units") == canonical
     before = reopened.list_run_units("354130", "run-units")
     divergent = (unit_a, _unit("unit-c").model_copy(update={"run_id": "run-units"}))
@@ -460,21 +459,26 @@ def test_limita_ancestralidade_longa_sem_recursao(adapter, clock, monkeypatch) -
     calls = []
     monkeypatch.setattr(sqlite_publication, "deserialize_model",
                         lambda *args: (calls.append(None), deserialize(*args))[1])
-    assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07") == ()
     assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 2) == ()
-    assert len(calls) <= 35
     with adapter.write_transaction() as connection:
+        for index in range(2):
+            shared = base.model_copy(update={
+                "manifest_id": f"shared-{index}", "snapshot_id": f"shared-{index}",
+                "manifest_key": f"raw/354130/CNES/2026-07/shared-{index}/manifest.json",
+                "snapshot_mode": "DELTA", "sequence": 2, "base_snapshot_id": "missing",
+                "previous_manifest_sha256": "d" * 64, "manifest_sha256": "e" * 64})
+            adapter.put_manifest_record(connection, shared)
         for index in range(100):
             broken = base.model_copy(update={
                 "manifest_id": f"invalid-{index:03}", "snapshot_id": f"invalid-{index:03}",
                 "manifest_key": f"raw/354130/CNES/2026-07/invalid-{index:03}/manifest.json",
-                "snapshot_mode": "DELTA", "sequence": 2, "base_snapshot_id": "missing",
+                "snapshot_mode": "DELTA", "sequence": 3, "base_snapshot_id": "missing",
                 "previous_manifest_sha256": "e" * 64,
                 "created_at": clock.now() + timedelta(days=1, seconds=index)})
             adapter.put_manifest_record(connection, broken)
     calls.clear()
     assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 2) == ()
-    assert len(calls) <= 8
+    assert len(calls) <= 10
     levels = tuple(tuple(base.model_copy(update={
         "manifest_id": f"branch-{level}-{index}", "sequence": level + 2,
     }) for index in range(31)) for level in range(4))
@@ -486,14 +490,11 @@ def test_limita_ancestralidade_longa_sem_recursao(adapter, clock, monkeypatch) -
     graph.update({item.manifest_id: levels[level - 1] if level else ()
                   for level, siblings in enumerate(levels) for item in siblings})
     graph.update({valid[index].manifest_id: (valid[index - 1],) for index in range(1, 4)})
-    expansions = []
     def predecessors(connection, identity, current, limit):
-        expansions.append(current.manifest_id)
-        if len(expansions) > 200:
-            raise RuntimeError("ancestry_expansion")
         return graph.get(current.manifest_id, ())
     monkeypatch.setattr(sqlite_publication, "_predecessors", predecessors)
-    chain = sqlite_publication._build_ancestry(None, (), head, 100)
-    assert tuple(item.manifest_id for item in chain)[-1] == "branch-head"
-    assert len(expansions) <= 10
-    assert sqlite_publication._build_ancestry(None, (), head, 20) is None
+    assert sqlite_publication._build_ancestry(None, (), head, 100) is not None
+    monkeypatch.setattr(sqlite_publication, "_build_ancestry", lambda *args: ())
+    with adapter.read_connection() as connection:
+        identity = ("354130", "CNES", "ST", "2026-07")
+        assert sqlite_publication._select_raw_chain(connection, identity, 2) == ()

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -20,7 +20,7 @@ from cnes_domain.control_plane.commands import (
 from cnes_domain.control_plane.entities import DatasetPointer, RunDependency, Tenant
 from cnes_domain.control_plane.enums import DispatchOutcome, RunState
 from cnes_domain.control_plane.errors import Conflict, LeaseLost
-from cnes_infra.control_plane import sqlite_adapter, sqlite_schema
+from cnes_infra.control_plane import sqlite_adapter, sqlite_publication, sqlite_schema
 from cnes_infra.control_plane.sqlite_adapter import (
     SQLiteControlPlane,
     _is_network_filesystem,
@@ -473,12 +473,10 @@ def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> 
         adapter.put_run(run)
     recoverable = adapter.list_recoverable_runs(clock.now(), 2)
     assert tuple((run.tenant_id, run.run_id) for run in recoverable) == (
-        ("a", "run-shared"),
-        ("a", "run-z"),
-    )
+        ("a", "run-shared"), ("a", "run-z"))
 
 
-def test_limita_ancestralidade_longa_sem_recursao(adapter, clock) -> None:
+def test_limita_ancestralidade_longa_sem_recursao(adapter, clock, monkeypatch) -> None:
     base = _raw_record("deep-1", "deep-agent", 1, clock.now())
     previous = None
     with adapter.write_transaction() as connection:
@@ -493,5 +491,10 @@ def test_limita_ancestralidade_longa_sem_recursao(adapter, clock) -> None:
                 "created_at": clock.now() + timedelta(seconds=sequence)})
             adapter.put_manifest_record(connection, record)
             previous = record.manifest_sha256
+    deserialize = sqlite_publication.deserialize_model
+    calls = []
+    monkeypatch.setattr(sqlite_publication, "deserialize_model",
+                        lambda *args: (calls.append(None), deserialize(*args))[1])
     assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07") == ()
     assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 2) == ()
+    assert len(calls) <= 35

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -113,10 +113,8 @@ def test_serializa_claim_renovacao_e_publicacao_concorrentes(
     adapter, database_path, clock
 ) -> None:
     _prepare_job(adapter)
-    writers = (
-        SQLiteControlPlane(database_path, clock.now),
-        SQLiteControlPlane(database_path, clock.now),
-    )
+    writers = (SQLiteControlPlane(database_path, clock.now),
+               SQLiteControlPlane(database_path, clock.now))
     claims = _race(
         lambda: writers[0].claim_job(_claim_job("job-a", "worker-a", clock)),
         lambda: writers[1].claim_job(_claim_job("job-a", "worker-b", clock)),
@@ -146,10 +144,8 @@ def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, 
     _prepare_job(adapter)
     claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
     assert claimed is not None
-    writers = (
-        SQLiteControlPlane(database_path, clock.now),
-        SQLiteControlPlane(database_path, clock.now),
-    )
+    writers = (SQLiteControlPlane(database_path, clock.now),
+               SQLiteControlPlane(database_path, clock.now))
     renew = RenewJobLease(
         tenant_id="354130", job_id="job-a", owner="worker-a",
         fencing_token=claimed.fencing_token, now=clock.now(), lease_seconds=60)
@@ -200,7 +196,6 @@ def test_converte_busy_em_erro_local(adapter, database_path, clock, monkeypatch)
 
 def test_traduz_falha_de_conexao_em_erro_local(tmp_path, clock, monkeypatch) -> None:
     broken = SQLiteControlPlane(tmp_path / "broken.sqlite3", clock.now)
-
     def fail_connect():
         raise sqlite3.OperationalError("disk_unavailable")
 
@@ -214,7 +209,6 @@ def test_traduz_falha_de_conexao_em_erro_local(tmp_path, clock, monkeypatch) -> 
 def test_propaga_erro_operacional_que_nao_e_contencao(tmp_path, clock) -> None:
     uninitialized = SQLiteControlPlane(tmp_path / "empty.sqlite3", clock.now)
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
-
     with pytest.raises(sqlite3.OperationalError, match="no such table"):
         uninitialized.put_tenant(tenant)
 
@@ -238,11 +232,8 @@ def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, cl
         )
     adapter.put_run(_run("run-a", RunState.WAITING_INPUTS))
     command = PutRunUnits(
-        tenant_id="354130",
-        run_id="run-a",
-        expected_run_state=RunState.PROCESSING,
-        units=(_unit("unit-a"),),
-    )
+        tenant_id="354130", run_id="run-a", expected_run_state=RunState.PROCESSING,
+        units=(_unit("unit-a"),))
     with pytest.raises(Conflict, match="run_state_conflict"):
         adapter.put_run_units(command)
 
@@ -256,9 +247,7 @@ def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None
     pointer = adapter.publish_dataset(_publish("run-a", "published", None, False))
     idempotency = BeginIdempotency(
         tenant_id="354130", scope="jobs", key="key-a", request_hash="a" * 64,
-        resource_id="job-a", now=clock.now(),
-        expires_at=clock.now() + timedelta(minutes=5),
-    )
+        resource_id="job-a", now=clock.now(), expires_at=clock.now() + timedelta(minutes=5))
     adapter.begin_idempotency(idempotency)
     adapter.put_run(_run("run-units"))
     unit_a = _unit("unit-a").model_copy(update={"run_id": "run-units"})
@@ -289,13 +278,11 @@ def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> No
 
 @pytest.mark.parametrize(
     "network_path",
-    [
-        pytest.param(r"\\server\share\control.sqlite3"),
-        pytest.param("smb://server/share/control.sqlite3"),
-        pytest.param("nfs://server/share/control.sqlite3"),
-        pytest.param("/net/server/share/control.sqlite3"),
-        pytest.param("/Network/Servers/server/share/control.sqlite3"),
-    ],
+    [pytest.param(r"\\server\share\control.sqlite3"),
+     pytest.param("smb://server/share/control.sqlite3"),
+     pytest.param("nfs://server/share/control.sqlite3"),
+     pytest.param("/net/server/share/control.sqlite3"),
+     pytest.param("/Network/Servers/server/share/control.sqlite3")],
 )
 def test_detecta_formas_conhecidas_de_filesystem_de_rede_sem_proc(
     network_path, tmp_path, monkeypatch
@@ -304,7 +291,6 @@ def test_detecta_formas_conhecidas_de_filesystem_de_rede_sem_proc(
         raise OSError("proc_unavailable")
 
     monkeypatch.setattr(sqlite_schema.Path, "read_text", unavailable)
-
     assert _is_network_filesystem(sqlite_adapter.Path(network_path))
     assert not _is_network_filesystem(tmp_path / "control.sqlite3")
 
@@ -312,7 +298,6 @@ def test_detecta_formas_conhecidas_de_filesystem_de_rede_sem_proc(
 def test_rejeita_inicializacao_quando_wal_nao_e_ativado(tmp_path, clock, monkeypatch) -> None:
     adapter = SQLiteControlPlane(tmp_path / "control.sqlite3", clock.now)
     monkeypatch.setattr(adapter, "_connect", lambda: sqlite3.connect(":memory:"))
-
     with pytest.raises(_SQLiteFilesystemError, match="sqlite_wal_unavailable"):
         adapter.initialize()
 
@@ -365,6 +350,8 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
     )
     with pytest.raises(Conflict, match="dispatch_terminal"):
         adapter.bind_run_dispatch(bind.model_copy(update={"dispatch_id": dispatch.dispatch_id}))
+    with pytest.raises(Conflict, match="dispatch_units_conflict"):
+        _reserve(adapter, clock, unit_ids=("unit-a",))
     replacement = _reserve(adapter, clock, unit_ids=dispatch.unit_ids)
     assert (replacement.generation, replacement.dispatch_id != dispatch.dispatch_id) == (2, True)
     reclaimed = adapter.claim_run_unit(
@@ -376,6 +363,10 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
     )
     other = _claim_unit_command(replacement.dispatch_id, "worker-c", clock)
     assert adapter.claim_run_unit(other) is None
+    clock.advance(timedelta(seconds=31))
+    with pytest.raises(Conflict, match="dispatch_units_conflict"):
+        _reserve(adapter, clock, unit_ids=("unit-a",))
+    assert _reserve(adapter, clock, unit_ids=dispatch.unit_ids).generation == 3
 
 def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:
     dispatch = _prepare_unit(adapter, clock)
@@ -488,3 +479,22 @@ def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> 
         ("a", "run-shared"),
         ("a", "run-z"),
     )
+
+
+def test_limita_ancestralidade_longa_sem_recursao(adapter, clock) -> None:
+    base = _raw_record("deep-1", "deep-agent", 1, clock.now())
+    previous = None
+    with adapter.write_transaction() as connection:
+        for sequence in range(1, 1102):
+            snapshot = f"deep-{sequence}"
+            record = base.model_copy(update={
+                "manifest_id": f"manifest-deep-agent-{snapshot}", "snapshot_id": snapshot,
+                "manifest_key": f"raw/354130/CNES/2026-07/{snapshot}/manifest.json",
+                "snapshot_mode": "FULL" if sequence == 1 else "DELTA",
+                "base_snapshot_id": None if sequence == 1 else "deep-1", "sequence": sequence,
+                "previous_manifest_sha256": previous, "manifest_sha256": f"{sequence:064x}",
+                "created_at": clock.now() + timedelta(seconds=sequence)})
+            adapter.put_manifest_record(connection, record)
+            previous = record.manifest_sha256
+    assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07") == ()
+    assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 2) == ()

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -145,17 +145,12 @@ def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, 
         assert reclaimed is None
         assert renewed.fencing_token == 1
         assert adapter.get_job("354130", "job-a") == renewed
-def test_incrementa_fence_apos_expiracao_ou_lease_ausente(adapter, clock) -> None:
+def test_incrementa_fence_apos_expiracao(adapter, clock) -> None:
     _prepare_job(adapter)
     first = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
     clock.advance(timedelta(seconds=31))
     second = adapter.claim_job(_claim_job("job-a", "worker-b", clock))
     assert (first.fencing_token, second.fencing_token) == (1, 2)
-    missing_lease = _job("job-b").model_copy(update={"state": first.state})
-    adapter.create_job(missing_lease, _event("job-b-created"))
-    assert missing_lease in adapter.list_claimable_jobs("354130", "agent-a", 10)
-    reclaimed = adapter.claim_job(_claim_job("job-b", "worker-c", clock))
-    assert (reclaimed.attempt, reclaimed.fencing_token) == (1, 1)
 def test_configura_busy_timeout_de_cinco_segundos(adapter) -> None:
     with adapter.read_connection() as connection:
         assert connection.execute("PRAGMA busy_timeout").fetchone() == (5000,)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -1,0 +1,236 @@
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from threading import Barrier
+from typing import Any
+
+import pytest
+
+from cnes_domain.control_plane.commands import (
+    BeginIdempotency,
+    RenewJobLease,
+    TransitionRun,
+)
+from cnes_domain.control_plane.entities import DatasetPointer, Tenant
+from cnes_domain.control_plane.enums import RunState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.control_plane import sqlite_adapter
+from cnes_infra.control_plane.sqlite_adapter import (
+    SQLiteControlPlane,
+    _SQLiteBusyError,
+    _SQLiteFilesystemError,
+)
+from packages.cnes_infra.tests.contracts.clock import (
+    MutableClock,
+    _agent,
+    _claim_job,
+    _event,
+    _job,
+    _put_units,
+    _raw_record,
+    _run,
+    _store_record,
+    _unit,
+)
+from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
+
+_NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
+
+
+@pytest.fixture
+def clock() -> MutableClock:
+    return MutableClock(_NOW)
+
+
+@pytest.fixture
+def database_path(tmp_path):
+    return tmp_path / "control-plane.sqlite3"
+
+
+@pytest.fixture
+def adapter(database_path, clock) -> SQLiteControlPlane:
+    control_plane = SQLiteControlPlane(database_path, clock.now)
+    control_plane.initialize()
+    return control_plane
+
+
+def _capture(action: Any, barrier: Barrier) -> Any:
+    barrier.wait()
+    try:
+        return action()
+    except Exception as error:
+        return error
+
+
+def _race(first: Any, second: Any) -> tuple[Any, Any]:
+    barrier = Barrier(3)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = (
+            executor.submit(_capture, first, barrier),
+            executor.submit(_capture, second, barrier),
+        )
+        barrier.wait()
+        return tuple(future.result() for future in futures)
+
+
+def _prepare_job(adapter: SQLiteControlPlane) -> None:
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+
+
+def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> None:
+    adapter.put_run(_run("run-a"))
+    adapter.put_agent(_agent("agent-a"))
+    existing = _event("event-collision")
+    adapter.create_job(_job("job-a"), existing)
+    transition = TransitionRun(
+        tenant_id="354130",
+        run_id="run-a",
+        expected_state=RunState.PROCESSING,
+        new_state=RunState.PUBLISHING,
+    )
+    conflicting = existing.model_copy(update={"aggregate_id": "run-a"})
+
+    with pytest.raises(Conflict, match="outbox_event_conflict"):
+        adapter.transition_run(transition, conflicting)
+
+    assert adapter.get_run("354130", "run-a") == _run("run-a")
+    assert adapter.pending_outbox(10) == (existing,)
+
+
+def test_serializa_claim_renovacao_e_publicacao_concorrentes(
+    adapter, database_path, clock
+) -> None:
+    _prepare_job(adapter)
+    writers = (
+        SQLiteControlPlane(database_path, clock.now),
+        SQLiteControlPlane(database_path, clock.now),
+    )
+    claims = _race(
+        lambda: writers[0].claim_job(_claim_job("job-a", "worker-a", clock)),
+        lambda: writers[1].claim_job(_claim_job("job-a", "worker-b", clock)),
+    )
+    winners = [result for result in claims if result is not None]
+    assert len(winners) == 1
+    claimed = winners[0]
+    renew = RenewJobLease(
+        tenant_id="354130",
+        job_id="job-a",
+        owner=claimed.lease_owner,
+        fencing_token=claimed.fencing_token,
+        now=clock.now(),
+        lease_seconds=60,
+    )
+    renewals = _race(
+        lambda: writers[0].renew_job_lease(renew),
+        lambda: writers[1].renew_job_lease(renew),
+    )
+    assert renewals[0] == renewals[1]
+    adapter.put_run(_run("run-pub-a", RunState.PUBLISHING))
+    adapter.put_run(_run("run-pub-b", RunState.PUBLISHING))
+    publications = _race(
+        lambda: writers[0].publish_dataset(_publish("run-pub-a", "pub-a", None, False)),
+        lambda: writers[1].publish_dataset(_publish("run-pub-b", "pub-b", None, False)),
+    )
+    assert sum(isinstance(result, DatasetPointer) for result in publications) == 1
+    assert sum(isinstance(result, Conflict) for result in publications) == 1
+
+
+def test_incrementa_fence_apos_expiracao(adapter, clock) -> None:
+    _prepare_job(adapter)
+    first = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    clock.advance(timedelta(seconds=31))
+
+    second = adapter.claim_job(_claim_job("job-a", "worker-b", clock))
+
+    assert first is not None
+    assert second is not None
+    assert (first.fencing_token, second.fencing_token) == (1, 2)
+
+
+def test_converte_esgotamento_do_busy_timeout_em_erro_local(adapter, database_path, clock) -> None:
+    blocker = sqlite3.connect(database_path, isolation_level=None)
+    blocker.execute("BEGIN IMMEDIATE")
+    tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
+    try:
+        with pytest.raises(_SQLiteBusyError, match="sqlite_busy"):
+            adapter.put_tenant(tenant)
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+
+def test_reabertura_preserva_registros_leases_pointer_idempotencia_e_outbox(
+    adapter, database_path, clock
+) -> None:
+    tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
+    adapter.put_tenant(tenant)
+    _prepare_job(adapter)
+    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    pointer = adapter.publish_dataset(_publish("run-a", "published", None, False))
+    idempotency = BeginIdempotency(
+        tenant_id="354130",
+        scope="jobs",
+        key="key-a",
+        request_hash="a" * 64,
+        resource_id="job-a",
+        now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5),
+    )
+    adapter.begin_idempotency(idempotency)
+
+    reopened = SQLiteControlPlane(database_path, clock.now)
+    reopened.initialize()
+
+    assert reopened.get_tenant(tenant.tenant_id) == tenant
+    assert reopened.get_job("354130", "job-a") == claimed
+    assert reopened.get_dataset_pointer("354130", "gold") == pointer
+    assert not reopened.begin_idempotency(idempotency).created
+    assert reopened.pending_outbox(10) == adapter.pending_outbox(10)
+
+
+def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> None:
+    monkeypatch.setattr(sqlite_adapter, "_is_network_filesystem", lambda path: True)
+    adapter = SQLiteControlPlane(tmp_path / "network" / "control.sqlite3", clock.now)
+
+    with pytest.raises(_SQLiteFilesystemError, match="sqlite_network_filesystem"):
+        adapter.initialize()
+
+
+def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
+    adapter.put_agent(_agent("agent-order"))
+    for job_id in ("job-b", "job-a"):
+        adapter.create_job(_job(job_id, "agent-order"), _event(f"created-{job_id}"))
+    adapter.put_run(_run("run-b", RunState.WAITING_INPUTS))
+    adapter.put_run(_run("run-a", RunState.WAITING_INPUTS))
+    adapter.put_run(_run("run-units"))
+    units = tuple(
+        _unit(unit_id).model_copy(update={"run_id": "run-units"})
+        for unit_id in ("unit-a", "unit-b")
+    )
+    _put_units(adapter, units, "run-units")
+    base = _raw_record("base-agent-raw", "agent-raw", 1, clock.now())
+    delta = _raw_record(
+        "delta", "agent-raw", 2, clock.now() + timedelta(seconds=1)
+    )
+    _store_record(adapter, base, clock)
+    _store_record(adapter, delta, clock)
+
+    assert tuple(job.job_id for job in adapter.list_claimable_jobs(
+        "354130", "agent-order", 1
+    )) == ("job-a",)
+    assert tuple(run.run_id for run in adapter.list_waiting_runs_for_dependency(
+        "354130", "CNES", "ST", "2026-07", 1
+    )) == ("run-a",)
+    assert adapter.list_recoverable_runs(clock.now(), 1)[0].run_id == "run-a"
+    assert tuple(unit.unit_id for unit in adapter.list_run_units(
+        "354130", "run-units"
+    )) == ("unit-a", "unit-b")
+    assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 1) == ()
+    assert len(adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 2)) == 2
+    pending = adapter.pending_outbox(1)
+    assert len(pending) == 1
+    assert pending[0] == min(adapter.pending_outbox(100), key=lambda event: (
+        event.created_at, event.event_id
+    ))

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -275,7 +275,7 @@ def test_replay_dispatch_e_recaptura(adapter, database_path, clock) -> None:
     started = adapter.bind_run_dispatch(bind)
     expired = started.model_copy(update={"lease_until": bind.now})
     _write_dispatch(adapter, expired)
-    assert reopened.bind_run_dispatch(bind) == expired
+    assert reopened.bind_run_dispatch(bind) == started
     for update in ({"now": bind.now + timedelta(seconds=1)}, {"lease_seconds": 31},
                    {"execution_ref": "exec-b"}):
         _no(Conflict, "dispatch_bind_conflict", lambda update=update: reopened.bind_run_dispatch(
@@ -287,7 +287,7 @@ def test_replay_dispatch_e_recaptura(adapter, database_path, clock) -> None:
     _no(Conflict, "dispatch_expired", lambda: adapter.finish_run_dispatch(
         finish.model_copy(update={"finished_at": dispatch.lease_until})))
     finished = adapter.finish_run_dispatch(finish)
-    _no(Conflict, "dispatch_terminal", lambda: adapter.bind_run_dispatch(bind))
+    assert adapter.bind_run_dispatch(bind) == started
     expired = finished.model_copy(update={"lease_until": finish.finished_at})
     _write_dispatch(reopened, expired)
     assert reopened.finish_run_dispatch(finish) == expired

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -1,8 +1,9 @@
-import sqlite3  # noqa: I001
+import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from threading import Barrier
 from typing import Any
+
 import pytest
 
 from cnes_domain.control_plane.commands import (
@@ -42,6 +43,8 @@ from packages.cnes_infra.tests.contracts.clock import (
     _unit,
 )
 from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
+
+
 @pytest.fixture
 def clock() -> MutableClock:
     return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
@@ -219,9 +222,21 @@ def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None
     divergent = (unit_a, _unit("unit-c").model_copy(update={"run_id": "run-units"}))
     _no(Conflict, "units_conflict", lambda: _put_units(reopened, divergent, "run-units"))
     assert reopened.list_run_units("354130", "run-units") == before
-def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> None:
-    monkeypatch.setattr(sqlite_adapter, "_is_network_filesystem", lambda path: True)
-    adapter = SQLiteControlPlane(tmp_path / "network" / "control.sqlite3", clock.now)
+@pytest.mark.parametrize("filesystem", [pytest.param("nfs"), pytest.param("cifs")])
+def test_rejeita_banco_symlink_para_filesystem_de_rede(
+    tmp_path, clock, monkeypatch, filesystem
+) -> None:
+    mount = tmp_path / "network"
+    mount.mkdir()
+    database_path = tmp_path / "local" / "control.sqlite3"
+    database_path.parent.mkdir()
+    database_path.symlink_to(mount / "control.sqlite3")
+
+    def mounts(_path, **_kwargs) -> str:
+        return f"server:/share {mount} {filesystem} rw 0 0\\n"
+
+    monkeypatch.setattr(sqlite_schema.Path, "read_text", mounts)
+    adapter = SQLiteControlPlane(database_path, clock.now)
     _no(_SQLiteFilesystemError, "sqlite_network_filesystem", adapter.initialize)
 @pytest.mark.parametrize(
     "network_path",

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -389,7 +389,7 @@ def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) ->
     assert adapter.publish_dataset(first) == pointer
     adapter.put_run(_run("run-b", RunState.PUBLISHING))
     adapter.publish_dataset(_publish("run-b", "published-b", "run-a", False))
-    _no(Conflict, "pointer_cas", lambda: adapter.publish_dataset(first))
+    assert adapter.publish_dataset(first) == pointer
 def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock, monkeypatch) -> None:
     adapter.put_agent(_agent("agent-order"))
     for job_id in ("job-b", "job-a"):

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -264,9 +264,7 @@ def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, cl
         adapter.put_run_units(command)
 
 
-def test_reabertura_preserva_registros_leases_pointer_idempotencia_e_outbox(
-    adapter, database_path, clock
-) -> None:
+def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None:
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
     adapter.put_tenant(tenant)
     _prepare_job(adapter)
@@ -274,24 +272,29 @@ def test_reabertura_preserva_registros_leases_pointer_idempotencia_e_outbox(
     adapter.put_run(_run("run-a", RunState.PUBLISHING))
     pointer = adapter.publish_dataset(_publish("run-a", "published", None, False))
     idempotency = BeginIdempotency(
-        tenant_id="354130",
-        scope="jobs",
-        key="key-a",
-        request_hash="a" * 64,
-        resource_id="job-a",
-        now=clock.now(),
+        tenant_id="354130", scope="jobs", key="key-a", request_hash="a" * 64,
+        resource_id="job-a", now=clock.now(),
         expires_at=clock.now() + timedelta(minutes=5),
     )
     adapter.begin_idempotency(idempotency)
-
+    adapter.put_run(_run("run-units"))
+    unit_a = _unit("unit-a").model_copy(update={"run_id": "run-units"})
+    unit_b = _unit("unit-b").model_copy(update={"run_id": "run-units"})
+    canonical = (unit_a, unit_b)
+    assert _put_units(adapter, (unit_b, unit_a), "run-units") == canonical
     reopened = SQLiteControlPlane(database_path, clock.now)
     reopened.initialize()
-
     assert reopened.get_tenant(tenant.tenant_id) == tenant
     assert reopened.get_job("354130", "job-a") == claimed
     assert reopened.get_dataset_pointer("354130", "gold") == pointer
     assert not reopened.begin_idempotency(idempotency).created
     assert reopened.pending_outbox(10) == adapter.pending_outbox(10)
+    assert _put_units(reopened, canonical, "run-units") == canonical
+    before = reopened.list_run_units("354130", "run-units")
+    divergent = (unit_a, _unit("unit-c").model_copy(update={"run_id": "run-units"}))
+    with pytest.raises(Conflict, match="units_conflict"):
+        _put_units(reopened, divergent, "run-units")
+    assert reopened.list_run_units("354130", "run-units") == before
 
 
 def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -51,17 +51,14 @@ _NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
 @pytest.fixture
 def clock() -> MutableClock:
     return MutableClock(_NOW)
-
 @pytest.fixture
 def database_path(tmp_path):
     return tmp_path / "control-plane.sqlite3"
-
 @pytest.fixture
 def adapter(database_path, clock) -> SQLiteControlPlane:
     control_plane = SQLiteControlPlane(database_path, clock.now)
     control_plane.initialize()
     return control_plane
-
 def _capture(action: Any, barrier: Barrier) -> Any:
     barrier.wait()
     try:
@@ -76,11 +73,9 @@ def _race(first: Any, second: Any) -> tuple[Any, Any]:
                    executor.submit(_capture, second, barrier))
         barrier.wait()
         return tuple(future.result() for future in futures)
-
 def _prepare_job(adapter: SQLiteControlPlane) -> None:
     adapter.put_agent(_agent("agent-a"))
     adapter.create_job(_job("job-a"), _event("job-created"))
-
 def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> None:
     adapter.put_run(_run("run-a"))
     adapter.put_agent(_agent("agent-a"))
@@ -97,7 +92,6 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
         adapter.transition_run(transition, conflicting)
     assert adapter.get_run("354130", "run-a") == _run("run-a")
     assert adapter.pending_outbox(10) == (existing,)
-
 def test_serializa_claim_renovacao_e_publicacao_concorrentes(
     adapter, database_path, clock
 ) -> None:
@@ -122,7 +116,6 @@ def test_serializa_claim_renovacao_e_publicacao_concorrentes(
         lambda: writers[1].publish_dataset(_publish("run-pub-b", "pub-b", None, False)))
     assert sum(isinstance(result, DatasetPointer) for result in publications) == 1
     assert sum(isinstance(result, Conflict) for result in publications) == 1
-
 def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, clock) -> None:
     _prepare_job(adapter)
     claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
@@ -145,7 +138,6 @@ def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, 
         assert reclaimed is None
         assert renewed.fencing_token == 1
         assert adapter.get_job("354130", "job-a") == renewed
-
 def test_incrementa_fence_apos_expiracao_ou_lease_ausente(adapter, clock) -> None:
     _prepare_job(adapter)
     first = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
@@ -160,11 +152,9 @@ def test_incrementa_fence_apos_expiracao_ou_lease_ausente(adapter, clock) -> Non
     reclaimed = adapter.claim_job(_claim_job("job-b", "worker-c", clock))
     assert reclaimed is not None
     assert (reclaimed.attempt, reclaimed.fencing_token) == (1, 1)
-
 def test_configura_busy_timeout_de_cinco_segundos(adapter) -> None:
     with adapter.read_connection() as connection:
         assert connection.execute("PRAGMA busy_timeout").fetchone() == (5000,)
-
 def test_converte_busy_em_erro_local(adapter, database_path, clock, monkeypatch) -> None:
     monkeypatch.setattr(sqlite_adapter, "_BUSY_TIMEOUT_MS", 1)
     blocker = sqlite3.connect(database_path, isolation_level=None)
@@ -176,7 +166,6 @@ def test_converte_busy_em_erro_local(adapter, database_path, clock, monkeypatch)
     finally:
         blocker.rollback()
         blocker.close()
-
 def test_traduz_falha_de_conexao_em_erro_local(tmp_path, clock, monkeypatch) -> None:
     broken = SQLiteControlPlane(tmp_path / "broken.sqlite3", clock.now)
     def fail_connect():
@@ -186,7 +175,6 @@ def test_traduz_falha_de_conexao_em_erro_local(tmp_path, clock, monkeypatch) -> 
         broken.initialize()
     with pytest.raises(_SQLiteFilesystemError, match="sqlite_filesystem"):
         broken.get_tenant("354130")
-
 def test_propaga_erro_operacional_que_nao_e_contencao(tmp_path, clock) -> None:
     uninitialized = SQLiteControlPlane(tmp_path / "empty.sqlite3", clock.now)
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
@@ -498,3 +486,15 @@ def test_limita_ancestralidade_longa_sem_recursao(adapter, clock, monkeypatch) -
     assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07") == ()
     assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 2) == ()
     assert len(calls) <= 35
+    with adapter.write_transaction() as connection:
+        for index in range(100):
+            broken = base.model_copy(update={
+                "manifest_id": f"invalid-{index:03}", "snapshot_id": f"invalid-{index:03}",
+                "manifest_key": f"raw/354130/CNES/2026-07/invalid-{index:03}/manifest.json",
+                "snapshot_mode": "DELTA", "sequence": 2, "base_snapshot_id": "missing",
+                "previous_manifest_sha256": "e" * 64,
+                "created_at": clock.now() + timedelta(days=1, seconds=index)})
+            adapter.put_manifest_record(connection, broken)
+    calls.clear()
+    assert adapter.list_raw_manifest_chain("354130", "CNES", "ST", "2026-07", 2) == ()
+    assert len(calls) <= 8

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -52,11 +52,9 @@ _NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
 def clock() -> MutableClock:
     return MutableClock(_NOW)
 
-
 @pytest.fixture
 def database_path(tmp_path):
     return tmp_path / "control-plane.sqlite3"
-
 
 @pytest.fixture
 def adapter(database_path, clock) -> SQLiteControlPlane:
@@ -64,14 +62,12 @@ def adapter(database_path, clock) -> SQLiteControlPlane:
     control_plane.initialize()
     return control_plane
 
-
 def _capture(action: Any, barrier: Barrier) -> Any:
     barrier.wait()
     try:
         return action()
     except Exception as error:
         return error
-
 
 def _race(first: Any, second: Any) -> tuple[Any, Any]:
     barrier = Barrier(3)
@@ -81,11 +77,9 @@ def _race(first: Any, second: Any) -> tuple[Any, Any]:
         barrier.wait()
         return tuple(future.result() for future in futures)
 
-
 def _prepare_job(adapter: SQLiteControlPlane) -> None:
     adapter.put_agent(_agent("agent-a"))
     adapter.create_job(_job("job-a"), _event("job-created"))
-
 
 def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> None:
     adapter.put_run(_run("run-a"))
@@ -103,7 +97,6 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
         adapter.transition_run(transition, conflicting)
     assert adapter.get_run("354130", "run-a") == _run("run-a")
     assert adapter.pending_outbox(10) == (existing,)
-
 
 def test_serializa_claim_renovacao_e_publicacao_concorrentes(
     adapter, database_path, clock
@@ -130,7 +123,6 @@ def test_serializa_claim_renovacao_e_publicacao_concorrentes(
     assert sum(isinstance(result, DatasetPointer) for result in publications) == 1
     assert sum(isinstance(result, Conflict) for result in publications) == 1
 
-
 def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, clock) -> None:
     _prepare_job(adapter)
     claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
@@ -154,7 +146,6 @@ def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, 
         assert renewed.fencing_token == 1
         assert adapter.get_job("354130", "job-a") == renewed
 
-
 def test_incrementa_fence_apos_expiracao_ou_lease_ausente(adapter, clock) -> None:
     _prepare_job(adapter)
     first = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
@@ -170,11 +161,9 @@ def test_incrementa_fence_apos_expiracao_ou_lease_ausente(adapter, clock) -> Non
     assert reclaimed is not None
     assert (reclaimed.attempt, reclaimed.fencing_token) == (1, 1)
 
-
 def test_configura_busy_timeout_de_cinco_segundos(adapter) -> None:
     with adapter.read_connection() as connection:
         assert connection.execute("PRAGMA busy_timeout").fetchone() == (5000,)
-
 
 def test_converte_busy_em_erro_local(adapter, database_path, clock, monkeypatch) -> None:
     monkeypatch.setattr(sqlite_adapter, "_BUSY_TIMEOUT_MS", 1)
@@ -188,7 +177,6 @@ def test_converte_busy_em_erro_local(adapter, database_path, clock, monkeypatch)
         blocker.rollback()
         blocker.close()
 
-
 def test_traduz_falha_de_conexao_em_erro_local(tmp_path, clock, monkeypatch) -> None:
     broken = SQLiteControlPlane(tmp_path / "broken.sqlite3", clock.now)
     def fail_connect():
@@ -199,13 +187,11 @@ def test_traduz_falha_de_conexao_em_erro_local(tmp_path, clock, monkeypatch) -> 
     with pytest.raises(_SQLiteFilesystemError, match="sqlite_filesystem"):
         broken.get_tenant("354130")
 
-
 def test_propaga_erro_operacional_que_nao_e_contencao(tmp_path, clock) -> None:
     uninitialized = SQLiteControlPlane(tmp_path / "empty.sqlite3", clock.now)
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
     with pytest.raises(sqlite3.OperationalError, match="no such table"):
         uninitialized.put_tenant(tenant)
-
 
 def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, clock) -> None:
     _prepare_job(adapter)
@@ -223,7 +209,6 @@ def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, cl
         units=(_unit("unit-a"),))
     with pytest.raises(Conflict, match="run_state_conflict"):
         adapter.put_run_units(command)
-
 
 def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None:
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
@@ -255,13 +240,11 @@ def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None
         _put_units(reopened, divergent, "run-units")
     assert reopened.list_run_units("354130", "run-units") == before
 
-
 def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> None:
     monkeypatch.setattr(sqlite_adapter, "_is_network_filesystem", lambda path: True)
     adapter = SQLiteControlPlane(tmp_path / "network" / "control.sqlite3", clock.now)
     with pytest.raises(_SQLiteFilesystemError, match="sqlite_network_filesystem"):
         adapter.initialize()
-
 @pytest.mark.parametrize(
     "network_path",
     [pytest.param(r"\\server\share\control.sqlite3"),
@@ -361,7 +344,9 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
 
 
 @pytest.mark.parametrize("state", [None, RunState.WAITING_INPUTS])
-def test_rejeita_reserva_sem_run_pai_processing_sem_mutacao(adapter, clock, state) -> None:
+def test_rejeita_reserva_e_bind_sem_run_pai_processing_sem_mutacao(
+    adapter, clock, state
+) -> None:
     if state is not None:
         adapter.put_run(_run("run-a", state))
     with pytest.raises(Conflict, match="parent_not_processing"):
@@ -369,6 +354,20 @@ def test_rejeita_reserva_sem_run_pai_processing_sem_mutacao(adapter, clock, stat
     adapter.put_run(_run("run-a"))
     dispatch = _reserve(adapter, clock, unit_ids=("unit-b",))
     assert (dispatch.generation, dispatch.unit_ids) == (1, ("unit-b",))
+    if state is None:
+        with adapter.write_transaction() as connection:
+            connection.execute("DELETE FROM runs WHERE tenant_id = ? AND run_id = ?",
+                               ("354130", "run-a"))
+    else:
+        adapter.transition_run(TransitionRun(
+            tenant_id="354130", run_id="run-a", expected_state=RunState.PROCESSING,
+            new_state=RunState.PUBLISHING), _event("run-publishing"))
+    bind = BindRunDispatch(
+        tenant_id="354130", run_id="run-a", dispatch_id=dispatch.dispatch_id,
+        execution_ref="exec-delayed", now=clock.now(), lease_seconds=30)
+    with pytest.raises(Conflict, match="parent_not_processing"):
+        adapter.bind_run_dispatch(bind)
+    assert adapter.get_active_run_dispatch("354130", "run-a") == dispatch
 
 
 def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -8,14 +8,18 @@ import pytest
 
 from cnes_domain.control_plane.commands import (
     BeginIdempotency,
+    BindRunDispatch,
+    CancelJob,
     ClaimJob,
     FailRunUnit,
+    FinishRunDispatch,
+    PutRunUnits,
     RenewJobLease,
     ReserveRunDispatch,
     TransitionRun,
 )
 from cnes_domain.control_plane.entities import DatasetPointer, RunDependency, Tenant
-from cnes_domain.control_plane.enums import RunState
+from cnes_domain.control_plane.enums import DispatchOutcome, RunState
 from cnes_domain.control_plane.errors import Conflict, LeaseLost
 from cnes_infra.control_plane import sqlite_adapter, sqlite_schema
 from cnes_infra.control_plane.sqlite_adapter import (
@@ -29,6 +33,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _agent,
     _claim_job,
     _claim_unit_command,
+    _commit_command,
     _event,
     _job,
     _put_units,
@@ -96,6 +101,11 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
     )
     conflicting = existing.model_copy(update={"aggregate_id": "run-a"})
 
+    with pytest.raises(Conflict, match="run_state_conflict"):
+        adapter.transition_run(
+            transition.model_copy(update={"expected_state": RunState.WAITING_INPUTS}),
+            _event("invalid-transition"),
+        )
     with pytest.raises(Conflict, match="outbox_event_conflict"):
         adapter.transition_run(transition, conflicting)
 
@@ -192,7 +202,13 @@ def test_incrementa_fence_apos_expiracao(adapter, clock) -> None:
     assert (first.fencing_token, second.fencing_token) == (1, 2)
 
 
-def test_converte_esgotamento_do_busy_timeout_em_erro_local(adapter, database_path, clock) -> None:
+def test_configura_busy_timeout_de_cinco_segundos(adapter) -> None:
+    with adapter.read_connection() as connection:
+        assert connection.execute("PRAGMA busy_timeout").fetchone() == (5000,)
+
+
+def test_converte_busy_em_erro_local(adapter, database_path, clock, monkeypatch) -> None:
+    monkeypatch.setattr(sqlite_adapter, "_BUSY_TIMEOUT_MS", 1)
     blocker = sqlite3.connect(database_path, isolation_level=None)
     blocker.execute("BEGIN IMMEDIATE")
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
@@ -202,6 +218,55 @@ def test_converte_esgotamento_do_busy_timeout_em_erro_local(adapter, database_pa
     finally:
         blocker.rollback()
         blocker.close()
+
+
+def test_traduz_falha_de_conexao_em_erro_local(tmp_path, clock, monkeypatch) -> None:
+    broken = SQLiteControlPlane(tmp_path / "broken.sqlite3", clock.now)
+
+    def fail_connect():
+        raise sqlite3.OperationalError("disk_unavailable")
+
+    monkeypatch.setattr(broken, "_connect", fail_connect)
+    with pytest.raises(_SQLiteFilesystemError, match="sqlite_filesystem"):
+        broken.initialize()
+    with pytest.raises(_SQLiteFilesystemError, match="sqlite_filesystem"):
+        broken.get_tenant("354130")
+
+
+def test_propaga_erro_operacional_que_nao_e_contencao(tmp_path, clock) -> None:
+    uninitialized = SQLiteControlPlane(tmp_path / "empty.sqlite3", clock.now)
+    tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
+
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        uninitialized.put_tenant(tenant)
+
+
+def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, clock) -> None:
+    _prepare_job(adapter)
+    renew = RenewJobLease(
+        tenant_id="354130",
+        job_id="job-a",
+        owner="worker-a",
+        fencing_token=0,
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    with pytest.raises(LeaseLost, match="job_not_leased"):
+        adapter.renew_job_lease(renew)
+    with pytest.raises(Conflict, match="job_missing"):
+        adapter.cancel_job(
+            CancelJob(tenant_id="354130", job_id="missing", requested_by="user-a"),
+            _event("cancel-missing"),
+        )
+    adapter.put_run(_run("run-a", RunState.WAITING_INPUTS))
+    command = PutRunUnits(
+        tenant_id="354130",
+        run_id="run-a",
+        expected_run_state=RunState.PROCESSING,
+        units=(_unit("unit-a"),),
+    )
+    with pytest.raises(Conflict, match="run_state_conflict"):
+        adapter.put_run_units(command)
 
 
 def test_reabertura_preserva_registros_leases_pointer_idempotencia_e_outbox(
@@ -308,6 +373,79 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
     assert adapter.get_run("354130", "run-a").missing_sources == ("CNES/ST",)
 
 
+def test_rejeita_bind_de_dispatch_ausente_ou_terminal(adapter, clock) -> None:
+    adapter.put_run(_run("run-a"))
+    _put_units(adapter, (_unit("unit-a"),))
+    dispatch = adapter.reserve_run_dispatch(
+        ReserveRunDispatch(
+            tenant_id="354130",
+            run_id="run-a",
+            wave_id="a" * 16,
+            unit_ids=("unit-a",),
+            now=clock.now(),
+            lease_seconds=60,
+        )
+    )
+    bind = BindRunDispatch(
+        tenant_id="354130",
+        run_id="run-a",
+        dispatch_id="b" * 16,
+        execution_ref="exec-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    with pytest.raises(Conflict, match="dispatch_stale"):
+        adapter.bind_run_dispatch(bind)
+    adapter.finish_run_dispatch(
+        FinishRunDispatch(
+            tenant_id="354130",
+            run_id="run-a",
+            dispatch_id=dispatch.dispatch_id,
+            outcome=DispatchOutcome.FAILED,
+            finished_at=clock.now(),
+        )
+    )
+    with pytest.raises(Conflict, match="dispatch_terminal"):
+        adapter.bind_run_dispatch(bind.model_copy(update={"dispatch_id": dispatch.dispatch_id}))
+
+
+def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:
+    adapter.put_run(_run("run-a"))
+    _put_units(adapter, (_unit("unit-a"),))
+    dispatch = adapter.reserve_run_dispatch(
+        ReserveRunDispatch(
+            tenant_id="354130",
+            run_id="run-a",
+            wave_id="a" * 16,
+            unit_ids=("unit-a",),
+            now=clock.now(),
+            lease_seconds=60,
+        )
+    )
+    pending = _commit_command(dispatch.dispatch_id, "worker-a", 0)
+    with pytest.raises(LeaseLost, match="unit_not_leased"):
+        adapter.commit_run_unit(pending, _event("pending-commit"))
+    claimed = adapter.claim_run_unit(
+        _claim_unit_command(dispatch.dispatch_id, "worker-a", clock, "unit-a")
+    )
+    assert claimed is not None
+    clock.advance(timedelta(seconds=31))
+    expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    with pytest.raises(LeaseLost, match="lease_expired"):
+        adapter.commit_run_unit(expired, _event("expired-commit"))
+
+
+def test_rejeita_replay_de_versao_quando_pointer_ja_avancou(adapter) -> None:
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    first = _publish("run-a", "published-a", None, False)
+    adapter.publish_dataset(first)
+    adapter.put_run(_run("run-b", RunState.PUBLISHING))
+    adapter.publish_dataset(_publish("run-b", "published-b", "run-a", False))
+
+    with pytest.raises(Conflict, match="pointer_cas"):
+        adapter.publish_dataset(first)
+
+
 def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
     adapter.put_agent(_agent("agent-order"))
     for job_id in ("job-b", "job-a"):
@@ -340,3 +478,21 @@ def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
     assert pending[0] == min(adapter.pending_outbox(100), key=lambda event: (
         event.created_at, event.event_id
     ))
+
+
+def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> None:
+    runs = (
+        _run("run-a").model_copy(update={"tenant_id": "b"}),
+        _run("run-z").model_copy(update={"tenant_id": "a"}),
+        _run("run-shared").model_copy(update={"tenant_id": "b"}),
+        _run("run-shared").model_copy(update={"tenant_id": "a"}),
+    )
+    for run in runs:
+        adapter.put_run(run)
+
+    recoverable = adapter.list_recoverable_runs(clock.now(), 2)
+
+    assert tuple((run.tenant_id, run.run_id) for run in recoverable) == (
+        ("a", "run-shared"),
+        ("a", "run-z"),
+    )

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -46,8 +46,6 @@ from packages.cnes_infra.tests.contracts.clock import (
 from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
 
 _NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
-
-
 @pytest.fixture
 def clock() -> MutableClock:
     return MutableClock(_NOW)
@@ -65,7 +63,6 @@ def _capture(action: Any, barrier: Barrier) -> Any:
         return action()
     except Exception as error:
         return error
-
 def _race(first: Any, second: Any) -> tuple[Any, Any]:
     barrier = Barrier(3)
     with ThreadPoolExecutor(max_workers=2) as executor:
@@ -90,11 +87,19 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
             update={"expected_state": RunState.WAITING_INPUTS}), _event("invalid-transition"))
     with pytest.raises(Conflict, match="outbox_event_conflict"):
         adapter.transition_run(transition, conflicting)
-    assert adapter.get_run("354130", "run-a") == _run("run-a")
     assert adapter.pending_outbox(10) == (existing,)
-def test_serializa_claim_renovacao_e_publicacao_concorrentes(
-    adapter, database_path, clock
-) -> None:
+    event = _event("run-transitioned")
+    updated = adapter.transition_run(transition, event)
+    retry = SQLiteControlPlane(adapter._database_path, clock.now)
+    retry.initialize()
+    assert retry.transition_run(transition, event) == updated
+    before = (updated, retry.pending_outbox(10))
+    with pytest.raises(Conflict, match="run_transition_conflict"):
+        retry.transition_run(transition.model_copy(update={"missing_sources": ("CNES/ST",)}), event)
+    with pytest.raises(Conflict, match="run_transition_conflict"):
+        retry.transition_run(transition, event.model_copy(update={"payload": {}}))
+    assert before == (retry.get_run("354130", "run-a"), retry.pending_outbox(10))
+def test_serializa_escritores_concorrentes(adapter, database_path, clock) -> None:
     _prepare_job(adapter)
     writers = (SQLiteControlPlane(database_path, clock.now),
                SQLiteControlPlane(database_path, clock.now))
@@ -180,7 +185,6 @@ def test_propaga_erro_operacional_que_nao_e_contencao(tmp_path, clock) -> None:
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
     with pytest.raises(sqlite3.OperationalError, match="no such table"):
         uninitialized.put_tenant(tenant)
-
 def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, clock) -> None:
     _prepare_job(adapter)
     renew = RenewJobLease(
@@ -197,7 +201,6 @@ def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, cl
         units=(_unit("unit-a"),))
     with pytest.raises(Conflict, match="run_state_conflict"):
         adapter.put_run_units(command)
-
 def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None:
     tenant = Tenant(tenant_id="354130", municipality_name="Epitácio", created_at=clock.now())
     adapter.put_tenant(tenant)
@@ -240,9 +243,7 @@ def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> No
      pytest.param("/net/server/share/control.sqlite3"),
      pytest.param("/Network/Servers/server/share/control.sqlite3")],
 )
-def test_detecta_formas_conhecidas_de_filesystem_de_rede_sem_proc(
-    network_path, tmp_path, monkeypatch
-) -> None:
+def test_detecta_filesystem_de_rede(network_path, tmp_path, monkeypatch) -> None:
     def unavailable(*args, **kwargs):
         raise OSError("proc_unavailable")
     monkeypatch.setattr(sqlite_schema.Path, "read_text", unavailable)
@@ -271,9 +272,7 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
             ),
             _event(f"degraded-{unit_id}"))
     assert adapter.get_run("354130", "run-a").missing_sources == ("CNES/ST",)
-def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
-    adapter, database_path, clock
-) -> None:
+def test_replay_dispatch_e_recaptura(adapter, database_path, clock) -> None:
     dispatch = _prepare_unit(adapter, clock, ("unit-a", "unit-b"))
     reopened = SQLiteControlPlane(database_path, clock.now)
     assert _reserve(reopened, clock, unit_ids=("unit-a", "unit-b")) == dispatch
@@ -292,15 +291,22 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
     finish = FinishRunDispatch(
         tenant_id="354130", run_id="run-a", dispatch_id=dispatch.dispatch_id,
         outcome=DispatchOutcome.FAILED, finished_at=clock.now())
+    with pytest.raises(Conflict, match="dispatch_expired"):
+        adapter.finish_run_dispatch(finish.model_copy(update={"finished_at": dispatch.lease_until}))
     finished = adapter.finish_run_dispatch(finish)
     replay = SQLiteControlPlane(database_path, clock.now)
     replay.initialize()
     assert replay.finish_run_dispatch(finish) == finished
+    with pytest.raises(Conflict, match="dispatch_terminal"):
+        adapter.bind_run_dispatch(bind.model_copy(update={"dispatch_id": dispatch.dispatch_id}))
+    expired = finished.model_copy(update={"lease_until": finish.finished_at})
+    with replay.write_transaction() as connection:
+        connection.execute("UPDATE run_dispatches SET lease_until = ?, data = ? WHERE run_id = ?",
+            (expired.lease_until.isoformat(), expired.model_dump_json(), expired.run_id))
+    assert replay.finish_run_dispatch(finish) == expired
     with pytest.raises(Conflict, match="dispatch_finish_conflict"):
         replay.finish_run_dispatch(finish.model_copy(
             update={"finished_at": clock.now() + timedelta(microseconds=1)}))
-    with pytest.raises(Conflict, match="dispatch_terminal"):
-        adapter.bind_run_dispatch(bind.model_copy(update={"dispatch_id": dispatch.dispatch_id}))
     with pytest.raises(Conflict, match="dispatch_units_conflict"):
         _reserve(adapter, clock, unit_ids=("unit-a",))
     replacement = _reserve(adapter, clock, unit_ids=dispatch.unit_ids)
@@ -330,9 +336,7 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
         _reserve(reopened, clock, "a" * 16, ("unit-a",))
     assert _reserve(reopened, clock, "a" * 16, dispatch.unit_ids).generation == 5
 @pytest.mark.parametrize("state", [None, RunState.WAITING_INPUTS])
-def test_rejeita_reserva_e_bind_sem_run_pai_processing_sem_mutacao(
-    adapter, clock, state
-) -> None:
+def test_rejeita_dispatch_sem_run_processing(adapter, clock, state) -> None:
     if state is not None:
         adapter.put_run(_run("run-a", state))
     with pytest.raises(Conflict, match="parent_not_processing"):
@@ -367,7 +371,6 @@ def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> Non
     expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
     with pytest.raises(LeaseLost, match="lease_expired"):
         adapter.commit_run_unit(expired, _event("expired-commit"))
-
 @pytest.mark.parametrize("field", ["final_state", "missing_sources", "permit", "event"])
 def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) -> None:
     run = _run("run-a", RunState.PUBLISHING)
@@ -414,7 +417,6 @@ def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) ->
     adapter.publish_dataset(_publish("run-b", "published-b", "run-a", False))
     with pytest.raises(Conflict, match="pointer_cas"):
         adapter.publish_dataset(first)
-
 def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock, monkeypatch) -> None:
     adapter.put_agent(_agent("agent-order"))
     for job_id in ("job-b", "job-a"):
@@ -450,7 +452,6 @@ def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock, monkeypatc
     assert len(pending) == 1
     assert pending[0] == min(adapter.pending_outbox(100), key=lambda event: (
         event.created_at, event.event_id))
-
 def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> None:
     runs = (
         _run("run-a").model_copy(update={"tenant_id": "b"}),
@@ -463,7 +464,6 @@ def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> 
     recoverable = adapter.list_recoverable_runs(clock.now(), 2)
     assert tuple((run.tenant_id, run.run_id) for run in recoverable) == (
         ("a", "run-shared"), ("a", "run-z"))
-
 def test_limita_ancestralidade_longa_sem_recursao(adapter, clock, monkeypatch) -> None:
     base = _raw_record("deep-1", "deep-agent", 1, clock.now())
     previous = None

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -76,10 +76,8 @@ def _capture(action: Any, barrier: Barrier) -> Any:
 def _race(first: Any, second: Any) -> tuple[Any, Any]:
     barrier = Barrier(3)
     with ThreadPoolExecutor(max_workers=2) as executor:
-        futures = (
-            executor.submit(_capture, first, barrier),
-            executor.submit(_capture, second, barrier),
-        )
+        futures = (executor.submit(_capture, first, barrier),
+                   executor.submit(_capture, second, barrier))
         barrier.wait()
         return tuple(future.result() for future in futures)
 
@@ -99,10 +97,8 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
         new_state=RunState.PUBLISHING)
     conflicting = existing.model_copy(update={"aggregate_id": "run-a"})
     with pytest.raises(Conflict, match="run_state_conflict"):
-        adapter.transition_run(
-            transition.model_copy(update={"expected_state": RunState.WAITING_INPUTS}),
-            _event("invalid-transition"),
-        )
+        adapter.transition_run(transition.model_copy(
+            update={"expected_state": RunState.WAITING_INPUTS}), _event("invalid-transition"))
     with pytest.raises(Conflict, match="outbox_event_conflict"):
         adapter.transition_run(transition, conflicting)
     assert adapter.get_run("354130", "run-a") == _run("run-a")
@@ -115,27 +111,22 @@ def test_serializa_claim_renovacao_e_publicacao_concorrentes(
     _prepare_job(adapter)
     writers = (SQLiteControlPlane(database_path, clock.now),
                SQLiteControlPlane(database_path, clock.now))
-    claims = _race(
-        lambda: writers[0].claim_job(_claim_job("job-a", "worker-a", clock)),
-        lambda: writers[1].claim_job(_claim_job("job-a", "worker-b", clock)),
-    )
+    claims = _race(lambda: writers[0].claim_job(_claim_job("job-a", "worker-a", clock)),
+                   lambda: writers[1].claim_job(_claim_job("job-a", "worker-b", clock)))
     winners = [result for result in claims if result is not None]
     assert len(winners) == 1
     claimed = winners[0]
     renew = RenewJobLease(
         tenant_id="354130", job_id="job-a", owner=claimed.lease_owner,
         fencing_token=claimed.fencing_token, now=clock.now(), lease_seconds=60)
-    renewals = _race(
-        lambda: writers[0].renew_job_lease(renew),
-        lambda: writers[1].renew_job_lease(renew),
-    )
+    renewals = _race(lambda: writers[0].renew_job_lease(renew),
+                     lambda: writers[1].renew_job_lease(renew))
     assert renewals[0] == renewals[1]
     adapter.put_run(_run("run-pub-a", RunState.PUBLISHING))
     adapter.put_run(_run("run-pub-b", RunState.PUBLISHING))
     publications = _race(
         lambda: writers[0].publish_dataset(_publish("run-pub-a", "pub-a", None, False)),
-        lambda: writers[1].publish_dataset(_publish("run-pub-b", "pub-b", None, False)),
-    )
+        lambda: writers[1].publish_dataset(_publish("run-pub-b", "pub-b", None, False)))
     assert sum(isinstance(result, DatasetPointer) for result in publications) == 1
     assert sum(isinstance(result, Conflict) for result in publications) == 1
 
@@ -152,10 +143,8 @@ def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, 
     reclaim = ClaimJob(
         tenant_id="354130", job_id="job-a", owner="worker-b",
         now=clock.now() + timedelta(seconds=31), lease_seconds=30)
-    renewed, reclaimed = _race(
-        lambda: writers[0].renew_job_lease(renew),
-        lambda: writers[1].claim_job(reclaim),
-    )
+    renewed, reclaimed = _race(lambda: writers[0].renew_job_lease(renew),
+                               lambda: writers[1].claim_job(reclaim))
     if isinstance(renewed, LeaseLost):
         assert reclaimed is not None
         assert reclaimed.fencing_token == 2
@@ -166,7 +155,7 @@ def test_serializa_renovacao_contra_reclaim_concorrente(adapter, database_path, 
         assert adapter.get_job("354130", "job-a") == renewed
 
 
-def test_incrementa_fence_apos_expiracao(adapter, clock) -> None:
+def test_incrementa_fence_apos_expiracao_ou_lease_ausente(adapter, clock) -> None:
     _prepare_job(adapter)
     first = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
     clock.advance(timedelta(seconds=31))
@@ -174,6 +163,12 @@ def test_incrementa_fence_apos_expiracao(adapter, clock) -> None:
     assert first is not None
     assert second is not None
     assert (first.fencing_token, second.fencing_token) == (1, 2)
+    missing_lease = _job("job-b").model_copy(update={"state": first.state})
+    adapter.create_job(missing_lease, _event("job-b-created"))
+    assert missing_lease in adapter.list_claimable_jobs("354130", "agent-a", 10)
+    reclaimed = adapter.claim_job(_claim_job("job-b", "worker-c", clock))
+    assert reclaimed is not None
+    assert (reclaimed.attempt, reclaimed.fencing_token) == (1, 1)
 
 
 def test_configura_busy_timeout_de_cinco_segundos(adapter) -> None:
@@ -198,7 +193,6 @@ def test_traduz_falha_de_conexao_em_erro_local(tmp_path, clock, monkeypatch) -> 
     broken = SQLiteControlPlane(tmp_path / "broken.sqlite3", clock.now)
     def fail_connect():
         raise sqlite3.OperationalError("disk_unavailable")
-
     monkeypatch.setattr(broken, "_connect", fail_connect)
     with pytest.raises(_SQLiteFilesystemError, match="sqlite_filesystem"):
         broken.initialize()
@@ -216,20 +210,13 @@ def test_propaga_erro_operacional_que_nao_e_contencao(tmp_path, clock) -> None:
 def test_rejeita_job_nao_leased_cancelamento_ausente_e_estado_de_run(adapter, clock) -> None:
     _prepare_job(adapter)
     renew = RenewJobLease(
-        tenant_id="354130",
-        job_id="job-a",
-        owner="worker-a",
-        fencing_token=0,
-        now=clock.now(),
-        lease_seconds=30,
-    )
+        tenant_id="354130", job_id="job-a", owner="worker-a", fencing_token=0,
+        now=clock.now(), lease_seconds=30)
     with pytest.raises(LeaseLost, match="job_not_leased"):
         adapter.renew_job_lease(renew)
     with pytest.raises(Conflict, match="job_missing"):
-        adapter.cancel_job(
-            CancelJob(tenant_id="354130", job_id="missing", requested_by="user-a"),
-            _event("cancel-missing"),
-        )
+        adapter.cancel_job(CancelJob(
+            tenant_id="354130", job_id="missing", requested_by="user-a"), _event("cancel-missing"))
     adapter.put_run(_run("run-a", RunState.WAITING_INPUTS))
     command = PutRunUnits(
         tenant_id="354130", run_id="run-a", expected_run_state=RunState.PROCESSING,
@@ -272,7 +259,6 @@ def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None
 def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> None:
     monkeypatch.setattr(sqlite_adapter, "_is_network_filesystem", lambda path: True)
     adapter = SQLiteControlPlane(tmp_path / "network" / "control.sqlite3", clock.now)
-
     with pytest.raises(_SQLiteFilesystemError, match="sqlite_network_filesystem"):
         adapter.initialize()
 
@@ -289,7 +275,6 @@ def test_detecta_formas_conhecidas_de_filesystem_de_rede_sem_proc(
 ) -> None:
     def unavailable(*args, **kwargs):
         raise OSError("proc_unavailable")
-
     monkeypatch.setattr(sqlite_schema.Path, "read_text", unavailable)
     assert _is_network_filesystem(sqlite_adapter.Path(network_path))
     assert not _is_network_filesystem(tmp_path / "control.sqlite3")
@@ -321,7 +306,6 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
             ),
             _event(f"degraded-{unit_id}"),
         )
-
     assert adapter.get_run("354130", "run-a").missing_sources == ("CNES/ST",)
 
 def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
@@ -366,7 +350,20 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
     clock.advance(timedelta(seconds=31))
     with pytest.raises(Conflict, match="dispatch_units_conflict"):
         _reserve(adapter, clock, unit_ids=("unit-a",))
-    assert _reserve(adapter, clock, unit_ids=dispatch.unit_ids).generation == 3
+    third = _reserve(adapter, clock, unit_ids=dispatch.unit_ids)
+    assert third.generation == 3
+    adapter.finish_run_dispatch(FinishRunDispatch(
+        tenant_id="354130", run_id="run-a", dispatch_id=third.dispatch_id,
+        outcome=DispatchOutcome.FAILED, finished_at=clock.now()))
+    wave_b = _reserve(adapter, clock, "b" * 16, dispatch.unit_ids)
+    adapter.finish_run_dispatch(FinishRunDispatch(
+        tenant_id="354130", run_id="run-a", dispatch_id=wave_b.dispatch_id,
+        outcome=DispatchOutcome.FAILED, finished_at=clock.now()))
+    reopened = SQLiteControlPlane(database_path, clock.now)
+    reopened.initialize()
+    with pytest.raises(Conflict, match="dispatch_units_conflict"):
+        _reserve(reopened, clock, "a" * 16, ("unit-a",))
+    assert _reserve(reopened, clock, "a" * 16, dispatch.unit_ids).generation == 5
 
 def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:
     dispatch = _prepare_unit(adapter, clock)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -304,7 +304,6 @@ def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> No
     with pytest.raises(_SQLiteFilesystemError, match="sqlite_network_filesystem"):
         adapter.initialize()
 
-
 @pytest.mark.parametrize(
     "network_path",
     [
@@ -347,28 +346,31 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
         assert claimed is not None
         adapter.fail_run_unit(
             FailRunUnit(
-                tenant_id="354130",
-                run_id="run-a",
-                unit_id=unit_id,
-                dispatch_id=dispatch.dispatch_id,
-                owner=f"worker-{unit_id}",
+                tenant_id="354130", run_id="run-a", unit_id=unit_id,
+                dispatch_id=dispatch.dispatch_id, owner=f"worker-{unit_id}",
                 fencing_token=claimed.fencing_token,
-                error_code="optional_failed",
-                retryable=False,
+                error_code="optional_failed", retryable=False,
             ),
             _event(f"degraded-{unit_id}"),
         )
 
     assert adapter.get_run("354130", "run-a").missing_sources == ("CNES/ST",)
 
-
-def test_recaptura_lease_de_dispatch_superado_mas_exclui_dispatch_ativo(adapter, clock) -> None:
-    dispatch = _prepare_unit(adapter, clock)
+def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
+    adapter, database_path, clock
+) -> None:
+    dispatch = _prepare_unit(adapter, clock, ("unit-a", "unit-b"))
+    reopened = SQLiteControlPlane(database_path, clock.now)
+    assert _reserve(reopened, clock, unit_ids=("unit-a", "unit-b")) == dispatch
+    before = reopened.get_active_run_dispatch("354130", "run-a")
+    with pytest.raises(Conflict, match="dispatch_units_conflict"):
+        _reserve(reopened, clock, unit_ids=("unit-a",))
+    assert reopened.get_active_run_dispatch("354130", "run-a") == before
     claimed = adapter.claim_run_unit(_claim_unit_command(dispatch.dispatch_id, "worker-a", clock))
     assert claimed is not None
     bind = BindRunDispatch(
-        tenant_id="354130", run_id="run-a", dispatch_id="b" * 16,
-        execution_ref="exec-a", now=clock.now(), lease_seconds=30,
+        tenant_id="354130", run_id="run-a", dispatch_id="b" * 16, execution_ref="exec-a",
+        now=clock.now(), lease_seconds=30,
     )
     with pytest.raises(Conflict, match="dispatch_stale"):
         adapter.bind_run_dispatch(bind)
@@ -380,7 +382,7 @@ def test_recaptura_lease_de_dispatch_superado_mas_exclui_dispatch_ativo(adapter,
     )
     with pytest.raises(Conflict, match="dispatch_terminal"):
         adapter.bind_run_dispatch(bind.model_copy(update={"dispatch_id": dispatch.dispatch_id}))
-    replacement = _reserve(adapter, clock)
+    replacement = _reserve(adapter, clock, unit_ids=dispatch.unit_ids)
     assert (replacement.generation, replacement.dispatch_id != dispatch.dispatch_id) == (2, True)
     reclaimed = adapter.claim_run_unit(
         _claim_unit_command(replacement.dispatch_id, "worker-b", clock)
@@ -391,7 +393,6 @@ def test_recaptura_lease_de_dispatch_superado_mas_exclui_dispatch_ativo(adapter,
     )
     other = _claim_unit_command(replacement.dispatch_id, "worker-c", clock)
     assert adapter.claim_run_unit(other) is None
-
 
 def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:
     dispatch = _prepare_unit(adapter, clock)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -290,7 +290,7 @@ def test_replay_dispatch_e_recaptura(adapter, database_path, clock) -> None:
     assert adapter.bind_run_dispatch(bind) == started
     expired = finished.model_copy(update={"lease_until": finish.finished_at})
     _write_dispatch(reopened, expired)
-    assert reopened.finish_run_dispatch(finish) == expired
+    assert reopened.finish_run_dispatch(finish) == finished
     _no(Conflict, "dispatch_finish_conflict", lambda: reopened.finish_run_dispatch(
         finish.model_copy(update={"finished_at": clock.now() + timedelta(microseconds=1)})))
     _no(Conflict, "dispatch_units_conflict", lambda: _reserve(

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -239,7 +239,6 @@ def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None
     with pytest.raises(Conflict, match="units_conflict"):
         _put_units(reopened, divergent, "run-units")
     assert reopened.list_run_units("354130", "run-units") == before
-
 def test_rejeita_banco_em_filesystem_de_rede(tmp_path, clock, monkeypatch) -> None:
     monkeypatch.setattr(sqlite_adapter, "_is_network_filesystem", lambda path: True)
     adapter = SQLiteControlPlane(tmp_path / "network" / "control.sqlite3", clock.now)
@@ -261,15 +260,11 @@ def test_detecta_formas_conhecidas_de_filesystem_de_rede_sem_proc(
     monkeypatch.setattr(sqlite_schema.Path, "read_text", unavailable)
     assert _is_network_filesystem(sqlite_adapter.Path(network_path))
     assert not _is_network_filesystem(tmp_path / "control.sqlite3")
-
-
 def test_rejeita_inicializacao_quando_wal_nao_e_ativado(tmp_path, clock, monkeypatch) -> None:
     adapter = SQLiteControlPlane(tmp_path / "control.sqlite3", clock.now)
     monkeypatch.setattr(adapter, "_connect", lambda: sqlite3.connect(":memory:"))
     with pytest.raises(_SQLiteFilesystemError, match="sqlite_wal_unavailable"):
         adapter.initialize()
-
-
 def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
     dependency = (RunDependency(source_type="CNES", file_subtype="ST", required=False),)
     adapter.put_run(_run("run-a", dependencies=dependency))
@@ -288,7 +283,6 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
             ),
             _event(f"degraded-{unit_id}"))
     assert adapter.get_run("354130", "run-a").missing_sources == ("CNES/ST",)
-
 def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
     adapter, database_path, clock
 ) -> None:
@@ -307,10 +301,16 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
     )
     with pytest.raises(Conflict, match="dispatch_stale"):
         adapter.bind_run_dispatch(bind)
-    adapter.finish_run_dispatch(
-        FinishRunDispatch(
-            tenant_id="354130", run_id="run-a", dispatch_id=dispatch.dispatch_id,
-            outcome=DispatchOutcome.FAILED, finished_at=clock.now()))
+    finish = FinishRunDispatch(
+        tenant_id="354130", run_id="run-a", dispatch_id=dispatch.dispatch_id,
+        outcome=DispatchOutcome.FAILED, finished_at=clock.now())
+    finished = adapter.finish_run_dispatch(finish)
+    replay = SQLiteControlPlane(database_path, clock.now)
+    replay.initialize()
+    assert replay.finish_run_dispatch(finish) == finished
+    with pytest.raises(Conflict, match="dispatch_finish_conflict"):
+        replay.finish_run_dispatch(finish.model_copy(
+            update={"finished_at": clock.now() + timedelta(microseconds=1)}))
     with pytest.raises(Conflict, match="dispatch_terminal"):
         adapter.bind_run_dispatch(bind.model_copy(update={"dispatch_id": dispatch.dispatch_id}))
     with pytest.raises(Conflict, match="dispatch_units_conflict"):
@@ -341,8 +341,6 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
     with pytest.raises(Conflict, match="dispatch_units_conflict"):
         _reserve(reopened, clock, "a" * 16, ("unit-a",))
     assert _reserve(reopened, clock, "a" * 16, dispatch.unit_ids).generation == 5
-
-
 @pytest.mark.parametrize("state", [None, RunState.WAITING_INPUTS])
 def test_rejeita_reserva_e_bind_sem_run_pai_processing_sem_mutacao(
     adapter, clock, state
@@ -368,8 +366,6 @@ def test_rejeita_reserva_e_bind_sem_run_pai_processing_sem_mutacao(
     with pytest.raises(Conflict, match="parent_not_processing"):
         adapter.bind_run_dispatch(bind)
     assert adapter.get_active_run_dispatch("354130", "run-a") == dispatch
-
-
 def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:
     dispatch = _prepare_unit(adapter, clock)
     pending = _commit_command(dispatch.dispatch_id, "worker-a", 0)
@@ -383,7 +379,6 @@ def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> Non
     expired = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
     with pytest.raises(LeaseLost, match="lease_expired"):
         adapter.commit_run_unit(expired, _event("expired-commit"))
-
 
 @pytest.mark.parametrize("field", ["final_state", "missing_sources", "permit", "event"])
 def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) -> None:
@@ -432,11 +427,17 @@ def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) ->
     with pytest.raises(Conflict, match="pointer_cas"):
         adapter.publish_dataset(first)
 
-
-def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
+def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock, monkeypatch) -> None:
     adapter.put_agent(_agent("agent-order"))
     for job_id in ("job-b", "job-a"):
         adapter.create_job(_job(job_id, "agent-order"), _event(f"created-{job_id}"))
+    with adapter.write_transaction() as connection:
+        connection.execute("UPDATE jobs SET state = ?, data = ? WHERE job_id = ?",
+                           ("SUCCEEDED", "{", "job-b"))
+    deserialize = sqlite_adapter.deserialize_model
+    calls = []
+    monkeypatch.setattr(sqlite_adapter, "deserialize_model",
+                        lambda *args: (calls.append(None), deserialize(*args))[1])
     adapter.put_run(_run("run-b", RunState.WAITING_INPUTS))
     adapter.put_run(_run("run-a", RunState.WAITING_INPUTS))
     adapter.put_run(_run("run-units"))
@@ -446,8 +447,10 @@ def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
     _put_units(adapter, units, "run-units")
     base = _raw_record("base-agent-raw", "agent-raw", 1, clock.now())
     _store_record(adapter, base, clock)
+    calls.clear()
     jobs = adapter.list_claimable_jobs("354130", "agent-order", 1)
     assert tuple(job.job_id for job in jobs) == ("job-a",)
+    assert len(calls) <= 2
     runs = adapter.list_waiting_runs_for_dependency("354130", "CNES", "ST", "2026-07", 1)
     assert tuple(run.run_id for run in runs) == ("run-a",)
     assert adapter.list_recoverable_runs(clock.now(), 1)[0].run_id == "run-a"
@@ -459,7 +462,6 @@ def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
     assert len(pending) == 1
     assert pending[0] == min(adapter.pending_outbox(100), key=lambda event: (
         event.created_at, event.event_id))
-
 
 def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> None:
     runs = (
@@ -473,7 +475,6 @@ def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> 
     recoverable = adapter.list_recoverable_runs(clock.now(), 2)
     assert tuple((run.tenant_id, run.run_id) for run in recoverable) == (
         ("a", "run-shared"), ("a", "run-z"))
-
 
 def test_limita_ancestralidade_longa_sem_recursao(adapter, clock, monkeypatch) -> None:
     base = _raw_record("deep-1", "deep-agent", 1, clock.now())

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -202,12 +202,14 @@ def test_reabertura_canonicaliza_unidades(adapter, database_path, clock) -> None
     canonical = (unit_a, unit_b)
     assert _put_units(adapter, (unit_b, unit_a), "run-units") == canonical
     adapter.put_run(_run("run-units", RunState.PUBLISHING))
+    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    assert claimed is not None
     with adapter.write_transaction() as connection:
         connection.executescript("ALTER TABLE job_creation_writes DROP COLUMN job_data;"
                                  "ALTER TABLE runs DROP COLUMN unit_registry_data;")
     reopened = SQLiteControlPlane(database_path, clock.now)
     reopened.initialize()
-    assert reopened.create_job(_job("job-a"), _event("job-created")) == _job("job-a")
+    assert reopened.create_job(_job("job-a"), _event("job-created")) == claimed
     reopened.initialize()
     permit = publication.publication_permit.model_copy(update={"binding_context": object()})
     assert reopened.publish_dataset(publication.model_copy(

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -3,7 +3,6 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from threading import Barrier
 from typing import Any
-
 import pytest
 
 from cnes_domain.control_plane.commands import (
@@ -86,10 +85,9 @@ def test_reverte_transicao_e_outbox_quando_evento_conflita(adapter, clock) -> No
     transition = TransitionRun(
         tenant_id="354130", run_id="run-a", expected_state=RunState.PROCESSING,
         new_state=RunState.PUBLISHING)
-    conflicting = existing.model_copy(update={"aggregate_id": "run-a"})
     _no(Conflict, "run_state_conflict", lambda: adapter.transition_run(transition.model_copy(
         update={"expected_state": RunState.WAITING_INPUTS}), _event("invalid-transition")))
-    _no(Conflict, "outbox_event_conflict", lambda: adapter.transition_run(transition, conflicting))
+    _no(Conflict, "outbox_event_conflict", lambda: adapter.transition_run(transition, existing))
     assert adapter.pending_outbox(10) == (existing,)
     event = _event("run-transitioned")
     updated = adapter.transition_run(transition, event)
@@ -267,6 +265,7 @@ def test_replay_dispatch_e_recaptura(adapter, database_path, clock) -> None:
         reopened, clock, unit_ids=("unit-a",)))
     assert reopened.get_active_run_dispatch("354130", "run-a") == before
     claimed = adapter.claim_run_unit(_claim_unit_command(dispatch.dispatch_id, "worker-a", clock))
+    _put_units(adapter, (_unit("unit-a"), _unit("unit-b")))
     bind = BindRunDispatch(
         tenant_id="354130", run_id="run-a", dispatch_id="b" * 16, execution_ref="exec-a",
         now=clock.now(), lease_seconds=30)

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -294,8 +294,7 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
     dispatch = _reserve(adapter, clock, unit_ids=("unit-a", "unit-b"))
     for unit_id in ("unit-a", "unit-b"):
         claimed = adapter.claim_run_unit(
-            _claim_unit_command(dispatch.dispatch_id, f"worker-{unit_id}", clock, unit_id)
-        )
+            _claim_unit_command(dispatch.dispatch_id, f"worker-{unit_id}", clock, unit_id))
         assert claimed is not None
         adapter.fail_run_unit(
             FailRunUnit(
@@ -304,8 +303,7 @@ def test_deduplica_fonte_ausente_em_unidades_degradadas(adapter, clock) -> None:
                 fencing_token=claimed.fencing_token,
                 error_code="optional_failed", retryable=False,
             ),
-            _event(f"degraded-{unit_id}"),
-        )
+            _event(f"degraded-{unit_id}"))
     assert adapter.get_run("354130", "run-a").missing_sources == ("CNES/ST",)
 
 def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
@@ -329,9 +327,7 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
     adapter.finish_run_dispatch(
         FinishRunDispatch(
             tenant_id="354130", run_id="run-a", dispatch_id=dispatch.dispatch_id,
-            outcome=DispatchOutcome.FAILED, finished_at=clock.now(),
-        )
-    )
+            outcome=DispatchOutcome.FAILED, finished_at=clock.now()))
     with pytest.raises(Conflict, match="dispatch_terminal"):
         adapter.bind_run_dispatch(bind.model_copy(update={"dispatch_id": dispatch.dispatch_id}))
     with pytest.raises(Conflict, match="dispatch_units_conflict"):
@@ -339,12 +335,10 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
     replacement = _reserve(adapter, clock, unit_ids=dispatch.unit_ids)
     assert (replacement.generation, replacement.dispatch_id != dispatch.dispatch_id) == (2, True)
     reclaimed = adapter.claim_run_unit(
-        _claim_unit_command(replacement.dispatch_id, "worker-b", clock)
-    )
+        _claim_unit_command(replacement.dispatch_id, "worker-b", clock))
     assert reclaimed is not None
     assert (reclaimed.attempt, reclaimed.fencing_token, reclaimed.dispatch_id) == (
-        claimed.attempt + 1, claimed.fencing_token + 1, replacement.dispatch_id,
-    )
+        claimed.attempt + 1, claimed.fencing_token + 1, replacement.dispatch_id)
     other = _claim_unit_command(replacement.dispatch_id, "worker-c", clock)
     assert adapter.claim_run_unit(other) is None
     clock.advance(timedelta(seconds=31))
@@ -365,14 +359,25 @@ def test_replay_de_dispatch_exige_unidades_exatas_e_recaptura_lease_superada(
         _reserve(reopened, clock, "a" * 16, ("unit-a",))
     assert _reserve(reopened, clock, "a" * 16, dispatch.unit_ids).generation == 5
 
+
+@pytest.mark.parametrize("state", [None, RunState.WAITING_INPUTS])
+def test_rejeita_reserva_sem_run_pai_processing_sem_mutacao(adapter, clock, state) -> None:
+    if state is not None:
+        adapter.put_run(_run("run-a", state))
+    with pytest.raises(Conflict, match="parent_not_processing"):
+        _reserve(adapter, clock)
+    adapter.put_run(_run("run-a"))
+    dispatch = _reserve(adapter, clock, unit_ids=("unit-b",))
+    assert (dispatch.generation, dispatch.unit_ids) == (1, ("unit-b",))
+
+
 def test_rejeita_commit_de_unidade_nao_leased_ou_expirada(adapter, clock) -> None:
     dispatch = _prepare_unit(adapter, clock)
     pending = _commit_command(dispatch.dispatch_id, "worker-a", 0)
     with pytest.raises(LeaseLost, match="unit_not_leased"):
         adapter.commit_run_unit(pending, _event("pending-commit"))
     claim = _claim_unit_command(dispatch.dispatch_id, "worker-a", clock).model_copy(
-        update={"lease_seconds": 10}
-    )
+        update={"lease_seconds": 10})
     claimed = adapter.claim_run_unit(claim)
     assert claimed is not None
     clock.advance(timedelta(seconds=11))
@@ -394,8 +399,7 @@ def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) ->
     assert adapter.get_dataset_version("354130", "gold", "run-a") is None
     assert invalid_pointer.event not in adapter.pending_outbox(100)
     mismatched = first.model_copy(
-        update={"version": first.version.model_copy(update={"dataset_name": "silver"})}
-    )
+        update={"version": first.version.model_copy(update={"dataset_name": "silver"})})
     with pytest.raises(Conflict, match="run_dataset_mismatch"):
         adapter.publish_dataset(mismatched)
     assert adapter.get_run("354130", "run-a") == run
@@ -415,16 +419,14 @@ def test_rejeita_dataset_e_replay_divergentes_apos_publicacao(adapter, field) ->
     before = (
         adapter.get_run("354130", "run-a"), pointer,
         adapter.get_dataset_version("354130", "gold", "run-a"),
-        adapter.pending_outbox(100),
-    )
+        adapter.pending_outbox(100))
     with pytest.raises(Conflict, match="publication_replay_conflict"):
         adapter.publish_dataset(divergent)
     assert before == (
         adapter.get_run("354130", "run-a"),
         adapter.get_dataset_pointer("354130", "gold"),
         adapter.get_dataset_version("354130", "gold", "run-a"),
-        adapter.pending_outbox(100),
-    )
+        adapter.pending_outbox(100))
     assert adapter.publish_dataset(first) == pointer
     adapter.put_run(_run("run-b", RunState.PUBLISHING))
     adapter.publish_dataset(_publish("run-b", "published-b", "run-a", False))
@@ -441,8 +443,7 @@ def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
     adapter.put_run(_run("run-units"))
     units = tuple(
         _unit(unit_id).model_copy(update={"run_id": "run-units"})
-        for unit_id in ("unit-a", "unit-b")
-    )
+        for unit_id in ("unit-a", "unit-b"))
     _put_units(adapter, units, "run-units")
     base = _raw_record("base-agent-raw", "agent-raw", 1, clock.now())
     _store_record(adapter, base, clock)
@@ -458,8 +459,7 @@ def test_ordena_e_limita_todos_os_metodos_de_listagem(adapter, clock) -> None:
     pending = adapter.pending_outbox(1)
     assert len(pending) == 1
     assert pending[0] == min(adapter.pending_outbox(100), key=lambda event: (
-        event.created_at, event.event_id
-    ))
+        event.created_at, event.event_id))
 
 
 def test_ordena_runs_recuperaveis_por_tenant_antes_do_limite(adapter, clock) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
+++ b/packages/cnes_infra/tests/control_plane/test_sqlite_races.py
@@ -1,4 +1,4 @@
-import sqlite3
+import sqlite3  # noqa: I001
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from threading import Barrier
@@ -44,8 +44,6 @@ from packages.cnes_infra.tests.contracts.clock import (
     _unit,
 )
 from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
-
-
 @pytest.fixture
 def clock() -> MutableClock:
     return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
@@ -299,6 +297,8 @@ def test_replay_dispatch_e_recaptura(adapter, database_path, clock) -> None:
         finish.model_copy(update={"finished_at": clock.now() + timedelta(microseconds=1)})))
     _no(Conflict, "dispatch_units_conflict", lambda: _reserve(
         adapter, clock, unit_ids=("unit-a",)))
+    _no(Conflict, "dispatch_live", lambda: _reserve(adapter, clock, unit_ids=dispatch.unit_ids))
+    clock.advance(timedelta(seconds=31))
     replacement = _reserve(adapter, clock, unit_ids=dispatch.unit_ids)
     assert (replacement.generation, replacement.dispatch_id != dispatch.dispatch_id) == (2, True)
     reclaimed = adapter.claim_run_unit(


### PR DESCRIPTION
## Objetivo

Implementar `SQLiteControlPlane` completo e compatível com `ControlPlanePort`, preservando
atomicidade entre mutações de domínio e outbox, isolamento por tenant e fencing monotônico.

## Allowlist alterada

- `packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py`
- `packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py`
- `packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py`
- `packages/cnes_infra/src/cnes_infra/control_plane/sqlite_idempotency.py`
- `packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py`
- `packages/cnes_infra/tests/control_plane/test_sqlite_adapter.py`
- `packages/cnes_infra/tests/control_plane/test_sqlite_races.py`

## Decisões e riscos

- Conexões por operação, FK, WAL validado, busy timeout limitado e `BEGIN IMMEDIATE`.
- Boundary variádica normaliza kwargs/defaults imediatamente para helpers com até quatro
  parâmetros.
- Cancelamento aceita somente `LEASED -> CANCEL_REQUESTED`; replay é idempotente.
- Identidade do manifest inclui tenant, agente, fonte, subtipo, competência e snapshot mode.
- Mounts de rede conhecidos são rejeitados; não há suporte SQLite cross-host.
- Os débitos globais conhecidos de `chaos_infra` e cobertura histórica ficam fora da
  allowlist; a suite focada passa o gate configurado.

## Evidência RED/GREEN

- RED inicial: módulo SQLite ausente.
- REDs regressivos: defaults/kwargs, manifest divergente, tenant cruzado, missing sources
  duplicadas, mounts fora de `/proc` e WAL não ativado.
- GREEN final do controller: `87 passed`, 100% line/branch; Ruff global verde.
- Dois rounds de revisão corrigiram compatibilidade de porta, invariantes de identidade,
  corrida renewal/reclaim e cobertura completa dos observáveis do contrato.
- O terceiro round corrigiu imutabilidade de manifests, ancestry de DELTAs, timeout de 5 s,
  ordenação global e o race determinístico do CI `33401155186`.
- O quarto round faz dispatch terminal avançar geração, rejeita escrita tardia de unidade
  após término e impede publicação quando o dataset da versão diverge do run.
- O quinto round permite reclaim fenced de lease da geração superseded, preserva identidade
  em decisões de acesso e exige replay de publicação integralmente idêntico.
- A rodada excepcional canonicaliza o registro de unidades por `unit_id`, tornando replay
  independente da ordem fornecida antes ou depois de restart.
- A rodada final rejeita replay divergente da mesma wave e torna complete/fail terminal
  idempotente após perda de resposta, preservando progressão retryable legítima.
- O fechamento torna writes terminais de unidades idempotentes por comando/evento canônico e
  rejeita aliases de publicação diferentes de `current` antes de qualquer mutação; oito
  regressões foram comprovadas RED antes da correção.
- `wave_id` preserva o conjunto ordenado em todas as gerações e a ancestry de manifests é
  iterativa e limitada, falhando fechada sem `RecursionError` em cadeias acima de mil itens.
- A identidade histórica de cada wave é persistida além do dispatch atual e leases nulos são
  reclaimable sem `TypeError`, inclusive após reopen.
- Heads de manifest são paginados por keyset e cada predecessor é buscado por identidade/hash
  com `LIMIT`; a regressão caiu de 2.202 para no máximo 35 desserializações.
- O cursor inclui `manifest_id` como desempate único e reserva de dispatch exige Run PROCESSING
  na mesma transação, antes de persistir identidade ou consumir generation.
- O bind relê o Run na própria transação e só converte RESERVED para STARTED enquanto o pai
  permanece PROCESSING; pai removido/transicionado deixa o dispatch inalterado.
- Criação de job e término de dispatch persistem envelopes canônicos para replay exato; a
  listagem claimable filtra e limita em SQL antes de desserializar.
- Finalização de cancelamento também persiste comando/evento canônicos; o scan de heads tem
  orçamento global de quatro páginas proporcionais ao `limit` e falha fechado ao esgotar.
- O enqueue central rejeita fresh events já entregues; cinco mutações representativas
  comprovam rollback integral enquanto delivery e replays canônicos permanecem independentes.
- Enqueue também vincula tenant antes da mutação; criação de access exige PENDING e cancelamento/
  decisão de acesso persistem envelopes canônicos para replay exato após restart.
- Transições de Run persistem comando/evento canônicos; finish terminal valida replay antes do
  deadline, mantendo retry exato válido após expiração e rejeitando dispatch live expirado.
- Bind persiste comando canônico e valida STARTED antes de expiry; ancestry memoiza predecessores
  e usa orçamento global, evitando expansão exponencial de siblings inválidos.
- Reserva valida a totalidade das unidades persistidas antes de gravar wave/dispatch; leitura de
  dispatch ativo exige Run `PROCESSING`, ocultando execuções após qualquer transição do pai.
- Replay de criação de access request persiste e compara o envelope canônico integral antes de
  retornar; substituição de dispatch inclui leases vivos da wave terminal anterior na verificação.
- Run persiste registry canônico imutável para replay de unidades após execução; criação de job
  persiste snapshot+evento originais, e evento de outbox já consumido conflita em mutação nova.
- Publication omite `binding_context` runtime-only do envelope canônico; delivery valida UTC antes
  de escrever; ancestry compartilha orçamento/cache entre heads e `initialize()` migra snapshots
  adicionados em bancos existentes de modo idempotente.

## SHA testado

`c2ff9c9b1a144af7b16f361e5887ea58915b1040`

Refs #122
