### PR TITLE
feat(control-plane): add dynamodb adapter

### DIFF
--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -20,7 +20,6 @@ from cnes_domain.control_plane.entities import (
 )
 from cnes_domain.control_plane.enums import AgentState, JobState, RunState, RunUnitState
 from cnes_domain.control_plane.errors import Conflict, NotFound
-from cnes_domain.control_plane.ids import run_dependency_key
 from cnes_domain.control_plane.transitions import (
     transition_job,
     transition_run,
@@ -30,6 +29,7 @@ from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
 from cnes_infra.control_plane.dynamodb_codec import (
     Action,
     Item,
+    bounded_candidates,
     check_action,
     decode_model,
     encode_marker,
@@ -39,11 +39,13 @@ from cnes_infra.control_plane.dynamodb_codec import (
     put_action,
     query_all,
     query_partition,
+    strong_candidates,
 )
 from cnes_infra.control_plane.dynamodb_keys import (
     dependency_marker_key,
     entity_key,
     item_key,
+    key_component,
     run_entity_key,
     run_partition,
     timestamp,
@@ -95,33 +97,21 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         item = self._get_item(key)
         return decode_model(item, model_type) if item is not None else None
 
-    def _query(self, index_name: str, partition: str) -> tuple[Item, ...]:
-        return query_all(
-            self._client,
-            {
-                "TableName": self._table_name,
-                "IndexName": index_name,
-                "KeyConditionExpression": f"{index_name}pk = :partition",
-                "ExpressionAttributeValues": {":partition": {"S": partition}},
-            },
-        )
+    def _query(self, index_name: str, partition: str, *args: Any) -> Any:
+        request = {
+            "TableName": self._table_name,
+            "IndexName": index_name,
+            "KeyConditionExpression": f"{index_name}pk = :partition",
+            "ExpressionAttributeValues": {":partition": {"S": partition}},
+        }
+        if args:
+            return bounded_candidates(self._client, request, *args)
+        return query_all(self._client, request)
 
     def _strong_candidates[T: BaseModel](
         self, candidates: tuple[Item, ...], model_type: type[T]
     ) -> tuple[T, ...]:
-        keys = {
-            (
-                item.get("base_pk", item["pk"])["S"],
-                item.get("base_sk", item["sk"])["S"],
-            )
-            for item in candidates
-        }
-        models = []
-        for key in sorted(keys):
-            item = self._get_item(key)
-            if item is not None and item.get("entity", {}).get("S") == model_type.__name__.upper():
-                models.append(decode_model(item, model_type))
-        return tuple(models)
+        return strong_candidates(self._client, self._table_name, candidates, model_type)
 
     def _transact(self, actions: tuple[Action, ...]) -> None:
         execute_transaction(self._client, actions)
@@ -130,30 +120,34 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         self._client.put_item(TableName=self._table_name, Item=item)
 
     def _job_item(self, job: Job) -> Item:
-        identity = f"RAW#{job.tenant_id}#{job.source_type}#{job.file_subtype}#{job.competencia}"
+        values = (job.tenant_id, job.source_type, job.file_subtype, job.competencia)
+        identity = "RAW#" + "#".join(key_component(value) for value in values)
         attributes = {
             "gsi2pk": identity,
-            "gsi2sk": f"JOB#{timestamp(job.created_at)}#{job.agent_id}#{job.job_id}",
+            "gsi2sk": (
+                f"JOB#{timestamp(job.created_at)}#{key_component(job.agent_id)}#"
+                f"{key_component(job.job_id)}"
+            ),
         }
         if job.state in {JobState.PENDING, JobState.LEASED, JobState.FAILED_RETRYABLE}:
-            available = job.lease_until or job.created_at
             attributes |= {
-                "gsi1pk": f"JOB_CLAIM#{job.tenant_id}#{job.agent_id}",
-                "gsi1sk": f"{timestamp(available)}#{job.state.value}#{job.job_id}",
+                "gsi1pk": (
+                    f"JOB_CLAIM#{key_component(job.tenant_id)}#"
+                    f"{key_component(job.agent_id)}"
+                ),
+                "gsi1sk": f"{timestamp(job.created_at)}#{key_component(job.job_id)}",
             }
         key = entity_key(job.tenant_id, "JOB", job.job_id)
         return encode_model(job, "JOB", key, attributes)
 
     def _raw_item(self, record: RawManifestRecord) -> Item:
-        identity = (
-            f"RAW#{record.tenant_id}#{record.source_type}#"
-            f"{record.file_subtype}#{record.competencia}"
-        )
+        values = (record.tenant_id, record.source_type, record.file_subtype, record.competencia)
+        identity = "RAW#" + "#".join(key_component(value) for value in values)
         attributes = {
             "gsi2pk": identity,
             "gsi2sk": (
                 f"RAW#{record.sequence:020d}#{timestamp(record.created_at)}#"
-                f"{record.agent_id}#{record.snapshot_id}"
+                f"{key_component(record.agent_id)}#{key_component(record.snapshot_id)}"
             ),
         }
         key = entity_key(record.tenant_id, "RAW", record.manifest_id)
@@ -164,14 +158,19 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         if run.state in _RECOVERABLE:
             attributes = {
                 "gsi4pk": "RUN_RECOVERABLE",
-                "gsi4sk": f"{timestamp(run.created_at)}#{run.tenant_id}#{run.run_id}",
+                "gsi4sk": (
+                    f"{timestamp(run.created_at)}#{key_component(run.tenant_id)}#"
+                    f"{key_component(run.run_id)}"
+                ),
             }
         return encode_model(run, "RUN", run_entity_key(run.tenant_id, run.run_id), attributes)
 
     def _unit_item(self, unit: RunUnit) -> Item:
         attributes = {
-            "gsi5pk": f"RUN_ITEMS#{unit.tenant_id}#{unit.run_id}",
-            "gsi5sk": f"UNIT#{unit.unit_id}",
+            "gsi5pk": (
+                f"RUN_ITEMS#{key_component(unit.tenant_id)}#{key_component(unit.run_id)}"
+            ),
+            "gsi5sk": f"UNIT#{key_component(unit.unit_id)}",
         }
         return encode_model(
             unit,
@@ -230,8 +229,8 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
 
     def latest_succeeded_job(self, *args: str) -> Job | None:
         """Retorna o job concluído mais recente da identidade."""
-        tenant_id, agent_id, source_type, file_subtype, competencia = args
-        partition = f"RAW#{tenant_id}#{source_type}#{file_subtype}#{competencia}"
+        agent_id = args[1]
+        partition = "RAW#" + "#".join(key_component(value) for value in args[:1] + args[2:])
         candidates = self._strong_candidates(self._query("gsi2", partition), Job)
         matches = (
             job
@@ -244,7 +243,8 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         """Retorna a cadeia válida de manifestos raw."""
         tenant_id, source_type, file_subtype, competencia, *rest = args
         limit = rest[0] if rest else 31
-        partition = f"RAW#{tenant_id}#{source_type}#{file_subtype}#{competencia}"
+        values = (tenant_id, source_type, file_subtype, competencia)
+        partition = "RAW#" + "#".join(key_component(value) for value in values)
         records = list(self._strong_candidates(self._query("gsi2", partition), RawManifestRecord))
         candidates = sorted(
             records,
@@ -290,9 +290,10 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         agent = self.get_agent(tenant_id, agent_id)
         if agent is None or agent.state is not AgentState.ACTIVE:
             return ()
-        partition = f"JOB_CLAIM#{tenant_id}#{agent_id}"
-        jobs = self._strong_candidates(self._query("gsi1", partition), Job)
-        eligible = [job for job in jobs if self._job_is_claimable(job, self._clock())]
+        partition = f"JOB_CLAIM#{key_component(tenant_id)}#{key_component(agent_id)}"
+        eligible = self._query(
+            "gsi1", partition, Job, lambda job: self._job_is_claimable(job, self._clock()), limit
+        )
         return tuple(sorted(eligible, key=lambda job: (job.created_at, job.job_id))[:limit])
 
     @staticmethod
@@ -310,13 +311,13 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             return
         base_key = run_entity_key(run.tenant_id, run.run_id)
         for dependency in run.dependencies:
-            identity = run_dependency_key(
-                run.tenant_id, dependency.source_type, dependency.file_subtype, run.competencia
-            )
+            values = (run.tenant_id, dependency.source_type,
+                      dependency.file_subtype, run.competencia)
+            identity = "RUN_DEP#" + "#".join(key_component(value) for value in values)
             marker_key = dependency_marker_key(run.tenant_id, run.run_id, identity)
             attributes = {
                 "gsi3pk": identity,
-                "gsi3sk": f"{timestamp(run.created_at)}#{run.run_id}",
+                "gsi3sk": f"{timestamp(run.created_at)}#{key_component(run.run_id)}",
             }
             self._put_direct(encode_marker("RUN_DEP", marker_key, base_key, attributes))
 
@@ -328,26 +329,25 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         """Lista runs aguardando uma dependência."""
         tenant_id, source_type, file_subtype, competencia, *rest = args
         limit = rest[0] if rest else 100
-        identity = run_dependency_key(tenant_id, source_type, file_subtype, competencia)
-        runs = self._strong_candidates(self._query("gsi3", identity), Run)
-        valid = [
-            run
-            for run in runs
-            if run.state is RunState.WAITING_INPUTS
-            and run.tenant_id == tenant_id
-            and run.competencia == competencia
-            and any(
-                (dep.source_type, dep.file_subtype) == (source_type, file_subtype)
-                for dep in run.dependencies
+        values = (tenant_id, source_type, file_subtype, competencia)
+        identity = "RUN_DEP#" + "#".join(key_component(value) for value in values)
+        def valid(run: Run) -> bool:
+            return (
+                run.state is RunState.WAITING_INPUTS
+                and run.tenant_id == tenant_id
+                and run.competencia == competencia
+                and any((dep.source_type, dep.file_subtype) == (source_type, file_subtype)
+                        for dep in run.dependencies)
             )
-        ]
-        return tuple(sorted(valid, key=lambda run: (run.created_at, run.run_id))[:limit])
+        runs = self._query("gsi3", identity, Run, valid, limit)
+        return tuple(sorted(runs, key=lambda run: (run.created_at, run.run_id))[:limit])
 
     def list_recoverable_runs(self, now: datetime, limit: int = 100) -> tuple[Run, ...]:
         """Lista runs recuperáveis no instante informado."""
-        runs = self._strong_candidates(self._query("gsi4", "RUN_RECOVERABLE"), Run)
-        valid = [run for run in runs if run.state in _RECOVERABLE and run.created_at <= now]
-        ordered = sorted(valid, key=lambda run: (run.created_at, run.run_id, run.tenant_id))
+        valid = self._query(
+            "gsi4", "RUN_RECOVERABLE", Run,
+            lambda run: run.state in _RECOVERABLE and run.created_at <= now, limit)
+        ordered = sorted(valid, key=lambda run: (run.created_at, run.tenant_id, run.run_id))
         return tuple(ordered[:limit])
 
     def transition_run(self, command: TransitionRun, event: OutboxEvent) -> Run:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from itertools import pairwise
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
@@ -127,12 +126,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
     def _transact(self, actions: tuple[Action, ...]) -> None:
         execute_transaction(self._client, actions)
 
-    def _event_action(self, event: OutboxEvent) -> Action:
-        existing = self._get_outbox_event(event.event_id)
-        if existing is not None:
-            raise Conflict("event_id_conflict")
-        return put_action(self._table_name, self._outbox_item(event), None)
-
     def _put_direct(self, item: Item) -> None:
         self._client.put_item(TableName=self._table_name, Item=item)
 
@@ -226,7 +219,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             return existing
         actions = (
             put_action(self._table_name, self._job_item(job), None),
-            self._event_action(event),
+            self._event_action(job.tenant_id, event),
         )
         self._transact(actions)
         return job
@@ -275,21 +268,22 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         records: list[RawManifestRecord], head: RawManifestRecord
     ) -> tuple[RawManifestRecord, ...]:
         base = head.snapshot_id if head.sequence == 1 else head.base_snapshot_id
-        chain = [
-            item
-            for item in records
-            if item.agent_id == head.agent_id
-            and base in (item.snapshot_id, item.base_snapshot_id)
-            and item.sequence <= head.sequence
-        ]
-        chain.sort(key=lambda item: item.sequence)
-        sequences = [item.sequence for item in chain]
-        hashes_match = all(
-            current.previous_manifest_sha256 == previous.manifest_sha256
-            for previous, current in pairwise(chain)
-        )
-        valid = sequences == list(range(1, head.sequence + 1)) and hashes_match
-        return tuple(chain) if valid else ()
+        chain = [head]
+        current = head
+        while current.sequence > 1:
+            predecessors = [
+                item for item in records
+                if item.agent_id == head.agent_id
+                and item.sequence == current.sequence - 1
+                and item.manifest_sha256 == current.previous_manifest_sha256
+                and base in (item.snapshot_id, item.base_snapshot_id)
+            ]
+            if len(predecessors) != 1:
+                return ()
+            current = predecessors[0]
+            chain.append(current)
+        chain.reverse()
+        return tuple(chain) if current.snapshot_id == base else ()
 
     def list_claimable_jobs(self, tenant_id: str, agent_id: str, limit: int) -> tuple[Job, ...]:
         """Lista jobs elegíveis para claim."""
@@ -370,7 +364,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         )
         actions = (
             put_action(self._table_name, self._run_item(updated), payload(item)),
-            self._event_action(event),
+            self._event_action(command.tenant_id, event),
         )
         self._transact(actions)
         return updated
@@ -386,8 +380,11 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         if run.state is not command.expected_run_state:
             raise Conflict("run_state_conflict")
         existing = tuple(
-            self._get_model(unit_key(unit.tenant_id, unit.run_id, unit.unit_id), RunUnit)
-            for unit in command.units
+            decode_model(item, RunUnit)
+            for item in query_partition(
+                self._client, self._table_name,
+                run_partition(command.tenant_id, command.run_id), "UNIT#"
+            )
         )
         if any(existing):
             if existing == command.units:
@@ -421,7 +418,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         self._transact(
             (
                 put_action(self._table_name, self._job_item(updated), payload(item)),
-                self._event_action(event),
+                self._event_action(command.tenant_id, event),
             )
         )
         return updated
@@ -451,7 +448,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         updated_run = transition_run(run, RunState.CANCELED)
         actions = [put_action(self._table_name, self._run_item(updated_run), payload(run_item))]
         actions.extend(self._cancel_unit_action(unit, run) for unit in cancellable)
-        actions.append(self._event_action(event))
+        actions.append(self._event_action(command.tenant_id, event))
         self._transact(tuple(actions))
         return updated_run
 
@@ -472,7 +469,9 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
                 raise Conflict("access_request_conflict")
             self._require_event_replay(request.tenant_id, event)
             return
-        self._transact((put_action(self._table_name, item, None), self._event_action(event)))
+        self._transact(
+            (put_action(self._table_name, item, None), self._event_action(request.tenant_id, event))
+        )
 
     def get_access_request(self, tenant_id: str, request_id: str) -> AccessRequest | None:
         """Retorna a solicitação de acesso."""
@@ -494,7 +493,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         self._transact(
             (
                 put_action(self._table_name, updated, payload(item)),
-                self._event_action(event),
+                self._event_action(request.tenant_id, event),
             )
         )
         return request

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -398,10 +398,10 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         return units
     def list_run_units(self, tenant_id: str, run_id: str) -> tuple[RunUnit, ...]:
         """Lista as unidades do run."""
-        partition = f"RUN_ITEMS#{tenant_id}#{run_id}"
-        units = self._strong_candidates(self._query("gsi5", partition), RunUnit)
+        partition = run_partition(tenant_id, run_id)
+        items = query_partition(self._client, self._table_name, partition, "UNIT#")
+        units = (decode_model(item, RunUnit) for item in items)
         return tuple(sorted(units, key=lambda unit: unit.unit_id))
-
     def cancel_job(self, command: CancelJob, event: OutboxEvent) -> Job:
         """Solicita o cancelamento de um job leased."""
         key = entity_key(command.tenant_id, "JOB", command.job_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -30,6 +30,7 @@ from cnes_infra.control_plane.dynamodb_codec import (
     Action,
     Item,
     bounded_candidates,
+    bounded_partition,
     check_action,
     decode_model,
     encode_marker,
@@ -37,15 +38,14 @@ from cnes_infra.control_plane.dynamodb_codec import (
     execute_transaction,
     payload,
     put_action,
-    query_all,
     query_partition,
-    strong_candidates,
 )
 from cnes_infra.control_plane.dynamodb_keys import (
     dependency_marker_key,
     entity_key,
     item_key,
     key_component,
+    raw_partition,
     run_entity_key,
     run_partition,
     timestamp,
@@ -103,13 +103,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             "KeyConditionExpression": f"{index_name}pk = :partition",
             "ExpressionAttributeValues": {":partition": {"S": partition}},
         }
-        if args:
-            return bounded_candidates(self._client, request, *args)
-        return query_all(self._client, request)
-    def _strong_candidates[T: BaseModel](
-        self, candidates: tuple[Item, ...], model_type: type[T]
-    ) -> tuple[T, ...]:
-        return strong_candidates(self._client, self._table_name, candidates, model_type)
+        return bounded_candidates(self._client, request, *args)
     def _transact(self, actions: tuple[Action, ...]) -> None:
         execute_transaction(self._client, actions)
     def _put_direct(self, item: Item) -> None:
@@ -144,7 +138,9 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
                 f"{key_component(record.agent_id)}#{key_component(record.snapshot_id)}"
             ),
         }
-        key = entity_key(record.tenant_id, "RAW", record.manifest_id)
+        partition = raw_partition(
+            record.tenant_id, record.source_type, record.file_subtype, record.competencia)
+        key = partition, f"MANIFEST#{key_component(record.manifest_id)}"
         return encode_model(record, "RAWMANIFESTRECORD", key, attributes)
     def _run_item(self, run: Run) -> Item:
         attributes = {}
@@ -212,27 +208,33 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         return self._get_model(entity_key(tenant_id, "JOB", job_id), Job)
     def latest_succeeded_job(self, *args: str) -> Job | None:
         """Retorna o job concluído mais recente da identidade."""
-        agent_id = args[1]
-        partition = "RAW#" + "#".join(key_component(value) for value in args[:1] + args[2:])
-        candidates = self._strong_candidates(self._query("gsi2", partition), Job)
-        matches = (
-            job
-            for job in candidates
-            if job.agent_id == agent_id and job.state is JobState.SUCCEEDED
-        )
-        return max(matches, key=lambda job: (job.created_at, job.job_id), default=None)
-
+        tenant_id, agent_id, source_type, file_subtype, competencia = args
+        partition = raw_partition(tenant_id, source_type, file_subtype, competencia)
+        return self._get_model((partition, f"LATEST_JOB#{key_component(agent_id)}"), Job)
+    def _latest_job_action(self, job: Job) -> Action:
+        partition = raw_partition(
+            job.tenant_id, job.source_type, job.file_subtype, job.competencia)
+        key = partition, f"LATEST_JOB#{key_component(job.agent_id)}"
+        current_item = self._get_item(key)
+        marker = encode_model(job, "JOB", key)
+        if current_item is None:
+            return put_action(self._table_name, marker, None)
+        current = decode_model(current_item, Job)
+        if (current.created_at, current.job_id) >= (job.created_at, job.job_id):
+            return check_action(self._table_name, current_item)
+        return put_action(self._table_name, marker, payload(current_item))
     def list_raw_manifest_chain(self, *args: Any) -> tuple[ManifestRef, ...]:
         """Retorna a cadeia válida de manifestos raw."""
         tenant_id, source_type, file_subtype, competencia, *rest = args
         limit = rest[0] if rest else 31
-        items = query_partition(
-            self._client, self._table_name, *entity_key(tenant_id, "RAW", "")
-        )
+        if limit < 1:
+            return ()
+        partition = raw_partition(tenant_id, source_type, file_subtype, competencia)
+        items = bounded_partition(
+            self._client, self._table_name, (partition, "MANIFEST#"), limit * 10)
+        if items is None:
+            return ()
         records = [decode_model(item, RawManifestRecord) for item in items]
-        records = [record for record in records if (
-            record.source_type, record.file_subtype, record.competencia
-        ) == (source_type, file_subtype, competencia)]
         chains = tuple(filter(None, (self._valid_chain(records, head) for head in records)))
         ancestors = {item.manifest_id for chain in chains for item in chain[:-1]}
         endpoints = (chain for chain in chains if chain[-1].manifest_id not in ancestors)
@@ -249,7 +251,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
                 for item in chain
             )
         return ()
-
     @staticmethod
     def _valid_chain(
         records: list[RawManifestRecord], head: RawManifestRecord
@@ -271,7 +272,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             chain.append(current)
         chain.reverse()
         return tuple(chain) if current.snapshot_id == base else ()
-
     def list_claimable_jobs(self, tenant_id: str, agent_id: str, limit: int) -> tuple[Job, ...]:
         """Lista jobs elegíveis para claim."""
         agent = self.get_agent(tenant_id, agent_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -31,7 +31,6 @@ from cnes_infra.control_plane.dynamodb_codec import (
     Item,
     aggregate_replay,
     bounded_candidates,
-    bounded_partition,
     check_action,
     decode_model,
     encode_marker,
@@ -40,6 +39,8 @@ from cnes_infra.control_plane.dynamodb_codec import (
     payload,
     put_action,
     query_partition,
+    raw_head_chain,
+    raw_manifest_actions,
 )
 from cnes_infra.control_plane.dynamodb_keys import (
     dependency_marker_key,
@@ -141,6 +142,9 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             record.tenant_id, record.source_type, record.file_subtype, record.competencia)
         key = partition, f"MANIFEST#{key_component(record.manifest_id)}"
         return encode_model(record, "RAWMANIFESTRECORD", key, attributes)
+    def _raw_actions(self, record: RawManifestRecord) -> tuple[Action, ...]:
+        return raw_manifest_actions(
+            self._client, self._table_name, record, self._raw_item(record))
     def _run_item(self, run: Run) -> Item:
         attributes = {}
         if run.state in _RECOVERABLE:
@@ -226,51 +230,8 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         """Retorna a cadeia válida de manifestos raw."""
         tenant_id, source_type, file_subtype, competencia, *rest = args
         limit = rest[0] if rest else 31
-        if limit < 1:
-            return ()
         partition = raw_partition(tenant_id, source_type, file_subtype, competencia)
-        items = bounded_partition(
-            self._client, self._table_name, (partition, "MANIFEST#"), limit * 10)
-        if items is None:
-            return ()
-        records = [decode_model(item, RawManifestRecord) for item in items]
-        chains = tuple(filter(None, (self._valid_chain(records, head) for head in records)))
-        ancestors = {item.manifest_id for chain in chains for item in chain[:-1]}
-        endpoints = (chain for chain in chains if chain[-1].manifest_id not in ancestors)
-        ordered = sorted(
-            endpoints,
-            key=lambda chain: (chain[-1].created_at, chain[-1].agent_id, chain[-1].snapshot_id),
-            reverse=True,
-        )
-        for chain in ordered:
-            if len(chain) > limit:
-                return ()
-            return tuple(
-                ManifestRef(manifest_id=item.manifest_id, manifest_key=item.manifest_key)
-                for item in chain
-            )
-        return ()
-    @staticmethod
-    def _valid_chain(
-        records: list[RawManifestRecord], head: RawManifestRecord
-    ) -> tuple[RawManifestRecord, ...]:
-        base = head.snapshot_id if head.sequence == 1 else head.base_snapshot_id
-        chain = [head]
-        current = head
-        while current.sequence > 1:
-            predecessors = [
-                item for item in records
-                if item.agent_id == head.agent_id
-                and item.sequence == current.sequence - 1
-                and item.manifest_sha256 == current.previous_manifest_sha256
-                and base in (item.snapshot_id, item.base_snapshot_id)
-            ]
-            if len(predecessors) != 1:
-                return ()
-            current = predecessors[0]
-            chain.append(current)
-        chain.reverse()
-        return tuple(chain) if current.snapshot_id == base else ()
+        return raw_head_chain(self._client, self._table_name, partition, limit)
     def list_claimable_jobs(self, tenant_id: str, agent_id: str, limit: int) -> tuple[Job, ...]:
         """Lista jobs elegíveis para claim."""
         agent = self.get_agent(tenant_id, agent_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -28,6 +28,7 @@ from cnes_domain.control_plane.transitions import (
 from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
 from cnes_infra.control_plane.dynamodb_codec import (
     Action,
+    CandidateQuery,
     Item,
     aggregate_replay,
     bounded_candidates,
@@ -77,6 +78,8 @@ _NONTERMINAL_UNITS = {
     RunUnitState.LEASED,
     RunUnitState.FAILED_RETRYABLE,
 }
+
+
 class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
     """Persiste o plano de controle em uma tabela DynamoDB."""
 
@@ -84,7 +87,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         self._client = client
         self._table_name = table_name
         self._clock = clock
-
     def _get_item(self, key: tuple[str, str]) -> Item | None:
         response = self._client.get_item(
             TableName=self._table_name,
@@ -92,18 +94,19 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             ConsistentRead=True,
         )
         return response.get("Item")
-
     def _get_model[T: BaseModel](self, key: tuple[str, str], model_type: type[T]) -> T | None:
         item = self._get_item(key)
         return decode_model(item, model_type) if item is not None else None
-    def _query(self, index_name: str, partition: str, *args: Any) -> Any:
+    def _query[T: BaseModel](
+        self, index_name: str, partition: str, query: CandidateQuery[T]
+    ) -> tuple[T, ...]:
         request = {
             "TableName": self._table_name,
             "IndexName": index_name,
             "KeyConditionExpression": f"{index_name}pk = :partition",
             "ExpressionAttributeValues": {":partition": {"S": partition}},
         }
-        return bounded_candidates(self._client, request, *args)
+        return bounded_candidates(self._client, request, query)
     def _transact(self, actions: tuple[Action, ...]) -> None:
         execute_transaction(self._client, actions)
     def _put_direct(self, item: Item) -> None:
@@ -121,8 +124,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         if job.state in {JobState.PENDING, JobState.LEASED, JobState.FAILED_RETRYABLE}:
             attributes |= {
                 "gsi1pk": (
-                    f"JOB_CLAIM#{key_component(job.tenant_id)}#"
-                    f"{key_component(job.agent_id)}"
+                    f"JOB_CLAIM#{key_component(job.tenant_id)}#{key_component(job.agent_id)}"
                 ),
                 "gsi1sk": f"{timestamp(job.created_at)}#{key_component(job.job_id)}",
             }
@@ -139,12 +141,12 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             ),
         }
         partition = raw_partition(
-            record.tenant_id, record.source_type, record.file_subtype, record.competencia)
+            record.tenant_id, record.source_type, record.file_subtype, record.competencia
+        )
         key = partition, f"MANIFEST#{key_component(record.manifest_id)}"
         return encode_model(record, "RAWMANIFESTRECORD", key, attributes)
     def _raw_actions(self, record: RawManifestRecord) -> tuple[Action, ...]:
-        return raw_manifest_actions(
-            self._client, self._table_name, record, self._raw_item(record))
+        return raw_manifest_actions(self._client, self._table_name, record, self._raw_item(record))
     def _run_item(self, run: Run) -> Item:
         attributes = {}
         if run.state in _RECOVERABLE:
@@ -158,9 +160,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         return encode_model(run, "RUN", run_entity_key(run.tenant_id, run.run_id), attributes)
     def _unit_item(self, unit: RunUnit) -> Item:
         attributes = {
-            "gsi5pk": (
-                f"RUN_ITEMS#{key_component(unit.tenant_id)}#{key_component(unit.run_id)}"
-            ),
+            "gsi5pk": (f"RUN_ITEMS#{key_component(unit.tenant_id)}#{key_component(unit.run_id)}"),
             "gsi5sk": f"UNIT#{key_component(unit.unit_id)}",
         }
         return encode_model(
@@ -218,14 +218,17 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
     def get_job(self, tenant_id: str, job_id: str) -> Job | None:
         """Retorna o job solicitado."""
         return self._get_model(entity_key(tenant_id, "JOB", job_id), Job)
-    def latest_succeeded_job(self, *args: str) -> Job | None:
-        """Retorna o job concluído mais recente da identidade."""
-        tenant_id, agent_id, source_type, file_subtype, competencia = args
+    def latest_succeeded_job(
+        self, tenant_id: str, agent_id: str, source_type: str, file_subtype: str,
+        competencia: str) -> Job | None:
+        """Retorna o job concluído mais recente da identidade.
+        Args: tenant_id, agent_id, source_type, file_subtype, competencia.
+        Returns: Job encontrado, se houver.
+        """
         partition = raw_partition(tenant_id, source_type, file_subtype, competencia)
         return self._get_model((partition, f"LATEST_JOB#{key_component(agent_id)}"), Job)
     def _latest_job_action(self, job: Job) -> Action:
-        partition = raw_partition(
-            job.tenant_id, job.source_type, job.file_subtype, job.competencia)
+        partition = raw_partition(job.tenant_id, job.source_type, job.file_subtype, job.competencia)
         key = partition, f"LATEST_JOB#{key_component(job.agent_id)}"
         current_item = self._get_item(key)
         marker = encode_model(job, "JOB", key)
@@ -235,10 +238,13 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         if (current.created_at, current.job_id) >= (job.created_at, job.job_id):
             return check_action(self._table_name, current_item)
         return put_action(self._table_name, marker, payload(current_item))
-    def list_raw_manifest_chain(self, *args: Any) -> tuple[ManifestRef, ...]:
-        """Retorna a cadeia válida de manifestos raw."""
-        tenant_id, source_type, file_subtype, competencia, *rest = args
-        limit = rest[0] if rest else 31
+    def list_raw_manifest_chain(
+        self, tenant_id: str, source_type: str, file_subtype: str,
+        competencia: str, limit: int = 31) -> tuple[ManifestRef, ...]:
+        """Retorna a cadeia válida de manifestos raw.
+        Args: tenant_id, source_type, file_subtype, competencia, limit.
+        Returns: Manifestos ordenados da cadeia válida.
+        """
         partition = raw_partition(tenant_id, source_type, file_subtype, competencia)
         return raw_head_chain(self._client, self._table_name, partition, limit)
     def list_claimable_jobs(self, tenant_id: str, agent_id: str, limit: int) -> tuple[Job, ...]:
@@ -248,7 +254,8 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             return ()
         partition = f"JOB_CLAIM#{key_component(tenant_id)}#{key_component(agent_id)}"
         eligible = self._query(
-            "gsi1", partition, Job, lambda job: self._job_is_claimable(job, self._clock()), limit
+            "gsi1", partition,
+            CandidateQuery(Job, lambda job: self._job_is_claimable(job, self._clock()), limit),
         )
         return tuple(sorted(eligible, key=lambda job: (job.created_at, job.job_id))[:limit])
     @staticmethod
@@ -301,10 +308,13 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
     def get_run(self, tenant_id: str, run_id: str) -> Run | None:
         """Retorna o run solicitado."""
         return self._get_model(run_entity_key(tenant_id, run_id), Run)
-    def list_waiting_runs_for_dependency(self, *args: Any) -> tuple[Run, ...]:
-        """Lista runs aguardando uma dependência."""
-        tenant_id, source_type, file_subtype, competencia, *rest = args
-        limit = rest[0] if rest else 100
+    def list_waiting_runs_for_dependency(
+        self, tenant_id: str, source_type: str, file_subtype: str,
+        competencia: str, limit: int = 100) -> tuple[Run, ...]:
+        """Lista runs aguardando uma dependência.
+        Args: tenant_id, source_type, file_subtype, competencia, limit.
+        Returns: Runs elegíveis ordenados.
+        """
         values = (tenant_id, source_type, file_subtype, competencia)
         identity = "RUN_DEP#" + "#".join(key_component(value) for value in values)
         def valid(run: Run) -> bool:
@@ -315,13 +325,16 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
                 and any((dep.source_type, dep.file_subtype) == (source_type, file_subtype)
                         for dep in run.dependencies)
             )
-        runs = self._query("gsi3", identity, Run, valid, limit)
+        runs = self._query("gsi3", identity, CandidateQuery(Run, valid, limit))
         return tuple(sorted(runs, key=lambda run: (run.created_at, run.run_id))[:limit])
     def list_recoverable_runs(self, now: datetime, limit: int = 100) -> tuple[Run, ...]:
         """Lista runs recuperáveis no instante informado."""
         valid = self._query(
-            "gsi4", "RUN_RECOVERABLE", Run,
-            lambda run: run.state in _RECOVERABLE and run.created_at <= now, limit)
+            "gsi4", "RUN_RECOVERABLE",
+            CandidateQuery(
+                Run, lambda run: run.state in _RECOVERABLE and run.created_at <= now, limit
+            ),
+        )
         ordered = sorted(valid, key=lambda run: (run.created_at, run.tenant_id, run.run_id))
         return tuple(ordered[:limit])
     def transition_run(self, command: TransitionRun, event: OutboxEvent) -> Run:
@@ -411,8 +424,10 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         if run.state is not command.expected_state:
             raise Conflict("run_state_conflict")
         items = query_partition(
-            self._client, self._table_name,
-            run_partition(command.tenant_id, command.run_id), "UNIT#"
+            self._client,
+            self._table_name,
+            run_partition(command.tenant_id, command.run_id),
+            "UNIT#",
         )
         units = tuple(decode_model(item, RunUnit) for item in items)
         cancellable = tuple(unit for unit in units if unit.state in _NONTERMINAL_UNITS)
@@ -439,10 +454,12 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             self._require_access_replay(request, event, existing)
             return
         try:
-            self._transact((
-                put_action(self._table_name, item, None),
-                self._event_action(request.tenant_id, event),
-            ))
+            self._transact(
+                (
+                    put_action(self._table_name, item, None),
+                    self._event_action(request.tenant_id, event),
+                )
+            )
         except Conflict:
             winner = self._get_model(key, AccessRequest)
             if winner is None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -371,7 +371,8 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
 
     def put_run_units(self, command: PutRunUnits) -> tuple[RunUnit, ...]:
         """Persiste o grafo de unidades atomicamente."""
-        if len(command.units) >= 100:
+        units = tuple(sorted(command.units, key=lambda unit: unit.unit_id))
+        if len(units) >= 100:
             raise Conflict("transaction_limit")
         run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
         if run_item is None:
@@ -387,15 +388,14 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             )
         )
         if any(existing):
-            if existing == command.units:
-                return command.units
+            if existing == units:
+                return units
             raise Conflict("run_units_conflict")
         actions = (check_action(self._table_name, run_item),) + tuple(
-            put_action(self._table_name, self._unit_item(unit), None) for unit in command.units
+            put_action(self._table_name, self._unit_item(unit), None) for unit in units
         )
         self._transact(actions)
-        return command.units
-
+        return units
     def list_run_units(self, tenant_id: str, run_id: str) -> tuple[RunUnit, ...]:
         """Lista as unidades do run."""
         partition = f"RUN_ITEMS#{tenant_id}#{run_id}"
@@ -476,7 +476,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
     def get_access_request(self, tenant_id: str, request_id: str) -> AccessRequest | None:
         """Retorna a solicitação de acesso."""
         return self._get_model(entity_key(tenant_id, "ACCESS", request_id), AccessRequest)
-
     def decide_access_request(self, request: AccessRequest, event: OutboxEvent) -> AccessRequest:
         """Persiste a decisão de acesso atomicamente."""
         key = entity_key(request.tenant_id, "ACCESS", request.request_id)
@@ -487,7 +486,9 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         if existing == request:
             self._require_event_replay(request.tenant_id, event)
             return existing
-        if existing.state.value != "PENDING":
+        original_identity = (existing.tenant_id, existing.request_id, existing.user_id)
+        requested_identity = (request.tenant_id, request.request_id, request.user_id)
+        if existing.state.value != "PENDING" or original_identity != requested_identity:
             raise Conflict("access_request_conflict")
         updated = encode_model(request, "ACCESSREQUEST", key)
         self._transact(

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -204,7 +204,16 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             put_action(self._table_name, self._job_item(job), None),
             self._event_action(job.tenant_id, event),
         )
-        self._transact(actions)
+        try:
+            self._transact(actions)
+        except Conflict:
+            winner = self._get_model(key, Job)
+            if winner is None:
+                raise
+            if winner != job:
+                raise Conflict("job_conflict") from None
+            self._require_event_replay(job.tenant_id, event)
+            return winner
         return job
     def get_job(self, tenant_id: str, job_id: str) -> Job | None:
         """Retorna o job solicitado."""

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -436,13 +436,24 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         item = encode_model(request, "ACCESSREQUEST", key)
         existing = self._get_model(key, AccessRequest)
         if existing is not None:
-            if existing != request:
-                raise Conflict("access_request_conflict")
-            self._require_event_replay(request.tenant_id, event)
+            self._require_access_replay(request, event, existing)
             return
-        self._transact(
-            (put_action(self._table_name, item, None), self._event_action(request.tenant_id, event))
-        )
+        try:
+            self._transact((
+                put_action(self._table_name, item, None),
+                self._event_action(request.tenant_id, event),
+            ))
+        except Conflict:
+            winner = self._get_model(key, AccessRequest)
+            if winner is None:
+                raise
+            self._require_access_replay(request, event, winner)
+    def _require_access_replay(
+        self, request: AccessRequest, event: OutboxEvent, existing: AccessRequest
+    ) -> None:
+        if existing != request:
+            raise Conflict("access_request_conflict")
+        self._require_event_replay(request.tenant_id, event)
     def get_access_request(self, tenant_id: str, request_id: str) -> AccessRequest | None:
         """Retorna a solicitação de acesso."""
         return self._get_model(entity_key(tenant_id, "ACCESS", request_id), AccessRequest)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -157,7 +157,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
                 ),
             }
         return encode_model(run, "RUN", run_entity_key(run.tenant_id, run.run_id), attributes)
-
     def _unit_item(self, unit: RunUnit) -> Item:
         attributes = {
             "gsi5pk": (
@@ -171,35 +170,28 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             unit_key(unit.tenant_id, unit.run_id, unit.unit_id),
             attributes,
         )
-
     def get_tenant(self, tenant_id: str) -> Tenant | None:
         """Retorna o tenant solicitado."""
         return self._get_model(entity_key(tenant_id, "TENANT", tenant_id), Tenant)
-
     def put_tenant(self, tenant: Tenant) -> None:
         """Persiste um tenant."""
         self._put_direct(
             encode_model(tenant, "TENANT", entity_key(tenant.tenant_id, "TENANT", tenant.tenant_id))
         )
-
     def get_membership(self, tenant_id: str, user_id: str) -> Membership | None:
         """Retorna a associação solicitada."""
         return self._get_model(entity_key(tenant_id, "MEMBERSHIP", user_id), Membership)
-
     def put_membership(self, membership: Membership) -> None:
         """Persiste uma associação."""
         key = entity_key(membership.tenant_id, "MEMBERSHIP", membership.user_id)
         self._put_direct(encode_model(membership, "MEMBERSHIP", key))
-
     def get_agent(self, tenant_id: str, agent_id: str) -> Agent | None:
         """Retorna o agente solicitado."""
         return self._get_model(entity_key(tenant_id, "AGENT", agent_id), Agent)
-
     def put_agent(self, agent: Agent) -> None:
         """Persiste um agente."""
         key = entity_key(agent.tenant_id, "AGENT", agent.agent_id)
         self._put_direct(encode_model(agent, "AGENT", key))
-
     def create_job(self, job: Job, event: OutboxEvent) -> Job:
         """Cria um job e seu evento atomicamente."""
         key = entity_key(job.tenant_id, "JOB", job.job_id)
@@ -215,11 +207,9 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         )
         self._transact(actions)
         return job
-
     def get_job(self, tenant_id: str, job_id: str) -> Job | None:
         """Retorna o job solicitado."""
         return self._get_model(entity_key(tenant_id, "JOB", job_id), Job)
-
     def latest_succeeded_job(self, *args: str) -> Job | None:
         """Retorna o job concluído mais recente da identidade."""
         agent_id = args[1]
@@ -301,13 +291,13 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             job.state is JobState.LEASED and job.lease_until is not None and job.lease_until <= now
         )
 
-    def put_run(self, run: Run) -> None:
-        """Persiste um run e seus índices de dependência."""
+    def _dependency_actions(self, run: Run, reserved_actions: int) -> tuple[Action, ...]:
         if run.state is not RunState.WAITING_INPUTS:
-            self._put_direct(self._run_item(run))
-            return
-        actions = [put_action(self._table_name, self._run_item(run), None)]
+            return ()
+        if len(run.dependencies) + reserved_actions > 100:
+            raise Conflict("transaction_limit")
         base_key = run_entity_key(run.tenant_id, run.run_id)
+        actions = []
         for dependency in run.dependencies:
             values = (run.tenant_id, dependency.source_type,
                       dependency.file_subtype, run.competencia)
@@ -319,7 +309,16 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             }
             marker = encode_marker("RUN_DEP", marker_key, base_key, attributes)
             actions.append(put_action(self._table_name, marker, None))
-        self._transact(tuple(actions))
+        return tuple(actions)
+
+    def put_run(self, run: Run) -> None:
+        """Persiste um run e seus índices de dependência."""
+        if run.state is not RunState.WAITING_INPUTS:
+            self._put_direct(self._run_item(run))
+            return
+        actions = (put_action(self._table_name, self._run_item(run), None),
+                   *self._dependency_actions(run, 1))
+        self._transact(actions)
 
     def get_run(self, tenant_id: str, run_id: str) -> Run | None:
         """Retorna o run solicitado."""
@@ -364,6 +363,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         )
         actions = (
             put_action(self._table_name, self._run_item(updated), payload(item)),
+            *self._dependency_actions(updated, 2),
             self._event_action(command.tenant_id, event),
         )
         self._transact(actions)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -246,15 +246,15 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         values = (tenant_id, source_type, file_subtype, competencia)
         partition = "RAW#" + "#".join(key_component(value) for value in values)
         records = list(self._strong_candidates(self._query("gsi2", partition), RawManifestRecord))
-        candidates = sorted(
-            records,
-            key=lambda item: (item.created_at, item.agent_id, item.snapshot_id),
+        chains = tuple(filter(None, (self._valid_chain(records, head) for head in records)))
+        ancestors = {item.manifest_id for chain in chains for item in chain[:-1]}
+        endpoints = (chain for chain in chains if chain[-1].manifest_id not in ancestors)
+        ordered = sorted(
+            endpoints,
+            key=lambda chain: (chain[-1].created_at, chain[-1].agent_id, chain[-1].snapshot_id),
             reverse=True,
         )
-        for head in candidates:
-            chain = self._valid_chain(records, head)
-            if not chain:
-                continue
+        for chain in ordered:
             if len(chain) > limit:
                 return ()
             return tuple(

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -1,0 +1,486 @@
+"""DynamoDB control-plane adapter."""
+
+from __future__ import annotations
+
+from itertools import pairwise
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from cnes_domain.control_plane.entities import (
+    AccessRequest,
+    Agent,
+    Job,
+    ManifestRef,
+    Membership,
+    OutboxEvent,
+    RawManifestRecord,
+    Run,
+    RunUnit,
+    Tenant,
+)
+from cnes_domain.control_plane.enums import AgentState, JobState, RunState, RunUnitState
+from cnes_domain.control_plane.errors import Conflict, NotFound
+from cnes_domain.control_plane.ids import run_dependency_key
+from cnes_domain.control_plane.transitions import (
+    transition_job,
+    transition_run,
+    transition_run_unit,
+)
+from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
+from cnes_infra.control_plane.dynamodb_codec import (
+    Action,
+    Item,
+    check_action,
+    decode_model,
+    encode_marker,
+    encode_model,
+    execute_transaction,
+    payload,
+    put_action,
+)
+from cnes_infra.control_plane.dynamodb_keys import (
+    dependency_marker_key,
+    entity_key,
+    item_key,
+    run_entity_key,
+    timestamp,
+    unit_key,
+)
+from cnes_infra.control_plane.dynamodb_publication import DynamoDBPublication
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+
+    from cnes_domain.control_plane.commands import (
+        CancelJob,
+        FinalizeRunCancellation,
+        PutRunUnits,
+        TransitionRun,
+    )
+
+_RECOVERABLE = {
+    RunState.WAITING_INPUTS,
+    RunState.PROCESSING,
+    RunState.PUBLISHING,
+    RunState.CANCEL_REQUESTED,
+}
+_NONTERMINAL_UNITS = {
+    RunUnitState.PENDING,
+    RunUnitState.LEASED,
+    RunUnitState.FAILED_RETRYABLE,
+}
+
+
+class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
+    """Persiste o plano de controle em uma tabela DynamoDB."""
+
+    def __init__(self, client: Any, table_name: str, clock: Callable[[], datetime]) -> None:
+        self._client = client
+        self._table_name = table_name
+        self._clock = clock
+
+    def _get_item(self, key: tuple[str, str]) -> Item | None:
+        response = self._client.get_item(
+            TableName=self._table_name,
+            Key=item_key(*key),
+            ConsistentRead=True,
+        )
+        return response.get("Item")
+
+    def _get_model[T: BaseModel](self, key: tuple[str, str], model_type: type[T]) -> T | None:
+        item = self._get_item(key)
+        return decode_model(item, model_type) if item is not None else None
+
+    def _query(self, index_name: str, partition: str) -> tuple[Item, ...]:
+        response = self._client.query(
+            TableName=self._table_name,
+            IndexName=index_name,
+            KeyConditionExpression=f"{index_name}pk = :partition",
+            ExpressionAttributeValues={":partition": {"S": partition}},
+        )
+        return tuple(response.get("Items", ()))
+
+    def _strong_candidates[T: BaseModel](
+        self, candidates: tuple[Item, ...], model_type: type[T]
+    ) -> tuple[T, ...]:
+        keys = {
+            (
+                item.get("base_pk", item["pk"])["S"],
+                item.get("base_sk", item["sk"])["S"],
+            )
+            for item in candidates
+        }
+        models = []
+        for key in sorted(keys):
+            item = self._get_item(key)
+            if item is not None and item.get("entity", {}).get("S") == model_type.__name__.upper():
+                models.append(decode_model(item, model_type))
+        return tuple(models)
+
+    def _transact(self, actions: tuple[Action, ...]) -> None:
+        execute_transaction(self._client, actions)
+
+    def _event_action(self, event: OutboxEvent) -> Action:
+        existing = self._get_outbox_event(event.event_id)
+        if existing is not None:
+            raise Conflict("event_id_conflict")
+        return put_action(self._table_name, self._outbox_item(event), None)
+
+    def _put_direct(self, item: Item) -> None:
+        self._client.put_item(TableName=self._table_name, Item=item)
+
+    def _job_item(self, job: Job) -> Item:
+        identity = f"RAW#{job.tenant_id}#{job.source_type}#{job.file_subtype}#{job.competencia}"
+        attributes = {
+            "gsi2pk": identity,
+            "gsi2sk": f"JOB#{timestamp(job.created_at)}#{job.agent_id}#{job.job_id}",
+        }
+        if job.state in {JobState.PENDING, JobState.LEASED, JobState.FAILED_RETRYABLE}:
+            available = job.lease_until or job.created_at
+            attributes |= {
+                "gsi1pk": f"JOB_CLAIM#{job.tenant_id}#{job.agent_id}",
+                "gsi1sk": f"{timestamp(available)}#{job.state.value}#{job.job_id}",
+            }
+        key = entity_key(job.tenant_id, "JOB", job.job_id)
+        return encode_model(job, "JOB", key, attributes)
+
+    def _raw_item(self, record: RawManifestRecord) -> Item:
+        identity = (
+            f"RAW#{record.tenant_id}#{record.source_type}#"
+            f"{record.file_subtype}#{record.competencia}"
+        )
+        attributes = {
+            "gsi2pk": identity,
+            "gsi2sk": (
+                f"RAW#{record.sequence:020d}#{timestamp(record.created_at)}#"
+                f"{record.agent_id}#{record.snapshot_id}"
+            ),
+        }
+        key = entity_key(record.tenant_id, "RAW", record.manifest_id)
+        return encode_model(record, "RAWMANIFESTRECORD", key, attributes)
+
+    def _run_item(self, run: Run) -> Item:
+        attributes = {}
+        if run.state in _RECOVERABLE:
+            attributes = {
+                "gsi4pk": "RUN_RECOVERABLE",
+                "gsi4sk": f"{timestamp(run.created_at)}#{run.tenant_id}#{run.run_id}",
+            }
+        return encode_model(run, "RUN", run_entity_key(run.tenant_id, run.run_id), attributes)
+
+    def _unit_item(self, unit: RunUnit) -> Item:
+        attributes = {
+            "gsi5pk": f"RUN_ITEMS#{unit.tenant_id}#{unit.run_id}",
+            "gsi5sk": f"UNIT#{unit.unit_id}",
+        }
+        return encode_model(
+            unit,
+            "RUNUNIT",
+            unit_key(unit.tenant_id, unit.run_id, unit.unit_id),
+            attributes,
+        )
+
+    def get_tenant(self, tenant_id: str) -> Tenant | None:
+        """Retorna o tenant solicitado."""
+        return self._get_model(entity_key(tenant_id, "TENANT", tenant_id), Tenant)
+
+    def put_tenant(self, tenant: Tenant) -> None:
+        """Persiste um tenant."""
+        self._put_direct(
+            encode_model(tenant, "TENANT", entity_key(tenant.tenant_id, "TENANT", tenant.tenant_id))
+        )
+
+    def get_membership(self, tenant_id: str, user_id: str) -> Membership | None:
+        """Retorna a associação solicitada."""
+        return self._get_model(entity_key(tenant_id, "MEMBERSHIP", user_id), Membership)
+
+    def put_membership(self, membership: Membership) -> None:
+        """Persiste uma associação."""
+        key = entity_key(membership.tenant_id, "MEMBERSHIP", membership.user_id)
+        self._put_direct(encode_model(membership, "MEMBERSHIP", key))
+
+    def get_agent(self, tenant_id: str, agent_id: str) -> Agent | None:
+        """Retorna o agente solicitado."""
+        return self._get_model(entity_key(tenant_id, "AGENT", agent_id), Agent)
+
+    def put_agent(self, agent: Agent) -> None:
+        """Persiste um agente."""
+        key = entity_key(agent.tenant_id, "AGENT", agent.agent_id)
+        self._put_direct(encode_model(agent, "AGENT", key))
+
+    def create_job(self, job: Job, event: OutboxEvent) -> Job:
+        """Cria um job e seu evento atomicamente."""
+        key = entity_key(job.tenant_id, "JOB", job.job_id)
+        existing = self._get_model(key, Job)
+        if existing is not None:
+            if existing != job:
+                raise Conflict("job_conflict")
+            return existing
+        actions = (
+            put_action(self._table_name, self._job_item(job), None),
+            self._event_action(event),
+        )
+        self._transact(actions)
+        return job
+
+    def get_job(self, tenant_id: str, job_id: str) -> Job | None:
+        """Retorna o job solicitado."""
+        return self._get_model(entity_key(tenant_id, "JOB", job_id), Job)
+
+    def latest_succeeded_job(self, *args: str) -> Job | None:
+        """Retorna o job concluído mais recente da identidade."""
+        tenant_id, agent_id, source_type, file_subtype, competencia = args
+        partition = f"RAW#{tenant_id}#{source_type}#{file_subtype}#{competencia}"
+        candidates = self._strong_candidates(self._query("gsi2", partition), Job)
+        matches = (
+            job
+            for job in candidates
+            if job.agent_id == agent_id and job.state is JobState.SUCCEEDED
+        )
+        return max(matches, key=lambda job: (job.created_at, job.job_id), default=None)
+
+    def list_raw_manifest_chain(self, *args: Any) -> tuple[ManifestRef, ...]:
+        """Retorna a cadeia válida de manifestos raw."""
+        tenant_id, source_type, file_subtype, competencia, *rest = args
+        limit = rest[0] if rest else 31
+        partition = f"RAW#{tenant_id}#{source_type}#{file_subtype}#{competencia}"
+        records = list(self._strong_candidates(self._query("gsi2", partition), RawManifestRecord))
+        candidates = sorted(
+            records,
+            key=lambda item: (item.created_at, item.agent_id, item.snapshot_id),
+            reverse=True,
+        )
+        for head in candidates:
+            chain = self._valid_chain(records, head)
+            if not chain:
+                continue
+            if len(chain) > limit:
+                return ()
+            return tuple(
+                ManifestRef(manifest_id=item.manifest_id, manifest_key=item.manifest_key)
+                for item in chain
+            )
+        return ()
+
+    @staticmethod
+    def _valid_chain(
+        records: list[RawManifestRecord], head: RawManifestRecord
+    ) -> tuple[RawManifestRecord, ...]:
+        base = head.snapshot_id if head.sequence == 1 else head.base_snapshot_id
+        chain = [
+            item
+            for item in records
+            if item.agent_id == head.agent_id
+            and base in (item.snapshot_id, item.base_snapshot_id)
+            and item.sequence <= head.sequence
+        ]
+        chain.sort(key=lambda item: item.sequence)
+        sequences = [item.sequence for item in chain]
+        hashes_match = all(
+            current.previous_manifest_sha256 == previous.manifest_sha256
+            for previous, current in pairwise(chain)
+        )
+        valid = sequences == list(range(1, head.sequence + 1)) and hashes_match
+        return tuple(chain) if valid else ()
+
+    def list_claimable_jobs(self, tenant_id: str, agent_id: str, limit: int) -> tuple[Job, ...]:
+        """Lista jobs elegíveis para claim."""
+        agent = self.get_agent(tenant_id, agent_id)
+        if agent is None or agent.state is not AgentState.ACTIVE:
+            return ()
+        partition = f"JOB_CLAIM#{tenant_id}#{agent_id}"
+        jobs = self._strong_candidates(self._query("gsi1", partition), Job)
+        eligible = [job for job in jobs if self._job_is_claimable(job, self._clock())]
+        return tuple(sorted(eligible, key=lambda job: (job.created_at, job.job_id))[:limit])
+
+    @staticmethod
+    def _job_is_claimable(job: Job, now: datetime) -> bool:
+        if job.state in {JobState.PENDING, JobState.FAILED_RETRYABLE}:
+            return True
+        return (
+            job.state is JobState.LEASED and job.lease_until is not None and job.lease_until <= now
+        )
+
+    def put_run(self, run: Run) -> None:
+        """Persiste um run e seus índices de dependência."""
+        self._put_direct(self._run_item(run))
+        if run.state is not RunState.WAITING_INPUTS:
+            return
+        base_key = run_entity_key(run.tenant_id, run.run_id)
+        for dependency in run.dependencies:
+            identity = run_dependency_key(
+                run.tenant_id, dependency.source_type, dependency.file_subtype, run.competencia
+            )
+            marker_key = dependency_marker_key(run.tenant_id, run.run_id, identity)
+            attributes = {
+                "gsi3pk": identity,
+                "gsi3sk": f"{timestamp(run.created_at)}#{run.run_id}",
+            }
+            self._put_direct(encode_marker("RUN_DEP", marker_key, base_key, attributes))
+
+    def get_run(self, tenant_id: str, run_id: str) -> Run | None:
+        """Retorna o run solicitado."""
+        return self._get_model(run_entity_key(tenant_id, run_id), Run)
+
+    def list_waiting_runs_for_dependency(self, *args: Any) -> tuple[Run, ...]:
+        """Lista runs aguardando uma dependência."""
+        tenant_id, source_type, file_subtype, competencia, *rest = args
+        limit = rest[0] if rest else 100
+        identity = run_dependency_key(tenant_id, source_type, file_subtype, competencia)
+        runs = self._strong_candidates(self._query("gsi3", identity), Run)
+        valid = [
+            run
+            for run in runs
+            if run.state is RunState.WAITING_INPUTS
+            and run.tenant_id == tenant_id
+            and run.competencia == competencia
+            and any(
+                (dep.source_type, dep.file_subtype) == (source_type, file_subtype)
+                for dep in run.dependencies
+            )
+        ]
+        return tuple(sorted(valid, key=lambda run: (run.created_at, run.run_id))[:limit])
+
+    def list_recoverable_runs(self, now: datetime, limit: int = 100) -> tuple[Run, ...]:
+        """Lista runs recuperáveis no instante informado."""
+        runs = self._strong_candidates(self._query("gsi4", "RUN_RECOVERABLE"), Run)
+        valid = [run for run in runs if run.state in _RECOVERABLE and run.created_at <= now]
+        ordered = sorted(valid, key=lambda run: (run.created_at, run.run_id, run.tenant_id))
+        return tuple(ordered[:limit])
+
+    def transition_run(self, command: TransitionRun, event: OutboxEvent) -> Run:
+        """Transiciona um run e grava o evento atomicamente."""
+        key = run_entity_key(command.tenant_id, command.run_id)
+        item = self._get_item(key)
+        if item is None:
+            raise NotFound("run_missing")
+        run = decode_model(item, Run)
+        if run.state is not command.expected_state:
+            raise Conflict("run_state_conflict")
+        updated = transition_run(run, command.new_state).model_copy(
+            update={"missing_sources": command.missing_sources}
+        )
+        actions = (
+            put_action(self._table_name, self._run_item(updated), payload(item)),
+            self._event_action(event),
+        )
+        self._transact(actions)
+        return updated
+
+    def put_run_units(self, command: PutRunUnits) -> tuple[RunUnit, ...]:
+        """Persiste o grafo de unidades atomicamente."""
+        if len(command.units) >= 100:
+            raise Conflict("transaction_limit")
+        run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
+        if run_item is None:
+            raise NotFound("run_missing")
+        run = decode_model(run_item, Run)
+        if run.state is not command.expected_run_state:
+            raise Conflict("run_state_conflict")
+        existing = tuple(
+            self._get_model(unit_key(unit.tenant_id, unit.run_id, unit.unit_id), RunUnit)
+            for unit in command.units
+        )
+        if any(existing):
+            if existing == command.units:
+                return command.units
+            raise Conflict("run_units_conflict")
+        actions = (check_action(self._table_name, run_item),) + tuple(
+            put_action(self._table_name, self._unit_item(unit), None) for unit in command.units
+        )
+        self._transact(actions)
+        return command.units
+
+    def list_run_units(self, tenant_id: str, run_id: str) -> tuple[RunUnit, ...]:
+        """Lista as unidades do run."""
+        partition = f"RUN_ITEMS#{tenant_id}#{run_id}"
+        units = self._strong_candidates(self._query("gsi5", partition), RunUnit)
+        return tuple(sorted(units, key=lambda unit: unit.unit_id))
+
+    def cancel_job(self, command: CancelJob, event: OutboxEvent) -> Job:
+        """Solicita o cancelamento de um job leased."""
+        key = entity_key(command.tenant_id, "JOB", command.job_id)
+        item = self._get_item(key)
+        if item is None:
+            raise NotFound("job_missing")
+        job = decode_model(item, Job)
+        if job.state is JobState.CANCEL_REQUESTED:
+            return job
+        if job.state is not JobState.LEASED:
+            raise Conflict("job_state_conflict")
+        updated = transition_job(job, JobState.CANCEL_REQUESTED)
+        self._transact(
+            (
+                put_action(self._table_name, self._job_item(updated), payload(item)),
+                self._event_action(event),
+            )
+        )
+        return updated
+
+    def finalize_run_cancellation(
+        self, command: FinalizeRunCancellation, event: OutboxEvent
+    ) -> Run:
+        """Finaliza o cancelamento do agregado do run."""
+        run_key = run_entity_key(command.tenant_id, command.run_id)
+        run_item = self._get_item(run_key)
+        if run_item is None:
+            raise NotFound("run_missing")
+        run = decode_model(run_item, Run)
+        if run.state is RunState.CANCELED:
+            return run
+        if run.state is not command.expected_state:
+            raise Conflict("run_state_conflict")
+        units = self.list_run_units(command.tenant_id, command.run_id)
+        cancellable = tuple(unit for unit in units if unit.state in _NONTERMINAL_UNITS)
+        if len(cancellable) >= 99:
+            raise Conflict("transaction_limit")
+        updated_run = transition_run(run, RunState.CANCELED)
+        actions = [put_action(self._table_name, self._run_item(updated_run), payload(run_item))]
+        actions.extend(self._cancel_unit_action(unit, run) for unit in cancellable)
+        actions.append(self._event_action(event))
+        self._transact(tuple(actions))
+        return updated_run
+
+    def _cancel_unit_action(self, unit: RunUnit, run: Run) -> Action:
+        canceled = transition_run_unit(unit, RunUnitState.CANCELED, run).model_copy(
+            update={"lease_owner": None, "lease_until": None}
+        )
+        expected = payload(self._unit_item(unit))
+        return put_action(self._table_name, self._unit_item(canceled), expected)
+
+    def put_access_request(self, request: AccessRequest, event: OutboxEvent) -> None:
+        """Cria uma solicitação de acesso atomicamente."""
+        key = entity_key(request.tenant_id, "ACCESS", request.request_id)
+        item = encode_model(request, "ACCESSREQUEST", key)
+        existing = self._get_model(key, AccessRequest)
+        if existing is not None:
+            if existing != request:
+                raise Conflict("access_request_conflict")
+            return
+        self._transact((put_action(self._table_name, item, None), self._event_action(event)))
+
+    def get_access_request(self, tenant_id: str, request_id: str) -> AccessRequest | None:
+        """Retorna a solicitação de acesso."""
+        return self._get_model(entity_key(tenant_id, "ACCESS", request_id), AccessRequest)
+
+    def decide_access_request(self, request: AccessRequest, event: OutboxEvent) -> AccessRequest:
+        """Persiste a decisão de acesso atomicamente."""
+        key = entity_key(request.tenant_id, "ACCESS", request.request_id)
+        item = self._get_item(key)
+        if item is None:
+            raise NotFound("access_request_missing")
+        existing = decode_model(item, AccessRequest)
+        if existing == request:
+            return existing
+        if existing.state.value != "PENDING":
+            raise Conflict("access_request_conflict")
+        updated = encode_model(request, "ACCESSREQUEST", key)
+        self._transact(
+            (
+                put_action(self._table_name, updated, payload(item)),
+                self._event_action(event),
+            )
+        )
+        return request

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -38,12 +38,15 @@ from cnes_infra.control_plane.dynamodb_codec import (
     execute_transaction,
     payload,
     put_action,
+    query_all,
+    query_partition,
 )
 from cnes_infra.control_plane.dynamodb_keys import (
     dependency_marker_key,
     entity_key,
     item_key,
     run_entity_key,
+    run_partition,
     timestamp,
     unit_key,
 )
@@ -94,13 +97,15 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         return decode_model(item, model_type) if item is not None else None
 
     def _query(self, index_name: str, partition: str) -> tuple[Item, ...]:
-        response = self._client.query(
-            TableName=self._table_name,
-            IndexName=index_name,
-            KeyConditionExpression=f"{index_name}pk = :partition",
-            ExpressionAttributeValues={":partition": {"S": partition}},
+        return query_all(
+            self._client,
+            {
+                "TableName": self._table_name,
+                "IndexName": index_name,
+                "KeyConditionExpression": f"{index_name}pk = :partition",
+                "ExpressionAttributeValues": {":partition": {"S": partition}},
+            },
         )
-        return tuple(response.get("Items", ()))
 
     def _strong_candidates[T: BaseModel](
         self, candidates: tuple[Item, ...], model_type: type[T]
@@ -217,6 +222,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         if existing is not None:
             if existing != job:
                 raise Conflict("job_conflict")
+            self._require_event_replay(job.tenant_id, event)
             return existing
         actions = (
             put_action(self._table_name, self._job_item(job), None),
@@ -407,6 +413,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             raise NotFound("job_missing")
         job = decode_model(item, Job)
         if job.state is JobState.CANCEL_REQUESTED:
+            self._require_event_replay(job.tenant_id, event)
             return job
         if job.state is not JobState.LEASED:
             raise Conflict("job_state_conflict")
@@ -429,10 +436,15 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             raise NotFound("run_missing")
         run = decode_model(run_item, Run)
         if run.state is RunState.CANCELED:
+            self._require_event_replay(run.tenant_id, event)
             return run
         if run.state is not command.expected_state:
             raise Conflict("run_state_conflict")
-        units = self.list_run_units(command.tenant_id, command.run_id)
+        items = query_partition(
+            self._client, self._table_name,
+            run_partition(command.tenant_id, command.run_id), "UNIT#"
+        )
+        units = tuple(decode_model(item, RunUnit) for item in items)
         cancellable = tuple(unit for unit in units if unit.state in _NONTERMINAL_UNITS)
         if len(cancellable) >= 99:
             raise Conflict("transaction_limit")
@@ -458,6 +470,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         if existing is not None:
             if existing != request:
                 raise Conflict("access_request_conflict")
+            self._require_event_replay(request.tenant_id, event)
             return
         self._transact((put_action(self._table_name, item, None), self._event_action(event)))
 
@@ -473,6 +486,7 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             raise NotFound("access_request_missing")
         existing = decode_model(item, AccessRequest)
         if existing == request:
+            self._require_event_replay(request.tenant_id, event)
             return existing
         if existing.state.value != "PENDING":
             raise Conflict("access_request_conflict")

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -29,6 +29,7 @@ from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
 from cnes_infra.control_plane.dynamodb_codec import (
     Action,
     Item,
+    aggregate_replay,
     bounded_candidates,
     bounded_partition,
     check_action,
@@ -75,8 +76,6 @@ _NONTERMINAL_UNITS = {
     RunUnitState.LEASED,
     RunUnitState.FAILED_RETRYABLE,
 }
-
-
 class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
     """Persiste o plano de controle em uma tabela DynamoDB."""
 
@@ -282,7 +281,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             "gsi1", partition, Job, lambda job: self._job_is_claimable(job, self._clock()), limit
         )
         return tuple(sorted(eligible, key=lambda job: (job.created_at, job.job_id))[:limit])
-
     @staticmethod
     def _job_is_claimable(job: Job, now: datetime) -> bool:
         if job.state in {JobState.PENDING, JobState.FAILED_RETRYABLE}:
@@ -290,7 +288,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         return (
             job.state is JobState.LEASED and job.lease_until is not None and job.lease_until <= now
         )
-
     def _dependency_actions(self, run: Run, reserved_actions: int) -> tuple[Action, ...]:
         if run.state is not RunState.WAITING_INPUTS:
             return ()
@@ -310,20 +307,30 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             marker = encode_marker("RUN_DEP", marker_key, base_key, attributes)
             actions.append(put_action(self._table_name, marker, None))
         return tuple(actions)
-
     def put_run(self, run: Run) -> None:
         """Persiste um run e seus índices de dependência."""
         if run.state is not RunState.WAITING_INPUTS:
             self._put_direct(self._run_item(run))
             return
+        if self._waiting_run_replay(run):
+            return
         actions = (put_action(self._table_name, self._run_item(run), None),
                    *self._dependency_actions(run, 1))
-        self._transact(actions)
-
+        try:
+            self._transact(actions)
+        except Conflict:
+            if self._waiting_run_replay(run):
+                return
+            raise
+    def _waiting_run_replay(self, run: Run) -> bool:
+        actions = self._dependency_actions(run, 1)
+        children = tuple(action["Put"]["Item"] for action in actions)
+        child_key = dependency_marker_key(run.tenant_id, run.run_id, "")
+        expected = self._run_item(run), child_key, children
+        return aggregate_replay(self._client, self._table_name, expected)
     def get_run(self, tenant_id: str, run_id: str) -> Run | None:
         """Retorna o run solicitado."""
         return self._get_model(run_entity_key(tenant_id, run_id), Run)
-
     def list_waiting_runs_for_dependency(self, *args: Any) -> tuple[Run, ...]:
         """Lista runs aguardando uma dependência."""
         tenant_id, source_type, file_subtype, competencia, *rest = args
@@ -340,7 +347,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             )
         runs = self._query("gsi3", identity, Run, valid, limit)
         return tuple(sorted(runs, key=lambda run: (run.created_at, run.run_id))[:limit])
-
     def list_recoverable_runs(self, now: datetime, limit: int = 100) -> tuple[Run, ...]:
         """Lista runs recuperáveis no instante informado."""
         valid = self._query(
@@ -348,7 +354,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             lambda run: run.state in _RECOVERABLE and run.created_at <= now, limit)
         ordered = sorted(valid, key=lambda run: (run.created_at, run.tenant_id, run.run_id))
         return tuple(ordered[:limit])
-
     def transition_run(self, command: TransitionRun, event: OutboxEvent) -> Run:
         """Transiciona um run e grava o evento atomicamente."""
         key = run_entity_key(command.tenant_id, command.run_id)
@@ -368,7 +373,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         )
         self._transact(actions)
         return updated
-
     def put_run_units(self, command: PutRunUnits) -> tuple[RunUnit, ...]:
         """Persiste o grafo de unidades atomicamente."""
         units = tuple(sorted(command.units, key=lambda unit: unit.unit_id))
@@ -422,7 +426,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             )
         )
         return updated
-
     def finalize_run_cancellation(
         self, command: FinalizeRunCancellation, event: OutboxEvent
     ) -> Run:
@@ -451,14 +454,12 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         actions.append(self._event_action(command.tenant_id, event))
         self._transact(tuple(actions))
         return updated_run
-
     def _cancel_unit_action(self, unit: RunUnit, run: Run) -> Action:
         canceled = transition_run_unit(unit, RunUnitState.CANCELED, run).model_copy(
             update={"lease_owner": None, "lease_until": None}
         )
         expected = payload(self._unit_item(unit))
         return put_action(self._table_name, self._unit_item(canceled), expected)
-
     def put_access_request(self, request: AccessRequest, event: OutboxEvent) -> None:
         """Cria uma solicitação de acesso atomicamente."""
         key = entity_key(request.tenant_id, "ACCESS", request.request_id)
@@ -472,7 +473,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         self._transact(
             (put_action(self._table_name, item, None), self._event_action(request.tenant_id, event))
         )
-
     def get_access_request(self, tenant_id: str, request_id: str) -> AccessRequest | None:
         """Retorna a solicitação de acesso."""
         return self._get_model(entity_key(tenant_id, "ACCESS", request_id), AccessRequest)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -96,7 +96,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
     def _get_model[T: BaseModel](self, key: tuple[str, str], model_type: type[T]) -> T | None:
         item = self._get_item(key)
         return decode_model(item, model_type) if item is not None else None
-
     def _query(self, index_name: str, partition: str, *args: Any) -> Any:
         request = {
             "TableName": self._table_name,
@@ -107,18 +106,14 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         if args:
             return bounded_candidates(self._client, request, *args)
         return query_all(self._client, request)
-
     def _strong_candidates[T: BaseModel](
         self, candidates: tuple[Item, ...], model_type: type[T]
     ) -> tuple[T, ...]:
         return strong_candidates(self._client, self._table_name, candidates, model_type)
-
     def _transact(self, actions: tuple[Action, ...]) -> None:
         execute_transaction(self._client, actions)
-
     def _put_direct(self, item: Item) -> None:
         self._client.put_item(TableName=self._table_name, Item=item)
-
     def _job_item(self, job: Job) -> Item:
         values = (job.tenant_id, job.source_type, job.file_subtype, job.competencia)
         identity = "RAW#" + "#".join(key_component(value) for value in values)
@@ -139,7 +134,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             }
         key = entity_key(job.tenant_id, "JOB", job.job_id)
         return encode_model(job, "JOB", key, attributes)
-
     def _raw_item(self, record: RawManifestRecord) -> Item:
         values = (record.tenant_id, record.source_type, record.file_subtype, record.competencia)
         identity = "RAW#" + "#".join(key_component(value) for value in values)
@@ -152,7 +146,6 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         }
         key = entity_key(record.tenant_id, "RAW", record.manifest_id)
         return encode_model(record, "RAWMANIFESTRECORD", key, attributes)
-
     def _run_item(self, run: Run) -> Item:
         attributes = {}
         if run.state in _RECOVERABLE:
@@ -243,9 +236,13 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
         """Retorna a cadeia válida de manifestos raw."""
         tenant_id, source_type, file_subtype, competencia, *rest = args
         limit = rest[0] if rest else 31
-        values = (tenant_id, source_type, file_subtype, competencia)
-        partition = "RAW#" + "#".join(key_component(value) for value in values)
-        records = list(self._strong_candidates(self._query("gsi2", partition), RawManifestRecord))
+        items = query_partition(
+            self._client, self._table_name, *entity_key(tenant_id, "RAW", "")
+        )
+        records = [decode_model(item, RawManifestRecord) for item in items]
+        records = [record for record in records if (
+            record.source_type, record.file_subtype, record.competencia
+        ) == (source_type, file_subtype, competencia)]
         chains = tuple(filter(None, (self._valid_chain(records, head) for head in records)))
         ancestors = {item.manifest_id for chain in chains for item in chain[:-1]}
         endpoints = (chain for chain in chains if chain[-1].manifest_id not in ancestors)
@@ -306,9 +303,10 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
 
     def put_run(self, run: Run) -> None:
         """Persiste um run e seus índices de dependência."""
-        self._put_direct(self._run_item(run))
         if run.state is not RunState.WAITING_INPUTS:
+            self._put_direct(self._run_item(run))
             return
+        actions = [put_action(self._table_name, self._run_item(run), None)]
         base_key = run_entity_key(run.tenant_id, run.run_id)
         for dependency in run.dependencies:
             values = (run.tenant_id, dependency.source_type,
@@ -319,7 +317,9 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
                 "gsi3pk": identity,
                 "gsi3sk": f"{timestamp(run.created_at)}#{key_component(run.run_id)}",
             }
-            self._put_direct(encode_marker("RUN_DEP", marker_key, base_key, attributes))
+            marker = encode_marker("RUN_DEP", marker_key, base_key, attributes)
+            actions.append(put_action(self._table_name, marker, None))
+        self._transact(tuple(actions))
 
     def get_run(self, tenant_id: str, run_id: str) -> Run | None:
         """Retorna o run solicitado."""

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -94,10 +94,16 @@ class DynamoDBClaims:
         """Renova o lease de um job fenced."""
         item, job = self._leased_job(command.tenant_id, command.job_id)
         self._validate_job_fence(job, command.owner, command.fencing_token, command.now)
+        agent_item = self._active_agent_item(job)
         updated = job.model_copy(
             update={"lease_until": command.now + timedelta(seconds=command.lease_seconds)}
         )
-        self._transact((put_action(self._table_name, self._job_item(updated), payload(item)),))
+        self._transact(
+            (
+                check_action(self._table_name, agent_item),
+                put_action(self._table_name, self._job_item(updated), payload(item)),
+            )
+        )
         return updated
 
     def complete_job(self, command: CompleteJob, event: Any) -> Job:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -28,6 +28,7 @@ from cnes_infra.control_plane.dynamodb_codec import (
 from cnes_infra.control_plane.dynamodb_keys import (
     dispatch_key,
     entity_key,
+    key_component,
     run_entity_key,
     unit_key,
 )
@@ -52,7 +53,10 @@ class DynamoDBClaims:
 
     def _dispatch_item(self, dispatch: RunDispatch) -> Item:
         attributes = {
-            "gsi5pk": f"RUN_ITEMS#{dispatch.tenant_id}#{dispatch.run_id}",
+            "gsi5pk": (
+                f"RUN_ITEMS#{key_component(dispatch.tenant_id)}#"
+                f"{key_component(dispatch.run_id)}"
+            ),
             "gsi5sk": "DISPATCH#ACTIVE",
         }
         key = dispatch_key(dispatch.tenant_id, dispatch.run_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -61,7 +61,6 @@ class DynamoDBClaims:
         }
         key = dispatch_key(dispatch.tenant_id, dispatch.run_id)
         return encode_model(dispatch, "RUNDISPATCH", key, attributes)
-
     def claim_job(self, command: ClaimJob) -> Job | None:
         """Reivindica um job elegível com novo fence."""
         key = entity_key(command.tenant_id, "JOB", command.job_id)
@@ -93,7 +92,6 @@ class DynamoDBClaims:
         except Conflict:
             return None
         return updated
-
     def renew_job_lease(self, command: RenewJobLease) -> Job:
         """Renova o lease de um job fenced."""
         item, job = self._leased_job(command.tenant_id, command.job_id)
@@ -109,9 +107,9 @@ class DynamoDBClaims:
             )
         )
         return updated
-
-    def complete_job(self, command: CompleteJob, event: Any) -> Job:
-        """Conclui job, manifesto e evento atomicamente."""
+    def _complete_job_actions(
+        self, command: CompleteJob, event: Any
+    ) -> tuple[Job, tuple[Action, ...]]:
         item, job = self._leased_job(command.tenant_id, command.job_id)
         self._validate_job_fence(job, command.owner, command.fencing_token, self._clock())
         agent_item = self._active_agent_item(job)
@@ -144,7 +142,15 @@ class DynamoDBClaims:
             self._latest_job_action(updated),
             self._event_action(job.tenant_id, event),
         )
-        self._transact(actions)
+        return updated, actions
+    def complete_job(self, command: CompleteJob, event: Any) -> Job:
+        """Conclui job, manifesto e evento atomicamente."""
+        updated, actions = self._complete_job_actions(command, event)
+        try:
+            self._transact(actions)
+        except Conflict:
+            updated, actions = self._complete_job_actions(command, event)
+            self._transact(actions)
         return updated
     def fail_job(self, command: FailJob, event: Any) -> Job:
         """Falha um job leased e grava seu evento."""
@@ -167,7 +173,6 @@ class DynamoDBClaims:
             )
         )
         return updated
-
     def _leased_job(self, tenant_id: str, job_id: str) -> tuple[Item, Job]:
         item = self._get_item(entity_key(tenant_id, "JOB", job_id))
         if item is None:
@@ -176,7 +181,6 @@ class DynamoDBClaims:
         if job.state is not JobState.LEASED:
             raise LeaseLost("job_not_leased")
         return item, job
-
     @staticmethod
     def _validate_job_fence(job: Job, owner: str, fence: int, now: Any) -> None:
         if job.fencing_token != fence:
@@ -185,13 +189,11 @@ class DynamoDBClaims:
             raise LeaseLost("job_owner_lost")
         if job.lease_until is None or job.lease_until <= now:
             raise LeaseLost("job_lease_expired")
-
     def _active_agent_item(self, job: Job) -> Item:
         item = self._get_item(entity_key(job.tenant_id, "AGENT", job.agent_id))
         if item is None or decode_model(item, Agent).state is not AgentState.ACTIVE:
             raise LeaseLost("agent_revoked")
         return item
-
     def claim_run_unit(self, command: ClaimRunUnit) -> RunUnit | None:
         """Reivindica uma unidade despachada com novo fence."""
         context = self._unit_claim_context(command)
@@ -223,7 +225,6 @@ class DynamoDBClaims:
         except Conflict:
             return None
         return updated
-
     def _unit_claim_context(self, command: ClaimRunUnit) -> tuple[Any, ...] | None:
         run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
         dispatch_item = self._get_item(dispatch_key(command.tenant_id, command.run_id))
@@ -248,7 +249,6 @@ class DynamoDBClaims:
         if run.state is not RunState.PROCESSING or not valid_dispatch or not claimable:
             return None
         return run_item, dispatch_item, unit_item, unit
-
     def commit_run_unit(self, command: CommitRunUnit, event: Any) -> RunUnit:
         """Confirma a saída de uma unidade fenced."""
         context = self._leased_unit_context(command)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -1,0 +1,458 @@
+"""DynamoDB lease, fence, unit, and dispatch transactions."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from hashlib import sha256
+from typing import TYPE_CHECKING, Any
+
+from cnes_domain.control_plane.entities import Agent, Job, Run, RunDispatch, RunUnit
+from cnes_domain.control_plane.enums import (
+    AgentState,
+    DispatchState,
+    JobState,
+    RunState,
+    RunUnitState,
+)
+from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
+from cnes_domain.control_plane.transitions import transition_job, transition_run_unit
+from cnes_infra.control_plane.dynamodb_codec import (
+    Action,
+    Item,
+    check_action,
+    decode_model,
+    encode_model,
+    payload,
+    put_action,
+)
+from cnes_infra.control_plane.dynamodb_keys import (
+    dispatch_key,
+    entity_key,
+    run_entity_key,
+    unit_key,
+)
+
+if TYPE_CHECKING:
+    from cnes_domain.control_plane.commands import (
+        BindRunDispatch,
+        ClaimJob,
+        ClaimRunUnit,
+        CommitRunUnit,
+        CompleteJob,
+        FailJob,
+        FailRunUnit,
+        FinishRunDispatch,
+        RenewJobLease,
+        ReserveRunDispatch,
+    )
+
+
+class DynamoDBClaims:
+    """Implementa decisões protegidas por lease e fencing token."""
+
+    def _dispatch_item(self, dispatch: RunDispatch) -> Item:
+        attributes = {
+            "gsi5pk": f"RUN_ITEMS#{dispatch.tenant_id}#{dispatch.run_id}",
+            "gsi5sk": "DISPATCH#ACTIVE",
+        }
+        key = dispatch_key(dispatch.tenant_id, dispatch.run_id)
+        return encode_model(dispatch, "RUNDISPATCH", key, attributes)
+
+    def claim_job(self, command: ClaimJob) -> Job | None:
+        """Reivindica um job elegível com novo fence."""
+        key = entity_key(command.tenant_id, "JOB", command.job_id)
+        item = self._get_item(key)
+        if item is None:
+            return None
+        job = decode_model(item, Job)
+        agent_item = self._get_item(entity_key(command.tenant_id, "AGENT", job.agent_id))
+        if agent_item is None or decode_model(agent_item, Agent).state is not AgentState.ACTIVE:
+            return None
+        if not self._job_is_claimable(job, command.now):
+            return None
+        leased = transition_job(job, JobState.LEASED) if job.state is not JobState.LEASED else job
+        updated = leased.model_copy(
+            update={
+                "attempt": job.attempt + 1,
+                "fencing_token": job.fencing_token + 1,
+                "lease_owner": command.owner,
+                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+                "error_code": None,
+            }
+        )
+        actions = (
+            check_action(self._table_name, agent_item),
+            put_action(self._table_name, self._job_item(updated), payload(item)),
+        )
+        try:
+            self._transact(actions)
+        except Conflict:
+            return None
+        return updated
+
+    def renew_job_lease(self, command: RenewJobLease) -> Job:
+        """Renova o lease de um job fenced."""
+        item, job = self._leased_job(command.tenant_id, command.job_id)
+        self._validate_job_fence(job, command.owner, command.fencing_token, command.now)
+        updated = job.model_copy(
+            update={"lease_until": command.now + timedelta(seconds=command.lease_seconds)}
+        )
+        self._transact((put_action(self._table_name, self._job_item(updated), payload(item)),))
+        return updated
+
+    def complete_job(self, command: CompleteJob, event: Any) -> Job:
+        """Conclui job, manifesto e evento atomicamente."""
+        item, job = self._leased_job(command.tenant_id, command.job_id)
+        self._validate_job_fence(job, command.owner, command.fencing_token, self._clock())
+        agent_item = self._active_agent_item(job)
+        identity = (job.tenant_id, job.agent_id, job.source_type, job.file_subtype, job.competencia)
+        manifest_identity = (
+            command.manifest.tenant_id,
+            command.manifest.agent_id,
+            command.manifest.source_type,
+            command.manifest.file_subtype,
+            command.manifest.competencia,
+        )
+        if identity != manifest_identity:
+            raise Conflict("manifest_identity_conflict")
+        updated = Job.model_validate(
+            job.model_dump()
+            | {
+                "state": JobState.SUCCEEDED,
+                "lease_owner": None,
+                "lease_until": None,
+                "result_manifest_id": command.manifest.manifest_id,
+                "result_manifest_key": command.manifest.manifest_key,
+            }
+        )
+        actions = (
+            check_action(self._table_name, agent_item),
+            put_action(self._table_name, self._job_item(updated), payload(item)),
+            put_action(self._table_name, self._raw_item(command.manifest), None),
+            self._event_action(event),
+        )
+        self._transact(actions)
+        return updated
+
+    def fail_job(self, command: FailJob, event: Any) -> Job:
+        """Falha um job leased e grava seu evento."""
+        item, job = self._leased_job(command.tenant_id, command.job_id)
+        self._validate_job_fence(job, command.owner, command.fencing_token, self._clock())
+        state = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
+        updated = transition_job(job, state).model_copy(
+            update={
+                "lease_owner": None,
+                "lease_until": None,
+                "error_code": command.error_code,
+            }
+        )
+        self._transact(
+            (
+                put_action(self._table_name, self._job_item(updated), payload(item)),
+                self._event_action(event),
+            )
+        )
+        return updated
+
+    def _leased_job(self, tenant_id: str, job_id: str) -> tuple[Item, Job]:
+        item = self._get_item(entity_key(tenant_id, "JOB", job_id))
+        if item is None:
+            raise NotFound("job_missing")
+        job = decode_model(item, Job)
+        if job.state is not JobState.LEASED:
+            raise LeaseLost("job_not_leased")
+        return item, job
+
+    @staticmethod
+    def _validate_job_fence(job: Job, owner: str, fence: int, now: Any) -> None:
+        if job.fencing_token != fence:
+            raise FenceRejected("job_fence_rejected")
+        if job.lease_owner != owner:
+            raise LeaseLost("job_owner_lost")
+        if job.lease_until is None or job.lease_until <= now:
+            raise LeaseLost("job_lease_expired")
+
+    def _active_agent_item(self, job: Job) -> Item:
+        item = self._get_item(entity_key(job.tenant_id, "AGENT", job.agent_id))
+        if item is None or decode_model(item, Agent).state is not AgentState.ACTIVE:
+            raise LeaseLost("agent_revoked")
+        return item
+
+    def claim_run_unit(self, command: ClaimRunUnit) -> RunUnit | None:
+        """Reivindica uma unidade despachada com novo fence."""
+        context = self._unit_claim_context(command)
+        if context is None:
+            return None
+        run_item, dispatch_item, unit_item, unit = context
+        leased = (
+            transition_run_unit(unit, RunUnitState.LEASED)
+            if unit.state is not RunUnitState.LEASED
+            else unit
+        )
+        updated = leased.model_copy(
+            update={
+                "attempt": unit.attempt + 1,
+                "fencing_token": unit.fencing_token + 1,
+                "lease_owner": command.owner,
+                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+                "dispatch_id": command.dispatch_id,
+                "error_code": None,
+            }
+        )
+        actions = (
+            check_action(self._table_name, run_item),
+            check_action(self._table_name, dispatch_item),
+            put_action(self._table_name, self._unit_item(updated), payload(unit_item)),
+        )
+        try:
+            self._transact(actions)
+        except Conflict:
+            return None
+        return updated
+
+    def _unit_claim_context(self, command: ClaimRunUnit) -> tuple[Any, ...] | None:
+        run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
+        dispatch_item = self._get_item(dispatch_key(command.tenant_id, command.run_id))
+        unit_item = self._get_item(unit_key(command.tenant_id, command.run_id, command.unit_id))
+        if run_item is None or dispatch_item is None or unit_item is None:
+            return None
+        run = decode_model(run_item, Run)
+        dispatch = decode_model(dispatch_item, RunDispatch)
+        unit = decode_model(unit_item, RunUnit)
+        valid_dispatch = (
+            dispatch.dispatch_id == command.dispatch_id
+            and dispatch.state in {DispatchState.RESERVED, DispatchState.STARTED}
+            and dispatch.lease_until > command.now
+            and command.unit_id in dispatch.unit_ids
+        )
+        claimable = unit.state in {RunUnitState.PENDING, RunUnitState.FAILED_RETRYABLE}
+        claimable = claimable or (
+            unit.state is RunUnitState.LEASED
+            and unit.lease_until is not None
+            and unit.lease_until <= command.now
+        )
+        if run.state is not RunState.PROCESSING or not valid_dispatch or not claimable:
+            return None
+        return run_item, dispatch_item, unit_item, unit
+
+    def commit_run_unit(self, command: CommitRunUnit, event: Any) -> RunUnit:
+        """Confirma a saída de uma unidade fenced."""
+        context = self._leased_unit_context(command)
+        run_item, dispatch_item, unit_item, run, unit = context
+        candidate = unit.model_copy(
+            update={
+                "output_manifests": command.output_manifests,
+                "lease_owner": None,
+                "lease_until": None,
+            }
+        )
+        updated = transition_run_unit(candidate, RunUnitState.SUCCEEDED, run)
+        actions = (
+            check_action(self._table_name, run_item),
+            check_action(self._table_name, dispatch_item),
+            put_action(self._table_name, self._unit_item(updated), payload(unit_item)),
+            self._event_action(event),
+        )
+        self._transact(actions)
+        return updated
+
+    def fail_run_unit(self, command: FailRunUnit, event: Any) -> RunUnit:
+        """Falha ou degrada uma unidade fenced."""
+        context = self._leased_unit_context(command)
+        run_item, dispatch_item, unit_item, run, unit = context
+        state = self._failed_unit_state(run, unit, command.retryable)
+        candidate = unit.model_copy(
+            update={
+                "error_code": command.error_code,
+                "lease_owner": None,
+                "lease_until": None,
+            }
+        )
+        updated = transition_run_unit(candidate, state, run)
+        actions: list[Action] = [
+            check_action(self._table_name, dispatch_item),
+            put_action(self._table_name, self._unit_item(updated), payload(unit_item)),
+        ]
+        if state is RunUnitState.SUCCEEDED_DEGRADED:
+            source = f"{unit.source_type}/{unit.file_subtype}"
+            missing = tuple(sorted({*run.missing_sources, source}))
+            updated_run = run.model_copy(update={"missing_sources": missing})
+            actions.append(
+                put_action(self._table_name, self._run_item(updated_run), payload(run_item))
+            )
+        else:
+            actions.append(check_action(self._table_name, run_item))
+        actions.append(self._event_action(event))
+        self._transact(tuple(actions))
+        return updated
+
+    def _leased_unit_context(self, command: Any) -> tuple[Any, ...]:
+        run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
+        dispatch_item = self._get_item(dispatch_key(command.tenant_id, command.run_id))
+        unit_item = self._get_item(unit_key(command.tenant_id, command.run_id, command.unit_id))
+        if run_item is None or dispatch_item is None or unit_item is None:
+            raise NotFound("unit_context_missing")
+        run = decode_model(run_item, Run)
+        dispatch = decode_model(dispatch_item, RunDispatch)
+        unit = decode_model(unit_item, RunUnit)
+        if run.state is not RunState.PROCESSING:
+            raise LeaseLost("run_not_processing")
+        self._validate_dispatch_lease(dispatch, command.dispatch_id, self._clock())
+        self._validate_unit_fence(unit, command, self._clock())
+        return run_item, dispatch_item, unit_item, run, unit
+
+    @staticmethod
+    def _validate_dispatch_lease(dispatch: RunDispatch, dispatch_id: str, now: Any) -> None:
+        if dispatch.dispatch_id != dispatch_id:
+            raise FenceRejected("dispatch_fence_rejected")
+        if dispatch.state not in {DispatchState.RESERVED, DispatchState.STARTED}:
+            raise LeaseLost("dispatch_terminal")
+        if dispatch.lease_until <= now:
+            raise LeaseLost("dispatch_expired")
+
+    @staticmethod
+    def _validate_unit_fence(unit: RunUnit, command: Any, now: Any) -> None:
+        if unit.fencing_token != command.fencing_token:
+            raise FenceRejected("unit_fence_rejected")
+        if unit.dispatch_id != command.dispatch_id:
+            raise FenceRejected("unit_dispatch_rejected")
+        if unit.lease_owner != command.owner:
+            raise LeaseLost("unit_owner_lost")
+        if unit.lease_until is None or unit.lease_until <= now:
+            raise LeaseLost("unit_lease_expired")
+
+    @staticmethod
+    def _failed_unit_state(run: Run, unit: RunUnit, retryable: bool) -> RunUnitState:
+        if retryable:
+            return RunUnitState.FAILED_RETRYABLE
+        dependency = next(
+            (
+                item
+                for item in run.dependencies
+                if (item.source_type, item.file_subtype) == (unit.source_type, unit.file_subtype)
+            ),
+            None,
+        )
+        if dependency is not None and not dependency.required:
+            return RunUnitState.SUCCEEDED_DEGRADED
+        return RunUnitState.FAILED_FINAL
+
+    def reserve_run_dispatch(self, command: ReserveRunDispatch) -> RunDispatch:
+        """Reserva uma geração de dispatch do run."""
+        run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
+        if run_item is None or decode_model(run_item, Run).state is not RunState.PROCESSING:
+            raise Conflict("run_not_processing")
+        current_item = self._get_item(dispatch_key(command.tenant_id, command.run_id))
+        current = decode_model(current_item, RunDispatch) if current_item else None
+        replay = self._dispatch_replay(current, command)
+        if replay is not None:
+            return replay
+        unit_items = self._dispatch_unit_items(command)
+        generation = 1 if current is None else current.generation + 1
+        raw_id = f"{command.tenant_id}\x1f{command.run_id}\x1f{command.wave_id}\x1f{generation}"
+        dispatch = RunDispatch(
+            tenant_id=command.tenant_id,
+            run_id=command.run_id,
+            wave_id=command.wave_id,
+            dispatch_id=sha256(raw_id.encode()).hexdigest()[:16],
+            generation=generation,
+            unit_ids=command.unit_ids,
+            state=DispatchState.RESERVED,
+            lease_until=command.now + timedelta(seconds=command.lease_seconds),
+        )
+        expected = payload(current_item) if current_item is not None else None
+        actions = [check_action(self._table_name, run_item)]
+        actions.extend(check_action(self._table_name, item) for item in unit_items)
+        actions.append(put_action(self._table_name, self._dispatch_item(dispatch), expected))
+        self._transact(tuple(actions))
+        return dispatch
+
+    @staticmethod
+    def _dispatch_replay(
+        current: RunDispatch | None, command: ReserveRunDispatch
+    ) -> RunDispatch | None:
+        if current is None:
+            return None
+        active = current.state is not DispatchState.TERMINAL and current.lease_until > command.now
+        same = current.wave_id == command.wave_id and current.unit_ids == command.unit_ids
+        if active and same:
+            return current
+        replaceable = current.state is DispatchState.TERMINAL or (
+            current.state is DispatchState.RESERVED and current.lease_until <= command.now
+        )
+        if not replaceable:
+            raise Conflict("active_dispatch_conflict")
+        return None
+
+    def _dispatch_unit_items(self, command: ReserveRunDispatch) -> tuple[Item, ...]:
+        items = []
+        for unit_id in command.unit_ids:
+            item = self._get_item(unit_key(command.tenant_id, command.run_id, unit_id))
+            if item is None:
+                raise Conflict("dispatch_unit_missing")
+            unit = decode_model(item, RunUnit)
+            claimable = unit.state in {RunUnitState.PENDING, RunUnitState.FAILED_RETRYABLE}
+            claimable = claimable or (
+                unit.state is RunUnitState.LEASED
+                and unit.lease_until is not None
+                and unit.lease_until <= command.now
+            )
+            if not claimable:
+                raise Conflict("dispatch_unit_unavailable")
+            items.append(item)
+        return tuple(items)
+
+    def bind_run_dispatch(self, command: BindRunDispatch) -> RunDispatch:
+        """Vincula o dispatch a uma execução externa."""
+        item, dispatch = self._required_dispatch(command.tenant_id, command.run_id)
+        self._validate_dispatch_lease(dispatch, command.dispatch_id, command.now)
+        if dispatch.state is DispatchState.STARTED:
+            if dispatch.execution_ref == command.execution_ref:
+                return dispatch
+            raise Conflict("dispatch_binding_conflict")
+        updated = dispatch.model_copy(
+            update={
+                "state": DispatchState.STARTED,
+                "execution_ref": command.execution_ref,
+                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+            }
+        )
+        self._transact((put_action(self._table_name, self._dispatch_item(updated), payload(item)),))
+        return updated
+
+    def finish_run_dispatch(self, command: FinishRunDispatch) -> RunDispatch:
+        """Finaliza um dispatch ativo."""
+        item, dispatch = self._required_dispatch(command.tenant_id, command.run_id)
+        if dispatch.dispatch_id != command.dispatch_id:
+            raise Conflict("dispatch_id_conflict")
+        if dispatch.state is DispatchState.TERMINAL:
+            if dispatch.terminal_outcome is command.outcome:
+                return dispatch
+            raise Conflict("dispatch_outcome_conflict")
+        if dispatch.lease_until <= command.finished_at:
+            raise Conflict("dispatch_expired")
+        updated = dispatch.model_copy(
+            update={
+                "state": DispatchState.TERMINAL,
+                "terminal_outcome": command.outcome,
+            }
+        )
+        self._transact((put_action(self._table_name, self._dispatch_item(updated), payload(item)),))
+        return updated
+
+    def _required_dispatch(self, tenant_id: str, run_id: str) -> tuple[Item, RunDispatch]:
+        item = self._get_item(dispatch_key(tenant_id, run_id))
+        if item is None:
+            raise NotFound("dispatch_missing")
+        return item, decode_model(item, RunDispatch)
+
+    def get_active_run_dispatch(self, tenant_id: str, run_id: str) -> RunDispatch | None:
+        """Retorna o dispatch ativo do run."""
+        item = self._get_item(dispatch_key(tenant_id, run_id))
+        if item is None:
+            return None
+        dispatch = decode_model(item, RunDispatch)
+        active = (
+            dispatch.state is not DispatchState.TERMINAL and dispatch.lease_until > self._clock()
+        )
+        return dispatch if active else None

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -141,11 +141,11 @@ class DynamoDBClaims:
             check_action(self._table_name, agent_item),
             put_action(self._table_name, self._job_item(updated), payload(item)),
             put_action(self._table_name, self._raw_item(command.manifest), None),
+            self._latest_job_action(updated),
             self._event_action(job.tenant_id, event),
         )
         self._transact(actions)
         return updated
-
     def fail_job(self, command: FailJob, event: Any) -> Job:
         """Falha um job leased e grava seu evento."""
         item, job = self._leased_job(command.tenant_id, command.job_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -269,9 +269,9 @@ class DynamoDBClaims:
         )
         self._transact(actions)
         return updated
-
-    def fail_run_unit(self, command: FailRunUnit, event: Any) -> RunUnit:
-        """Falha ou degrada uma unidade fenced."""
+    def _fail_run_unit_actions(
+        self, command: FailRunUnit, event: Any
+    ) -> tuple[RunUnit, tuple[Action, ...]]:
         context = self._leased_unit_context(command)
         run_item, dispatch_item, unit_item, run, unit = context
         state = self._failed_unit_state(run, unit, command.retryable)
@@ -297,9 +297,16 @@ class DynamoDBClaims:
         else:
             actions.append(check_action(self._table_name, run_item))
         actions.append(self._event_action(command.tenant_id, event))
-        self._transact(tuple(actions))
+        return updated, tuple(actions)
+    def fail_run_unit(self, command: FailRunUnit, event: Any) -> RunUnit:
+        """Falha ou degrada uma unidade fenced."""
+        updated, actions = self._fail_run_unit_actions(command, event)
+        try:
+            self._transact(actions)
+        except Conflict:
+            updated, actions = self._fail_run_unit_actions(command, event)
+            self._transact(actions)
         return updated
-
     def _leased_unit_context(self, command: Any) -> tuple[Any, ...]:
         run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
         dispatch_item = self._get_item(dispatch_key(command.tenant_id, command.run_id))
@@ -314,7 +321,6 @@ class DynamoDBClaims:
         self._validate_dispatch_lease(dispatch, command.dispatch_id, self._clock())
         self._validate_unit_fence(unit, command, self._clock())
         return run_item, dispatch_item, unit_item, run, unit
-
     @staticmethod
     def _validate_dispatch_lease(dispatch: RunDispatch, dispatch_id: str, now: Any) -> None:
         if dispatch.dispatch_id != dispatch_id:
@@ -323,7 +329,6 @@ class DynamoDBClaims:
             raise LeaseLost("dispatch_terminal")
         if dispatch.lease_until <= now:
             raise LeaseLost("dispatch_expired")
-
     @staticmethod
     def _validate_unit_fence(unit: RunUnit, command: Any, now: Any) -> None:
         if unit.fencing_token != command.fencing_token:
@@ -334,7 +339,6 @@ class DynamoDBClaims:
             raise LeaseLost("unit_owner_lost")
         if unit.lease_until is None or unit.lease_until <= now:
             raise LeaseLost("unit_lease_expired")
-
     @staticmethod
     def _failed_unit_state(run: Run, unit: RunUnit, retryable: bool) -> RunUnitState:
         if retryable:
@@ -350,7 +354,6 @@ class DynamoDBClaims:
         if dependency is not None and not dependency.required:
             return RunUnitState.SUCCEEDED_DEGRADED
         return RunUnitState.FAILED_FINAL
-
     def reserve_run_dispatch(self, command: ReserveRunDispatch) -> RunDispatch:
         """Reserva uma geração de dispatch do run."""
         run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
@@ -387,7 +390,6 @@ class DynamoDBClaims:
         actions.append(put_action(self._table_name, self._dispatch_item(dispatch), expected))
         self._transact(tuple(actions))
         return dispatch
-
     @staticmethod
     def _dispatch_replay(
         current: RunDispatch | None, command: ReserveRunDispatch
@@ -402,7 +404,6 @@ class DynamoDBClaims:
         if not replaceable:
             raise Conflict("active_dispatch_conflict")
         return None
-
     def _replacement_unit_items(self, dispatch: RunDispatch, now: Any) -> tuple[Item, ...]:
         items = []
         for unit_id in dispatch.unit_ids:
@@ -419,7 +420,6 @@ class DynamoDBClaims:
                 raise Conflict("dispatch_unit_unavailable")
             items.append(item)
         return tuple(items)
-
     def _dispatch_unit_items(self, command: ReserveRunDispatch) -> tuple[Item, ...]:
         items = []
         for unit_id in command.unit_ids:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -115,13 +115,15 @@ class DynamoDBClaims:
         item, job = self._leased_job(command.tenant_id, command.job_id)
         self._validate_job_fence(job, command.owner, command.fencing_token, self._clock())
         agent_item = self._active_agent_item(job)
-        identity = (job.tenant_id, job.agent_id, job.source_type, job.file_subtype, job.competencia)
+        identity = (job.tenant_id, job.agent_id, job.source_type, job.file_subtype,
+                    job.competencia, job.requested_snapshot_mode)
         manifest_identity = (
             command.manifest.tenant_id,
             command.manifest.agent_id,
             command.manifest.source_type,
             command.manifest.file_subtype,
             command.manifest.competencia,
+            command.manifest.snapshot_mode,
         )
         if identity != manifest_identity:
             raise Conflict("manifest_identity_conflict")
@@ -360,7 +362,7 @@ class DynamoDBClaims:
         if replay is not None:
             return replay
         prior_unit_items = ()
-        if current is not None and current.state is not DispatchState.TERMINAL:
+        if current is not None:
             prior_unit_items = self._replacement_unit_items(current, command.now)
         unit_items = self._dispatch_unit_items(command)
         generation = 1 if current is None else current.generation + 1

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -54,8 +54,7 @@ class DynamoDBClaims:
     def _dispatch_item(self, dispatch: RunDispatch) -> Item:
         attributes = {
             "gsi5pk": (
-                f"RUN_ITEMS#{key_component(dispatch.tenant_id)}#"
-                f"{key_component(dispatch.run_id)}"
+                f"RUN_ITEMS#{key_component(dispatch.tenant_id)}#{key_component(dispatch.run_id)}"
             ),
             "gsi5sk": "DISPATCH#ACTIVE",
         }
@@ -113,15 +112,13 @@ class DynamoDBClaims:
         item, job = self._leased_job(command.tenant_id, command.job_id)
         self._validate_job_fence(job, command.owner, command.fencing_token, self._clock())
         agent_item = self._active_agent_item(job)
-        identity = (job.tenant_id, job.agent_id, job.source_type, job.file_subtype,
-                    job.competencia, job.requested_snapshot_mode)
+        identity = (job.tenant_id, job.agent_id, job.source_type, job.file_subtype, job.competencia)
         manifest_identity = (
             command.manifest.tenant_id,
             command.manifest.agent_id,
             command.manifest.source_type,
             command.manifest.file_subtype,
             command.manifest.competencia,
-            command.manifest.snapshot_mode,
         )
         if identity != manifest_identity:
             raise Conflict("manifest_identity_conflict")
@@ -145,13 +142,16 @@ class DynamoDBClaims:
         return updated, actions
     def complete_job(self, command: CompleteJob, event: Any) -> Job:
         """Conclui job, manifesto e evento atomicamente."""
-        updated, actions = self._complete_job_actions(command, event)
-        try:
-            self._transact(actions)
-        except Conflict:
+        conflict = None
+        for _ in range(3):
             updated, actions = self._complete_job_actions(command, event)
-            self._transact(actions)
-        return updated
+            try:
+                self._transact(actions)
+            except Conflict as error:
+                conflict = error
+                continue
+            return updated
+        raise TimeoutError("transaction_contention") from conflict
     def fail_job(self, command: FailJob, event: Any) -> Job:
         """Falha um job leased e grava seu evento."""
         item, job = self._leased_job(command.tenant_id, command.job_id)
@@ -234,19 +234,14 @@ class DynamoDBClaims:
         run = decode_model(run_item, Run)
         dispatch = decode_model(dispatch_item, RunDispatch)
         unit = decode_model(unit_item, RunUnit)
-        valid_dispatch = (
-            dispatch.dispatch_id == command.dispatch_id
-            and dispatch.state in {DispatchState.RESERVED, DispatchState.STARTED}
-            and dispatch.lease_until > command.now
-            and command.unit_id in dispatch.unit_ids
-        )
-        claimable = unit.state in {RunUnitState.PENDING, RunUnitState.FAILED_RETRYABLE}
-        claimable = claimable or (
-            unit.state is RunUnitState.LEASED
-            and unit.lease_until is not None
-            and unit.lease_until <= command.now
-        )
-        if run.state is not RunState.PROCESSING or not valid_dispatch or not claimable:
+        if (
+            run.state is not RunState.PROCESSING
+            or dispatch.dispatch_id != command.dispatch_id
+            or dispatch.state not in {DispatchState.RESERVED, DispatchState.STARTED}
+            or dispatch.lease_until <= command.now
+            or command.unit_id not in dispatch.unit_ids
+            or not self._unit_is_claimable(unit, command.now)
+        ):
             return None
         return run_item, dispatch_item, unit_item, unit
     def commit_run_unit(self, command: CommitRunUnit, event: Any) -> RunUnit:
@@ -339,6 +334,7 @@ class DynamoDBClaims:
             raise LeaseLost("unit_owner_lost")
         if unit.lease_until is None or unit.lease_until <= now:
             raise LeaseLost("unit_lease_expired")
+
     @staticmethod
     def _failed_unit_state(run: Run, unit: RunUnit, retryable: bool) -> RunUnitState:
         if retryable:
@@ -354,6 +350,7 @@ class DynamoDBClaims:
         if dependency is not None and not dependency.required:
             return RunUnitState.SUCCEEDED_DEGRADED
         return RunUnitState.FAILED_FINAL
+
     def reserve_run_dispatch(self, command: ReserveRunDispatch) -> RunDispatch:
         """Reserva uma geração de dispatch do run."""
         run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
@@ -382,28 +379,26 @@ class DynamoDBClaims:
         )
         expected = payload(current_item) if current_item is not None else None
         checked_items = {
-            (item["pk"]["S"], item["sk"]["S"]): item
-            for item in (*prior_unit_items, *unit_items)
+            (item["pk"]["S"], item["sk"]["S"]): item for item in (*prior_unit_items, *unit_items)
         }
         actions = [check_action(self._table_name, run_item)]
         actions.extend(check_action(self._table_name, item) for item in checked_items.values())
         actions.append(put_action(self._table_name, self._dispatch_item(dispatch), expected))
         self._transact(tuple(actions))
         return dispatch
+
     @staticmethod
     def _dispatch_replay(
         current: RunDispatch | None, command: ReserveRunDispatch
     ) -> RunDispatch | None:
         if current is None:
             return None
-        active = current.state is not DispatchState.TERMINAL and current.lease_until > command.now
-        same = current.wave_id == command.wave_id and current.unit_ids == command.unit_ids
-        if active and same:
-            return current
-        replaceable = current.state is DispatchState.TERMINAL or current.lease_until <= command.now
-        if not replaceable:
+        if current.state is DispatchState.TERMINAL or current.lease_until <= command.now:
+            return None
+        if current.wave_id != command.wave_id or current.unit_ids != command.unit_ids:
             raise Conflict("active_dispatch_conflict")
-        return None
+        return current
+
     def _replacement_unit_items(self, dispatch: RunDispatch, now: Any) -> tuple[Item, ...]:
         items = []
         for unit_id in dispatch.unit_ids:
@@ -420,6 +415,7 @@ class DynamoDBClaims:
                 raise Conflict("dispatch_unit_unavailable")
             items.append(item)
         return tuple(items)
+
     def _dispatch_unit_items(self, command: ReserveRunDispatch) -> tuple[Item, ...]:
         items = []
         for unit_id in command.unit_ids:
@@ -427,16 +423,18 @@ class DynamoDBClaims:
             if item is None:
                 raise Conflict("dispatch_unit_missing")
             unit = decode_model(item, RunUnit)
-            claimable = unit.state in {RunUnitState.PENDING, RunUnitState.FAILED_RETRYABLE}
-            claimable = claimable or (
-                unit.state is RunUnitState.LEASED
-                and unit.lease_until is not None
-                and unit.lease_until <= command.now
-            )
-            if not claimable:
+            if not self._unit_is_claimable(unit, command.now):
                 raise Conflict("dispatch_unit_unavailable")
             items.append(item)
         return tuple(items)
+
+    @staticmethod
+    def _unit_is_claimable(unit: RunUnit, now: Any) -> bool:
+        return unit.state in {RunUnitState.PENDING, RunUnitState.FAILED_RETRYABLE} or (
+            unit.state is RunUnitState.LEASED
+            and unit.lease_until is not None
+            and unit.lease_until <= now
+        )
 
     def bind_run_dispatch(self, command: BindRunDispatch) -> RunDispatch:
         """Vincula o dispatch a uma execução externa."""
@@ -456,10 +454,12 @@ class DynamoDBClaims:
                 "lease_until": command.now + timedelta(seconds=command.lease_seconds),
             }
         )
-        self._transact((
-            check_action(self._table_name, run_item),
-            put_action(self._table_name, self._dispatch_item(updated), payload(item)),
-        ))
+        self._transact(
+            (
+                check_action(self._table_name, run_item),
+                put_action(self._table_name, self._dispatch_item(updated), payload(item)),
+            )
+        )
         return updated
 
     def finish_run_dispatch(self, command: FinishRunDispatch) -> RunDispatch:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -129,7 +129,7 @@ class DynamoDBClaims:
             check_action(self._table_name, agent_item),
             put_action(self._table_name, self._job_item(updated), payload(item)),
             put_action(self._table_name, self._raw_item(command.manifest), None),
-            self._event_action(event),
+            self._event_action(job.tenant_id, event),
         )
         self._transact(actions)
         return updated
@@ -149,7 +149,7 @@ class DynamoDBClaims:
         self._transact(
             (
                 put_action(self._table_name, self._job_item(updated), payload(item)),
-                self._event_action(event),
+                self._event_action(job.tenant_id, event),
             )
         )
         return updated
@@ -251,7 +251,7 @@ class DynamoDBClaims:
             check_action(self._table_name, run_item),
             check_action(self._table_name, dispatch_item),
             put_action(self._table_name, self._unit_item(updated), payload(unit_item)),
-            self._event_action(event),
+            self._event_action(command.tenant_id, event),
         )
         self._transact(actions)
         return updated
@@ -282,7 +282,7 @@ class DynamoDBClaims:
             )
         else:
             actions.append(check_action(self._table_name, run_item))
-        actions.append(self._event_action(event))
+        actions.append(self._event_action(command.tenant_id, event))
         self._transact(tuple(actions))
         return updated
 
@@ -347,6 +347,8 @@ class DynamoDBClaims:
         replay = self._dispatch_replay(current, command)
         if replay is not None:
             return replay
+        if current is not None and current.state is not DispatchState.TERMINAL:
+            self._validate_replacement_units(current, command.now)
         unit_items = self._dispatch_unit_items(command)
         generation = 1 if current is None else current.generation + 1
         raw_id = f"{command.tenant_id}\x1f{command.run_id}\x1f{command.wave_id}\x1f{generation}"
@@ -377,12 +379,24 @@ class DynamoDBClaims:
         same = current.wave_id == command.wave_id and current.unit_ids == command.unit_ids
         if active and same:
             return current
-        replaceable = current.state is DispatchState.TERMINAL or (
-            current.state is DispatchState.RESERVED and current.lease_until <= command.now
-        )
+        replaceable = current.state is DispatchState.TERMINAL or current.lease_until <= command.now
         if not replaceable:
             raise Conflict("active_dispatch_conflict")
         return None
+
+    def _validate_replacement_units(self, dispatch: RunDispatch, now: Any) -> None:
+        for unit_id in dispatch.unit_ids:
+            item = self._get_item(unit_key(dispatch.tenant_id, dispatch.run_id, unit_id))
+            if item is None:
+                raise Conflict("dispatch_unit_missing")
+            unit = decode_model(item, RunUnit)
+            live = (
+                unit.state is RunUnitState.LEASED
+                and unit.lease_until is not None
+                and unit.lease_until > now
+            )
+            if live:
+                raise Conflict("dispatch_unit_unavailable")
 
     def _dispatch_unit_items(self, command: ReserveRunDispatch) -> tuple[Item, ...]:
         items = []

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -113,18 +113,13 @@ class DynamoDBClaims:
         self._validate_job_fence(job, command.owner, command.fencing_token, self._clock())
         agent_item = self._active_agent_item(job)
         identity = (job.tenant_id, job.agent_id, job.source_type, job.file_subtype, job.competencia)
-        manifest_identity = (
-            command.manifest.tenant_id,
-            command.manifest.agent_id,
-            command.manifest.source_type,
-            command.manifest.file_subtype,
-            command.manifest.competencia,
-        )
+        manifest_identity = (command.manifest.tenant_id, command.manifest.agent_id,
+                             command.manifest.source_type, command.manifest.file_subtype,
+                             command.manifest.competencia)
         if identity != manifest_identity:
             raise Conflict("manifest_identity_conflict")
         updated = Job.model_validate(
-            job.model_dump()
-            | {
+            job.model_dump() | {
                 "state": JobState.SUCCEEDED,
                 "lease_owner": None,
                 "lease_until": None,
@@ -132,14 +127,26 @@ class DynamoDBClaims:
                 "result_manifest_key": command.manifest.manifest_key,
             }
         )
-        actions = (
-            check_action(self._table_name, agent_item),
+        actions = (check_action(self._table_name, agent_item),
             put_action(self._table_name, self._job_item(updated), payload(item)),
             *self._raw_actions(command.manifest),
             self._latest_job_action(updated),
             self._event_action(job.tenant_id, event),
         )
         return updated, actions
+    def _complete_job_replay(self, command: CompleteJob, event: Any, updated: Job) -> bool:
+        raw_item = self._raw_item(command.manifest)
+        return (
+            self.get_job(command.tenant_id, command.job_id) == updated
+            and self._get_model(
+                (raw_item["pk"]["S"], raw_item["sk"]["S"]), type(command.manifest)
+            ) == command.manifest
+            and self.latest_succeeded_job(
+                command.tenant_id, command.manifest.agent_id, command.manifest.source_type,
+                command.manifest.file_subtype, command.manifest.competencia,
+            ) == updated
+            and self._event_replay_matches(self._get_outbox_event(event.event_id), event)
+        )
     def complete_job(self, command: CompleteJob, event: Any) -> Job:
         """Conclui job, manifesto e evento atomicamente."""
         conflict = None
@@ -149,6 +156,8 @@ class DynamoDBClaims:
                 self._transact(actions)
             except Conflict as error:
                 conflict = error
+                if self._complete_job_replay(command, event, updated):
+                    return updated
                 continue
             return updated
         raise TimeoutError("transaction_contention") from conflict
@@ -350,7 +359,6 @@ class DynamoDBClaims:
         if dependency is not None and not dependency.required:
             return RunUnitState.SUCCEEDED_DEGRADED
         return RunUnitState.FAILED_FINAL
-
     def reserve_run_dispatch(self, command: ReserveRunDispatch) -> RunDispatch:
         """Reserva uma geração de dispatch do run."""
         run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
@@ -386,7 +394,6 @@ class DynamoDBClaims:
         actions.append(put_action(self._table_name, self._dispatch_item(dispatch), expected))
         self._transact(tuple(actions))
         return dispatch
-
     @staticmethod
     def _dispatch_replay(
         current: RunDispatch | None, command: ReserveRunDispatch
@@ -398,7 +405,6 @@ class DynamoDBClaims:
         if current.wave_id != command.wave_id or current.unit_ids != command.unit_ids:
             raise Conflict("active_dispatch_conflict")
         return current
-
     def _replacement_unit_items(self, dispatch: RunDispatch, now: Any) -> tuple[Item, ...]:
         items = []
         for unit_id in dispatch.unit_ids:
@@ -415,7 +421,6 @@ class DynamoDBClaims:
                 raise Conflict("dispatch_unit_unavailable")
             items.append(item)
         return tuple(items)
-
     def _dispatch_unit_items(self, command: ReserveRunDispatch) -> tuple[Item, ...]:
         items = []
         for unit_id in command.unit_ids:
@@ -427,7 +432,6 @@ class DynamoDBClaims:
                 raise Conflict("dispatch_unit_unavailable")
             items.append(item)
         return tuple(items)
-
     @staticmethod
     def _unit_is_claimable(unit: RunUnit, now: Any) -> bool:
         return unit.state in {RunUnitState.PENDING, RunUnitState.FAILED_RETRYABLE} or (
@@ -435,7 +439,6 @@ class DynamoDBClaims:
             and unit.lease_until is not None
             and unit.lease_until <= now
         )
-
     def bind_run_dispatch(self, command: BindRunDispatch) -> RunDispatch:
         """Vincula o dispatch a uma execução externa."""
         run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
@@ -461,7 +464,6 @@ class DynamoDBClaims:
             )
         )
         return updated
-
     def finish_run_dispatch(self, command: FinishRunDispatch) -> RunDispatch:
         """Finaliza um dispatch ativo."""
         item, dispatch = self._required_dispatch(command.tenant_id, command.run_id)
@@ -481,13 +483,11 @@ class DynamoDBClaims:
         )
         self._transact((put_action(self._table_name, self._dispatch_item(updated), payload(item)),))
         return updated
-
     def _required_dispatch(self, tenant_id: str, run_id: str) -> tuple[Item, RunDispatch]:
         item = self._get_item(dispatch_key(tenant_id, run_id))
         if item is None:
             raise NotFound("dispatch_missing")
         return item, decode_model(item, RunDispatch)
-
     def get_active_run_dispatch(self, tenant_id: str, run_id: str) -> RunDispatch | None:
         """Retorna o dispatch ativo do run."""
         item = self._get_item(dispatch_key(tenant_id, run_id))

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -144,6 +144,7 @@ class DynamoDBClaims:
         """Falha um job leased e grava seu evento."""
         item, job = self._leased_job(command.tenant_id, command.job_id)
         self._validate_job_fence(job, command.owner, command.fencing_token, self._clock())
+        agent_item = self._active_agent_item(job)
         state = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
         updated = transition_job(job, state).model_copy(
             update={
@@ -154,6 +155,7 @@ class DynamoDBClaims:
         )
         self._transact(
             (
+                check_action(self._table_name, agent_item),
                 put_action(self._table_name, self._job_item(updated), payload(item)),
                 self._event_action(job.tenant_id, event),
             )
@@ -432,6 +434,9 @@ class DynamoDBClaims:
 
     def bind_run_dispatch(self, command: BindRunDispatch) -> RunDispatch:
         """Vincula o dispatch a uma execução externa."""
+        run_item = self._get_item(run_entity_key(command.tenant_id, command.run_id))
+        if run_item is None or decode_model(run_item, Run).state is not RunState.PROCESSING:
+            raise Conflict("run_not_processing")
         item, dispatch = self._required_dispatch(command.tenant_id, command.run_id)
         self._validate_dispatch_lease(dispatch, command.dispatch_id, command.now)
         if dispatch.state is DispatchState.STARTED:
@@ -445,7 +450,10 @@ class DynamoDBClaims:
                 "lease_until": command.now + timedelta(seconds=command.lease_seconds),
             }
         )
-        self._transact((put_action(self._table_name, self._dispatch_item(updated), payload(item)),))
+        self._transact((
+            check_action(self._table_name, run_item),
+            put_action(self._table_name, self._dispatch_item(updated), payload(item)),
+        ))
         return updated
 
     def finish_run_dispatch(self, command: FinishRunDispatch) -> RunDispatch:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -140,7 +140,7 @@ class DynamoDBClaims:
         actions = (
             check_action(self._table_name, agent_item),
             put_action(self._table_name, self._job_item(updated), payload(item)),
-            put_action(self._table_name, self._raw_item(command.manifest), None),
+            *self._raw_actions(command.manifest),
             self._latest_job_action(updated),
             self._event_action(job.tenant_id, event),
         )

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -347,8 +347,9 @@ class DynamoDBClaims:
         replay = self._dispatch_replay(current, command)
         if replay is not None:
             return replay
+        prior_unit_items = ()
         if current is not None and current.state is not DispatchState.TERMINAL:
-            self._validate_replacement_units(current, command.now)
+            prior_unit_items = self._replacement_unit_items(current, command.now)
         unit_items = self._dispatch_unit_items(command)
         generation = 1 if current is None else current.generation + 1
         raw_id = f"{command.tenant_id}\x1f{command.run_id}\x1f{command.wave_id}\x1f{generation}"
@@ -363,8 +364,12 @@ class DynamoDBClaims:
             lease_until=command.now + timedelta(seconds=command.lease_seconds),
         )
         expected = payload(current_item) if current_item is not None else None
+        checked_items = {
+            (item["pk"]["S"], item["sk"]["S"]): item
+            for item in (*prior_unit_items, *unit_items)
+        }
         actions = [check_action(self._table_name, run_item)]
-        actions.extend(check_action(self._table_name, item) for item in unit_items)
+        actions.extend(check_action(self._table_name, item) for item in checked_items.values())
         actions.append(put_action(self._table_name, self._dispatch_item(dispatch), expected))
         self._transact(tuple(actions))
         return dispatch
@@ -384,7 +389,8 @@ class DynamoDBClaims:
             raise Conflict("active_dispatch_conflict")
         return None
 
-    def _validate_replacement_units(self, dispatch: RunDispatch, now: Any) -> None:
+    def _replacement_unit_items(self, dispatch: RunDispatch, now: Any) -> tuple[Item, ...]:
+        items = []
         for unit_id in dispatch.unit_ids:
             item = self._get_item(unit_key(dispatch.tenant_id, dispatch.run_id, unit_id))
             if item is None:
@@ -397,6 +403,8 @@ class DynamoDBClaims:
             )
             if live:
                 raise Conflict("dispatch_unit_unavailable")
+            items.append(item)
+        return tuple(items)
 
     def _dispatch_unit_items(self, command: ReserveRunDispatch) -> tuple[Item, ...]:
         items = []

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -149,6 +149,35 @@ def query_partition(client: Any, table_name: str, partition: str, prefix: str) -
     )
 
 
+def aggregate_items(
+    client: Any, table_name: str, base_key: tuple[str, str], child_key: tuple[str, str]
+) -> tuple[Item | None, tuple[Item, ...]]:
+    """Relê fortemente um agregado e todos os filhos do prefixo."""
+    response = client.get_item(
+        TableName=table_name, Key=item_key(*base_key), ConsistentRead=True)
+    return response.get("Item"), query_partition(client, table_name, *child_key)
+
+
+def aggregate_replay(
+    client: Any, table_name: str, expected: tuple[Item, tuple[str, str], tuple[Item, ...]]
+) -> bool:
+    """Reconhece replay exato de um agregado base e seus filhos."""
+    base, child_key, children = expected
+    base_key = base["pk"]["S"], base["sk"]["S"]
+    current, current_children = aggregate_items(client, table_name, base_key, child_key)
+    if current is None:
+        if current_children:
+            raise Conflict("run_dependency_conflict")
+        return False
+    if current != base:
+        raise Conflict("run_conflict")
+    def keyed(items: tuple[Item, ...]) -> dict[tuple[str, str], Item]:
+        return {(item["pk"]["S"], item["sk"]["S"]): item for item in items}
+    if keyed(current_children) != keyed(children):
+        raise Conflict("run_dependency_conflict")
+    return True
+
+
 def bounded_partition(
     client: Any, table_name: str, key: tuple[str, str], max_items: int
 ) -> tuple[Item, ...] | None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -214,6 +214,78 @@ def _ancestry_item(
     return item
 
 
+def _waiting_item(record: RawManifestRecord, ancestry: Item) -> Item | None:
+    if record.sequence == 1:
+        return None
+    prefix = _ancestry_prefix(
+        record, record.sequence - 1, str(record.previous_manifest_sha256)).replace(
+            "ANCESTRY#", "WAITING#", 1)
+    return {
+        "pk": ancestry["pk"], "sk": {"S": prefix + key_component(record.manifest_id)},
+        "entity": {"S": "RAWWAITING"}, "payload": {"S": record.model_dump_json()},
+        "base_pk": ancestry["pk"], "base_sk": ancestry["sk"],
+    }
+
+
+def _waiting_children(
+    client: Any, table_name: str, record: RawManifestRecord, remaining: int
+) -> tuple[Item, ...]:
+    partition = raw_partition(
+        record.tenant_id, record.source_type, record.file_subtype, record.competencia)
+    prefix = _ancestry_prefix(record, record.sequence, record.manifest_sha256).replace(
+        "ANCESTRY#", "WAITING#", 1)
+    response = client.query(
+        TableName=table_name,
+        KeyConditionExpression="pk = :partition AND begins_with(sk, :prefix)",
+        ExpressionAttributeValues={
+            ":partition": {"S": partition}, ":prefix": {"S": prefix}},
+        ConsistentRead=True,
+        Limit=remaining + 1)
+    children = tuple(response.get("Items", ()))
+    if len(children) > remaining:
+        raise Conflict("transaction_limit")
+    return children
+
+
+def _chain_action(table_name: str, ancestry: Item, chain: tuple[dict[str, str], ...]) -> Action:
+    updated = dict(ancestry)
+    updated["chain"] = {"S": json.dumps(chain, separators=(",", ":"))}
+    return {"Put": {
+        "TableName": table_name, "Item": updated,
+        "ConditionExpression": "attribute_exists(pk) AND attribute_not_exists(chain)"}}
+
+
+def _repair_descendants(
+    client: Any, table_name: str, root: RawManifestRecord, root_chain: tuple[dict[str, str], ...]
+) -> tuple[tuple[Action, ...], tuple[tuple[RawManifestRecord, tuple[dict[str, str], ...]], ...]]:
+    actions: list[Action] = []
+    endpoints = []
+    pending = [(root, root_chain)]
+    visited = 0
+    while pending:
+        parent, chain = pending.pop()
+        children = _waiting_children(client, table_name, parent, 92 - visited)
+        visited += len(children)
+        if not children:
+            endpoints.append((parent, chain))
+            continue
+        for marker in children:
+            child = decode_model(marker, RawManifestRecord)
+            key = marker["base_pk"]["S"], marker["base_sk"]["S"]
+            ancestry = client.get_item(
+                TableName=table_name, Key=item_key(*key), ConsistentRead=True).get("Item")
+            if ancestry is None:
+                raise Conflict("raw_ancestry_conflict")
+            ref = {"manifest_id": child.manifest_id, "manifest_key": child.manifest_key}
+            child_chain = (*chain, ref)
+            if "chain" not in ancestry:
+                actions.append(_chain_action(table_name, ancestry, child_chain))
+            elif tuple(json.loads(ancestry["chain"]["S"])) != child_chain:
+                raise Conflict("raw_ancestry_conflict")
+            pending.append((child, child_chain))
+    return tuple(actions), tuple(endpoints)
+
+
 def _head_action(
     client: Any, table_name: str, record: RawManifestRecord, chain: tuple[dict[str, str], ...]
 ) -> Action:
@@ -246,8 +318,17 @@ def raw_manifest_actions(
     chain = _manifest_chain(client, table_name, record, partition)
     ancestry = _ancestry_item(record, raw_item, chain)
     actions = [put_action(table_name, raw_item, None), put_action(table_name, ancestry, None)]
+    waiting = _waiting_item(record, ancestry)
+    if waiting is not None:
+        actions.append(put_action(table_name, waiting, None))
     if chain is not None:
-        actions.append(_head_action(client, table_name, record, chain))
+        repairs, endpoints = _repair_descendants(client, table_name, record, chain)
+        actions.extend(repairs)
+        head_record, head_chain = max(
+            endpoints,
+            key=lambda item: (
+                item[0].created_at, item[0].agent_id, item[0].snapshot_id))
+        actions.append(_head_action(client, table_name, head_record, head_chain))
     return tuple(actions)
 
 

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -133,6 +133,11 @@ def execute_transaction(client: Any, actions: Iterable[Action]) -> None:
         client.transact_write_items(TransactItems=list(normalized))
     except ClientError as error:
         code = error.response.get("Error", {}).get("Code")
-        if code in {"ConditionalCheckFailedException", "TransactionCanceledException"}:
+        reasons = error.response.get("CancellationReasons") or ()
+        reason_codes = {reason.get("Code") for reason in reasons} - {None, "None"}
+        conditional = code == "TransactionCanceledException" and reason_codes == {
+            "ConditionalCheckFailed"
+        }
+        if conditional:
             raise Conflict("transaction_conflict") from error
         raise

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -80,25 +80,6 @@ def query_pages(client: Any, request: dict[str, Any]) -> Iterator[tuple[Item, ..
         page_request["ExclusiveStartKey"] = last_key
 
 
-def strong_candidates[T: BaseModel](
-    client: Any, table_name: str, candidates: tuple[Item, ...], model_type: type[T]
-) -> tuple[T, ...]:
-    """Relê candidatos únicos na tabela base."""
-    keys = {
-        (item.get("base_pk", item["pk"])["S"], item.get("base_sk", item["sk"])["S"])
-        for item in candidates
-    }
-    models = []
-    for key in sorted(keys):
-        response = client.get_item(
-            TableName=table_name, Key=item_key(*key), ConsistentRead=True
-        )
-        item = response.get("Item")
-        if item is not None and item.get("entity", {}).get("S") == model_type.__name__.upper():
-            models.append(decode_model(item, model_type))
-    return tuple(models)
-
-
 def bounded_candidates[T: BaseModel](
     client: Any,
     request: dict[str, Any],
@@ -166,6 +147,31 @@ def query_partition(client: Any, table_name: str, partition: str, prefix: str) -
             "ConsistentRead": True,
         },
     )
+
+
+def bounded_partition(
+    client: Any, table_name: str, key: tuple[str, str], max_items: int
+) -> tuple[Item, ...] | None:
+    """Consulta uma partição forte dentro de orçamento fechado."""
+    items: list[Item] = []
+    request: dict[str, Any] = {
+        "TableName": table_name,
+        "KeyConditionExpression": "pk = :partition AND begins_with(sk, :prefix)",
+        "ExpressionAttributeValues": {
+            ":partition": {"S": key[0]}, ":prefix": {"S": key[1]}},
+        "ConsistentRead": True,
+    }
+    for _ in range(max_items + 1):
+        request["Limit"] = max_items + 1 - len(items)
+        response = client.query(**request)
+        items.extend(response.get("Items", ()))
+        last_key = response.get("LastEvaluatedKey")
+        if len(items) > max_items:
+            return None
+        if not last_key:
+            return tuple(items)
+        request["ExclusiveStartKey"] = last_key
+    return None
 
 
 def put_action(table_name: str, item: Item, expected_payload: str | None) -> Action:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -214,9 +214,7 @@ def _ancestry_item(
     return item
 
 
-def _waiting_item(record: RawManifestRecord, ancestry: Item) -> Item | None:
-    if record.sequence == 1:
-        return None
+def _waiting_item(record: RawManifestRecord, ancestry: Item) -> Item:
     prefix = _ancestry_prefix(
         record, record.sequence - 1, str(record.previous_manifest_sha256)).replace(
             "ANCESTRY#", "WAITING#", 1)
@@ -225,6 +223,19 @@ def _waiting_item(record: RawManifestRecord, ancestry: Item) -> Item | None:
         "entity": {"S": "RAWWAITING"}, "payload": {"S": record.model_dump_json()},
         "base_pk": ancestry["pk"], "base_sk": ancestry["sk"],
     }
+
+
+def _raw_version_action(client: Any, table_name: str, partition: str) -> Action:
+    key = partition, "RAWVERSION#CURRENT"
+    current = client.get_item(
+        TableName=table_name, Key=item_key(*key), ConsistentRead=True).get("Item")
+    generation = 1 if current is None else int(payload(current)) + 1
+    item = {
+        "pk": {"S": partition}, "sk": {"S": key[1]},
+        "entity": {"S": "RAWVERSION"}, "payload": {"S": str(generation)},
+    }
+    expected = None if current is None else payload(current)
+    return put_action(table_name, item, expected)
 
 
 def _waiting_children(
@@ -315,10 +326,11 @@ def raw_manifest_actions(
 ) -> tuple[Action, ...]:
     """Cria manifesto, ancestry e HEAD atomicamente."""
     partition = raw_item["pk"]["S"]
+    version = _raw_version_action(client, table_name, partition)
     chain = _manifest_chain(client, table_name, record, partition)
     ancestry = _ancestry_item(record, raw_item, chain)
     actions = [put_action(table_name, raw_item, None), put_action(table_name, ancestry, None)]
-    waiting = _waiting_item(record, ancestry)
+    waiting = _waiting_item(record, ancestry) if chain is None else None
     if waiting is not None:
         actions.append(put_action(table_name, waiting, None))
     if chain is not None:
@@ -329,6 +341,7 @@ def raw_manifest_actions(
             key=lambda item: (
                 item[0].created_at, item[0].agent_id, item[0].snapshot_id))
         actions.append(_head_action(client, table_name, head_record, head_chain))
+    actions.append(version)
     return tuple(actions)
 
 

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -1,7 +1,8 @@
 """DynamoDB item codec and transaction construction."""
 
 import json
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from dataclasses import dataclass
 from typing import Any
 
 from botocore.exceptions import ClientError
@@ -13,6 +14,13 @@ from cnes_infra.control_plane.dynamodb_keys import item_key, key_component, raw_
 
 type Item = dict[str, dict[str, Any]]
 type Action = dict[str, dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class CandidateQuery[T: BaseModel]:
+    model_type: type[T]
+    predicate: Callable[[T], bool]
+    limit: int
 
 
 def encode_model(
@@ -85,11 +93,10 @@ def query_pages(client: Any, request: dict[str, Any]) -> Iterator[tuple[Item, ..
 def bounded_candidates[T: BaseModel](
     client: Any,
     request: dict[str, Any],
-    *args: Any,
+    query: CandidateQuery[T],
 ) -> tuple[T, ...]:
     """Relê candidatos válidos até preencher o limite solicitado."""
-    model_type, predicate, limit = args
-    if limit <= 0:
+    if query.limit <= 0:
         return ()
     page_request = dict(request)
     index = request["IndexName"]
@@ -97,11 +104,13 @@ def bounded_candidates[T: BaseModel](
     base_items = {}
     models = []
     while True:
-        page_request["Limit"] = limit - len(models)
+        page_request["Limit"] = query.limit - len(models)
         response = client.query(**page_request)
         for candidate in response.get("Items", ()):
-            key = (candidate.get("base_pk", candidate["pk"])["S"],
-                   candidate.get("base_sk", candidate["sk"])["S"])
+            key = (
+                candidate.get("base_pk", candidate["pk"])["S"],
+                candidate.get("base_sk", candidate["sk"])["S"],
+            )
             signature = (*key, candidate[f"{index}pk"]["S"], candidate[f"{index}sk"]["S"])
             if signature in seen:
                 continue
@@ -111,12 +120,12 @@ def bounded_candidates[T: BaseModel](
                     TableName=request["TableName"], Key=item_key(*key), ConsistentRead=True
                 ).get("Item")
             item = base_items[key]
-            if not _candidate_matches(item, candidate, index, model_type):
+            if not _candidate_matches(item, candidate, index, query.model_type):
                 continue
-            model = decode_model(item, model_type)
-            if predicate(model):
+            model = decode_model(item, query.model_type)
+            if query.predicate(model):
                 models.append(model)
-                if len(models) == limit:
+                if len(models) == query.limit:
                     return tuple(models)
         last_key = response.get("LastEvaluatedKey")
         if not last_key:
@@ -155,8 +164,7 @@ def aggregate_items(
     client: Any, table_name: str, base_key: tuple[str, str], child_key: tuple[str, str]
 ) -> tuple[Item | None, tuple[Item, ...]]:
     """Relê fortemente um agregado e todos os filhos do prefixo."""
-    response = client.get_item(
-        TableName=table_name, Key=item_key(*base_key), ConsistentRead=True)
+    response = client.get_item(TableName=table_name, Key=item_key(*base_key), ConsistentRead=True)
     return response.get("Item"), query_partition(client, table_name, *child_key)
 
 
@@ -173,8 +181,10 @@ def aggregate_replay(
         return False
     if current != base:
         raise Conflict("run_conflict")
+
     def keyed(items: tuple[Item, ...]) -> dict[tuple[str, str], Item]:
         return {(item["pk"]["S"], item["sk"]["S"]): item for item in items}
+
     if keyed(current_children) != keyed(children):
         raise Conflict("run_dependency_conflict")
     return True
@@ -205,8 +215,10 @@ def _ancestry_item(
 ) -> Item:
     prefix = _ancestry_prefix(record, record.sequence, record.manifest_sha256)
     item = {
-        "pk": raw_item["pk"], "sk": {"S": prefix + key_component(record.manifest_id)},
-        "entity": {"S": "RAWANCESTRY"}, "base_pk": raw_item["pk"],
+        "pk": raw_item["pk"],
+        "sk": {"S": prefix + key_component(record.manifest_id)},
+        "entity": {"S": "RAWANCESTRY"},
+        "base_pk": raw_item["pk"],
         "base_sk": raw_item["sk"],
     }
     if chain is not None:
@@ -216,23 +228,29 @@ def _ancestry_item(
 
 def _waiting_item(record: RawManifestRecord, ancestry: Item) -> Item:
     prefix = _ancestry_prefix(
-        record, record.sequence - 1, str(record.previous_manifest_sha256)).replace(
-            "ANCESTRY#", "WAITING#", 1)
+        record, record.sequence - 1, str(record.previous_manifest_sha256)
+    ).replace("ANCESTRY#", "WAITING#", 1)
     return {
-        "pk": ancestry["pk"], "sk": {"S": prefix + key_component(record.manifest_id)},
-        "entity": {"S": "RAWWAITING"}, "payload": {"S": record.model_dump_json()},
-        "base_pk": ancestry["pk"], "base_sk": ancestry["sk"],
+        "pk": ancestry["pk"],
+        "sk": {"S": prefix + key_component(record.manifest_id)},
+        "entity": {"S": "RAWWAITING"},
+        "payload": {"S": record.model_dump_json()},
+        "base_pk": ancestry["pk"],
+        "base_sk": ancestry["sk"],
     }
 
 
 def _raw_version_action(client: Any, table_name: str, partition: str) -> Action:
     key = partition, "RAWVERSION#CURRENT"
-    current = client.get_item(
-        TableName=table_name, Key=item_key(*key), ConsistentRead=True).get("Item")
+    current = client.get_item(TableName=table_name, Key=item_key(*key), ConsistentRead=True).get(
+        "Item"
+    )
     generation = 1 if current is None else int(payload(current)) + 1
     item = {
-        "pk": {"S": partition}, "sk": {"S": key[1]},
-        "entity": {"S": "RAWVERSION"}, "payload": {"S": str(generation)},
+        "pk": {"S": partition},
+        "sk": {"S": key[1]},
+        "entity": {"S": "RAWVERSION"},
+        "payload": {"S": str(generation)},
     }
     expected = None if current is None else payload(current)
     return put_action(table_name, item, expected)
@@ -242,16 +260,18 @@ def _waiting_children(
     client: Any, table_name: str, record: RawManifestRecord, remaining: int
 ) -> tuple[Item, ...]:
     partition = raw_partition(
-        record.tenant_id, record.source_type, record.file_subtype, record.competencia)
+        record.tenant_id, record.source_type, record.file_subtype, record.competencia
+    )
     prefix = _ancestry_prefix(record, record.sequence, record.manifest_sha256).replace(
-        "ANCESTRY#", "WAITING#", 1)
+        "ANCESTRY#", "WAITING#", 1
+    )
     response = client.query(
         TableName=table_name,
         KeyConditionExpression="pk = :partition AND begins_with(sk, :prefix)",
-        ExpressionAttributeValues={
-            ":partition": {"S": partition}, ":prefix": {"S": prefix}},
+        ExpressionAttributeValues={":partition": {"S": partition}, ":prefix": {"S": prefix}},
         ConsistentRead=True,
-        Limit=remaining + 1)
+        Limit=remaining + 1,
+    )
     children = tuple(response.get("Items", ()))
     if len(children) > remaining:
         raise Conflict("transaction_limit")
@@ -261,9 +281,13 @@ def _waiting_children(
 def _chain_action(table_name: str, ancestry: Item, chain: tuple[dict[str, str], ...]) -> Action:
     updated = dict(ancestry)
     updated["chain"] = {"S": json.dumps(chain, separators=(",", ":"))}
-    return {"Put": {
-        "TableName": table_name, "Item": updated,
-        "ConditionExpression": "attribute_exists(pk) AND attribute_not_exists(chain)"}}
+    return {
+        "Put": {
+            "TableName": table_name,
+            "Item": updated,
+            "ConditionExpression": "attribute_exists(pk) AND attribute_not_exists(chain)",
+        }
+    }
 
 
 def _repair_descendants(
@@ -284,7 +308,8 @@ def _repair_descendants(
             child = decode_model(marker, RawManifestRecord)
             key = marker["base_pk"]["S"], marker["base_sk"]["S"]
             ancestry = client.get_item(
-                TableName=table_name, Key=item_key(*key), ConsistentRead=True).get("Item")
+                TableName=table_name, Key=item_key(*key), ConsistentRead=True
+            ).get("Item")
             if ancestry is None:
                 raise Conflict("raw_ancestry_conflict")
             ref = {"manifest_id": child.manifest_id, "manifest_key": child.manifest_key}
@@ -301,21 +326,29 @@ def _head_action(
     client: Any, table_name: str, record: RawManifestRecord, chain: tuple[dict[str, str], ...]
 ) -> Action:
     partition = raw_partition(
-        record.tenant_id, record.source_type, record.file_subtype, record.competencia)
+        record.tenant_id, record.source_type, record.file_subtype, record.competencia
+    )
     key = partition, "HEAD#CURRENT"
     current = client.get_item(TableName=table_name, Key=item_key(*key), ConsistentRead=True).get(
-        "Item")
+        "Item"
+    )
     ordering = (
         f"{timestamp(record.created_at)}#{key_component(record.agent_id)}#"
-        f"{key_component(record.snapshot_id)}")
+        f"{key_component(record.snapshot_id)}"
+    )
     data = {"ordering": ordering, "chain": chain}
-    head = {"pk": {"S": partition}, "sk": {"S": key[1]}, "entity": {"S": "RAWHEAD"},
-            "payload": {"S": json.dumps(data, separators=(",", ":"))}}
+    head = {
+        "pk": {"S": partition},
+        "sk": {"S": key[1]},
+        "entity": {"S": "RAWHEAD"},
+        "payload": {"S": json.dumps(data, separators=(",", ":"))},
+    }
     if current is None:
         return put_action(table_name, head, None)
     previous = json.loads(current["payload"]["S"])
     descendant = previous["chain"][-1]["manifest_id"] in {
-        item["manifest_id"] for item in chain[:-1]}
+        item["manifest_id"] for item in chain[:-1]
+    }
     if descendant or ordering > previous["ordering"]:
         return put_action(table_name, head, payload(current))
     return check_action(table_name, current)
@@ -337,9 +370,8 @@ def raw_manifest_actions(
         repairs, endpoints = _repair_descendants(client, table_name, record, chain)
         actions.extend(repairs)
         head_record, head_chain = max(
-            endpoints,
-            key=lambda item: (
-                item[0].created_at, item[0].agent_id, item[0].snapshot_id))
+            endpoints, key=lambda item: (item[0].created_at, item[0].agent_id, item[0].snapshot_id)
+        )
         actions.append(_head_action(client, table_name, head_record, head_chain))
     actions.append(version)
     return tuple(actions)
@@ -352,7 +384,8 @@ def raw_head_chain(
     if limit < 1:
         return ()
     response = client.get_item(
-        TableName=table_name, Key=item_key(partition, "HEAD#CURRENT"), ConsistentRead=True)
+        TableName=table_name, Key=item_key(partition, "HEAD#CURRENT"), ConsistentRead=True
+    )
     head = response.get("Item")
     if head is None:
         return ()
@@ -362,17 +395,15 @@ def raw_head_chain(
     return tuple(ManifestRef.model_validate(item) for item in chain)
 
 
-def unique_partition_item(
-    client: Any, table_name: str, partition: str, prefix: str
-) -> Item | None:
+def unique_partition_item(client: Any, table_name: str, partition: str, prefix: str) -> Item | None:
     """Retorna o único item forte de um prefixo, limitado a dois."""
     response = client.query(
         TableName=table_name,
         KeyConditionExpression="pk = :partition AND begins_with(sk, :prefix)",
-        ExpressionAttributeValues={
-            ":partition": {"S": partition}, ":prefix": {"S": prefix}},
+        ExpressionAttributeValues={":partition": {"S": partition}, ":prefix": {"S": prefix}},
         ConsistentRead=True,
-        Limit=2)
+        Limit=2,
+    )
     items = response.get("Items", ())
     return items[0] if len(items) == 1 else None
 

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -1,0 +1,109 @@
+"""DynamoDB item codec and transaction construction."""
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from botocore.exceptions import ClientError
+from pydantic import BaseModel
+
+from cnes_domain.control_plane.errors import Conflict
+
+type Item = dict[str, dict[str, Any]]
+type Action = dict[str, dict[str, Any]]
+
+
+def encode_model(
+    model: BaseModel,
+    entity: str,
+    key: tuple[str, str],
+    attributes: Mapping[str, str] | None = None,
+) -> Item:
+    """Codifica um modelo sem introduzir Decimal."""
+    item: Item = {
+        "pk": {"S": key[0]},
+        "sk": {"S": key[1]},
+        "entity": {"S": entity},
+        "payload": {"S": model.model_dump_json()},
+    }
+    for name, value in (attributes or {}).items():
+        item[name] = {"S": value}
+    return item
+
+
+def encode_marker(
+    entity: str,
+    key: tuple[str, str],
+    base_key: tuple[str, str],
+    attributes: Mapping[str, str],
+) -> Item:
+    """Codifica um marcador eventual apontando à base."""
+    item: Item = {
+        "pk": {"S": key[0]},
+        "sk": {"S": key[1]},
+        "entity": {"S": entity},
+        "base_pk": {"S": base_key[0]},
+        "base_sk": {"S": base_key[1]},
+    }
+    for name, value in attributes.items():
+        item[name] = {"S": value}
+    return item
+
+
+def decode_model[T: BaseModel](item: Item, model_type: type[T]) -> T:
+    """Decodifica e valida o payload de um modelo."""
+    return model_type.model_validate_json(item["payload"]["S"])
+
+
+def payload(item: Item) -> str:
+    """Retorna o payload usado pelo compare-and-set."""
+    return str(item["payload"]["S"])
+
+
+def put_action(table_name: str, item: Item, expected_payload: str | None) -> Action:
+    """Cria uma ação Put condicional."""
+    request: dict[str, Any] = {"TableName": table_name, "Item": item}
+    if expected_payload is None:
+        request["ConditionExpression"] = "attribute_not_exists(pk)"
+    else:
+        request["ConditionExpression"] = "payload = :expected"
+        request["ExpressionAttributeValues"] = {":expected": {"S": expected_payload}}
+    return {"Put": request}
+
+
+def check_action(table_name: str, item: Item) -> Action:
+    """Cria uma ação ConditionCheck pelo payload."""
+    return {
+        "ConditionCheck": {
+            "TableName": table_name,
+            "Key": {"pk": item["pk"], "sk": item["sk"]},
+            "ConditionExpression": "payload = :expected",
+            "ExpressionAttributeValues": {":expected": item["payload"]},
+        }
+    }
+
+
+def _action_key(action: Action) -> tuple[str, str]:
+    request = next(iter(action.values()))
+    values = request.get("Item", request.get("Key"))
+    return str(values["pk"]["S"]), str(values["sk"]["S"])
+
+
+def _validate_actions(actions: tuple[Action, ...]) -> None:
+    if len(actions) > 100:
+        raise Conflict("transaction_limit")
+    keys = tuple(_action_key(action) for action in actions)
+    if len(set(keys)) != len(keys):
+        raise Conflict("duplicate_transaction_key")
+
+
+def execute_transaction(client: Any, actions: Iterable[Action]) -> None:
+    """Valida e envia uma transação de chaves únicas."""
+    normalized = tuple(actions)
+    _validate_actions(normalized)
+    try:
+        client.transact_write_items(TransactItems=list(normalized))
+    except ClientError as error:
+        code = error.response.get("Error", {}).get("Code")
+        if code in {"ConditionalCheckFailedException", "TransactionCanceledException"}:
+            raise Conflict("transaction_conflict") from error
+        raise

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -59,6 +59,35 @@ def payload(item: Item) -> str:
     return str(item["payload"]["S"])
 
 
+def query_all(client: Any, request: dict[str, Any]) -> tuple[Item, ...]:
+    """Percorre todas as páginas de uma Query."""
+    items: list[Item] = []
+    page_request = dict(request)
+    while True:
+        response = client.query(**page_request)
+        items.extend(response.get("Items", ()))
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            return tuple(items)
+        page_request["ExclusiveStartKey"] = last_key
+
+
+def query_partition(client: Any, table_name: str, partition: str, prefix: str) -> tuple[Item, ...]:
+    """Consulta uma partição base com leitura forte."""
+    return query_all(
+        client,
+        {
+            "TableName": table_name,
+            "KeyConditionExpression": "pk = :partition AND begins_with(sk, :prefix)",
+            "ExpressionAttributeValues": {
+                ":partition": {"S": partition},
+                ":prefix": {"S": prefix},
+            },
+            "ConsistentRead": True,
+        },
+    )
+
+
 def put_action(table_name: str, item: Item, expected_payload: str | None) -> Action:
     """Cria uma ação Put condicional."""
     request: dict[str, Any] = {"TableName": table_name, "Item": item}

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -1,12 +1,13 @@
 """DynamoDB item codec and transaction construction."""
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from typing import Any
 
 from botocore.exceptions import ClientError
 from pydantic import BaseModel
 
 from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.control_plane.dynamodb_keys import item_key
 
 type Item = dict[str, dict[str, Any]]
 type Action = dict[str, dict[str, Any]]
@@ -62,14 +63,93 @@ def payload(item: Item) -> str:
 def query_all(client: Any, request: dict[str, Any]) -> tuple[Item, ...]:
     """Percorre todas as páginas de uma Query."""
     items: list[Item] = []
+    for page in query_pages(client, request):
+        items.extend(page)
+    return tuple(items)
+
+
+def query_pages(client: Any, request: dict[str, Any]) -> Iterator[tuple[Item, ...]]:
+    """Percorre páginas de uma Query sob demanda."""
     page_request = dict(request)
     while True:
         response = client.query(**page_request)
-        items.extend(response.get("Items", ()))
+        yield tuple(response.get("Items", ()))
         last_key = response.get("LastEvaluatedKey")
         if not last_key:
-            return tuple(items)
+            return
         page_request["ExclusiveStartKey"] = last_key
+
+
+def strong_candidates[T: BaseModel](
+    client: Any, table_name: str, candidates: tuple[Item, ...], model_type: type[T]
+) -> tuple[T, ...]:
+    """Relê candidatos únicos na tabela base."""
+    keys = {
+        (item.get("base_pk", item["pk"])["S"], item.get("base_sk", item["sk"])["S"])
+        for item in candidates
+    }
+    models = []
+    for key in sorted(keys):
+        response = client.get_item(
+            TableName=table_name, Key=item_key(*key), ConsistentRead=True
+        )
+        item = response.get("Item")
+        if item is not None and item.get("entity", {}).get("S") == model_type.__name__.upper():
+            models.append(decode_model(item, model_type))
+    return tuple(models)
+
+
+def bounded_candidates[T: BaseModel](
+    client: Any,
+    request: dict[str, Any],
+    *args: Any,
+) -> tuple[T, ...]:
+    """Relê candidatos válidos até preencher o limite solicitado."""
+    model_type, predicate, limit = args
+    if limit <= 0:
+        return ()
+    page_request = dict(request)
+    index = request["IndexName"]
+    seen = set()
+    base_items = {}
+    models = []
+    while True:
+        page_request["Limit"] = limit - len(models)
+        response = client.query(**page_request)
+        for candidate in response.get("Items", ()):
+            key = (candidate.get("base_pk", candidate["pk"])["S"],
+                   candidate.get("base_sk", candidate["sk"])["S"])
+            signature = (*key, candidate[f"{index}pk"]["S"], candidate[f"{index}sk"]["S"])
+            if signature in seen:
+                continue
+            seen.add(signature)
+            if key not in base_items:
+                base_items[key] = client.get_item(
+                    TableName=request["TableName"], Key=item_key(*key), ConsistentRead=True
+                ).get("Item")
+            item = base_items[key]
+            if not _candidate_matches(item, candidate, index, model_type):
+                continue
+            model = decode_model(item, model_type)
+            if predicate(model):
+                models.append(model)
+                if len(models) == limit:
+                    return tuple(models)
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            return tuple(models)
+        page_request["ExclusiveStartKey"] = last_key
+
+
+def _candidate_matches(
+    item: Item | None, candidate: Item, index: str, model_type: type[BaseModel]
+) -> bool:
+    if item is None or item.get("entity", {}).get("S") != model_type.__name__.upper():
+        return False
+    names = (f"{index}pk", f"{index}sk")
+    return not all(name in item for name in names) or all(
+        item[name] == candidate.get(name) for name in names
+    )
 
 
 def query_partition(client: Any, table_name: str, partition: str, prefix: str) -> tuple[Item, ...]:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -1,13 +1,15 @@
 """DynamoDB item codec and transaction construction."""
 
+import json
 from collections.abc import Iterable, Iterator, Mapping
 from typing import Any
 
 from botocore.exceptions import ClientError
 from pydantic import BaseModel
 
+from cnes_domain.control_plane.entities import ManifestRef, RawManifestRecord
 from cnes_domain.control_plane.errors import Conflict
-from cnes_infra.control_plane.dynamodb_keys import item_key
+from cnes_infra.control_plane.dynamodb_keys import item_key, key_component, raw_partition, timestamp
 
 type Item = dict[str, dict[str, Any]]
 type Action = dict[str, dict[str, Any]]
@@ -178,29 +180,107 @@ def aggregate_replay(
     return True
 
 
-def bounded_partition(
-    client: Any, table_name: str, key: tuple[str, str], max_items: int
-) -> tuple[Item, ...] | None:
-    """Consulta uma partição forte dentro de orçamento fechado."""
-    items: list[Item] = []
-    request: dict[str, Any] = {
-        "TableName": table_name,
-        "KeyConditionExpression": "pk = :partition AND begins_with(sk, :prefix)",
-        "ExpressionAttributeValues": {
-            ":partition": {"S": key[0]}, ":prefix": {"S": key[1]}},
-        "ConsistentRead": True,
+def _ancestry_prefix(record: RawManifestRecord, sequence: int, digest: str) -> str:
+    base = record.snapshot_id if record.sequence == 1 else record.base_snapshot_id
+    values = (record.agent_id, str(base), f"{sequence:020d}", digest)
+    return "ANCESTRY#" + "#".join(map(key_component, values)) + "#"
+
+
+def _manifest_chain(
+    client: Any, table_name: str, record: RawManifestRecord, partition: str
+) -> tuple[dict[str, str], ...] | None:
+    ref = {"manifest_id": record.manifest_id, "manifest_key": record.manifest_key}
+    if record.sequence == 1:
+        return (ref,)
+    prefix = _ancestry_prefix(record, record.sequence - 1, str(record.previous_manifest_sha256))
+    predecessor = unique_partition_item(client, table_name, partition, prefix)
+    if predecessor is None or "chain" not in predecessor:
+        return None
+    chain = tuple(json.loads(predecessor["chain"]["S"]))
+    return (*chain, ref)
+
+
+def _ancestry_item(
+    record: RawManifestRecord, raw_item: Item, chain: tuple[dict[str, str], ...] | None
+) -> Item:
+    prefix = _ancestry_prefix(record, record.sequence, record.manifest_sha256)
+    item = {
+        "pk": raw_item["pk"], "sk": {"S": prefix + key_component(record.manifest_id)},
+        "entity": {"S": "RAWANCESTRY"}, "base_pk": raw_item["pk"],
+        "base_sk": raw_item["sk"],
     }
-    for _ in range(max_items + 1):
-        request["Limit"] = max_items + 1 - len(items)
-        response = client.query(**request)
-        items.extend(response.get("Items", ()))
-        last_key = response.get("LastEvaluatedKey")
-        if len(items) > max_items:
-            return None
-        if not last_key:
-            return tuple(items)
-        request["ExclusiveStartKey"] = last_key
-    return None
+    if chain is not None:
+        item["chain"] = {"S": json.dumps(chain, separators=(",", ":"))}
+    return item
+
+
+def _head_action(
+    client: Any, table_name: str, record: RawManifestRecord, chain: tuple[dict[str, str], ...]
+) -> Action:
+    partition = raw_partition(
+        record.tenant_id, record.source_type, record.file_subtype, record.competencia)
+    key = partition, "HEAD#CURRENT"
+    current = client.get_item(TableName=table_name, Key=item_key(*key), ConsistentRead=True).get(
+        "Item")
+    ordering = (
+        f"{timestamp(record.created_at)}#{key_component(record.agent_id)}#"
+        f"{key_component(record.snapshot_id)}")
+    data = {"ordering": ordering, "chain": chain}
+    head = {"pk": {"S": partition}, "sk": {"S": key[1]}, "entity": {"S": "RAWHEAD"},
+            "payload": {"S": json.dumps(data, separators=(",", ":"))}}
+    if current is None:
+        return put_action(table_name, head, None)
+    previous = json.loads(current["payload"]["S"])
+    descendant = previous["chain"][-1]["manifest_id"] in {
+        item["manifest_id"] for item in chain[:-1]}
+    if descendant or ordering > previous["ordering"]:
+        return put_action(table_name, head, payload(current))
+    return check_action(table_name, current)
+
+
+def raw_manifest_actions(
+    client: Any, table_name: str, record: RawManifestRecord, raw_item: Item
+) -> tuple[Action, ...]:
+    """Cria manifesto, ancestry e HEAD atomicamente."""
+    partition = raw_item["pk"]["S"]
+    chain = _manifest_chain(client, table_name, record, partition)
+    ancestry = _ancestry_item(record, raw_item, chain)
+    actions = [put_action(table_name, raw_item, None), put_action(table_name, ancestry, None)]
+    if chain is not None:
+        actions.append(_head_action(client, table_name, record, chain))
+    return tuple(actions)
+
+
+def raw_head_chain(
+    client: Any, table_name: str, partition: str, limit: int
+) -> tuple[ManifestRef, ...]:
+    """Lê fortemente a cadeia HEAD materializada."""
+    if limit < 1:
+        return ()
+    response = client.get_item(
+        TableName=table_name, Key=item_key(partition, "HEAD#CURRENT"), ConsistentRead=True)
+    head = response.get("Item")
+    if head is None:
+        return ()
+    chain = json.loads(head["payload"]["S"])["chain"]
+    if len(chain) > limit:
+        return ()
+    return tuple(ManifestRef.model_validate(item) for item in chain)
+
+
+def unique_partition_item(
+    client: Any, table_name: str, partition: str, prefix: str
+) -> Item | None:
+    """Retorna o único item forte de um prefixo, limitado a dois."""
+    response = client.query(
+        TableName=table_name,
+        KeyConditionExpression="pk = :partition AND begins_with(sk, :prefix)",
+        ExpressionAttributeValues={
+            ":partition": {"S": partition}, ":prefix": {"S": prefix}},
+        ConsistentRead=True,
+        Limit=2)
+    items = response.get("Items", ())
+    return items[0] if len(items) == 1 else None
 
 
 def put_action(table_name: str, item: Item, expected_payload: str | None) -> Action:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_keys.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_keys.py
@@ -23,6 +23,12 @@ def run_partition(tenant_id: str, run_id: str) -> str:
     return f"{tenant_partition(tenant_id)}#RUN#{key_component(run_id)}"
 
 
+def raw_partition(tenant_id: str, source_type: str, file_subtype: str, competencia: str) -> str:
+    """Cria a partição base de uma identidade raw."""
+    identity = "#".join(map(key_component, (source_type, file_subtype, competencia)))
+    return f"{tenant_partition(tenant_id)}#RAW#{identity}"
+
+
 def entity_key(tenant_id: str, entity: str, identifier: str) -> tuple[str, str]:
     """Cria a chave base de uma entidade do tenant."""
     return tenant_partition(tenant_id), f"{entity}#{key_component(identifier)}"

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_keys.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_keys.py
@@ -3,9 +3,14 @@
 from datetime import datetime
 
 
+def key_component(value: str) -> str:
+    """Codifica componente preservando ordem e removendo ambiguidade."""
+    return value.encode().hex()
+
+
 def tenant_partition(tenant_id: str) -> str:
     """Cria a partição base do tenant."""
-    return f"TENANT#{tenant_id}"
+    return f"TENANT#{key_component(tenant_id)}"
 
 
 def global_partition() -> str:
@@ -15,12 +20,12 @@ def global_partition() -> str:
 
 def run_partition(tenant_id: str, run_id: str) -> str:
     """Cria a partição agregada do run."""
-    return f"{tenant_partition(tenant_id)}#RUN#{run_id}"
+    return f"{tenant_partition(tenant_id)}#RUN#{key_component(run_id)}"
 
 
 def entity_key(tenant_id: str, entity: str, identifier: str) -> tuple[str, str]:
     """Cria a chave base de uma entidade do tenant."""
-    return tenant_partition(tenant_id), f"{entity}#{identifier}"
+    return tenant_partition(tenant_id), f"{entity}#{key_component(identifier)}"
 
 
 def run_entity_key(tenant_id: str, run_id: str) -> tuple[str, str]:
@@ -30,7 +35,7 @@ def run_entity_key(tenant_id: str, run_id: str) -> tuple[str, str]:
 
 def unit_key(tenant_id: str, run_id: str, unit_id: str) -> tuple[str, str]:
     """Cria a chave base de uma unidade."""
-    return run_partition(tenant_id, run_id), f"UNIT#{unit_id}"
+    return run_partition(tenant_id, run_id), f"UNIT#{key_component(unit_id)}"
 
 
 def dispatch_key(tenant_id: str, run_id: str) -> tuple[str, str]:
@@ -40,27 +45,35 @@ def dispatch_key(tenant_id: str, run_id: str) -> tuple[str, str]:
 
 def idempotency_key(tenant_id: str, scope: str, key: str) -> tuple[str, str]:
     """Cria a chave base de idempotência."""
-    return tenant_partition(tenant_id), f"IDEMPOTENCY#{scope}#{key}"
+    return tenant_partition(tenant_id), (
+        f"IDEMPOTENCY#{key_component(scope)}#{key_component(key)}"
+    )
 
 
 def version_key(tenant_id: str, dataset_name: str, version_id: str) -> tuple[str, str]:
     """Cria a chave base de uma versão."""
-    return tenant_partition(tenant_id), f"VERSION#{dataset_name}#{version_id}"
+    return tenant_partition(tenant_id), (
+        f"VERSION#{key_component(dataset_name)}#{key_component(version_id)}"
+    )
 
 
 def pointer_key(tenant_id: str, dataset_name: str, pointer_name: str) -> tuple[str, str]:
     """Cria a chave base de um ponteiro."""
-    return tenant_partition(tenant_id), f"POINTER#{dataset_name}#{pointer_name}"
+    return tenant_partition(tenant_id), (
+        f"POINTER#{key_component(dataset_name)}#{key_component(pointer_name)}"
+    )
 
 
 def outbox_key(event_id: str) -> tuple[str, str]:
     """Cria a chave global de um evento."""
-    return global_partition(), f"OUTBOX#{event_id}"
+    return global_partition(), f"OUTBOX#{key_component(event_id)}"
 
 
 def dependency_marker_key(tenant_id: str, run_id: str, dependency_key: str) -> tuple[str, str]:
     """Cria a chave de um marcador de dependência."""
-    return tenant_partition(tenant_id), f"RUN_DEP#{run_id}#{dependency_key}"
+    return tenant_partition(tenant_id), (
+        f"RUN_DEP#{key_component(run_id)}#{key_component(dependency_key)}"
+    )
 
 
 def timestamp(value: datetime) -> str:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_keys.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_keys.py
@@ -1,0 +1,73 @@
+"""Pure DynamoDB control-plane key builders."""
+
+from datetime import datetime
+
+
+def tenant_partition(tenant_id: str) -> str:
+    """Cria a partição base do tenant."""
+    return f"TENANT#{tenant_id}"
+
+
+def global_partition() -> str:
+    """Cria a partição global com prefixo de tenant."""
+    return "TENANT#_GLOBAL"
+
+
+def run_partition(tenant_id: str, run_id: str) -> str:
+    """Cria a partição agregada do run."""
+    return f"{tenant_partition(tenant_id)}#RUN#{run_id}"
+
+
+def entity_key(tenant_id: str, entity: str, identifier: str) -> tuple[str, str]:
+    """Cria a chave base de uma entidade do tenant."""
+    return tenant_partition(tenant_id), f"{entity}#{identifier}"
+
+
+def run_entity_key(tenant_id: str, run_id: str) -> tuple[str, str]:
+    """Cria a chave base de um run."""
+    return entity_key(tenant_id, "RUN", run_id)
+
+
+def unit_key(tenant_id: str, run_id: str, unit_id: str) -> tuple[str, str]:
+    """Cria a chave base de uma unidade."""
+    return run_partition(tenant_id, run_id), f"UNIT#{unit_id}"
+
+
+def dispatch_key(tenant_id: str, run_id: str) -> tuple[str, str]:
+    """Cria a chave base do dispatch ativo."""
+    return run_partition(tenant_id, run_id), "DISPATCH#ACTIVE"
+
+
+def idempotency_key(tenant_id: str, scope: str, key: str) -> tuple[str, str]:
+    """Cria a chave base de idempotência."""
+    return tenant_partition(tenant_id), f"IDEMPOTENCY#{scope}#{key}"
+
+
+def version_key(tenant_id: str, dataset_name: str, version_id: str) -> tuple[str, str]:
+    """Cria a chave base de uma versão."""
+    return tenant_partition(tenant_id), f"VERSION#{dataset_name}#{version_id}"
+
+
+def pointer_key(tenant_id: str, dataset_name: str, pointer_name: str) -> tuple[str, str]:
+    """Cria a chave base de um ponteiro."""
+    return tenant_partition(tenant_id), f"POINTER#{dataset_name}#{pointer_name}"
+
+
+def outbox_key(event_id: str) -> tuple[str, str]:
+    """Cria a chave global de um evento."""
+    return global_partition(), f"OUTBOX#{event_id}"
+
+
+def dependency_marker_key(tenant_id: str, run_id: str, dependency_key: str) -> tuple[str, str]:
+    """Cria a chave de um marcador de dependência."""
+    return tenant_partition(tenant_id), f"RUN_DEP#{run_id}#{dependency_key}"
+
+
+def timestamp(value: datetime) -> str:
+    """Codifica um instante UTC ordenável."""
+    return value.isoformat(timespec="microseconds")
+
+
+def item_key(pk: str, sk: str) -> dict[str, dict[str, str]]:
+    """Codifica uma chave no formato low-level do DynamoDB."""
+    return {"pk": {"S": pk}, "sk": {"S": sk}}

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -68,6 +68,8 @@ class DynamoDBPublication:
         return encode_model(event, "OUTBOXEVENT", outbox_key(event.event_id), attributes)
 
     def _event_action(self, tenant_id: str, event: OutboxEvent) -> Action:
+        if event.delivered_at is not None:
+            raise Conflict("event_delivery_conflict")
         if event.tenant_id != tenant_id:
             raise Conflict("event_tenant_conflict")
         existing = self._get_outbox_event(event.event_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -1,0 +1,212 @@
+"""DynamoDB idempotency, publication, and outbox transactions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cnes_domain.control_plane.commands import (
+    BeginIdempotency,
+    IdempotencyOutcome,
+    PublishDataset,
+)
+from cnes_domain.control_plane.entities import (
+    DatasetPointer,
+    DatasetVersion,
+    IdempotencyRecord,
+    OutboxEvent,
+    Run,
+)
+from cnes_domain.control_plane.enums import RunState
+from cnes_domain.control_plane.errors import Conflict, NotFound
+from cnes_domain.control_plane.transitions import transition_run
+from cnes_infra.control_plane.dynamodb_codec import (
+    Item,
+    decode_model,
+    encode_model,
+    payload,
+    put_action,
+)
+from cnes_infra.control_plane.dynamodb_keys import (
+    idempotency_key,
+    outbox_key,
+    pointer_key,
+    run_entity_key,
+    timestamp,
+    version_key,
+)
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+class DynamoDBPublication:
+    """Implementa idempotência, publicação atômica e entrega de outbox."""
+
+    def _idempotency_item(self, record: IdempotencyRecord) -> Item:
+        key = idempotency_key(record.tenant_id, record.scope, record.key)
+        item = encode_model(record, "IDEMPOTENCYRECORD", key)
+        item["expires_at"] = {"N": str(int(record.expires_at.timestamp()))}
+        return item
+
+    def _version_item(self, version: DatasetVersion) -> Item:
+        key = version_key(version.tenant_id, version.dataset_name, version.version_id)
+        return encode_model(version, "DATASETVERSION", key)
+
+    def _pointer_item(self, pointer: DatasetPointer) -> Item:
+        key = pointer_key(pointer.tenant_id, pointer.dataset_name, pointer.pointer_name)
+        return encode_model(pointer, "DATASETPOINTER", key)
+
+    def _outbox_item(self, event: OutboxEvent) -> Item:
+        attributes = {}
+        if event.delivered_at is None:
+            attributes = {
+                "gsi6pk": "OUTBOX#PENDING",
+                "gsi6sk": f"{timestamp(event.created_at)}#{event.event_id}",
+            }
+        return encode_model(event, "OUTBOXEVENT", outbox_key(event.event_id), attributes)
+
+    def begin_idempotency(self, command: BeginIdempotency) -> IdempotencyOutcome:
+        """Inicia ou reproduz uma operação idempotente."""
+        key = idempotency_key(command.tenant_id, command.scope, command.key)
+        item = self._get_item(key)
+        outcome = self._existing_idempotency(item, command)
+        if outcome is not None:
+            return outcome
+        record = IdempotencyRecord(
+            tenant_id=command.tenant_id,
+            scope=command.scope,
+            key=command.key,
+            request_hash=command.request_hash,
+            status="STARTED",
+            resource_id=command.resource_id,
+            created_at=command.now,
+            expires_at=command.expires_at,
+        )
+        expected = payload(item) if item is not None else None
+        try:
+            self._transact(
+                (put_action(self._table_name, self._idempotency_item(record), expected),)
+            )
+        except Conflict:
+            current = self._get_item(key)
+            replay = self._existing_idempotency(current, command)
+            if replay is not None:
+                return replay
+            raise
+        return IdempotencyOutcome(record=record, created=True)
+
+    @staticmethod
+    def _existing_idempotency(
+        item: Item | None, command: BeginIdempotency
+    ) -> IdempotencyOutcome | None:
+        if item is None:
+            return None
+        record = decode_model(item, IdempotencyRecord)
+        if record.expires_at <= command.now:
+            return None
+        if record.request_hash != command.request_hash:
+            raise Conflict("idempotency_hash_conflict")
+        return IdempotencyOutcome(record=record, created=False)
+
+    def publish_dataset(self, command: PublishDataset) -> DatasetPointer:
+        """Publica versão, ponteiro, run e evento atomicamente."""
+        run_key = run_entity_key(command.version.tenant_id, command.version.run_id)
+        run_item = self._get_item(run_key)
+        if run_item is None:
+            raise NotFound("run_missing")
+        run = decode_model(run_item, Run)
+        replay = self._publication_replay(command, run)
+        if replay is not None:
+            return replay
+        if run.state is not RunState.PUBLISHING:
+            raise Conflict("run_not_publishing")
+        pointer_key_value = pointer_key(
+            command.version.tenant_id, command.version.dataset_name, command.pointer_name
+        )
+        pointer_item = self._get_item(pointer_key_value)
+        current = decode_model(pointer_item, DatasetPointer) if pointer_item else None
+        current_version = current.version_id if current is not None else None
+        if current_version != command.expected_version_id:
+            raise Conflict("pointer_version_conflict")
+        pointer = DatasetPointer(
+            tenant_id=command.version.tenant_id,
+            dataset_name=command.version.dataset_name,
+            pointer_name=command.pointer_name,
+            version_id=command.version.version_id,
+            updated_at=self._clock(),
+        )
+        updated_run = transition_run(run, command.final_state).model_copy(
+            update={"missing_sources": command.missing_sources}
+        )
+        expected_pointer = payload(pointer_item) if pointer_item is not None else None
+        actions = (
+            put_action(self._table_name, self._version_item(command.version), None),
+            put_action(self._table_name, self._pointer_item(pointer), expected_pointer),
+            put_action(self._table_name, self._run_item(updated_run), payload(run_item)),
+            self._event_action(command.event),
+        )
+        self._transact(actions)
+        return pointer
+
+    def _publication_replay(self, command: PublishDataset, run: Run) -> DatasetPointer | None:
+        terminal = {RunState.PUBLISHED, RunState.PUBLISHED_DEGRADED}
+        if run.state not in terminal:
+            return None
+        version = self.get_dataset_version(
+            command.version.tenant_id,
+            command.version.dataset_name,
+            command.version.version_id,
+        )
+        pointer = self.get_dataset_pointer(command.version.tenant_id, command.version.dataset_name)
+        event = self._get_outbox_event(command.event.event_id)
+        exact = (
+            run.state is command.final_state
+            and run.missing_sources == command.missing_sources
+            and version == command.version
+            and pointer is not None
+            and pointer.version_id == command.version.version_id
+            and event == command.event
+        )
+        if not exact:
+            raise Conflict("publication_replay_conflict")
+        return pointer
+
+    def get_dataset_pointer(self, tenant_id: str, dataset_name: str) -> DatasetPointer | None:
+        """Retorna o ponteiro current do dataset."""
+        key = pointer_key(tenant_id, dataset_name, "current")
+        return self._get_model(key, DatasetPointer)
+
+    def get_dataset_version(
+        self, tenant_id: str, dataset_name: str, version_id: str
+    ) -> DatasetVersion | None:
+        """Retorna uma versão publicada do dataset."""
+        key = version_key(tenant_id, dataset_name, version_id)
+        return self._get_model(key, DatasetVersion)
+
+    def _get_outbox_event(self, event_id: str) -> OutboxEvent | None:
+        return self._get_model(outbox_key(event_id), OutboxEvent)
+
+    def get_outbox_event(self, event_id: str) -> OutboxEvent | None:
+        """Retorna um evento pela identidade global."""
+        return self._get_outbox_event(event_id)
+
+    def pending_outbox(self, limit: int) -> tuple[OutboxEvent, ...]:
+        """Lista eventos pendentes globalmente."""
+        candidates = self._query("gsi6", "OUTBOX#PENDING")
+        events = self._strong_candidates(candidates, OutboxEvent)
+        pending = (event for event in events if event.delivered_at is None)
+        return tuple(sorted(pending, key=lambda event: (event.created_at, event.event_id))[:limit])
+
+    def mark_outbox_delivered(self, event_id: str, delivered_at: datetime) -> None:
+        """Marca um evento global como entregue."""
+        key = outbox_key(event_id)
+        item = self._get_item(key)
+        if item is None:
+            raise NotFound("outbox_event_missing")
+        event = decode_model(item, OutboxEvent)
+        if event.delivered_at is not None:
+            if event.delivered_at != delivered_at:
+                raise Conflict("outbox_delivery_conflict")
+            return
+        updated = event.model_copy(update={"delivered_at": delivered_at})
+        self._transact((put_action(self._table_name, self._outbox_item(updated), payload(item)),))

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -208,10 +208,40 @@ class DynamoDBPublication:
 
     def pending_outbox(self, limit: int) -> tuple[OutboxEvent, ...]:
         """Lista eventos pendentes globalmente."""
-        candidates = self._query("gsi6", "OUTBOX#PENDING")
-        events = self._strong_candidates(candidates, OutboxEvent)
-        pending = (event for event in events if event.delivered_at is None)
-        return tuple(sorted(pending, key=lambda event: (event.created_at, event.event_id))[:limit])
+        if limit <= 0:
+            return ()
+        request = {
+            "TableName": self._table_name,
+            "IndexName": "gsi6",
+            "KeyConditionExpression": "gsi6pk = :partition",
+            "ExpressionAttributeValues": {":partition": {"S": "OUTBOX#PENDING"}},
+            "ScanIndexForward": True,
+        }
+        events = []
+        seen = set()
+        while True:
+            response = self._client.query(**request)
+            for candidate in response.get("Items", ()):
+                key = (
+                    candidate.get("base_pk", candidate["pk"])["S"],
+                    candidate.get("base_sk", candidate["sk"])["S"],
+                )
+                if key in seen:
+                    continue
+                seen.add(key)
+                item = self._get_item(key)
+                if item is None or item.get("entity", {}).get("S") != "OUTBOXEVENT":
+                    continue
+                event = decode_model(item, OutboxEvent)
+                if event.delivered_at is not None:
+                    continue
+                events.append(event)
+                if len(events) == limit:
+                    return tuple(events)
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                return tuple(events)
+            request["ExclusiveStartKey"] = last_key
 
     def mark_outbox_delivered(self, event_id: str, delivered_at: datetime) -> None:
         """Marca um evento global como entregue."""

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -29,6 +29,7 @@ from cnes_infra.control_plane.dynamodb_codec import (
 )
 from cnes_infra.control_plane.dynamodb_keys import (
     idempotency_key,
+    key_component,
     outbox_key,
     pointer_key,
     run_entity_key,
@@ -62,7 +63,7 @@ class DynamoDBPublication:
         if event.delivered_at is None:
             attributes = {
                 "gsi6pk": "OUTBOX#PENDING",
-                "gsi6sk": f"{timestamp(event.created_at)}#{event.event_id}",
+                "gsi6sk": f"{timestamp(event.created_at)}#{key_component(event.event_id)}",
             }
         return encode_model(event, "OUTBOXEVENT", outbox_key(event.event_id), attributes)
 

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -241,6 +241,7 @@ class DynamoDBPublication:
         events = []
         seen = set()
         while True:
+            request["Limit"] = limit - len(events)
             response = self._client.query(**request)
             for candidate in response.get("Items", ()):
                 key = (

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -127,6 +127,7 @@ class DynamoDBPublication:
         if run_item is None:
             raise NotFound("run_missing")
         run = decode_model(run_item, Run)
+        self._validate_publication_run(command, run)
         replay = self._publication_replay(command, run)
         if replay is not None:
             return replay
@@ -159,6 +160,16 @@ class DynamoDBPublication:
         )
         self._transact(actions)
         return pointer
+
+    @staticmethod
+    def _validate_publication_run(command: PublishDataset, run: Run) -> None:
+        expected_key = (
+            f"reconciliation/{run.tenant_id}/{run.competencia}/{run.run_id}/run-manifest.json"
+        )
+        if (command.version.dataset_name, command.version.run_manifest_key) != (
+            run.dataset_name, expected_key
+        ):
+            raise Conflict("publication_run_conflict")
 
     def _publication_replay(self, command: PublishDataset, run: Run) -> DatasetPointer | None:
         terminal = {RunState.PUBLISHED, RunState.PUBLISHED_DEGRADED}

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -158,7 +158,16 @@ class DynamoDBPublication:
             put_action(self._table_name, self._run_item(updated_run), payload(run_item)),
             self._event_action(command.version.tenant_id, command.event),
         )
-        self._transact(actions)
+        try:
+            self._transact(actions)
+        except Conflict:
+            winner_item = self._get_item(run_key)
+            if winner_item is None:
+                raise
+            winner = self._publication_replay(command, decode_model(winner_item, Run))
+            if winner is None:
+                raise
+            return winner
         return pointer
 
     @staticmethod
@@ -167,7 +176,8 @@ class DynamoDBPublication:
             f"reconciliation/{run.tenant_id}/{run.competencia}/{run.run_id}/run-manifest.json"
         )
         if (command.version.dataset_name, command.version.run_manifest_key) != (
-            run.dataset_name, expected_key
+            run.dataset_name,
+            expected_key,
         ):
             raise Conflict("publication_run_conflict")
 
@@ -227,9 +237,7 @@ class DynamoDBPublication:
         """Retorna um evento pela identidade global."""
         return self._get_outbox_event(event_id)
 
-    def _pending_outbox_event(
-        self, candidate: Item, key: tuple[str, str]
-    ) -> OutboxEvent | None:
+    def _pending_outbox_event(self, candidate: Item, key: tuple[str, str]) -> OutboxEvent | None:
         item = self._get_item(key)
         if item is None or item.get("entity", {}).get("S") != "OUTBOXEVENT":
             return None

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -20,6 +20,7 @@ from cnes_domain.control_plane.enums import RunState
 from cnes_domain.control_plane.errors import Conflict, NotFound
 from cnes_domain.control_plane.transitions import transition_run
 from cnes_infra.control_plane.dynamodb_codec import (
+    Action,
     Item,
     decode_model,
     encode_model,
@@ -64,6 +65,14 @@ class DynamoDBPublication:
                 "gsi6sk": f"{timestamp(event.created_at)}#{event.event_id}",
             }
         return encode_model(event, "OUTBOXEVENT", outbox_key(event.event_id), attributes)
+
+    def _event_action(self, tenant_id: str, event: OutboxEvent) -> Action:
+        if event.tenant_id != tenant_id:
+            raise Conflict("event_tenant_conflict")
+        existing = self._get_outbox_event(event.event_id)
+        if existing is not None:
+            raise Conflict("event_id_conflict")
+        return put_action(self._table_name, self._outbox_item(event), None)
 
     def begin_idempotency(self, command: BeginIdempotency) -> IdempotencyOutcome:
         """Inicia ou reproduz uma operação idempotente."""
@@ -143,7 +152,7 @@ class DynamoDBPublication:
             put_action(self._table_name, self._version_item(command.version), None),
             put_action(self._table_name, self._pointer_item(pointer), expected_pointer),
             put_action(self._table_name, self._run_item(updated_run), payload(run_item)),
-            self._event_action(command.event),
+            self._event_action(command.version.tenant_id, command.event),
         )
         self._transact(actions)
         return pointer
@@ -157,7 +166,10 @@ class DynamoDBPublication:
             command.version.dataset_name,
             command.version.version_id,
         )
-        pointer = self.get_dataset_pointer(command.version.tenant_id, command.version.dataset_name)
+        key = pointer_key(
+            command.version.tenant_id, command.version.dataset_name, command.pointer_name
+        )
+        pointer = self._get_model(key, DatasetPointer)
         event = self._get_outbox_event(command.event.event_id)
         exact = (
             run.state is command.final_state

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -224,9 +224,9 @@ class DynamoDBPublication:
 
     @staticmethod
     def _event_replay_matches(current: OutboxEvent | None, event: OutboxEvent) -> bool:
-        if current is None:
+        if current is None or event.delivered_at is not None:
             return False
-        return current.model_copy(update={"delivered_at": event.delivered_at}) == event
+        return current.model_copy(update={"delivered_at": None}) == event
 
     def _require_event_replay(self, tenant_id: str, event: OutboxEvent) -> None:
         current = self._get_outbox_event(event.event_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -177,7 +177,7 @@ class DynamoDBPublication:
             and version == command.version
             and pointer is not None
             and pointer.version_id == command.version.version_id
-            and event == command.event
+            and self._event_replay_matches(event, command.event)
         )
         if not exact:
             raise Conflict("publication_replay_conflict")
@@ -198,8 +198,15 @@ class DynamoDBPublication:
     def _get_outbox_event(self, event_id: str) -> OutboxEvent | None:
         return self._get_model(outbox_key(event_id), OutboxEvent)
 
+    @staticmethod
+    def _event_replay_matches(current: OutboxEvent | None, event: OutboxEvent) -> bool:
+        if current is None:
+            return False
+        return current.model_copy(update={"delivered_at": event.delivered_at}) == event
+
     def _require_event_replay(self, tenant_id: str, event: OutboxEvent) -> None:
-        if event.tenant_id != tenant_id or self._get_outbox_event(event.event_id) != event:
+        current = self._get_outbox_event(event.event_id)
+        if event.tenant_id != tenant_id or not self._event_replay_matches(current, event):
             raise Conflict("event_id_conflict")
 
     def get_outbox_event(self, event_id: str) -> OutboxEvent | None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -206,6 +206,19 @@ class DynamoDBPublication:
         """Retorna um evento pela identidade global."""
         return self._get_outbox_event(event_id)
 
+    def _pending_outbox_event(
+        self, candidate: Item, key: tuple[str, str]
+    ) -> OutboxEvent | None:
+        item = self._get_item(key)
+        if item is None or item.get("entity", {}).get("S") != "OUTBOXEVENT":
+            return None
+        event = decode_model(item, OutboxEvent)
+        current_index = (item.get("gsi6pk"), item.get("gsi6sk"))
+        candidate_index = (candidate.get("gsi6pk"), candidate.get("gsi6sk"))
+        if event.delivered_at is not None or current_index != candidate_index:
+            return None
+        return event
+
     def pending_outbox(self, limit: int) -> tuple[OutboxEvent, ...]:
         """Lista eventos pendentes globalmente."""
         if limit <= 0:
@@ -228,13 +241,10 @@ class DynamoDBPublication:
                 )
                 if key in seen:
                     continue
+                event = self._pending_outbox_event(candidate, key)
+                if event is None:
+                    continue
                 seen.add(key)
-                item = self._get_item(key)
-                if item is None or item.get("entity", {}).get("S") != "OUTBOXEVENT":
-                    continue
-                event = decode_model(item, OutboxEvent)
-                if event.delivered_at is not None:
-                    continue
                 events.append(event)
                 if len(events) == limit:
                     return tuple(events)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py
@@ -186,6 +186,10 @@ class DynamoDBPublication:
     def _get_outbox_event(self, event_id: str) -> OutboxEvent | None:
         return self._get_model(outbox_key(event_id), OutboxEvent)
 
+    def _require_event_replay(self, tenant_id: str, event: OutboxEvent) -> None:
+        if event.tenant_id != tenant_id or self._get_outbox_event(event.event_id) != event:
+            raise Conflict("event_id_conflict")
+
     def get_outbox_event(self, event_id: str) -> OutboxEvent | None:
         """Retorna um evento pela identidade global."""
         return self._get_outbox_event(event_id)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -63,14 +63,14 @@ class ClientSpy:
         self.client = client
         self.transactions: list[list[dict[str, Any]]] = []
         self.calls: list[str] = []
-        self.query_limits: list[int | None] = []
+        self.query_requests: list[dict[str, Any]] = []
     def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("transact_write_items")
         self.transactions.append(kwargs["TransactItems"])
         return self.client.transact_write_items(**kwargs)
     def query(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("query")
-        self.query_limits.append(kwargs.get("Limit"))
+        self.query_requests.append(dict(kwargs))
         kwargs.setdefault("Limit", getattr(self, "query_limit", 100))
         return self.client.query(**kwargs)
     def __getattr__(self, name: str) -> Any:
@@ -129,7 +129,8 @@ def _store_record_matching_mode(adapter: Any, record: Any, clock: MutableClock) 
     job_id = f"job-{record.agent_id}-{record.snapshot_id}"
     job = _job(job_id, record.agent_id, record.tenant_id).model_copy(update={
         "source_type": record.source_type, "file_subtype": record.file_subtype,
-        "competencia": record.competencia, "requested_snapshot_mode": record.snapshot_mode})
+        "competencia": record.competencia, "requested_snapshot_mode": record.snapshot_mode,
+        "created_at": record.created_at})
     adapter.put_agent(_agent(record.agent_id, tenant_id=record.tenant_id))
     adapter.create_job(job, _event(f"created-{job_id}", tenant_id=record.tenant_id))
     claimed = adapter.claim_job(_claim_job(job_id, "raw-worker", clock, record.tenant_id))
@@ -145,9 +146,8 @@ def _put_many_units(adapter: DynamoDBControlPlane, amount: int) -> tuple[Any, ..
     command = PutRunUnits(
         tenant_id=_TENANT, run_id="run-a", expected_run_state=RunState.PROCESSING, units=units)
     return adapter.put_run_units(command)
-def _expected_item(
-    model: Any, entity: str, key: tuple[str, str], indexes: dict[str, str]
-) -> dict[str, Any]:
+def _expected_item(model: Any, entity: str, key: tuple[str, str],
+    indexes: dict[str, str]) -> dict[str, Any]:
     item = {
         "pk": {"S": key[0]},
         "sk": {"S": key[1]},

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -43,7 +43,6 @@ from packages.cnes_infra.tests.contracts.control_plane_contract import (
 _TABLE_NAME = "cnesdata-control-plane"
 _INDEXES = tuple(f"gsi{number}" for number in range(1, 7))
 
-
 class ClientSpy:
     def __init__(self, client: Any) -> None:
         self.client = client
@@ -66,7 +65,6 @@ class ClientSpy:
 
         return tracked
 
-
 class FailingTransactionClient(ClientSpy):
     def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("transact_write_items")
@@ -75,7 +73,6 @@ class FailingTransactionClient(ClientSpy):
             {"Error": {"Code": "TransactionCanceledException", "Message": "cancelled"}},
             "TransactWriteItems",
         )
-
 
 def _create_table(client: object) -> None:
     index_attributes = tuple(f"{index}{suffix}" for index in _INDEXES for suffix in ("pk", "sk"))
@@ -109,7 +106,6 @@ def _create_table(client: object) -> None:
         TimeToLiveSpecification={"Enabled": True, "AttributeName": "expires_at"},
     )
 
-
 @pytest.fixture
 def dynamodb_adapter() -> Iterator[tuple[DynamoDBControlPlane, MutableClock]]:
     with mock_aws():
@@ -117,7 +113,6 @@ def dynamodb_adapter() -> Iterator[tuple[DynamoDBControlPlane, MutableClock]]:
         _create_table(client)
         clock = MutableClock(_NOW)
         yield DynamoDBControlPlane(client, _TABLE_NAME, clock.now), clock
-
 
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
 def test_cumpre_contrato_compartilhado(
@@ -127,10 +122,8 @@ def test_cumpre_contrato_compartilhado(
     adapter, clock = dynamodb_adapter
     case.run(adapter, clock)
 
-
 def _many_units(amount: int) -> tuple[Any, ...]:
     return tuple(_unit(f"unit-{index:03d}") for index in range(amount))
-
 
 def _put_many_units(adapter: DynamoDBControlPlane, amount: int) -> tuple[Any, ...]:
     units = _many_units(amount)
@@ -143,7 +136,6 @@ def _put_many_units(adapter: DynamoDBControlPlane, amount: int) -> tuple[Any, ..
         )
     )
 
-
 def _expected_item(
     model: Any, entity: str, key: tuple[str, str], indexes: dict[str, str]
 ) -> dict[str, Any]:
@@ -155,7 +147,6 @@ def _expected_item(
     }
     return item | {name: {"S": value} for name, value in indexes.items()}
 
-
 def _expected_put(item: dict[str, Any], expected: str | None) -> dict[str, Any]:
     request = {"TableName": _TABLE_NAME, "Item": item}
     request["ConditionExpression"] = (
@@ -165,7 +156,6 @@ def _expected_put(item: dict[str, Any], expected: str | None) -> dict[str, Any]:
         request["ExpressionAttributeValues"] = {":expected": {"S": expected}}
     return {"Put": request}
 
-
 def _transaction_action(identifier: str) -> dict[str, Any]:
     item = {
         "pk": {"S": "TENANT#354130"},
@@ -173,7 +163,6 @@ def _transaction_action(identifier: str) -> dict[str, Any]:
         "payload": {"S": "{}"},
     }
     return put_action(_TABLE_NAME, item, None)
-
 
 def _expected_unit_action(index: int, state: RunUnitState) -> dict[str, Any]:
     unit = _unit(f"unit-{index:03d}").model_copy(update={"state": state})
@@ -189,7 +178,6 @@ def _expected_unit_action(index: int, state: RunUnitState) -> dict[str, Any]:
     expected = None if state is RunUnitState.PENDING else _unit(f"unit-{index:03d}")
     return _expected_put(item, expected.model_dump_json() if expected is not None else None)
 
-
 def _hide_unit_from_gsi(adapter: DynamoDBControlPlane, unit_id: str) -> None:
     item = adapter._client.get_item(
         TableName=_TABLE_NAME,
@@ -199,7 +187,6 @@ def _hide_unit_from_gsi(adapter: DynamoDBControlPlane, unit_id: str) -> None:
     item.pop("gsi5pk")
     item.pop("gsi5sk")
     adapter._client.put_item(TableName=_TABLE_NAME, Item=item)
-
 
 def test_grava_99_unidades_em_ate_100_acoes_unicas(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
@@ -227,7 +214,6 @@ def test_grava_99_unidades_em_ate_100_acoes_unicas(
         _put_many_units(adapter, 98)
     assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
 
-
 def test_rejeita_100_unidades_antes_de_chamar_boto3(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -238,12 +224,31 @@ def test_rejeita_100_unidades_antes_de_chamar_boto3(
         _put_many_units(adapter, 100)
     assert spy.calls == []
 
+def test_rejeita_uniao_de_99_unidades_antes_de_transacao(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    adapter.put_run(_run("run-a"))
+    units = _put_many_units(adapter, 99)
+    first = ReserveRunDispatch(
+        tenant_id=_TENANT, run_id="run-a", wave_id="a" * 16,
+        unit_ids=tuple(unit.unit_id for unit in units[:98]), now=clock.now(), lease_seconds=30,
+    )
+    adapter.reserve_run_dispatch(first)
+    clock.advance(timedelta(seconds=31))
+    spy = ClientSpy(adapter._client)
+    adapter._client = spy
+    replacement = first.model_copy(update={
+        "wave_id": "b" * 16, "unit_ids": ("unit-098",), "now": clock.now(),
+    })
+    with pytest.raises(Conflict, match="transaction_limit"):
+        adapter.reserve_run_dispatch(replacement)
+    assert spy.transactions == []
 
 def _prepare_cancellation(adapter: DynamoDBControlPlane, amount: int) -> None:
     adapter.put_run(_run("run-a"))
     _put_many_units(adapter, amount)
     adapter.put_run(_run("run-a", RunState.CANCEL_REQUESTED))
-
 
 def _finalize(adapter: DynamoDBControlPlane, clock: MutableClock) -> Any:
     command = FinalizeRunCancellation(
@@ -253,7 +258,6 @@ def _finalize(adapter: DynamoDBControlPlane, clock: MutableClock) -> Any:
         canceled_at=clock.now(),
     )
     return adapter.finalize_run_cancellation(command, _event("run-canceled"))
-
 
 def test_cancela_98_unidades_em_100_acoes_unicas(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
@@ -284,7 +288,6 @@ def test_cancela_98_unidades_em_100_acoes_unicas(
         _expected_put(event_item, None),
     ]
 
-
 def test_rejeita_cancelamento_de_99_unidades_sem_transacao(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -300,7 +303,6 @@ def test_rejeita_cancelamento_de_99_unidades_sem_transacao(
     assert all(unit.state.value == "PENDING" for unit in adapter.list_run_units(_TENANT, "run-a"))
     assert adapter.get_outbox_event("run-canceled") is None
 
-
 def test_rejeita_transacao_com_chaves_duplicadas_ou_mais_de_100_acoes(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -313,7 +315,6 @@ def test_rejeita_transacao_com_chaves_duplicadas_ou_mais_de_100_acoes(
     with pytest.raises(Conflict, match="transaction_limit"):
         execute_transaction(spy, actions)
     assert spy.calls == []
-
 
 def test_moto_cancela_transacao_inteira_quando_condicao_falha(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
@@ -335,7 +336,6 @@ def test_moto_cancela_transacao_inteira_quando_condicao_falha(
         execute_transaction(adapter._client, actions)
     assert adapter.get_run(_TENANT, "run-a") == original
     assert adapter.get_outbox_event("existing") == existing_event
-
 
 def test_claims_retornam_none_quando_cas_perde_corrida(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
@@ -359,7 +359,6 @@ def test_claims_retornam_none_quando_cas_perde_corrida(
     )
     assert adapter.claim_run_unit(command) is None
 
-
 def test_unit_ausente_nao_e_reivindicada_nem_finalizada(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -376,7 +375,6 @@ def test_unit_ausente_nao_e_reivindicada_nem_finalizada(
     assert adapter.claim_run_unit(claim) is None
     with pytest.raises(NotFound, match="unit_context_missing"):
         adapter.commit_run_unit(_commit_command("a" * 16, "worker-a", 1), _event("missing-unit"))
-
 
 def test_dispatch_terminal_invalida_commit_de_unidade(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
@@ -399,8 +397,7 @@ def test_dispatch_terminal_invalida_commit_de_unidade(
             _event("terminal-dispatch"),
         )
 
-
-def test_dispatch_expirado_rejeita_substituicao_que_omite_lease_vivo(
+def test_dispatch_expirado_rejeita_corrida_que_aluga_unidade_omitida(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
     adapter, clock = dynamodb_adapter
@@ -421,18 +418,26 @@ def test_dispatch_expirado_rejeita_substituicao_que_omite_lease_vivo(
     with pytest.raises(Conflict, match="dispatch_unit_missing"):
         adapter.reserve_run_dispatch(reserve)
     _put_many_units(adapter, 2)
-    dispatch = adapter.reserve_run_dispatch(
-        reserve.model_copy(update={"unit_ids": ("unit-000", "unit-001")})
-    )
-    claim = ClaimRunUnit(
-        tenant_id=_TENANT, run_id="run-a", unit_id="unit-001",
-        dispatch_id=dispatch.dispatch_id, owner="worker-a", now=clock.now(), lease_seconds=60,
-    )
-    assert adapter.claim_run_unit(claim) is not None
+    both = reserve.model_copy(update={"unit_ids": ("unit-000", "unit-001")})
+    dispatch = adapter.reserve_run_dispatch(both)
     clock.advance(timedelta(seconds=31))
-    replacement = reserve.model_copy(
-        update={"wave_id": "b" * 16, "now": clock.now()}
-    )
+    replacement = reserve.model_copy(update={"wave_id": "b" * 16, "now": clock.now()})
+    contender = DynamoDBControlPlane(adapter._client, _TABLE_NAME, clock.now)
+    transact = adapter._transact
+    def lease_omitted_then_replace(actions: Any) -> None:
+        claim = ClaimRunUnit(
+            tenant_id=_TENANT, run_id="run-a", unit_id="unit-001",
+            dispatch_id=dispatch.dispatch_id, owner="worker-a",
+            now=_NOW + timedelta(seconds=29), lease_seconds=60,
+        )
+        assert contender.claim_run_unit(claim) is not None
+        transact(actions)
+    adapter._transact = lease_omitted_then_replace
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.reserve_run_dispatch(replacement)
+    adapter._transact = transact
+    assert adapter._required_dispatch(_TENANT, "run-a")[1] == dispatch
+    assert adapter.list_run_units(_TENANT, "run-a")[1].state is RunUnitState.LEASED
     with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
         adapter.reserve_run_dispatch(replacement)
     adapter._client.delete_item(
@@ -445,7 +450,6 @@ def test_dispatch_expirado_rejeita_substituicao_que_omite_lease_vivo(
     adapter._put_direct(adapter._unit_item(terminal))
     with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
         adapter.reserve_run_dispatch(replacement.model_copy(update={"unit_ids": ("unit-001",)}))
-
 
 def test_dispatch_started_expirado_e_recuperavel_sem_lease_vivo(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
@@ -466,7 +470,6 @@ def test_dispatch_started_expirado_e_recuperavel_sem_lease_vivo(
     )
     assert recovered.generation == 2
 
-
 def test_commit_rejeita_dispatch_da_unidade_obsoleto(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -480,7 +483,6 @@ def test_commit_rejeita_dispatch_da_unidade_obsoleto(
             _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
             _event("stale-unit-dispatch"),
         )
-
 
 def test_validador_rejeita_lease_corrompido_sem_prazo() -> None:
     unit = _unit("unit-a").model_copy(

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -183,23 +183,16 @@ def _store_waiting(adapter: DynamoDBControlPlane, run: Any, event_id: str) -> An
     return run
 def _expected_unit_action(index: int, state: RunUnitState) -> dict[str, Any]:
     unit = _unit(f"unit-{index:03d}").model_copy(update={"state": state})
-    item = _expected_item(
-        unit,
-        "RUNUNIT",
-        unit_key(_TENANT, "run-a", f"unit-{index:03d}"),
-        {
-            "gsi5pk": f"RUN_ITEMS#{key_component(_TENANT)}#{key_component('run-a')}",
-            "gsi5sk": f"UNIT#{key_component(f'unit-{index:03d}')}",
-        },
-    )
+    indexes = {
+        "gsi5pk": f"RUN_ITEMS#{key_component(_TENANT)}#{key_component('run-a')}",
+        "gsi5sk": f"UNIT#{key_component(f'unit-{index:03d}')}"}
+    item = _expected_item(unit, "RUNUNIT",
+        unit_key(_TENANT, "run-a", f"unit-{index:03d}"), indexes)
     expected = None if state is RunUnitState.PENDING else _unit(f"unit-{index:03d}")
     return _expected_put(item, expected.model_dump_json() if expected is not None else None)
 def _hide_unit_from_gsi(adapter: DynamoDBControlPlane, unit_id: str) -> None:
-    item = adapter._client.get_item(
-        TableName=_TABLE_NAME,
-        Key=item_key(*unit_key(_TENANT, "run-a", unit_id)),
-        ConsistentRead=True,
-    )["Item"]
+    item = adapter._client.get_item(TableName=_TABLE_NAME,
+        Key=item_key(*unit_key(_TENANT, "run-a", unit_id)), ConsistentRead=True)["Item"]
     item.pop("gsi5pk")
     item.pop("gsi5sk")
     adapter._client.put_item(TableName=_TABLE_NAME, Item=item)
@@ -214,12 +207,9 @@ def test_grava_99_unidades_em_ate_100_acoes_unicas(ctx: _DynamoContext) -> None:
     run = _run("run-a")
     expected_check = {
         "ConditionCheck": {
-            "TableName": _TABLE_NAME,
-            "Key": item_key(*run_entity_key(_TENANT, "run-a")),
+            "TableName": _TABLE_NAME, "Key": item_key(*run_entity_key(_TENANT, "run-a")),
             "ConditionExpression": "payload = :expected",
-            "ExpressionAttributeValues": {":expected": {"S": run.model_dump_json()}},
-        }
-    }
+            "ExpressionAttributeValues": {":expected": {"S": run.model_dump_json()}}}}
     assert actions == [
         expected_check,
         *(_expected_unit_action(index, RunUnitState.PENDING) for index in range(99)),
@@ -240,15 +230,13 @@ def test_rejeita_uniao_de_99_unidades_antes_de_transacao(ctx: _DynamoContext) ->
     units = _put_many_units(adapter, 99)
     first = ReserveRunDispatch(
         tenant_id=_TENANT, run_id="run-a", wave_id="a" * 16,
-        unit_ids=tuple(unit.unit_id for unit in units[:98]), now=clock.now(), lease_seconds=30,
-    )
+        unit_ids=tuple(unit.unit_id for unit in units[:98]), now=clock.now(), lease_seconds=30)
     adapter.reserve_run_dispatch(first)
     clock.advance(timedelta(seconds=31))
     spy = ClientSpy(adapter._client)
     adapter._client = spy
-    replacement = first.model_copy(update={
-        "wave_id": "b" * 16, "unit_ids": ("unit-098",), "now": clock.now(),
-    })
+    replacement = first.model_copy(update={"wave_id": "b" * 16,
+        "unit_ids": ("unit-098",), "now": clock.now()})
     with pytest.raises(Conflict, match="transaction_limit"):
         adapter.reserve_run_dispatch(replacement)
     assert spy.transactions == []
@@ -258,11 +246,8 @@ def _prepare_cancellation(adapter: DynamoDBControlPlane, amount: int) -> None:
     adapter.put_run(_run("run-a", RunState.CANCEL_REQUESTED))
 def _finalize(adapter: DynamoDBControlPlane, clock: MutableClock) -> Any:
     command = FinalizeRunCancellation(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        expected_state=RunState.CANCEL_REQUESTED,
-        canceled_at=clock.now(),
-    )
+        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.CANCEL_REQUESTED,
+        canceled_at=clock.now())
     return adapter.finalize_run_cancellation(command, _event("run-canceled"))
 def test_cancela_98_unidades_em_100_acoes_unicas(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
@@ -276,16 +261,10 @@ def test_cancela_98_unidades_em_100_acoes_unicas(ctx: _DynamoContext) -> None:
     run_item = _expected_item(canceled, "RUN", run_entity_key(_TENANT, "run-a"), {})
     original_payload = _run("run-a", RunState.CANCEL_REQUESTED).model_dump_json()
     event = _event("run-canceled")
-    event_item = _expected_item(
-        event,
-        "OUTBOXEVENT",
-        outbox_key("run-canceled"),
-        {
-            "gsi6pk": "OUTBOX#PENDING",
-            "gsi6sk": f"{_NOW.isoformat(timespec='microseconds')}#"
-                       f"{key_component('run-canceled')}",
-        },
-    )
+    indexes = {"gsi6pk": "OUTBOX#PENDING",
+        "gsi6sk": f"{_NOW.isoformat(timespec='microseconds')}#"
+                  f"{key_component('run-canceled')}"}
+    event_item = _expected_item(event, "OUTBOXEVENT", outbox_key("run-canceled"), indexes)
     assert actions == [
         _expected_put(run_item, original_payload),
         *(_expected_unit_action(index, RunUnitState.CANCELED) for index in range(98)),
@@ -338,11 +317,44 @@ def test_waiting_reverte_run_quando_marcador_falha(state: RunState, ctx: _Dynamo
     identity = "RUN_DEP#" + "#".join(map(key_component, (_TENANT, "SOURCE-0", "ST", "2026-07")))
     marker_key = dependency_marker_key(_TENANT, "run-a", identity)
     adapter._client.put_item(TableName=_TABLE_NAME, Item=item_key(*marker_key))
-    with pytest.raises(Conflict, match="transaction_conflict"):
+    error = "transaction_conflict" if state is RunState.PLANNED else "run_dependency_conflict"
+    with pytest.raises(Conflict, match=error):
         _store_waiting(adapter, run, "waiting-rollback")
     expected = run if state is RunState.PLANNED else None
     assert adapter.get_run(_TENANT, "run-a") == expected
     assert adapter.get_outbox_event("waiting-rollback") is None
+def test_put_waiting_recupera_resposta_perdida_e_rejeita_divergencias(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, _ = ctx
+    run = _dependency_run(2, RunState.WAITING_INPUTS, "run-replay")
+    transact = adapter._transact
+    def commit_then_lose_response(actions: Any) -> None:
+        transact(actions)
+        raise Conflict("transaction_conflict")
+    adapter._transact = commit_then_lose_response
+    adapter.put_run(run)
+    adapter._transact = transact
+    adapter._client = spy = ClientSpy(adapter._client)
+    adapter.put_run(run)
+    assert any(request.get("ConsistentRead") is True for request in spy.query_requests)
+    before = spy.scan(TableName=_TABLE_NAME)["Items"]
+    divergent = run.model_copy(update={"created_at": _NOW + timedelta(seconds=1)})
+    with pytest.raises(Conflict, match="run_conflict"):
+        adapter.put_run(divergent)
+    assert spy.scan(TableName=_TABLE_NAME)["Items"] == before
+    marker = next(item for item in before if item.get("entity", {}).get("S") == "RUN_DEP")
+    marker["gsi3sk"] = {"S": "divergent"}
+    spy.put_item(TableName=_TABLE_NAME, Item=marker)
+    changed = spy.scan(TableName=_TABLE_NAME)["Items"]
+    with pytest.raises(Conflict, match="run_dependency_conflict"):
+        adapter.put_run(run)
+    assert spy.scan(TableName=_TABLE_NAME)["Items"] == changed
+    fresh = _dependency_run(1, RunState.WAITING_INPUTS, "run-loser")
+    adapter._client = FailingTransactionClient(spy.client)
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.put_run(fresh)
+    assert adapter.get_run(_TENANT, "run-loser") is None
 def test_claims_retornam_none_quando_cas_perde_corrida(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
     adapter.put_agent(_agent("agent-a"))
@@ -352,27 +364,13 @@ def test_claims_retornam_none_quando_cas_perde_corrida(ctx: _DynamoContext) -> N
     adapter._client = adapter._client.client
     dispatch = _prepare_unit(adapter, clock)
     adapter._client = FailingTransactionClient(adapter._client)
-    command = ClaimRunUnit(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        unit_id="unit-a",
-        dispatch_id=dispatch.dispatch_id,
-        owner="worker-a",
-        now=clock.now(),
-        lease_seconds=30,
-    )
+    command = ClaimRunUnit(tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
+        dispatch_id=dispatch.dispatch_id, owner="worker-a", now=clock.now(), lease_seconds=30)
     assert adapter.claim_run_unit(command) is None
 def test_unit_ausente_nao_e_reivindicada_nem_finalizada(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
-    claim = ClaimRunUnit(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        unit_id="unit-a",
-        dispatch_id="a" * 16,
-        owner="worker-a",
-        now=clock.now(),
-        lease_seconds=30,
-    )
+    claim = ClaimRunUnit(tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
+        dispatch_id="a" * 16, owner="worker-a", now=clock.now(), lease_seconds=30)
     assert adapter.claim_run_unit(claim) is None
     with pytest.raises(NotFound, match="unit_context_missing"):
         adapter.commit_run_unit(_commit_command("a" * 16, "worker-a", 1), _event("missing-unit"))

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -1,0 +1,470 @@
+from collections.abc import Iterator
+from typing import Any
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from cnes_domain.control_plane.commands import (
+    BindRunDispatch,
+    ClaimRunUnit,
+    FinalizeRunCancellation,
+    FinishRunDispatch,
+    PutRunUnits,
+    ReserveRunDispatch,
+    TransitionRun,
+)
+from cnes_domain.control_plane.enums import DispatchOutcome, RunState
+from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
+from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
+from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
+from cnes_infra.control_plane.dynamodb_codec import execute_transaction, put_action
+from packages.cnes_infra.tests.contracts.clock import (
+    _NOW,
+    _TENANT,
+    MutableClock,
+    _agent,
+    _claim_job,
+    _claim_unit,
+    _commit_command,
+    _event,
+    _job,
+    _prepare_unit,
+    _run,
+    _unit,
+)
+from packages.cnes_infra.tests.contracts.control_plane_contract import (
+    ControlPlaneCase,
+    control_plane_cases,
+)
+
+_TABLE_NAME = "cnesdata-control-plane"
+_INDEXES = tuple(f"gsi{number}" for number in range(1, 7))
+
+
+class ClientSpy:
+    def __init__(self, client: Any) -> None:
+        self.client = client
+        self.transactions: list[list[dict[str, Any]]] = []
+        self.calls: list[str] = []
+
+    def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append("transact_write_items")
+        self.transactions.append(kwargs["TransactItems"])
+        return self.client.transact_write_items(**kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        attribute = getattr(self.client, name)
+        if not callable(attribute):
+            return attribute
+
+        def tracked(**kwargs: Any) -> Any:
+            self.calls.append(name)
+            return attribute(**kwargs)
+
+        return tracked
+
+
+class FailingTransactionClient(ClientSpy):
+    def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append("transact_write_items")
+        self.transactions.append(kwargs["TransactItems"])
+        raise ClientError(
+            {"Error": {"Code": "TransactionCanceledException", "Message": "cancelled"}},
+            "TransactWriteItems",
+        )
+
+
+def _create_table(client: object) -> None:
+    index_attributes = tuple(f"{index}{suffix}" for index in _INDEXES for suffix in ("pk", "sk"))
+    attribute_definitions = [
+        {"AttributeName": name, "AttributeType": "S"} for name in ("pk", "sk", *index_attributes)
+    ]
+    global_secondary_indexes = [
+        {
+            "IndexName": index,
+            "KeySchema": [
+                {"AttributeName": f"{index}pk", "KeyType": "HASH"},
+                {"AttributeName": f"{index}sk", "KeyType": "RANGE"},
+            ],
+            "Projection": {"ProjectionType": "ALL"},
+            "ProvisionedThroughput": {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+        }
+        for index in _INDEXES
+    ]
+    client.create_table(
+        TableName=_TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=attribute_definitions,
+        GlobalSecondaryIndexes=global_secondary_indexes,
+        ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+    )
+    client.update_time_to_live(
+        TableName=_TABLE_NAME,
+        TimeToLiveSpecification={"Enabled": True, "AttributeName": "expires_at"},
+    )
+
+
+@pytest.fixture
+def dynamodb_adapter() -> Iterator[tuple[DynamoDBControlPlane, MutableClock]]:
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-east-1")
+        _create_table(client)
+        clock = MutableClock(_NOW)
+        yield DynamoDBControlPlane(client, _TABLE_NAME, clock.now), clock
+
+
+@pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
+def test_cumpre_contrato_compartilhado(
+    case: ControlPlaneCase,
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    case.run(adapter, clock)
+
+
+def _many_units(amount: int) -> tuple[Any, ...]:
+    return tuple(_unit(f"unit-{index:03d}") for index in range(amount))
+
+
+def _put_many_units(adapter: DynamoDBControlPlane, amount: int) -> tuple[Any, ...]:
+    units = _many_units(amount)
+    return adapter.put_run_units(
+        PutRunUnits(
+            tenant_id=_TENANT,
+            run_id="run-a",
+            expected_run_state=RunState.PROCESSING,
+            units=units,
+        )
+    )
+
+
+def _action_key(action: dict[str, Any]) -> tuple[str, str]:
+    request = next(iter(action.values()))
+    values = request.get("Item", request.get("Key"))
+    return values["pk"]["S"], values["sk"]["S"]
+
+
+def test_grava_99_unidades_em_ate_100_acoes_unicas(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, _ = dynamodb_adapter
+    adapter.put_run(_run("run-a"))
+    spy = ClientSpy(adapter._client)
+    adapter._client = spy
+
+    assert _put_many_units(adapter, 99) == _many_units(99)
+
+    actions = spy.transactions[-1]
+    keys = [_action_key(action) for action in actions]
+    assert len(actions) == 100
+    assert tuple(next(iter(action)) for action in actions) == (
+        "ConditionCheck",
+        *("Put" for _ in range(99)),
+    )
+    assert len(keys) == len(set(keys))
+
+
+def test_rejeita_100_unidades_antes_de_chamar_boto3(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, _ = dynamodb_adapter
+    spy = ClientSpy(adapter._client)
+    adapter._client = spy
+
+    with pytest.raises(Conflict, match="transaction_limit"):
+        _put_many_units(adapter, 100)
+
+    assert spy.calls == []
+
+
+def _prepare_cancellation(adapter: DynamoDBControlPlane, amount: int) -> None:
+    adapter.put_run(_run("run-a"))
+    _put_many_units(adapter, amount)
+    adapter.put_run(_run("run-a", RunState.CANCEL_REQUESTED))
+
+
+def _finalize(adapter: DynamoDBControlPlane, clock: MutableClock) -> Any:
+    command = FinalizeRunCancellation(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        expected_state=RunState.CANCEL_REQUESTED,
+        canceled_at=clock.now(),
+    )
+    return adapter.finalize_run_cancellation(command, _event("run-canceled"))
+
+
+def test_cancela_98_unidades_em_100_acoes_unicas(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    _prepare_cancellation(adapter, 98)
+    spy = ClientSpy(adapter._client)
+    adapter._client = spy
+
+    assert _finalize(adapter, clock).state is RunState.CANCELED
+
+    actions = spy.transactions[-1]
+    keys = [_action_key(action) for action in actions]
+    assert len(actions) == 100
+    assert all(tuple(action) == ("Put",) for action in actions)
+    assert len(keys) == len(set(keys))
+
+
+def test_rejeita_cancelamento_de_99_unidades_sem_transacao(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    _prepare_cancellation(adapter, 99)
+    spy = ClientSpy(adapter._client)
+    adapter._client = spy
+
+    with pytest.raises(Conflict, match="transaction_limit"):
+        _finalize(adapter, clock)
+
+    assert spy.transactions == []
+    assert adapter.get_run(_TENANT, "run-a").state is RunState.CANCEL_REQUESTED
+    assert all(unit.state.value == "PENDING" for unit in adapter.list_run_units(_TENANT, "run-a"))
+    assert adapter.get_outbox_event("run-canceled") is None
+
+
+def test_rejeita_chaves_duplicadas_antes_de_enviar_transacao(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, _ = dynamodb_adapter
+    spy = ClientSpy(adapter._client)
+    item = {
+        "pk": {"S": "TENANT#354130"},
+        "sk": {"S": "TEST#same"},
+        "payload": {"S": "{}"},
+    }
+    action = put_action(_TABLE_NAME, item, None)
+
+    with pytest.raises(Conflict, match="duplicate_transaction_key"):
+        execute_transaction(spy, (action, action))
+
+    assert spy.transactions == []
+
+
+def test_transacao_falha_sem_mutar_run_ou_outbox(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, _ = dynamodb_adapter
+    original = _run("run-a")
+    adapter.put_run(original)
+    adapter._client = FailingTransactionClient(adapter._client)
+    command = TransitionRun(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        expected_state=RunState.PROCESSING,
+        new_state=RunState.FAILED,
+    )
+
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.transition_run(command, _event("run-failed"))
+
+    assert adapter.get_run(_TENANT, "run-a") == original
+    assert adapter.get_outbox_event("run-failed") is None
+
+
+def test_rejeita_mais_de_100_acoes_antes_do_cliente(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, _ = dynamodb_adapter
+    spy = ClientSpy(adapter._client)
+    actions = tuple(
+        put_action(
+            _TABLE_NAME,
+            {
+                "pk": {"S": "TENANT#354130"},
+                "sk": {"S": f"TEST#{index}"},
+                "payload": {"S": "{}"},
+            },
+            None,
+        )
+        for index in range(101)
+    )
+    with pytest.raises(Conflict, match="transaction_limit"):
+        execute_transaction(spy, actions)
+    assert spy.calls == []
+
+
+def test_claim_job_retorna_none_quando_cas_perde_corrida(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    adapter._client = FailingTransactionClient(adapter._client)
+
+    assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
+
+
+def test_claim_unit_retorna_none_quando_cas_perde_corrida(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    dispatch = _prepare_unit(adapter, clock)
+    adapter._client = FailingTransactionClient(adapter._client)
+    command = ClaimRunUnit(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        unit_id="unit-a",
+        dispatch_id=dispatch.dispatch_id,
+        owner="worker-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
+
+    assert adapter.claim_run_unit(command) is None
+
+
+def test_unit_ausente_nao_e_reivindicada_nem_finalizada(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    claim = ClaimRunUnit(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        unit_id="unit-a",
+        dispatch_id="a" * 16,
+        owner="worker-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    assert adapter.claim_run_unit(claim) is None
+    with pytest.raises(NotFound, match="unit_context_missing"):
+        adapter.commit_run_unit(_commit_command("a" * 16, "worker-a", 1), _event("missing-unit"))
+
+
+def test_dispatch_terminal_invalida_commit_de_unidade(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    adapter.finish_run_dispatch(
+        FinishRunDispatch(
+            tenant_id=_TENANT,
+            run_id="run-a",
+            dispatch_id=dispatch.dispatch_id,
+            outcome=DispatchOutcome.CANCELED,
+            finished_at=clock.now(),
+        )
+    )
+
+    with pytest.raises(LeaseLost, match="dispatch_terminal"):
+        adapter.commit_run_unit(
+            _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
+            _event("terminal-dispatch"),
+        )
+
+
+def test_dispatch_ausente_ou_sem_run_e_rejeitado(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    reserve = ReserveRunDispatch(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        wave_id="a" * 16,
+        unit_ids=("unit-a",),
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    with pytest.raises(Conflict, match="run_not_processing"):
+        adapter.reserve_run_dispatch(reserve)
+    assert adapter.get_active_run_dispatch(_TENANT, "run-a") is None
+    bind = BindRunDispatch(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        dispatch_id="a" * 16,
+        execution_ref="exec-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    with pytest.raises(NotFound, match="dispatch_missing"):
+        adapter.bind_run_dispatch(bind)
+
+
+def test_dispatch_rejeita_unidade_ausente_ou_terminal(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    adapter.put_run(_run("run-a"))
+    reserve = ReserveRunDispatch(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        wave_id="a" * 16,
+        unit_ids=("unit-000",),
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    with pytest.raises(Conflict, match="dispatch_unit_missing"):
+        adapter.reserve_run_dispatch(reserve)
+    _put_many_units(adapter, 1)
+    dispatch = adapter.reserve_run_dispatch(reserve)
+    claimed = adapter.claim_run_unit(
+        ClaimRunUnit(
+            tenant_id=_TENANT,
+            run_id="run-a",
+            unit_id="unit-000",
+            dispatch_id=dispatch.dispatch_id,
+            owner="worker-a",
+            now=clock.now(),
+            lease_seconds=30,
+        )
+    )
+    adapter.commit_run_unit(
+        _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token).model_copy(
+            update={"unit_id": "unit-000"}
+        ),
+        _event("unit-complete"),
+    )
+    adapter.finish_run_dispatch(
+        FinishRunDispatch(
+            tenant_id=_TENANT,
+            run_id="run-a",
+            dispatch_id=dispatch.dispatch_id,
+            outcome=DispatchOutcome.SUCCEEDED,
+            finished_at=clock.now(),
+        )
+    )
+    with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
+        adapter.reserve_run_dispatch(reserve.model_copy(update={"wave_id": "b" * 16}))
+
+
+def test_commit_rejeita_dispatch_da_unidade_obsoleto(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, clock = dynamodb_adapter
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    stale = claimed.model_copy(update={"dispatch_id": "b" * 16})
+    adapter._put_direct(adapter._unit_item(stale))
+
+    with pytest.raises(FenceRejected, match="unit_dispatch_rejected"):
+        adapter.commit_run_unit(
+            _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
+            _event("stale-unit-dispatch"),
+        )
+
+
+def test_validador_rejeita_lease_corrompido_sem_prazo() -> None:
+    unit = _unit("unit-a").model_copy(
+        update={
+            "state": "LEASED",
+            "fencing_token": 1,
+            "dispatch_id": "a" * 16,
+            "lease_owner": "worker-a",
+            "lease_until": None,
+        }
+    )
+    command = _commit_command("a" * 16, "worker-a", 1)
+
+    with pytest.raises(LeaseLost, match="unit_lease_expired"):
+        DynamoDBClaims._validate_unit_fence(unit, command, _NOW)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -64,6 +64,7 @@ class ClientSpy:
         self.transactions: list[list[dict[str, Any]]] = []
         self.calls: list[str] = []
         self.query_requests: list[dict[str, Any]] = []
+        self.requests: list[tuple[str, dict[str, Any]]] = []
     def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("transact_write_items")
         self.transactions.append(kwargs["TransactItems"])
@@ -79,6 +80,7 @@ class ClientSpy:
             return attribute
         def tracked(**kwargs: Any) -> Any:
             self.calls.append(name)
+            self.requests.append((name, dict(kwargs)))
             return attribute(**kwargs)
         return tracked
 class FailingTransactionClient(ClientSpy):

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from datetime import timedelta
 from typing import Any
 
 import boto3
@@ -222,6 +223,9 @@ def test_grava_99_unidades_em_ate_100_acoes_unicas(
         expected_check,
         *(_expected_unit_action(index, RunUnitState.PENDING) for index in range(99)),
     ]
+    with pytest.raises(Conflict, match="run_units_conflict"):
+        _put_many_units(adapter, 98)
+    assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
 
 
 def test_rejeita_100_unidades_antes_de_chamar_boto3(
@@ -396,78 +400,71 @@ def test_dispatch_terminal_invalida_commit_de_unidade(
         )
 
 
-def test_dispatch_ausente_ou_sem_run_e_rejeitado(
+def test_dispatch_expirado_rejeita_substituicao_que_omite_lease_vivo(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
     adapter, clock = dynamodb_adapter
     reserve = ReserveRunDispatch(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        wave_id="a" * 16,
-        unit_ids=("unit-a",),
-        now=clock.now(),
-        lease_seconds=30,
+        tenant_id=_TENANT, run_id="run-a", wave_id="a" * 16,
+        unit_ids=("unit-000",), now=clock.now(), lease_seconds=30,
     )
     with pytest.raises(Conflict, match="run_not_processing"):
         adapter.reserve_run_dispatch(reserve)
     assert adapter.get_active_run_dispatch(_TENANT, "run-a") is None
     bind = BindRunDispatch(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        dispatch_id="a" * 16,
-        execution_ref="exec-a",
-        now=clock.now(),
-        lease_seconds=30,
+        tenant_id=_TENANT, run_id="run-a", dispatch_id="a" * 16,
+        execution_ref="missing", now=clock.now(), lease_seconds=30,
     )
     with pytest.raises(NotFound, match="dispatch_missing"):
         adapter.bind_run_dispatch(bind)
+    adapter.put_run(_run("run-a"))
+    with pytest.raises(Conflict, match="dispatch_unit_missing"):
+        adapter.reserve_run_dispatch(reserve)
+    _put_many_units(adapter, 2)
+    dispatch = adapter.reserve_run_dispatch(
+        reserve.model_copy(update={"unit_ids": ("unit-000", "unit-001")})
+    )
+    claim = ClaimRunUnit(
+        tenant_id=_TENANT, run_id="run-a", unit_id="unit-001",
+        dispatch_id=dispatch.dispatch_id, owner="worker-a", now=clock.now(), lease_seconds=60,
+    )
+    assert adapter.claim_run_unit(claim) is not None
+    clock.advance(timedelta(seconds=31))
+    replacement = reserve.model_copy(
+        update={"wave_id": "b" * 16, "now": clock.now()}
+    )
+    with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
+        adapter.reserve_run_dispatch(replacement)
+    adapter._client.delete_item(
+        TableName=_TABLE_NAME,
+        Key={"pk": {"S": f"TENANT#{_TENANT}#RUN#run-a"}, "sk": {"S": "UNIT#unit-001"}},
+    )
+    with pytest.raises(Conflict, match="dispatch_unit_missing"):
+        adapter.reserve_run_dispatch(replacement)
+    terminal = _unit("unit-001").model_copy(update={"state": RunUnitState.SUCCEEDED})
+    adapter._put_direct(adapter._unit_item(terminal))
+    with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
+        adapter.reserve_run_dispatch(replacement.model_copy(update={"unit_ids": ("unit-001",)}))
 
 
-def test_dispatch_rejeita_unidade_ausente_ou_terminal(
+def test_dispatch_started_expirado_e_recuperavel_sem_lease_vivo(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
     adapter, clock = dynamodb_adapter
-    adapter.put_run(_run("run-a"))
-    reserve = ReserveRunDispatch(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        wave_id="a" * 16,
-        unit_ids=("unit-000",),
-        now=clock.now(),
-        lease_seconds=30,
+    dispatch = _prepare_unit(adapter, clock)
+    bind = BindRunDispatch(
+        tenant_id=_TENANT, run_id="run-a", dispatch_id=dispatch.dispatch_id,
+        execution_ref="exec-b", now=clock.now(), lease_seconds=1,
     )
-    with pytest.raises(Conflict, match="dispatch_unit_missing"):
-        adapter.reserve_run_dispatch(reserve)
-    _put_many_units(adapter, 1)
-    dispatch = adapter.reserve_run_dispatch(reserve)
-    claimed = adapter.claim_run_unit(
-        ClaimRunUnit(
-            tenant_id=_TENANT,
-            run_id="run-a",
-            unit_id="unit-000",
-            dispatch_id=dispatch.dispatch_id,
-            owner="worker-a",
-            now=clock.now(),
-            lease_seconds=30,
+    adapter.bind_run_dispatch(bind)
+    clock.advance(timedelta(seconds=2))
+    recovered = adapter.reserve_run_dispatch(
+        ReserveRunDispatch(
+            tenant_id=_TENANT, run_id="run-a", wave_id="b" * 16,
+            unit_ids=("unit-a",), now=clock.now(), lease_seconds=30,
         )
     )
-    adapter.commit_run_unit(
-        _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token).model_copy(
-            update={"unit_id": "unit-000"}
-        ),
-        _event("unit-complete"),
-    )
-    adapter.finish_run_dispatch(
-        FinishRunDispatch(
-            tenant_id=_TENANT,
-            run_id="run-a",
-            dispatch_id=dispatch.dispatch_id,
-            outcome=DispatchOutcome.SUCCEEDED,
-            finished_at=clock.now(),
-        )
-    )
-    with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
-        adapter.reserve_run_dispatch(reserve.model_copy(update={"wave_id": "b" * 16}))
+    assert recovered.generation == 2
 
 
 def test_commit_rejeita_dispatch_da_unidade_obsoleto(

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -21,7 +21,13 @@ from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost,
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
 from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
 from cnes_infra.control_plane.dynamodb_codec import execute_transaction, payload, put_action
-from cnes_infra.control_plane.dynamodb_keys import run_entity_key
+from cnes_infra.control_plane.dynamodb_keys import (
+    item_key,
+    key_component,
+    outbox_key,
+    run_entity_key,
+    unit_key,
+)
 from packages.cnes_infra.tests.contracts.clock import (
     _NOW,
     _TENANT,
@@ -43,6 +49,10 @@ from packages.cnes_infra.tests.contracts.control_plane_contract import (
 
 _TABLE_NAME = "cnesdata-control-plane"
 _INDEXES = tuple(f"gsi{number}" for number in range(1, 7))
+type _DynamoContext = tuple[DynamoDBControlPlane, MutableClock]
+@pytest.fixture
+def ctx(dynamodb_adapter: _DynamoContext) -> _DynamoContext:
+    return dynamodb_adapter
 class ClientSpy:
     def __init__(self, client: Any) -> None:
         self.client = client
@@ -160,10 +170,10 @@ def _expected_unit_action(index: int, state: RunUnitState) -> dict[str, Any]:
     item = _expected_item(
         unit,
         "RUNUNIT",
-        (f"TENANT#{_TENANT}#RUN#run-a", f"UNIT#unit-{index:03d}"),
+        unit_key(_TENANT, "run-a", f"unit-{index:03d}"),
         {
-            "gsi5pk": f"RUN_ITEMS#{_TENANT}#run-a",
-            "gsi5sk": f"UNIT#unit-{index:03d}",
+            "gsi5pk": f"RUN_ITEMS#{key_component(_TENANT)}#{key_component('run-a')}",
+            "gsi5sk": f"UNIT#{key_component(f'unit-{index:03d}')}",
         },
     )
     expected = None if state is RunUnitState.PENDING else _unit(f"unit-{index:03d}")
@@ -171,16 +181,14 @@ def _expected_unit_action(index: int, state: RunUnitState) -> dict[str, Any]:
 def _hide_unit_from_gsi(adapter: DynamoDBControlPlane, unit_id: str) -> None:
     item = adapter._client.get_item(
         TableName=_TABLE_NAME,
-        Key={"pk": {"S": f"TENANT#{_TENANT}#RUN#run-a"}, "sk": {"S": f"UNIT#{unit_id}"}},
+        Key=item_key(*unit_key(_TENANT, "run-a", unit_id)),
         ConsistentRead=True,
     )["Item"]
     item.pop("gsi5pk")
     item.pop("gsi5sk")
     adapter._client.put_item(TableName=_TABLE_NAME, Item=item)
-def test_grava_99_unidades_em_ate_100_acoes_unicas(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, _ = dynamodb_adapter
+def test_grava_99_unidades_em_ate_100_acoes_unicas(ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
     adapter.put_run(_run("run-a"))
     spy = ClientSpy(adapter._client)
     adapter._client = spy
@@ -191,7 +199,7 @@ def test_grava_99_unidades_em_ate_100_acoes_unicas(
     expected_check = {
         "ConditionCheck": {
             "TableName": _TABLE_NAME,
-            "Key": {"pk": {"S": f"TENANT#{_TENANT}"}, "sk": {"S": "RUN#run-a"}},
+            "Key": item_key(*run_entity_key(_TENANT, "run-a")),
             "ConditionExpression": "payload = :expected",
             "ExpressionAttributeValues": {":expected": {"S": run.model_dump_json()}},
         }
@@ -203,19 +211,15 @@ def test_grava_99_unidades_em_ate_100_acoes_unicas(
     with pytest.raises(Conflict, match="run_units_conflict"):
         _put_many_units(adapter, 98)
     assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
-def test_rejeita_100_unidades_antes_de_chamar_boto3(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, _ = dynamodb_adapter
+def test_rejeita_100_unidades_antes_de_chamar_boto3(ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
     spy = ClientSpy(adapter._client)
     adapter._client = spy
     with pytest.raises(Conflict, match="transaction_limit"):
         _put_many_units(adapter, 100)
     assert spy.calls == []
-def test_rejeita_uniao_de_99_unidades_antes_de_transacao(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+def test_rejeita_uniao_de_99_unidades_antes_de_transacao(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
     adapter.put_run(_run("run-a"))
     units = _put_many_units(adapter, 99)
     first = ReserveRunDispatch(
@@ -244,10 +248,8 @@ def _finalize(adapter: DynamoDBControlPlane, clock: MutableClock) -> Any:
         canceled_at=clock.now(),
     )
     return adapter.finalize_run_cancellation(command, _event("run-canceled"))
-def test_cancela_98_unidades_em_100_acoes_unicas(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+def test_cancela_98_unidades_em_100_acoes_unicas(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
     _prepare_cancellation(adapter, 98)
     _hide_unit_from_gsi(adapter, "unit-097")
     spy = ClientSpy(adapter._client)
@@ -255,16 +257,17 @@ def test_cancela_98_unidades_em_100_acoes_unicas(
     assert _finalize(adapter, clock).state is RunState.CANCELED
     actions = spy.transactions[-1]
     canceled = _run("run-a", RunState.CANCELED)
-    run_item = _expected_item(canceled, "RUN", (f"TENANT#{_TENANT}", "RUN#run-a"), {})
+    run_item = _expected_item(canceled, "RUN", run_entity_key(_TENANT, "run-a"), {})
     original_payload = _run("run-a", RunState.CANCEL_REQUESTED).model_dump_json()
     event = _event("run-canceled")
     event_item = _expected_item(
         event,
         "OUTBOXEVENT",
-        ("TENANT#_GLOBAL", "OUTBOX#run-canceled"),
+        outbox_key("run-canceled"),
         {
             "gsi6pk": "OUTBOX#PENDING",
-            "gsi6sk": f"{_NOW.isoformat(timespec='microseconds')}#run-canceled",
+            "gsi6sk": f"{_NOW.isoformat(timespec='microseconds')}#"
+                       f"{key_component('run-canceled')}",
         },
     )
     assert actions == [
@@ -272,10 +275,8 @@ def test_cancela_98_unidades_em_100_acoes_unicas(
         *(_expected_unit_action(index, RunUnitState.CANCELED) for index in range(98)),
         _expected_put(event_item, None),
     ]
-def test_rejeita_cancelamento_de_99_unidades_sem_transacao(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+def test_rejeita_cancelamento_de_99_unidades_sem_transacao(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
     _prepare_cancellation(adapter, 99)
     _hide_unit_from_gsi(adapter, "unit-098")
     spy = ClientSpy(adapter._client)
@@ -428,7 +429,7 @@ def test_dispatch_expirado_rejeita_corrida_que_aluga_unidade_omitida(
         adapter.reserve_run_dispatch(replacement)
     adapter._client.delete_item(
         TableName=_TABLE_NAME,
-        Key={"pk": {"S": f"TENANT#{_TENANT}#RUN#run-a"}, "sk": {"S": "UNIT#unit-001"}},
+        Key=item_key(*unit_key(_TENANT, "run-a", "unit-001")),
     )
     with pytest.raises(Conflict, match="dispatch_unit_missing"):
         adapter.reserve_run_dispatch(replacement)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Iterator  # noqa: I001
 from datetime import timedelta
 from typing import Any
 
@@ -8,49 +8,23 @@ from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from cnes_domain.control_plane.commands import (
-    BindRunDispatch,
-    ClaimRunUnit,
-    CompleteJob,
-    FinalizeRunCancellation,
-    FinishRunDispatch,
-    PutRunUnits,
-    ReserveRunDispatch,
-    TransitionRun,
-)
-from cnes_domain.control_plane.entities import RunDependency
+    BindRunDispatch, ClaimRunUnit, CompleteJob, FailRunUnit, FinalizeRunCancellation,
+    FinishRunDispatch, PutRunUnits, ReserveRunDispatch, TransitionRun)
+from cnes_domain.control_plane.entities import AccessRequest, RunDependency
+from cnes_domain.control_plane.enums import AccessRequestState
 from cnes_domain.control_plane.enums import DispatchOutcome, DispatchState, RunState, RunUnitState
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
 from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
 from cnes_infra.control_plane.dynamodb_codec import execute_transaction, put_action
 from cnes_infra.control_plane.dynamodb_keys import (
-    dependency_marker_key,
-    item_key,
-    key_component,
-    outbox_key,
-    run_entity_key,
-    unit_key,
-)
+    dependency_marker_key, item_key, key_component, outbox_key, run_entity_key, unit_key)
 from packages.cnes_infra.tests.contracts import control_plane_contract
 from packages.cnes_infra.tests.contracts.clock import (
-    _NOW,
-    _TENANT,
-    MutableClock,
-    _agent,
-    _claim_job,
-    _claim_unit,
-    _claim_unit_command,
-    _commit_command,
-    _event,
-    _job,
-    _prepare_unit,
-    _run,
-    _unit,
-)
+    _NOW, _TENANT, MutableClock, _agent, _claim_job, _claim_unit, _claim_unit_command,
+    _commit_command, _event, _job, _prepare_unit, _run, _unit)
 from packages.cnes_infra.tests.contracts.control_plane_contract import (
-    ControlPlaneCase,
-    control_plane_cases,
-)
+    ControlPlaneCase, control_plane_cases)
 
 _TABLE_NAME = "cnesdata-control-plane"
 _INDEXES = tuple(f"gsi{number}" for number in range(1, 7))
@@ -369,6 +343,32 @@ def test_claims_retornam_none_quando_cas_perde_corrida(ctx: _DynamoContext) -> N
     command = ClaimRunUnit(tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
         dispatch_id=dispatch.dispatch_id, owner="worker-a", now=clock.now(), lease_seconds=30)
     assert adapter.claim_run_unit(command) is None
+def test_falha_opcional_rele_parent_apos_cas_concorrente(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    dependency = RunDependency(source_type="CNES", file_subtype="ST", required=False)
+    adapter.put_run(_run("run-a", dependencies=(dependency,)))
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = FailRunUnit(tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
+        dispatch_id=dispatch.dispatch_id, owner="worker-a", fencing_token=claimed.fencing_token,
+        error_code="optional_failed", retryable=False)
+    transact = adapter._transact
+    def parent_wins(actions: Any) -> None:
+        current = adapter.get_run(_TENANT, "run-a")
+        adapter.put_run(current.model_copy(update={"missing_sources": ("SIHD/AIH",)}))
+        transact(actions)
+    adapter._transact = parent_wins
+    failed = adapter.fail_run_unit(command, _event("unit-degraded"))
+    assert (failed.state, adapter.get_run(_TENANT, "run-a").missing_sources) == (
+        RunUnitState.SUCCEEDED_DEGRADED, ("CNES/ST", "SIHD/AIH"))
+def test_access_request_propaga_conflito_sem_winner(ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
+    request = AccessRequest(tenant_id=_TENANT, request_id="missing-winner", user_id="user-a",
+                            state=AccessRequestState.PENDING, decided_by=None, decided_at=None)
+    adapter._client = FailingTransactionClient(adapter._client)
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.put_access_request(request, _event("missing-winner"))
+    assert adapter.get_access_request(_TENANT, "missing-winner") is None
 def test_unit_ausente_nao_e_reivindicada_nem_finalizada(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
     claim = ClaimRunUnit(tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -10,6 +10,7 @@ from moto import mock_aws
 from cnes_domain.control_plane.commands import (
     BindRunDispatch,
     ClaimRunUnit,
+    CompleteJob,
     FinalizeRunCancellation,
     FinishRunDispatch,
     PutRunUnits,
@@ -17,7 +18,7 @@ from cnes_domain.control_plane.commands import (
     TransitionRun,
 )
 from cnes_domain.control_plane.entities import RunDependency
-from cnes_domain.control_plane.enums import DispatchOutcome, RunState, RunUnitState
+from cnes_domain.control_plane.enums import DispatchOutcome, DispatchState, RunState, RunUnitState
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
 from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
@@ -30,6 +31,7 @@ from cnes_infra.control_plane.dynamodb_keys import (
     run_entity_key,
     unit_key,
 )
+from packages.cnes_infra.tests.contracts import control_plane_contract
 from packages.cnes_infra.tests.contracts.clock import (
     _NOW,
     _TENANT,
@@ -37,6 +39,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _agent,
     _claim_job,
     _claim_unit,
+    _claim_unit_command,
     _commit_command,
     _event,
     _job,
@@ -82,23 +85,18 @@ class FailingTransactionClient(ClientSpy):
     def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("transact_write_items")
         self.transactions.append(kwargs["TransactItems"])
-        raise ClientError(
-            {"Error": {"Code": "TransactionCanceledException", "Message": "cancelled"},
-             "CancellationReasons": [{"Code": "ConditionalCheckFailed"}]},
-            "TransactWriteItems",
-        )
+        response = {"Error": {"Code": "TransactionCanceledException", "Message": "cancelled"},
+                    "CancellationReasons": [{"Code": "ConditionalCheckFailed"}]}
+        raise ClientError(response, "TransactWriteItems")
 def _create_table(client: object) -> None:
     index_attributes = tuple(f"{index}{suffix}" for index in _INDEXES for suffix in ("pk", "sk"))
-    attribute_definitions = [
-        {"AttributeName": name, "AttributeType": "S"} for name in ("pk", "sk", *index_attributes)
-    ]
+    attribute_definitions = [{"AttributeName": name, "AttributeType": "S"}
+                             for name in ("pk", "sk", *index_attributes)]
     global_secondary_indexes = [
         {
             "IndexName": index,
-            "KeySchema": [
-                {"AttributeName": f"{index}pk", "KeyType": "HASH"},
-                {"AttributeName": f"{index}sk", "KeyType": "RANGE"},
-            ],
+            "KeySchema": [{"AttributeName": f"{index}pk", "KeyType": "HASH"},
+                          {"AttributeName": f"{index}sk", "KeyType": "RANGE"}],
             "Projection": {"ProjectionType": "ALL"},
             "ProvisionedThroughput": {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
         }
@@ -106,18 +104,14 @@ def _create_table(client: object) -> None:
     ]
     client.create_table(
         TableName=_TABLE_NAME,
-        KeySchema=[
-            {"AttributeName": "pk", "KeyType": "HASH"},
-            {"AttributeName": "sk", "KeyType": "RANGE"},
-        ],
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"},
+                   {"AttributeName": "sk", "KeyType": "RANGE"}],
         AttributeDefinitions=attribute_definitions,
         GlobalSecondaryIndexes=global_secondary_indexes,
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    client.update_time_to_live(
-        TableName=_TABLE_NAME,
-        TimeToLiveSpecification={"Enabled": True, "AttributeName": "expires_at"},
-    )
+    client.update_time_to_live(TableName=_TABLE_NAME,
+        TimeToLiveSpecification={"Enabled": True, "AttributeName": "expires_at"})
 @pytest.fixture
 def dynamodb_adapter() -> Iterator[tuple[DynamoDBControlPlane, MutableClock]]:
     with mock_aws():
@@ -126,24 +120,31 @@ def dynamodb_adapter() -> Iterator[tuple[DynamoDBControlPlane, MutableClock]]:
         clock = MutableClock(_NOW)
         yield DynamoDBControlPlane(client, _TABLE_NAME, clock.now), clock
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
-def test_cumpre_contrato_compartilhado(
-    case: ControlPlaneCase,
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+def test_cumpre_contrato(case: ControlPlaneCase, ctx: _DynamoContext, monkeypatch: Any) -> None:
+    adapter, clock = ctx
+    if case.name == "raw_chains":
+        monkeypatch.setattr(control_plane_contract, "_store_record", _store_record_matching_mode)
     case.run(adapter, clock)
+def _store_record_matching_mode(adapter: Any, record: Any, clock: MutableClock) -> None:
+    job_id = f"job-{record.agent_id}-{record.snapshot_id}"
+    job = _job(job_id, record.agent_id, record.tenant_id).model_copy(update={
+        "source_type": record.source_type, "file_subtype": record.file_subtype,
+        "competencia": record.competencia, "requested_snapshot_mode": record.snapshot_mode})
+    adapter.put_agent(_agent(record.agent_id, tenant_id=record.tenant_id))
+    adapter.create_job(job, _event(f"created-{job_id}", tenant_id=record.tenant_id))
+    claimed = adapter.claim_job(_claim_job(job_id, "raw-worker", clock, record.tenant_id))
+    assert claimed is not None
+    command = CompleteJob(
+        tenant_id=record.tenant_id, job_id=job_id, owner="raw-worker",
+        fencing_token=claimed.fencing_token, manifest=record)
+    adapter.complete_job(command, _event(f"completed-{job_id}", tenant_id=record.tenant_id))
 def _many_units(amount: int) -> tuple[Any, ...]:
     return tuple(_unit(f"unit-{index:03d}") for index in range(amount))
 def _put_many_units(adapter: DynamoDBControlPlane, amount: int) -> tuple[Any, ...]:
     units = tuple(reversed(_many_units(amount)))
-    return adapter.put_run_units(
-        PutRunUnits(
-            tenant_id=_TENANT,
-            run_id="run-a",
-            expected_run_state=RunState.PROCESSING,
-            units=units,
-        )
-    )
+    command = PutRunUnits(
+        tenant_id=_TENANT, run_id="run-a", expected_run_state=RunState.PROCESSING, units=units)
+    return adapter.put_run_units(command)
 def _expected_item(
     model: Any, entity: str, key: tuple[str, str], indexes: dict[str, str]
 ) -> dict[str, Any]:
@@ -172,8 +173,7 @@ def _transaction_action(identifier: str) -> dict[str, Any]:
 def _dependency_run(count: int, state: RunState, run_id: str) -> Any:
     return _run(run_id, state, tuple(
         RunDependency(source_type=f"SOURCE-{index}", file_subtype="ST", required=True)
-        for index in range(count)
-    ))
+        for index in range(count)))
 def _store_waiting(adapter: DynamoDBControlPlane, run: Any, event_id: str) -> Any:
     if run.state is RunState.PLANNED:
         command = TransitionRun(tenant_id=_TENANT, run_id=run.run_id, expected_state=run.state,
@@ -418,27 +418,27 @@ def test_dispatch_expirado_rejeita_unidade_omitida(ctx: _DynamoContext) -> None:
     clock.advance(timedelta(seconds=31))
     replacement = reserve.model_copy(update={"wave_id": "b" * 16, "now": clock.now()})
     contender = DynamoDBControlPlane(adapter._client, _TABLE_NAME, clock.now)
+    claim_clock = MutableClock(_NOW + timedelta(seconds=29))
+    claim = _claim_unit_command(dispatch.dispatch_id, "worker-a", claim_clock, "unit-001")
+    assert contender.claim_run_unit(claim) is not None
+    terminal_dispatch = dispatch.model_copy(update={
+        "state": DispatchState.TERMINAL, "terminal_outcome": DispatchOutcome.CANCELED})
+    adapter._put_direct(adapter._dispatch_item(terminal_dispatch))
+    with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
+        adapter.reserve_run_dispatch(replacement)
+    adapter._put_direct(adapter._unit_item(_unit("unit-001")))
     transact = adapter._transact
-    def lease_omitted_then_replace(actions: Any) -> None:
-        claim = ClaimRunUnit(
-            tenant_id=_TENANT, run_id="run-a", unit_id="unit-001",
-            dispatch_id=dispatch.dispatch_id, owner="worker-a",
-            now=_NOW + timedelta(seconds=29), lease_seconds=60,
-        )
-        assert contender.claim_run_unit(claim) is not None
+    def mutate_prior_then_replace(actions: Any) -> None:
+        stale = _unit("unit-001").model_copy(update={"state": RunUnitState.SUCCEEDED})
+        contender._put_direct(contender._unit_item(stale))
         transact(actions)
-    adapter._transact = lease_omitted_then_replace
+    adapter._transact = mutate_prior_then_replace
     with pytest.raises(Conflict, match="transaction_conflict"):
         adapter.reserve_run_dispatch(replacement)
     adapter._transact = transact
-    assert adapter._required_dispatch(_TENANT, "run-a")[1] == dispatch
-    assert adapter.list_run_units(_TENANT, "run-a")[1].state is RunUnitState.LEASED
-    with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
-        adapter.reserve_run_dispatch(replacement)
+    assert adapter._required_dispatch(_TENANT, "run-a")[1] == terminal_dispatch
     adapter._client.delete_item(
-        TableName=_TABLE_NAME,
-        Key=item_key(*unit_key(_TENANT, "run-a", "unit-001")),
-    )
+        TableName=_TABLE_NAME, Key=item_key(*unit_key(_TENANT, "run-a", "unit-001")))
     with pytest.raises(Conflict, match="dispatch_unit_missing"):
         adapter.reserve_run_dispatch(replacement)
     terminal = _unit("unit-001").model_copy(update={"state": RunUnitState.SUCCEEDED})

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -58,7 +58,6 @@ class ClientSpy:
         attribute = getattr(self.client, name)
         if not callable(attribute):
             return attribute
-
         def tracked(**kwargs: Any) -> Any:
             self.calls.append(name)
             return attribute(**kwargs)
@@ -70,7 +69,8 @@ class FailingTransactionClient(ClientSpy):
         self.calls.append("transact_write_items")
         self.transactions.append(kwargs["TransactItems"])
         raise ClientError(
-            {"Error": {"Code": "TransactionCanceledException", "Message": "cancelled"}},
+            {"Error": {"Code": "TransactionCanceledException", "Message": "cancelled"},
+             "CancellationReasons": [{"Code": "ConditionalCheckFailed"}]},
             "TransactWriteItems",
         )
 
@@ -126,7 +126,7 @@ def _many_units(amount: int) -> tuple[Any, ...]:
     return tuple(_unit(f"unit-{index:03d}") for index in range(amount))
 
 def _put_many_units(adapter: DynamoDBControlPlane, amount: int) -> tuple[Any, ...]:
-    units = _many_units(amount)
+    units = tuple(reversed(_many_units(amount)))
     return adapter.put_run_units(
         PutRunUnits(
             tenant_id=_TENANT,
@@ -195,6 +195,7 @@ def test_grava_99_unidades_em_ate_100_acoes_unicas(
     adapter.put_run(_run("run-a"))
     spy = ClientSpy(adapter._client)
     adapter._client = spy
+    _put_many_units(adapter, 99)
     assert _put_many_units(adapter, 99) == _many_units(99)
     actions = spy.transactions[-1]
     run = _run("run-a")

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -14,6 +14,7 @@ from cnes_domain.control_plane.commands import (
     FinishRunDispatch,
     PutRunUnits,
     ReserveRunDispatch,
+    TransitionRun,
 )
 from cnes_domain.control_plane.enums import DispatchOutcome, RunState, RunUnitState
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
@@ -42,18 +43,19 @@ from packages.cnes_infra.tests.contracts.control_plane_contract import (
 
 _TABLE_NAME = "cnesdata-control-plane"
 _INDEXES = tuple(f"gsi{number}" for number in range(1, 7))
-
 class ClientSpy:
     def __init__(self, client: Any) -> None:
         self.client = client
         self.transactions: list[list[dict[str, Any]]] = []
         self.calls: list[str] = []
-
     def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("transact_write_items")
         self.transactions.append(kwargs["TransactItems"])
         return self.client.transact_write_items(**kwargs)
-
+    def query(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append("query")
+        kwargs.setdefault("Limit", getattr(self, "query_limit", 100))
+        return self.client.query(**kwargs)
     def __getattr__(self, name: str) -> Any:
         attribute = getattr(self.client, name)
         if not callable(attribute):
@@ -61,9 +63,7 @@ class ClientSpy:
         def tracked(**kwargs: Any) -> Any:
             self.calls.append(name)
             return attribute(**kwargs)
-
         return tracked
-
 class FailingTransactionClient(ClientSpy):
     def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("transact_write_items")
@@ -73,7 +73,6 @@ class FailingTransactionClient(ClientSpy):
              "CancellationReasons": [{"Code": "ConditionalCheckFailed"}]},
             "TransactWriteItems",
         )
-
 def _create_table(client: object) -> None:
     index_attributes = tuple(f"{index}{suffix}" for index in _INDEXES for suffix in ("pk", "sk"))
     attribute_definitions = [
@@ -105,7 +104,6 @@ def _create_table(client: object) -> None:
         TableName=_TABLE_NAME,
         TimeToLiveSpecification={"Enabled": True, "AttributeName": "expires_at"},
     )
-
 @pytest.fixture
 def dynamodb_adapter() -> Iterator[tuple[DynamoDBControlPlane, MutableClock]]:
     with mock_aws():
@@ -113,7 +111,6 @@ def dynamodb_adapter() -> Iterator[tuple[DynamoDBControlPlane, MutableClock]]:
         _create_table(client)
         clock = MutableClock(_NOW)
         yield DynamoDBControlPlane(client, _TABLE_NAME, clock.now), clock
-
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
 def test_cumpre_contrato_compartilhado(
     case: ControlPlaneCase,
@@ -121,10 +118,8 @@ def test_cumpre_contrato_compartilhado(
 ) -> None:
     adapter, clock = dynamodb_adapter
     case.run(adapter, clock)
-
 def _many_units(amount: int) -> tuple[Any, ...]:
     return tuple(_unit(f"unit-{index:03d}") for index in range(amount))
-
 def _put_many_units(adapter: DynamoDBControlPlane, amount: int) -> tuple[Any, ...]:
     units = tuple(reversed(_many_units(amount)))
     return adapter.put_run_units(
@@ -135,7 +130,6 @@ def _put_many_units(adapter: DynamoDBControlPlane, amount: int) -> tuple[Any, ..
             units=units,
         )
     )
-
 def _expected_item(
     model: Any, entity: str, key: tuple[str, str], indexes: dict[str, str]
 ) -> dict[str, Any]:
@@ -146,7 +140,6 @@ def _expected_item(
         "payload": {"S": model.model_dump_json()},
     }
     return item | {name: {"S": value} for name, value in indexes.items()}
-
 def _expected_put(item: dict[str, Any], expected: str | None) -> dict[str, Any]:
     request = {"TableName": _TABLE_NAME, "Item": item}
     request["ConditionExpression"] = (
@@ -155,7 +148,6 @@ def _expected_put(item: dict[str, Any], expected: str | None) -> dict[str, Any]:
     if expected is not None:
         request["ExpressionAttributeValues"] = {":expected": {"S": expected}}
     return {"Put": request}
-
 def _transaction_action(identifier: str) -> dict[str, Any]:
     item = {
         "pk": {"S": "TENANT#354130"},
@@ -163,7 +155,6 @@ def _transaction_action(identifier: str) -> dict[str, Any]:
         "payload": {"S": "{}"},
     }
     return put_action(_TABLE_NAME, item, None)
-
 def _expected_unit_action(index: int, state: RunUnitState) -> dict[str, Any]:
     unit = _unit(f"unit-{index:03d}").model_copy(update={"state": state})
     item = _expected_item(
@@ -177,7 +168,6 @@ def _expected_unit_action(index: int, state: RunUnitState) -> dict[str, Any]:
     )
     expected = None if state is RunUnitState.PENDING else _unit(f"unit-{index:03d}")
     return _expected_put(item, expected.model_dump_json() if expected is not None else None)
-
 def _hide_unit_from_gsi(adapter: DynamoDBControlPlane, unit_id: str) -> None:
     item = adapter._client.get_item(
         TableName=_TABLE_NAME,
@@ -187,7 +177,6 @@ def _hide_unit_from_gsi(adapter: DynamoDBControlPlane, unit_id: str) -> None:
     item.pop("gsi5pk")
     item.pop("gsi5sk")
     adapter._client.put_item(TableName=_TABLE_NAME, Item=item)
-
 def test_grava_99_unidades_em_ate_100_acoes_unicas(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -214,7 +203,6 @@ def test_grava_99_unidades_em_ate_100_acoes_unicas(
     with pytest.raises(Conflict, match="run_units_conflict"):
         _put_many_units(adapter, 98)
     assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
-
 def test_rejeita_100_unidades_antes_de_chamar_boto3(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -224,7 +212,6 @@ def test_rejeita_100_unidades_antes_de_chamar_boto3(
     with pytest.raises(Conflict, match="transaction_limit"):
         _put_many_units(adapter, 100)
     assert spy.calls == []
-
 def test_rejeita_uniao_de_99_unidades_antes_de_transacao(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -245,12 +232,10 @@ def test_rejeita_uniao_de_99_unidades_antes_de_transacao(
     with pytest.raises(Conflict, match="transaction_limit"):
         adapter.reserve_run_dispatch(replacement)
     assert spy.transactions == []
-
 def _prepare_cancellation(adapter: DynamoDBControlPlane, amount: int) -> None:
     adapter.put_run(_run("run-a"))
     _put_many_units(adapter, amount)
     adapter.put_run(_run("run-a", RunState.CANCEL_REQUESTED))
-
 def _finalize(adapter: DynamoDBControlPlane, clock: MutableClock) -> Any:
     command = FinalizeRunCancellation(
         tenant_id=_TENANT,
@@ -259,7 +244,6 @@ def _finalize(adapter: DynamoDBControlPlane, clock: MutableClock) -> Any:
         canceled_at=clock.now(),
     )
     return adapter.finalize_run_cancellation(command, _event("run-canceled"))
-
 def test_cancela_98_unidades_em_100_acoes_unicas(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -288,7 +272,6 @@ def test_cancela_98_unidades_em_100_acoes_unicas(
         *(_expected_unit_action(index, RunUnitState.CANCELED) for index in range(98)),
         _expected_put(event_item, None),
     ]
-
 def test_rejeita_cancelamento_de_99_unidades_sem_transacao(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -301,9 +284,11 @@ def test_rejeita_cancelamento_de_99_unidades_sem_transacao(
         _finalize(adapter, clock)
     assert spy.transactions == []
     assert adapter.get_run(_TENANT, "run-a").state is RunState.CANCEL_REQUESTED
-    assert all(unit.state.value == "PENDING" for unit in adapter.list_run_units(_TENANT, "run-a"))
+    spy.calls.clear()
+    spy.query_limit = 1
+    assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
+    assert spy.calls.count("query") == 99
     assert adapter.get_outbox_event("run-canceled") is None
-
 def test_rejeita_transacao_com_chaves_duplicadas_ou_mais_de_100_acoes(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -404,18 +389,18 @@ def test_dispatch_expirado_rejeita_corrida_que_aluga_unidade_omitida(
     adapter, clock = dynamodb_adapter
     reserve = ReserveRunDispatch(
         tenant_id=_TENANT, run_id="run-a", wave_id="a" * 16,
-        unit_ids=("unit-000",), now=clock.now(), lease_seconds=30,
-    )
+        unit_ids=("unit-000",), now=clock.now(), lease_seconds=30)
     with pytest.raises(Conflict, match="run_not_processing"):
         adapter.reserve_run_dispatch(reserve)
     assert adapter.get_active_run_dispatch(_TENANT, "run-a") is None
     bind = BindRunDispatch(
         tenant_id=_TENANT, run_id="run-a", dispatch_id="a" * 16,
-        execution_ref="missing", now=clock.now(), lease_seconds=30,
-    )
-    with pytest.raises(NotFound, match="dispatch_missing"):
+        execution_ref="missing", now=clock.now(), lease_seconds=30)
+    with pytest.raises(Conflict, match="run_not_processing"):
         adapter.bind_run_dispatch(bind)
     adapter.put_run(_run("run-a"))
+    with pytest.raises(NotFound, match="dispatch_missing"):
+        adapter.bind_run_dispatch(bind)
     with pytest.raises(Conflict, match="dispatch_unit_missing"):
         adapter.reserve_run_dispatch(reserve)
     _put_many_units(adapter, 2)
@@ -461,6 +446,19 @@ def test_dispatch_started_expirado_e_recuperavel_sem_lease_vivo(
         tenant_id=_TENANT, run_id="run-a", dispatch_id=dispatch.dispatch_id,
         execution_ref="exec-b", now=clock.now(), lease_seconds=1,
     )
+    contender = DynamoDBControlPlane(adapter._client, _TABLE_NAME, clock.now)
+    transact = adapter._transact
+    def cancel_then_bind(actions: Any) -> None:
+        contender.transition_run(
+            TransitionRun(tenant_id=_TENANT, run_id="run-a", expected_state=RunState.PROCESSING,
+                          new_state=RunState.CANCEL_REQUESTED), _event("cancel-before-bind"))
+        transact(actions)
+    adapter._transact = cancel_then_bind
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.bind_run_dispatch(bind)
+    adapter._transact = transact
+    assert adapter.get_active_run_dispatch(_TENANT, "run-a") == dispatch
+    adapter.put_run(_run("run-a"))
     adapter.bind_run_dispatch(bind)
     clock.advance(timedelta(seconds=2))
     recovered = adapter.reserve_run_dispatch(

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator  # noqa: I001
+from collections.abc import Callable, Iterator
 from datetime import timedelta
 from typing import Any
 
@@ -8,86 +8,155 @@ from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from cnes_domain.control_plane.commands import (
-    BindRunDispatch, ClaimRunUnit, CompleteJob, FailRunUnit, FinalizeRunCancellation,
-    FinishRunDispatch, PutRunUnits, ReserveRunDispatch, TransitionRun)
+    BindRunDispatch,
+    ClaimRunUnit,
+    FailRunUnit,
+    FinishRunDispatch,
+    PutRunUnits,
+    ReserveRunDispatch,
+    TransitionRun,
+)
 from cnes_domain.control_plane.entities import AccessRequest, RunDependency
-from cnes_domain.control_plane.enums import AccessRequestState
-from cnes_domain.control_plane.enums import DispatchOutcome, DispatchState, RunState, RunUnitState
+from cnes_domain.control_plane.enums import (
+    AccessRequestState,
+    DispatchOutcome,
+    DispatchState,
+    RunState,
+    RunUnitState,
+)
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
 from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
-from cnes_infra.control_plane.dynamodb_codec import execute_transaction, put_action
+from cnes_infra.control_plane.dynamodb_codec import put_action
 from cnes_infra.control_plane.dynamodb_keys import (
-    dependency_marker_key, item_key, key_component, outbox_key, run_entity_key, unit_key)
-from packages.cnes_infra.tests.contracts import control_plane_contract
+    item_key,
+    key_component,
+    unit_key,
+)
 from packages.cnes_infra.tests.contracts.clock import (
-    _NOW, _TENANT, MutableClock, _agent, _claim_job, _claim_unit, _claim_unit_command,
-    _commit_command, _event, _job, _prepare_unit, _run, _unit)
+    _NOW,
+    _TENANT,
+    MutableClock,
+    _agent,
+    _claim_job,
+    _claim_unit,
+    _claim_unit_command,
+    _commit_command,
+    _event,
+    _job,
+    _prepare_unit,
+    _run,
+    _unit,
+)
 from packages.cnes_infra.tests.contracts.control_plane_contract import (
-    ControlPlaneCase, control_plane_cases)
+    ControlPlaneCase,
+    control_plane_cases,
+)
 
 _TABLE_NAME = "cnesdata-control-plane"
 _INDEXES = tuple(f"gsi{number}" for number in range(1, 7))
 type _DynamoContext = tuple[DynamoDBControlPlane, MutableClock]
+type TransactionCallback = Callable[[list[dict[str, Any]]], None]
+
+
 @pytest.fixture
 def ctx(dynamodb_adapter: _DynamoContext) -> _DynamoContext:
     return dynamodb_adapter
+
+
 class ClientSpy:
-    def __init__(self, client: Any) -> None:
+    def __init__(
+        self,
+        client: Any,
+        before_transaction: TransactionCallback | None = None,
+        after_transaction: TransactionCallback | None = None,
+    ) -> None:
         self.client = client
+        self.before_transaction = before_transaction
+        self.after_transaction = after_transaction
         self.transactions: list[list[dict[str, Any]]] = []
         self.calls: list[str] = []
         self.query_requests: list[dict[str, Any]] = []
         self.requests: list[tuple[str, dict[str, Any]]] = []
+
     def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
+        actions: list[dict[str, Any]] = kwargs["TransactItems"]
         self.calls.append("transact_write_items")
-        self.transactions.append(kwargs["TransactItems"])
-        return self.client.transact_write_items(**kwargs)
+        self.transactions.append(actions)
+        if self.before_transaction is not None:
+            self.before_transaction(actions)
+        response = self.client.transact_write_items(**kwargs)
+        if self.after_transaction is not None:
+            self.after_transaction(actions)
+        return response
+
     def query(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("query")
         self.query_requests.append(dict(kwargs))
         kwargs.setdefault("Limit", getattr(self, "query_limit", 100))
         return self.client.query(**kwargs)
+
     def __getattr__(self, name: str) -> Any:
         attribute = getattr(self.client, name)
         if not callable(attribute):
             return attribute
+
         def tracked(**kwargs: Any) -> Any:
             self.calls.append(name)
             self.requests.append((name, dict(kwargs)))
             return attribute(**kwargs)
+
         return tracked
-class FailingTransactionClient(ClientSpy):
-    def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
-        self.calls.append("transact_write_items")
-        self.transactions.append(kwargs["TransactItems"])
-        response = {"Error": {"Code": "TransactionCanceledException", "Message": "cancelled"},
-                    "CancellationReasons": [{"Code": "ConditionalCheckFailed"}]}
-        raise ClientError(response, "TransactWriteItems")
+
+
+def _raise_transaction_canceled(_: list[dict[str, Any]]) -> None:
+    raise ClientError(
+        {
+            "Error": {"Code": "TransactionCanceledException", "Message": "cancelled"},
+            "CancellationReasons": [{"Code": "ConditionalCheckFailed"}],
+        },
+        "TransactWriteItems",
+    )
+
+
+def _lose_transaction_response(_: list[dict[str, Any]]) -> None:
+    raise Conflict("transaction_conflict")
+
+
 def _create_table(client: object) -> None:
     index_attributes = tuple(f"{index}{suffix}" for index in _INDEXES for suffix in ("pk", "sk"))
-    attribute_definitions = [{"AttributeName": name, "AttributeType": "S"}
-                             for name in ("pk", "sk", *index_attributes)]
+    attribute_definitions = [
+        {"AttributeName": name, "AttributeType": "S"} for name in ("pk", "sk", *index_attributes)
+    ]
+    throughput = {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5}
     global_secondary_indexes = [
         {
             "IndexName": index,
-            "KeySchema": [{"AttributeName": f"{index}pk", "KeyType": "HASH"},
-                          {"AttributeName": f"{index}sk", "KeyType": "RANGE"}],
+            "KeySchema": [
+                {"AttributeName": f"{index}pk", "KeyType": "HASH"},
+                {"AttributeName": f"{index}sk", "KeyType": "RANGE"},
+            ],
             "Projection": {"ProjectionType": "ALL"},
-            "ProvisionedThroughput": {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+            "ProvisionedThroughput": throughput,
         }
         for index in _INDEXES
     ]
     client.create_table(
         TableName=_TABLE_NAME,
-        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"},
-                   {"AttributeName": "sk", "KeyType": "RANGE"}],
+        KeySchema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=attribute_definitions,
         GlobalSecondaryIndexes=global_secondary_indexes,
-        ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+        ProvisionedThroughput=throughput,
     )
-    client.update_time_to_live(TableName=_TABLE_NAME,
-        TimeToLiveSpecification={"Enabled": True, "AttributeName": "expires_at"})
+    client.update_time_to_live(
+        TableName=_TABLE_NAME,
+        TimeToLiveSpecification={"Enabled": True, "AttributeName": "expires_at"},
+    )
+
+
 @pytest.fixture
 def dynamodb_adapter() -> Iterator[tuple[DynamoDBControlPlane, MutableClock]]:
     with mock_aws():
@@ -95,35 +164,29 @@ def dynamodb_adapter() -> Iterator[tuple[DynamoDBControlPlane, MutableClock]]:
         _create_table(client)
         clock = MutableClock(_NOW)
         yield DynamoDBControlPlane(client, _TABLE_NAME, clock.now), clock
+
+
 @pytest.mark.parametrize("case", control_plane_cases(), ids=lambda case: case.name)
-def test_cumpre_contrato(case: ControlPlaneCase, ctx: _DynamoContext, monkeypatch: Any) -> None:
+def test_cumpre_contrato(case: ControlPlaneCase, ctx: _DynamoContext) -> None:
     adapter, clock = ctx
-    if case.name == "raw_chains":
-        monkeypatch.setattr(control_plane_contract, "_store_record", _store_record_matching_mode)
     case.run(adapter, clock)
-def _store_record_matching_mode(adapter: Any, record: Any, clock: MutableClock) -> None:
-    job_id = f"job-{record.agent_id}-{record.snapshot_id}"
-    job = _job(job_id, record.agent_id, record.tenant_id).model_copy(update={
-        "source_type": record.source_type, "file_subtype": record.file_subtype,
-        "competencia": record.competencia, "requested_snapshot_mode": record.snapshot_mode,
-        "created_at": record.created_at})
-    adapter.put_agent(_agent(record.agent_id, tenant_id=record.tenant_id))
-    adapter.create_job(job, _event(f"created-{job_id}", tenant_id=record.tenant_id))
-    claimed = adapter.claim_job(_claim_job(job_id, "raw-worker", clock, record.tenant_id))
-    assert claimed is not None
-    command = CompleteJob(
-        tenant_id=record.tenant_id, job_id=job_id, owner="raw-worker",
-        fencing_token=claimed.fencing_token, manifest=record)
-    adapter.complete_job(command, _event(f"completed-{job_id}", tenant_id=record.tenant_id))
+
+
 def _many_units(amount: int) -> tuple[Any, ...]:
     return tuple(_unit(f"unit-{index:03d}") for index in range(amount))
+
+
 def _put_many_units(adapter: DynamoDBControlPlane, amount: int) -> tuple[Any, ...]:
     units = tuple(reversed(_many_units(amount)))
     command = PutRunUnits(
-        tenant_id=_TENANT, run_id="run-a", expected_run_state=RunState.PROCESSING, units=units)
+        tenant_id=_TENANT, run_id="run-a", expected_run_state=RunState.PROCESSING, units=units
+    )
     return adapter.put_run_units(command)
-def _expected_item(model: Any, entity: str, key: tuple[str, str],
-    indexes: dict[str, str]) -> dict[str, Any]:
+
+
+def _expected_item(
+    model: Any, entity: str, key: tuple[str, str], indexes: dict[str, str]
+) -> dict[str, Any]:
     item = {
         "pk": {"S": key[0]},
         "sk": {"S": key[1]},
@@ -131,6 +194,8 @@ def _expected_item(model: Any, entity: str, key: tuple[str, str],
         "payload": {"S": model.model_dump_json()},
     }
     return item | {name: {"S": value} for name, value in indexes.items()}
+
+
 def _expected_put(item: dict[str, Any], expected: str | None) -> dict[str, Any]:
     request = {"TableName": _TABLE_NAME, "Item": item}
     request["ConditionExpression"] = (
@@ -139,6 +204,8 @@ def _expected_put(item: dict[str, Any], expected: str | None) -> dict[str, Any]:
     if expected is not None:
         request["ExpressionAttributeValues"] = {":expected": {"S": expected}}
     return {"Put": request}
+
+
 def _transaction_action(identifier: str) -> dict[str, Any]:
     item = {
         "pk": {"S": "TENANT#354130"},
@@ -146,236 +213,134 @@ def _transaction_action(identifier: str) -> dict[str, Any]:
         "payload": {"S": "{}"},
     }
     return put_action(_TABLE_NAME, item, None)
+
+
 def _dependency_run(count: int, state: RunState, run_id: str) -> Any:
-    return _run(run_id, state, tuple(
-        RunDependency(source_type=f"SOURCE-{index}", file_subtype="ST", required=True)
-        for index in range(count)))
+    return _run(
+        run_id,
+        state,
+        tuple(
+            RunDependency(source_type=f"SOURCE-{index}", file_subtype="ST", required=True)
+            for index in range(count)
+        ),
+    )
+
+
 def _store_waiting(adapter: DynamoDBControlPlane, run: Any, event_id: str) -> Any:
     if run.state is RunState.PLANNED:
-        command = TransitionRun(tenant_id=_TENANT, run_id=run.run_id, expected_state=run.state,
-            new_state=RunState.WAITING_INPUTS)
+        command = TransitionRun(
+            tenant_id=_TENANT,
+            run_id=run.run_id,
+            expected_state=run.state,
+            new_state=RunState.WAITING_INPUTS,
+        )
         return adapter.transition_run(command, _event(event_id))
     adapter.put_run(run)
     return run
+
+
 def _expected_unit_action(index: int, state: RunUnitState) -> dict[str, Any]:
     unit = _unit(f"unit-{index:03d}").model_copy(update={"state": state})
     indexes = {
         "gsi5pk": f"RUN_ITEMS#{key_component(_TENANT)}#{key_component('run-a')}",
-        "gsi5sk": f"UNIT#{key_component(f'unit-{index:03d}')}"}
-    item = _expected_item(unit, "RUNUNIT",
-        unit_key(_TENANT, "run-a", f"unit-{index:03d}"), indexes)
+        "gsi5sk": f"UNIT#{key_component(f'unit-{index:03d}')}",
+    }
+    item = _expected_item(unit, "RUNUNIT", unit_key(_TENANT, "run-a", f"unit-{index:03d}"), indexes)
     expected = None if state is RunUnitState.PENDING else _unit(f"unit-{index:03d}")
     return _expected_put(item, expected.model_dump_json() if expected is not None else None)
+
+
 def _hide_unit_from_gsi(adapter: DynamoDBControlPlane, unit_id: str) -> None:
-    item = adapter._client.get_item(TableName=_TABLE_NAME,
-        Key=item_key(*unit_key(_TENANT, "run-a", unit_id)), ConsistentRead=True)["Item"]
+    item = adapter._client.get_item(
+        TableName=_TABLE_NAME,
+        Key=item_key(*unit_key(_TENANT, "run-a", unit_id)),
+        ConsistentRead=True,
+    )["Item"]
     item.pop("gsi5pk")
     item.pop("gsi5sk")
     adapter._client.put_item(TableName=_TABLE_NAME, Item=item)
-def test_grava_99_unidades_em_ate_100_acoes_unicas(ctx: _DynamoContext) -> None:
-    adapter, _ = ctx
-    adapter.put_run(_run("run-a"))
-    spy = ClientSpy(adapter._client)
-    adapter._client = spy
-    _put_many_units(adapter, 99)
-    assert _put_many_units(adapter, 99) == _many_units(99)
-    actions = spy.transactions[-1]
-    run = _run("run-a")
-    expected_check = {
-        "ConditionCheck": {
-            "TableName": _TABLE_NAME, "Key": item_key(*run_entity_key(_TENANT, "run-a")),
-            "ConditionExpression": "payload = :expected",
-            "ExpressionAttributeValues": {":expected": {"S": run.model_dump_json()}}}}
-    assert actions == [
-        expected_check,
-        *(_expected_unit_action(index, RunUnitState.PENDING) for index in range(99)),
-    ]
-    with pytest.raises(Conflict, match="run_units_conflict"):
-        _put_many_units(adapter, 98)
-    assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
-def test_rejeita_100_unidades_antes_de_chamar_boto3(ctx: _DynamoContext) -> None:
-    adapter, _ = ctx
-    spy = ClientSpy(adapter._client)
-    adapter._client = spy
-    with pytest.raises(Conflict, match="transaction_limit"):
-        _put_many_units(adapter, 100)
-    assert spy.calls == []
-def test_rejeita_uniao_de_99_unidades_antes_de_transacao(ctx: _DynamoContext) -> None:
-    adapter, clock = ctx
-    adapter.put_run(_run("run-a"))
-    units = _put_many_units(adapter, 99)
-    first = ReserveRunDispatch(
-        tenant_id=_TENANT, run_id="run-a", wave_id="a" * 16,
-        unit_ids=tuple(unit.unit_id for unit in units[:98]), now=clock.now(), lease_seconds=30)
-    adapter.reserve_run_dispatch(first)
-    clock.advance(timedelta(seconds=31))
-    spy = ClientSpy(adapter._client)
-    adapter._client = spy
-    replacement = first.model_copy(update={"wave_id": "b" * 16,
-        "unit_ids": ("unit-098",), "now": clock.now()})
-    with pytest.raises(Conflict, match="transaction_limit"):
-        adapter.reserve_run_dispatch(replacement)
-    assert spy.transactions == []
-def _prepare_cancellation(adapter: DynamoDBControlPlane, amount: int) -> None:
-    adapter.put_run(_run("run-a"))
-    _put_many_units(adapter, amount)
-    adapter.put_run(_run("run-a", RunState.CANCEL_REQUESTED))
-def _finalize(adapter: DynamoDBControlPlane, clock: MutableClock) -> Any:
-    command = FinalizeRunCancellation(
-        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.CANCEL_REQUESTED,
-        canceled_at=clock.now())
-    return adapter.finalize_run_cancellation(command, _event("run-canceled"))
-def test_cancela_98_unidades_em_100_acoes_unicas(ctx: _DynamoContext) -> None:
-    adapter, clock = ctx
-    _prepare_cancellation(adapter, 98)
-    _hide_unit_from_gsi(adapter, "unit-097")
-    spy = ClientSpy(adapter._client)
-    adapter._client = spy
-    assert _finalize(adapter, clock).state is RunState.CANCELED
-    actions = spy.transactions[-1]
-    canceled = _run("run-a", RunState.CANCELED)
-    run_item = _expected_item(canceled, "RUN", run_entity_key(_TENANT, "run-a"), {})
-    original_payload = _run("run-a", RunState.CANCEL_REQUESTED).model_dump_json()
-    event = _event("run-canceled")
-    indexes = {"gsi6pk": "OUTBOX#PENDING",
-        "gsi6sk": f"{_NOW.isoformat(timespec='microseconds')}#"
-                  f"{key_component('run-canceled')}"}
-    event_item = _expected_item(event, "OUTBOXEVENT", outbox_key("run-canceled"), indexes)
-    assert actions == [
-        _expected_put(run_item, original_payload),
-        *(_expected_unit_action(index, RunUnitState.CANCELED) for index in range(98)),
-        _expected_put(event_item, None),
-    ]
-def test_rejeita_cancelamento_de_99_unidades_sem_transacao(ctx: _DynamoContext) -> None:
-    adapter, clock = ctx
-    _prepare_cancellation(adapter, 99)
-    _hide_unit_from_gsi(adapter, "unit-098")
-    spy = ClientSpy(adapter._client)
-    adapter._client = spy
-    with pytest.raises(Conflict, match="transaction_limit"):
-        _finalize(adapter, clock)
-    assert spy.transactions == []
-    assert adapter.get_run(_TENANT, "run-a").state is RunState.CANCEL_REQUESTED
-    spy.calls.clear()
-    spy.query_limit = 1
-    assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
-    assert spy.calls.count("query") == 99
-    assert adapter.get_outbox_event("run-canceled") is None
-@pytest.mark.parametrize(("state","count"),[(RunState.WAITING_INPUTS,99),(RunState.PLANNED,98)])
-def test_waiting_limita_acoes_e_chaves(state: RunState, count: int, ctx: _DynamoContext) -> None:
-    adapter, _ = ctx
-    run = _dependency_run(count, state, "run-limit")
-    if state is RunState.PLANNED:
-        adapter.put_run(run)
-    spy = ClientSpy(adapter._client)
-    adapter._client = spy
-    overflow = _dependency_run(count + 1, state, "run-overflow")
-    if state is RunState.PLANNED:
-        adapter.put_run(overflow)
-    mutations = (len(spy.transactions), spy.calls.count("put_item"))
-    with pytest.raises(Conflict, match="transaction_limit"):
-        _store_waiting(adapter, overflow, "waiting-overflow")
-    assert (len(spy.transactions), spy.calls.count("put_item")) == mutations
-    _store_waiting(adapter, run, "waiting-limit")
-    actions = spy.transactions[-1]
-    keys = {(action["Put"]["Item"]["pk"]["S"], action["Put"]["Item"]["sk"]["S"])
-            for action in actions}
-    assert len(actions) == len(keys) == 100
-    action = _transaction_action("same")
-    with pytest.raises(Conflict, match="duplicate_transaction_key"):
-        execute_transaction(spy, (action, action))
-@pytest.mark.parametrize("state", [RunState.WAITING_INPUTS, RunState.PLANNED])
-def test_waiting_reverte_run_quando_marcador_falha(state: RunState, ctx: _DynamoContext) -> None:
-    adapter, _ = ctx
-    run = _dependency_run(1, state, "run-a")
-    if state is RunState.PLANNED:
-        adapter.put_run(run)
-    identity = "RUN_DEP#" + "#".join(map(key_component, (_TENANT, "SOURCE-0", "ST", "2026-07")))
-    marker_key = dependency_marker_key(_TENANT, "run-a", identity)
-    adapter._client.put_item(TableName=_TABLE_NAME, Item=item_key(*marker_key))
-    error = "transaction_conflict" if state is RunState.PLANNED else "run_dependency_conflict"
-    with pytest.raises(Conflict, match=error):
-        _store_waiting(adapter, run, "waiting-rollback")
-    expected = run if state is RunState.PLANNED else None
-    assert adapter.get_run(_TENANT, "run-a") == expected
-    assert adapter.get_outbox_event("waiting-rollback") is None
-def test_put_waiting_recupera_resposta_perdida_e_rejeita_divergencias(
-    ctx: _DynamoContext,
-) -> None:
-    adapter, _ = ctx
-    run = _dependency_run(2, RunState.WAITING_INPUTS, "run-replay")
-    transact = adapter._transact
-    def commit_then_lose_response(actions: Any) -> None:
-        transact(actions)
-        raise Conflict("transaction_conflict")
-    adapter._transact = commit_then_lose_response
-    adapter.put_run(run)
-    adapter._transact = transact
-    adapter._client = spy = ClientSpy(adapter._client)
-    adapter.put_run(run)
-    assert any(request.get("ConsistentRead") is True for request in spy.query_requests)
-    before = spy.scan(TableName=_TABLE_NAME)["Items"]
-    divergent = run.model_copy(update={"created_at": _NOW + timedelta(seconds=1)})
-    with pytest.raises(Conflict, match="run_conflict"):
-        adapter.put_run(divergent)
-    assert spy.scan(TableName=_TABLE_NAME)["Items"] == before
-    marker = next(item for item in before if item.get("entity", {}).get("S") == "RUN_DEP")
-    marker["gsi3sk"] = {"S": "divergent"}
-    spy.put_item(TableName=_TABLE_NAME, Item=marker)
-    changed = spy.scan(TableName=_TABLE_NAME)["Items"]
-    with pytest.raises(Conflict, match="run_dependency_conflict"):
-        adapter.put_run(run)
-    assert spy.scan(TableName=_TABLE_NAME)["Items"] == changed
-    fresh = _dependency_run(1, RunState.WAITING_INPUTS, "run-loser")
-    adapter._client = FailingTransactionClient(spy.client)
-    with pytest.raises(Conflict, match="transaction_conflict"):
-        adapter.put_run(fresh)
-    assert adapter.get_run(_TENANT, "run-loser") is None
 def test_claims_retornam_none_quando_cas_perde_corrida(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
     adapter.put_agent(_agent("agent-a"))
     adapter.create_job(_job("job-a"), _event("job-created"))
-    adapter._client = FailingTransactionClient(adapter._client)
+    adapter._client = ClientSpy(adapter._client, before_transaction=_raise_transaction_canceled)
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
     adapter._client = adapter._client.client
     dispatch = _prepare_unit(adapter, clock)
-    adapter._client = FailingTransactionClient(adapter._client)
-    command = ClaimRunUnit(tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
-        dispatch_id=dispatch.dispatch_id, owner="worker-a", now=clock.now(), lease_seconds=30)
+    adapter._client = ClientSpy(adapter._client, before_transaction=_raise_transaction_canceled)
+    command = ClaimRunUnit(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        unit_id="unit-a",
+        dispatch_id=dispatch.dispatch_id,
+        owner="worker-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
     assert adapter.claim_run_unit(command) is None
+
+
 def test_falha_opcional_rele_parent_apos_cas_concorrente(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
     dispatch = _prepare_unit(adapter, clock)
     dependency = RunDependency(source_type="CNES", file_subtype="ST", required=False)
     adapter.put_run(_run("run-a", dependencies=(dependency,)))
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
-    command = FailRunUnit(tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
-        dispatch_id=dispatch.dispatch_id, owner="worker-a", fencing_token=claimed.fencing_token,
-        error_code="optional_failed", retryable=False)
-    transact = adapter._transact
-    def parent_wins(actions: Any) -> None:
+    command = FailRunUnit(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        unit_id="unit-a",
+        dispatch_id=dispatch.dispatch_id,
+        owner="worker-a",
+        fencing_token=claimed.fencing_token,
+        error_code="optional_failed",
+        retryable=False,
+    )
+
+    def parent_wins(_: list[dict[str, Any]]) -> None:
         current = adapter.get_run(_TENANT, "run-a")
         adapter.put_run(current.model_copy(update={"missing_sources": ("SIHD/AIH",)}))
-        transact(actions)
-    adapter._transact = parent_wins
+
+    adapter._client = ClientSpy(adapter._client, before_transaction=parent_wins)
     failed = adapter.fail_run_unit(command, _event("unit-degraded"))
     assert (failed.state, adapter.get_run(_TENANT, "run-a").missing_sources) == (
-        RunUnitState.SUCCEEDED_DEGRADED, ("CNES/ST", "SIHD/AIH"))
+        RunUnitState.SUCCEEDED_DEGRADED,
+        ("CNES/ST", "SIHD/AIH"),
+    )
+
+
 def test_access_request_propaga_conflito_sem_winner(ctx: _DynamoContext) -> None:
     adapter, _ = ctx
-    request = AccessRequest(tenant_id=_TENANT, request_id="missing-winner", user_id="user-a",
-                            state=AccessRequestState.PENDING, decided_by=None, decided_at=None)
-    adapter._client = FailingTransactionClient(adapter._client)
+    request = AccessRequest(
+        tenant_id=_TENANT,
+        request_id="missing-winner",
+        user_id="user-a",
+        state=AccessRequestState.PENDING,
+        decided_by=None,
+        decided_at=None,
+    )
+    adapter._client = ClientSpy(adapter._client, before_transaction=_raise_transaction_canceled)
     with pytest.raises(Conflict, match="transaction_conflict"):
         adapter.put_access_request(request, _event("missing-winner"))
     assert adapter.get_access_request(_TENANT, "missing-winner") is None
+
+
 def test_unit_ausente_nao_e_reivindicada_nem_finalizada(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
-    claim = ClaimRunUnit(tenant_id=_TENANT, run_id="run-a", unit_id="unit-a",
-        dispatch_id="a" * 16, owner="worker-a", now=clock.now(), lease_seconds=30)
+    claim = ClaimRunUnit(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        unit_id="unit-a",
+        dispatch_id="a" * 16,
+        owner="worker-a",
+        now=clock.now(),
+        lease_seconds=30,
+    )
     assert adapter.claim_run_unit(claim) is None
     with pytest.raises(NotFound, match="unit_context_missing"):
         adapter.commit_run_unit(_commit_command("a" * 16, "worker-a", 1), _event("missing-unit"))
+
+
 def test_dispatch_terminal_invalida_commit_de_unidade(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
     dispatch = _prepare_unit(adapter, clock)
@@ -394,17 +359,29 @@ def test_dispatch_terminal_invalida_commit_de_unidade(ctx: _DynamoContext) -> No
             _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
             _event("terminal-dispatch"),
         )
+
+
 def test_dispatch_expirado_rejeita_unidade_omitida(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
     reserve = ReserveRunDispatch(
-        tenant_id=_TENANT, run_id="run-a", wave_id="a" * 16,
-        unit_ids=("unit-000",), now=clock.now(), lease_seconds=30)
+        tenant_id=_TENANT,
+        run_id="run-a",
+        wave_id="a" * 16,
+        unit_ids=("unit-000",),
+        now=clock.now(),
+        lease_seconds=30,
+    )
     with pytest.raises(Conflict, match="run_not_processing"):
         adapter.reserve_run_dispatch(reserve)
     assert adapter.get_active_run_dispatch(_TENANT, "run-a") is None
     bind = BindRunDispatch(
-        tenant_id=_TENANT, run_id="run-a", dispatch_id="a" * 16,
-        execution_ref="missing", now=clock.now(), lease_seconds=30)
+        tenant_id=_TENANT,
+        run_id="run-a",
+        dispatch_id="a" * 16,
+        execution_ref="missing",
+        now=clock.now(),
+        lease_seconds=30,
+    )
     with pytest.raises(Conflict, match="run_not_processing"):
         adapter.bind_run_dispatch(bind)
     adapter.put_run(_run("run-a"))
@@ -421,59 +398,79 @@ def test_dispatch_expirado_rejeita_unidade_omitida(ctx: _DynamoContext) -> None:
     claim_clock = MutableClock(_NOW + timedelta(seconds=29))
     claim = _claim_unit_command(dispatch.dispatch_id, "worker-a", claim_clock, "unit-001")
     assert contender.claim_run_unit(claim) is not None
-    terminal_dispatch = dispatch.model_copy(update={
-        "state": DispatchState.TERMINAL, "terminal_outcome": DispatchOutcome.CANCELED})
+    terminal_dispatch = dispatch.model_copy(
+        update={"state": DispatchState.TERMINAL, "terminal_outcome": DispatchOutcome.CANCELED}
+    )
     adapter._put_direct(adapter._dispatch_item(terminal_dispatch))
     with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
         adapter.reserve_run_dispatch(replacement)
     adapter._put_direct(adapter._unit_item(_unit("unit-001")))
-    transact = adapter._transact
-    def mutate_prior_then_replace(actions: Any) -> None:
+
+    def mutate_prior_then_replace(_: list[dict[str, Any]]) -> None:
         stale = _unit("unit-001").model_copy(update={"state": RunUnitState.SUCCEEDED})
         contender._put_direct(contender._unit_item(stale))
-        transact(actions)
-    adapter._transact = mutate_prior_then_replace
+
+    adapter._client = ClientSpy(adapter._client, before_transaction=mutate_prior_then_replace)
     with pytest.raises(Conflict, match="transaction_conflict"):
         adapter.reserve_run_dispatch(replacement)
-    adapter._transact = transact
+    adapter._client = adapter._client.client
     assert adapter._required_dispatch(_TENANT, "run-a")[1] == terminal_dispatch
     adapter._client.delete_item(
-        TableName=_TABLE_NAME, Key=item_key(*unit_key(_TENANT, "run-a", "unit-001")))
+        TableName=_TABLE_NAME, Key=item_key(*unit_key(_TENANT, "run-a", "unit-001"))
+    )
     with pytest.raises(Conflict, match="dispatch_unit_missing"):
         adapter.reserve_run_dispatch(replacement)
     terminal = _unit("unit-001").model_copy(update={"state": RunUnitState.SUCCEEDED})
     adapter._put_direct(adapter._unit_item(terminal))
     with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
         adapter.reserve_run_dispatch(replacement.model_copy(update={"unit_ids": ("unit-001",)}))
+
+
 def test_dispatch_started_expirado_e_recuperavel(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
     dispatch = _prepare_unit(adapter, clock)
     bind = BindRunDispatch(
-        tenant_id=_TENANT, run_id="run-a", dispatch_id=dispatch.dispatch_id,
-        execution_ref="exec-b", now=clock.now(), lease_seconds=1,
+        tenant_id=_TENANT,
+        run_id="run-a",
+        dispatch_id=dispatch.dispatch_id,
+        execution_ref="exec-b",
+        now=clock.now(),
+        lease_seconds=1,
     )
     contender = DynamoDBControlPlane(adapter._client, _TABLE_NAME, clock.now)
-    transact = adapter._transact
-    def cancel_then_bind(actions: Any) -> None:
+
+    def cancel_then_bind(_: list[dict[str, Any]]) -> None:
         contender.transition_run(
-            TransitionRun(tenant_id=_TENANT, run_id="run-a", expected_state=RunState.PROCESSING,
-                          new_state=RunState.CANCEL_REQUESTED), _event("cancel-before-bind"))
-        transact(actions)
-    adapter._transact = cancel_then_bind
+            TransitionRun(
+                tenant_id=_TENANT,
+                run_id="run-a",
+                expected_state=RunState.PROCESSING,
+                new_state=RunState.CANCEL_REQUESTED,
+            ),
+            _event("cancel-before-bind"),
+        )
+
+    adapter._client = ClientSpy(adapter._client, before_transaction=cancel_then_bind)
     with pytest.raises(Conflict, match="transaction_conflict"):
         adapter.bind_run_dispatch(bind)
-    adapter._transact = transact
+    adapter._client = adapter._client.client
     assert adapter.get_active_run_dispatch(_TENANT, "run-a") == dispatch
     adapter.put_run(_run("run-a"))
     adapter.bind_run_dispatch(bind)
     clock.advance(timedelta(seconds=2))
     recovered = adapter.reserve_run_dispatch(
         ReserveRunDispatch(
-            tenant_id=_TENANT, run_id="run-a", wave_id="b" * 16,
-            unit_ids=("unit-a",), now=clock.now(), lease_seconds=30,
+            tenant_id=_TENANT,
+            run_id="run-a",
+            wave_id="b" * 16,
+            unit_ids=("unit-a",),
+            now=clock.now(),
+            lease_seconds=30,
         )
     )
     assert recovered.generation == 2
+
+
 def test_commit_rejeita_dispatch_obsoleto(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
     dispatch = _prepare_unit(adapter, clock)
@@ -485,6 +482,8 @@ def test_commit_rejeita_dispatch_obsoleto(ctx: _DynamoContext) -> None:
             _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
             _event("stale-unit-dispatch"),
         )
+
+
 def test_validador_rejeita_lease_corrompido_sem_prazo() -> None:
     unit = _unit("unit-a").model_copy(
         update={

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -16,12 +16,14 @@ from cnes_domain.control_plane.commands import (
     ReserveRunDispatch,
     TransitionRun,
 )
+from cnes_domain.control_plane.entities import RunDependency
 from cnes_domain.control_plane.enums import DispatchOutcome, RunState, RunUnitState
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
 from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
-from cnes_infra.control_plane.dynamodb_codec import execute_transaction, payload, put_action
+from cnes_infra.control_plane.dynamodb_codec import execute_transaction, put_action
 from cnes_infra.control_plane.dynamodb_keys import (
+    dependency_marker_key,
     item_key,
     key_component,
     outbox_key,
@@ -292,38 +294,41 @@ def test_rejeita_cancelamento_de_99_unidades_sem_transacao(ctx: _DynamoContext) 
     assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
     assert spy.calls.count("query") == 99
     assert adapter.get_outbox_event("run-canceled") is None
-def test_rejeita_transacao_com_chaves_duplicadas_ou_mais_de_100_acoes(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, _ = dynamodb_adapter
+def test_put_run_limita_100_acoes_e_usa_chaves_unicas(ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
+    spy = ClientSpy(adapter._client)
+    adapter._client = spy
+    def waiting(count: int, run_id: str) -> Any:
+        dependencies = tuple(
+            RunDependency(source_type=f"SOURCE-{index}", file_subtype="ST", required=True)
+            for index in range(count)
+        )
+        return _run(run_id, RunState.WAITING_INPUTS, dependencies)
+    adapter.put_run(waiting(99, "run-99"))
+    actions = spy.transactions[-1]
+    keys = {(action["Put"]["Item"]["pk"]["S"], action["Put"]["Item"]["sk"]["S"])
+            for action in actions}
+    assert len(actions) == len(keys) == 100
+    calls = tuple(spy.calls)
+    with pytest.raises(Conflict, match="transaction_limit"):
+        adapter.put_run(waiting(100, "run-100"))
+    assert tuple(spy.calls) == calls
+def test_rejeita_transacao_com_chaves_duplicadas(ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
     spy = ClientSpy(adapter._client)
     action = _transaction_action("same")
     with pytest.raises(Conflict, match="duplicate_transaction_key"):
         execute_transaction(spy, (action, action))
-    actions = tuple(_transaction_action(str(index)) for index in range(101))
-    with pytest.raises(Conflict, match="transaction_limit"):
-        execute_transaction(spy, actions)
     assert spy.calls == []
-
-def test_moto_cancela_transacao_inteira_quando_condicao_falha(ctx: _DynamoContext) -> None:
+def test_put_run_reverte_run_quando_marcador_falha(ctx: _DynamoContext) -> None:
     adapter, _ = ctx
-    original = _run("run-a")
-    adapter.put_run(original)
-    existing_event = _event("existing")
-    adapter._put_direct(adapter._outbox_item(existing_event))
-    original_item = adapter._get_item(run_entity_key(_TENANT, "run-a"))
-    updated_item = _expected_item(
-        _run("run-a", RunState.FAILED), "RUN", run_entity_key(_TENANT, "run-a"), {}
-    )
-    actions = (
-        put_action(_TABLE_NAME, updated_item, payload(original_item)),
-        put_action(_TABLE_NAME, adapter._outbox_item(_event("existing")), None),
-    )
+    run = _run("run-a", RunState.WAITING_INPUTS)
+    identity = "RUN_DEP#" + "#".join(map(key_component, (_TENANT, "CNES", "ST", "2026-07")))
+    marker_key = dependency_marker_key(_TENANT, "run-a", identity)
+    adapter._client.put_item(TableName=_TABLE_NAME, Item=item_key(*marker_key))
     with pytest.raises(Conflict, match="transaction_conflict"):
-        execute_transaction(adapter._client, actions)
-    assert adapter.get_run(_TENANT, "run-a") == original
-    assert adapter.get_outbox_event("existing") == existing_event
-
+        adapter.put_run(run)
+    assert adapter.get_run(_TENANT, "run-a") is None
 def test_claims_retornam_none_quando_cas_perde_corrida(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -345,7 +350,6 @@ def test_claims_retornam_none_quando_cas_perde_corrida(
         lease_seconds=30,
     )
     assert adapter.claim_run_unit(command) is None
-
 def test_unit_ausente_nao_e_reivindicada_nem_finalizada(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -362,7 +366,6 @@ def test_unit_ausente_nao_e_reivindicada_nem_finalizada(
     assert adapter.claim_run_unit(claim) is None
     with pytest.raises(NotFound, match="unit_context_missing"):
         adapter.commit_run_unit(_commit_command("a" * 16, "worker-a", 1), _event("missing-unit"))
-
 def test_dispatch_terminal_invalida_commit_de_unidade(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -383,7 +386,6 @@ def test_dispatch_terminal_invalida_commit_de_unidade(
             _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
             _event("terminal-dispatch"),
         )
-
 def test_dispatch_expirado_rejeita_corrida_que_aluga_unidade_omitida(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
@@ -437,7 +439,6 @@ def test_dispatch_expirado_rejeita_corrida_que_aluga_unidade_omitida(
     adapter._put_direct(adapter._unit_item(terminal))
     with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
         adapter.reserve_run_dispatch(replacement.model_copy(update={"unit_ids": ("unit-001",)}))
-
 def test_dispatch_started_expirado_e_recuperavel_sem_lease_vivo(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -13,13 +13,13 @@ from cnes_domain.control_plane.commands import (
     FinishRunDispatch,
     PutRunUnits,
     ReserveRunDispatch,
-    TransitionRun,
 )
-from cnes_domain.control_plane.enums import DispatchOutcome, RunState
+from cnes_domain.control_plane.enums import DispatchOutcome, RunState, RunUnitState
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
 from cnes_infra.control_plane.dynamodb_claims import DynamoDBClaims
-from cnes_infra.control_plane.dynamodb_codec import execute_transaction, put_action
+from cnes_infra.control_plane.dynamodb_codec import execute_transaction, payload, put_action
+from cnes_infra.control_plane.dynamodb_keys import run_entity_key
 from packages.cnes_infra.tests.contracts.clock import (
     _NOW,
     _TENANT,
@@ -143,10 +143,61 @@ def _put_many_units(adapter: DynamoDBControlPlane, amount: int) -> tuple[Any, ..
     )
 
 
-def _action_key(action: dict[str, Any]) -> tuple[str, str]:
-    request = next(iter(action.values()))
-    values = request.get("Item", request.get("Key"))
-    return values["pk"]["S"], values["sk"]["S"]
+def _expected_item(
+    model: Any, entity: str, key: tuple[str, str], indexes: dict[str, str]
+) -> dict[str, Any]:
+    item = {
+        "pk": {"S": key[0]},
+        "sk": {"S": key[1]},
+        "entity": {"S": entity},
+        "payload": {"S": model.model_dump_json()},
+    }
+    return item | {name: {"S": value} for name, value in indexes.items()}
+
+
+def _expected_put(item: dict[str, Any], expected: str | None) -> dict[str, Any]:
+    request = {"TableName": _TABLE_NAME, "Item": item}
+    request["ConditionExpression"] = (
+        "attribute_not_exists(pk)" if expected is None else "payload = :expected"
+    )
+    if expected is not None:
+        request["ExpressionAttributeValues"] = {":expected": {"S": expected}}
+    return {"Put": request}
+
+
+def _transaction_action(identifier: str) -> dict[str, Any]:
+    item = {
+        "pk": {"S": "TENANT#354130"},
+        "sk": {"S": f"TEST#{identifier}"},
+        "payload": {"S": "{}"},
+    }
+    return put_action(_TABLE_NAME, item, None)
+
+
+def _expected_unit_action(index: int, state: RunUnitState) -> dict[str, Any]:
+    unit = _unit(f"unit-{index:03d}").model_copy(update={"state": state})
+    item = _expected_item(
+        unit,
+        "RUNUNIT",
+        (f"TENANT#{_TENANT}#RUN#run-a", f"UNIT#unit-{index:03d}"),
+        {
+            "gsi5pk": f"RUN_ITEMS#{_TENANT}#run-a",
+            "gsi5sk": f"UNIT#unit-{index:03d}",
+        },
+    )
+    expected = None if state is RunUnitState.PENDING else _unit(f"unit-{index:03d}")
+    return _expected_put(item, expected.model_dump_json() if expected is not None else None)
+
+
+def _hide_unit_from_gsi(adapter: DynamoDBControlPlane, unit_id: str) -> None:
+    item = adapter._client.get_item(
+        TableName=_TABLE_NAME,
+        Key={"pk": {"S": f"TENANT#{_TENANT}#RUN#run-a"}, "sk": {"S": f"UNIT#{unit_id}"}},
+        ConsistentRead=True,
+    )["Item"]
+    item.pop("gsi5pk")
+    item.pop("gsi5sk")
+    adapter._client.put_item(TableName=_TABLE_NAME, Item=item)
 
 
 def test_grava_99_unidades_em_ate_100_acoes_unicas(
@@ -156,17 +207,21 @@ def test_grava_99_unidades_em_ate_100_acoes_unicas(
     adapter.put_run(_run("run-a"))
     spy = ClientSpy(adapter._client)
     adapter._client = spy
-
     assert _put_many_units(adapter, 99) == _many_units(99)
-
     actions = spy.transactions[-1]
-    keys = [_action_key(action) for action in actions]
-    assert len(actions) == 100
-    assert tuple(next(iter(action)) for action in actions) == (
-        "ConditionCheck",
-        *("Put" for _ in range(99)),
-    )
-    assert len(keys) == len(set(keys))
+    run = _run("run-a")
+    expected_check = {
+        "ConditionCheck": {
+            "TableName": _TABLE_NAME,
+            "Key": {"pk": {"S": f"TENANT#{_TENANT}"}, "sk": {"S": "RUN#run-a"}},
+            "ConditionExpression": "payload = :expected",
+            "ExpressionAttributeValues": {":expected": {"S": run.model_dump_json()}},
+        }
+    }
+    assert actions == [
+        expected_check,
+        *(_expected_unit_action(index, RunUnitState.PENDING) for index in range(99)),
+    ]
 
 
 def test_rejeita_100_unidades_antes_de_chamar_boto3(
@@ -175,10 +230,8 @@ def test_rejeita_100_unidades_antes_de_chamar_boto3(
     adapter, _ = dynamodb_adapter
     spy = ClientSpy(adapter._client)
     adapter._client = spy
-
     with pytest.raises(Conflict, match="transaction_limit"):
         _put_many_units(adapter, 100)
-
     assert spy.calls == []
 
 
@@ -203,16 +256,29 @@ def test_cancela_98_unidades_em_100_acoes_unicas(
 ) -> None:
     adapter, clock = dynamodb_adapter
     _prepare_cancellation(adapter, 98)
+    _hide_unit_from_gsi(adapter, "unit-097")
     spy = ClientSpy(adapter._client)
     adapter._client = spy
-
     assert _finalize(adapter, clock).state is RunState.CANCELED
-
     actions = spy.transactions[-1]
-    keys = [_action_key(action) for action in actions]
-    assert len(actions) == 100
-    assert all(tuple(action) == ("Put",) for action in actions)
-    assert len(keys) == len(set(keys))
+    canceled = _run("run-a", RunState.CANCELED)
+    run_item = _expected_item(canceled, "RUN", (f"TENANT#{_TENANT}", "RUN#run-a"), {})
+    original_payload = _run("run-a", RunState.CANCEL_REQUESTED).model_dump_json()
+    event = _event("run-canceled")
+    event_item = _expected_item(
+        event,
+        "OUTBOXEVENT",
+        ("TENANT#_GLOBAL", "OUTBOX#run-canceled"),
+        {
+            "gsi6pk": "OUTBOX#PENDING",
+            "gsi6sk": f"{_NOW.isoformat(timespec='microseconds')}#run-canceled",
+        },
+    )
+    assert actions == [
+        _expected_put(run_item, original_payload),
+        *(_expected_unit_action(index, RunUnitState.CANCELED) for index in range(98)),
+        _expected_put(event_item, None),
+    ]
 
 
 def test_rejeita_cancelamento_de_99_unidades_sem_transacao(
@@ -220,94 +286,62 @@ def test_rejeita_cancelamento_de_99_unidades_sem_transacao(
 ) -> None:
     adapter, clock = dynamodb_adapter
     _prepare_cancellation(adapter, 99)
+    _hide_unit_from_gsi(adapter, "unit-098")
     spy = ClientSpy(adapter._client)
     adapter._client = spy
-
     with pytest.raises(Conflict, match="transaction_limit"):
         _finalize(adapter, clock)
-
     assert spy.transactions == []
     assert adapter.get_run(_TENANT, "run-a").state is RunState.CANCEL_REQUESTED
     assert all(unit.state.value == "PENDING" for unit in adapter.list_run_units(_TENANT, "run-a"))
     assert adapter.get_outbox_event("run-canceled") is None
 
 
-def test_rejeita_chaves_duplicadas_antes_de_enviar_transacao(
+def test_rejeita_transacao_com_chaves_duplicadas_ou_mais_de_100_acoes(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
     adapter, _ = dynamodb_adapter
     spy = ClientSpy(adapter._client)
-    item = {
-        "pk": {"S": "TENANT#354130"},
-        "sk": {"S": "TEST#same"},
-        "payload": {"S": "{}"},
-    }
-    action = put_action(_TABLE_NAME, item, None)
-
+    action = _transaction_action("same")
     with pytest.raises(Conflict, match="duplicate_transaction_key"):
         execute_transaction(spy, (action, action))
-
-    assert spy.transactions == []
-
-
-def test_transacao_falha_sem_mutar_run_ou_outbox(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, _ = dynamodb_adapter
-    original = _run("run-a")
-    adapter.put_run(original)
-    adapter._client = FailingTransactionClient(adapter._client)
-    command = TransitionRun(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        expected_state=RunState.PROCESSING,
-        new_state=RunState.FAILED,
-    )
-
-    with pytest.raises(Conflict, match="transaction_conflict"):
-        adapter.transition_run(command, _event("run-failed"))
-
-    assert adapter.get_run(_TENANT, "run-a") == original
-    assert adapter.get_outbox_event("run-failed") is None
-
-
-def test_rejeita_mais_de_100_acoes_antes_do_cliente(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, _ = dynamodb_adapter
-    spy = ClientSpy(adapter._client)
-    actions = tuple(
-        put_action(
-            _TABLE_NAME,
-            {
-                "pk": {"S": "TENANT#354130"},
-                "sk": {"S": f"TEST#{index}"},
-                "payload": {"S": "{}"},
-            },
-            None,
-        )
-        for index in range(101)
-    )
+    actions = tuple(_transaction_action(str(index)) for index in range(101))
     with pytest.raises(Conflict, match="transaction_limit"):
         execute_transaction(spy, actions)
     assert spy.calls == []
 
 
-def test_claim_job_retorna_none_quando_cas_perde_corrida(
+def test_moto_cancela_transacao_inteira_quando_condicao_falha(
+    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
+) -> None:
+    adapter, _ = dynamodb_adapter
+    original = _run("run-a")
+    adapter.put_run(original)
+    existing_event = _event("existing")
+    adapter._put_direct(adapter._outbox_item(existing_event))
+    original_item = adapter._get_item(run_entity_key(_TENANT, "run-a"))
+    updated_item = _expected_item(
+        _run("run-a", RunState.FAILED), "RUN", run_entity_key(_TENANT, "run-a"), {}
+    )
+    actions = (
+        put_action(_TABLE_NAME, updated_item, payload(original_item)),
+        put_action(_TABLE_NAME, adapter._outbox_item(_event("existing")), None),
+    )
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        execute_transaction(adapter._client, actions)
+    assert adapter.get_run(_TENANT, "run-a") == original
+    assert adapter.get_outbox_event("existing") == existing_event
+
+
+def test_claims_retornam_none_quando_cas_perde_corrida(
     dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
 ) -> None:
     adapter, clock = dynamodb_adapter
     adapter.put_agent(_agent("agent-a"))
     adapter.create_job(_job("job-a"), _event("job-created"))
     adapter._client = FailingTransactionClient(adapter._client)
-
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
-
-
-def test_claim_unit_retorna_none_quando_cas_perde_corrida(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+    adapter._client = adapter._client.client
     dispatch = _prepare_unit(adapter, clock)
     adapter._client = FailingTransactionClient(adapter._client)
     command = ClaimRunUnit(
@@ -319,7 +353,6 @@ def test_claim_unit_retorna_none_quando_cas_perde_corrida(
         now=clock.now(),
         lease_seconds=30,
     )
-
     assert adapter.claim_run_unit(command) is None
 
 
@@ -356,7 +389,6 @@ def test_dispatch_terminal_invalida_commit_de_unidade(
             finished_at=clock.now(),
         )
     )
-
     with pytest.raises(LeaseLost, match="dispatch_terminal"):
         adapter.commit_run_unit(
             _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
@@ -446,7 +478,6 @@ def test_commit_rejeita_dispatch_da_unidade_obsoleto(
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
     stale = claimed.model_copy(update={"dispatch_id": "b" * 16})
     adapter._put_direct(adapter._unit_item(stale))
-
     with pytest.raises(FenceRejected, match="unit_dispatch_rejected"):
         adapter.commit_run_unit(
             _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
@@ -465,6 +496,5 @@ def test_validador_rejeita_lease_corrompido_sem_prazo() -> None:
         }
     )
     command = _commit_command("a" * 16, "worker-a", 1)
-
     with pytest.raises(LeaseLost, match="unit_lease_expired"):
         DynamoDBClaims._validate_unit_fence(unit, command, _NOW)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -169,6 +169,18 @@ def _transaction_action(identifier: str) -> dict[str, Any]:
         "payload": {"S": "{}"},
     }
     return put_action(_TABLE_NAME, item, None)
+def _dependency_run(count: int, state: RunState, run_id: str) -> Any:
+    return _run(run_id, state, tuple(
+        RunDependency(source_type=f"SOURCE-{index}", file_subtype="ST", required=True)
+        for index in range(count)
+    ))
+def _store_waiting(adapter: DynamoDBControlPlane, run: Any, event_id: str) -> Any:
+    if run.state is RunState.PLANNED:
+        command = TransitionRun(tenant_id=_TENANT, run_id=run.run_id, expected_state=run.state,
+            new_state=RunState.WAITING_INPUTS)
+        return adapter.transition_run(command, _event(event_id))
+    adapter.put_run(run)
+    return run
 def _expected_unit_action(index: int, state: RunUnitState) -> dict[str, Any]:
     unit = _unit(f"unit-{index:03d}").model_copy(update={"state": state})
     item = _expected_item(
@@ -294,45 +306,45 @@ def test_rejeita_cancelamento_de_99_unidades_sem_transacao(ctx: _DynamoContext) 
     assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
     assert spy.calls.count("query") == 99
     assert adapter.get_outbox_event("run-canceled") is None
-def test_put_run_limita_100_acoes_e_usa_chaves_unicas(ctx: _DynamoContext) -> None:
+@pytest.mark.parametrize(("state","count"),[(RunState.WAITING_INPUTS,99),(RunState.PLANNED,98)])
+def test_waiting_limita_acoes_e_chaves(state: RunState, count: int, ctx: _DynamoContext) -> None:
     adapter, _ = ctx
+    run = _dependency_run(count, state, "run-limit")
+    if state is RunState.PLANNED:
+        adapter.put_run(run)
     spy = ClientSpy(adapter._client)
     adapter._client = spy
-    def waiting(count: int, run_id: str) -> Any:
-        dependencies = tuple(
-            RunDependency(source_type=f"SOURCE-{index}", file_subtype="ST", required=True)
-            for index in range(count)
-        )
-        return _run(run_id, RunState.WAITING_INPUTS, dependencies)
-    adapter.put_run(waiting(99, "run-99"))
+    overflow = _dependency_run(count + 1, state, "run-overflow")
+    if state is RunState.PLANNED:
+        adapter.put_run(overflow)
+    mutations = (len(spy.transactions), spy.calls.count("put_item"))
+    with pytest.raises(Conflict, match="transaction_limit"):
+        _store_waiting(adapter, overflow, "waiting-overflow")
+    assert (len(spy.transactions), spy.calls.count("put_item")) == mutations
+    _store_waiting(adapter, run, "waiting-limit")
     actions = spy.transactions[-1]
     keys = {(action["Put"]["Item"]["pk"]["S"], action["Put"]["Item"]["sk"]["S"])
             for action in actions}
     assert len(actions) == len(keys) == 100
-    calls = tuple(spy.calls)
-    with pytest.raises(Conflict, match="transaction_limit"):
-        adapter.put_run(waiting(100, "run-100"))
-    assert tuple(spy.calls) == calls
-def test_rejeita_transacao_com_chaves_duplicadas(ctx: _DynamoContext) -> None:
-    adapter, _ = ctx
-    spy = ClientSpy(adapter._client)
     action = _transaction_action("same")
     with pytest.raises(Conflict, match="duplicate_transaction_key"):
         execute_transaction(spy, (action, action))
-    assert spy.calls == []
-def test_put_run_reverte_run_quando_marcador_falha(ctx: _DynamoContext) -> None:
+@pytest.mark.parametrize("state", [RunState.WAITING_INPUTS, RunState.PLANNED])
+def test_waiting_reverte_run_quando_marcador_falha(state: RunState, ctx: _DynamoContext) -> None:
     adapter, _ = ctx
-    run = _run("run-a", RunState.WAITING_INPUTS)
-    identity = "RUN_DEP#" + "#".join(map(key_component, (_TENANT, "CNES", "ST", "2026-07")))
+    run = _dependency_run(1, state, "run-a")
+    if state is RunState.PLANNED:
+        adapter.put_run(run)
+    identity = "RUN_DEP#" + "#".join(map(key_component, (_TENANT, "SOURCE-0", "ST", "2026-07")))
     marker_key = dependency_marker_key(_TENANT, "run-a", identity)
     adapter._client.put_item(TableName=_TABLE_NAME, Item=item_key(*marker_key))
     with pytest.raises(Conflict, match="transaction_conflict"):
-        adapter.put_run(run)
-    assert adapter.get_run(_TENANT, "run-a") is None
-def test_claims_retornam_none_quando_cas_perde_corrida(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+        _store_waiting(adapter, run, "waiting-rollback")
+    expected = run if state is RunState.PLANNED else None
+    assert adapter.get_run(_TENANT, "run-a") == expected
+    assert adapter.get_outbox_event("waiting-rollback") is None
+def test_claims_retornam_none_quando_cas_perde_corrida(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
     adapter.put_agent(_agent("agent-a"))
     adapter.create_job(_job("job-a"), _event("job-created"))
     adapter._client = FailingTransactionClient(adapter._client)
@@ -350,10 +362,8 @@ def test_claims_retornam_none_quando_cas_perde_corrida(
         lease_seconds=30,
     )
     assert adapter.claim_run_unit(command) is None
-def test_unit_ausente_nao_e_reivindicada_nem_finalizada(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+def test_unit_ausente_nao_e_reivindicada_nem_finalizada(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
     claim = ClaimRunUnit(
         tenant_id=_TENANT,
         run_id="run-a",
@@ -366,10 +376,8 @@ def test_unit_ausente_nao_e_reivindicada_nem_finalizada(
     assert adapter.claim_run_unit(claim) is None
     with pytest.raises(NotFound, match="unit_context_missing"):
         adapter.commit_run_unit(_commit_command("a" * 16, "worker-a", 1), _event("missing-unit"))
-def test_dispatch_terminal_invalida_commit_de_unidade(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+def test_dispatch_terminal_invalida_commit_de_unidade(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
     dispatch = _prepare_unit(adapter, clock)
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
     adapter.finish_run_dispatch(
@@ -386,10 +394,8 @@ def test_dispatch_terminal_invalida_commit_de_unidade(
             _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
             _event("terminal-dispatch"),
         )
-def test_dispatch_expirado_rejeita_corrida_que_aluga_unidade_omitida(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+def test_dispatch_expirado_rejeita_unidade_omitida(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
     reserve = ReserveRunDispatch(
         tenant_id=_TENANT, run_id="run-a", wave_id="a" * 16,
         unit_ids=("unit-000",), now=clock.now(), lease_seconds=30)
@@ -439,10 +445,8 @@ def test_dispatch_expirado_rejeita_corrida_que_aluga_unidade_omitida(
     adapter._put_direct(adapter._unit_item(terminal))
     with pytest.raises(Conflict, match="dispatch_unit_unavailable"):
         adapter.reserve_run_dispatch(replacement.model_copy(update={"unit_ids": ("unit-001",)}))
-def test_dispatch_started_expirado_e_recuperavel_sem_lease_vivo(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+def test_dispatch_started_expirado_e_recuperavel(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
     dispatch = _prepare_unit(adapter, clock)
     bind = BindRunDispatch(
         tenant_id=_TENANT, run_id="run-a", dispatch_id=dispatch.dispatch_id,
@@ -470,11 +474,8 @@ def test_dispatch_started_expirado_e_recuperavel_sem_lease_vivo(
         )
     )
     assert recovered.generation == 2
-
-def test_commit_rejeita_dispatch_da_unidade_obsoleto(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, clock = dynamodb_adapter
+def test_commit_rejeita_dispatch_obsoleto(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
     dispatch = _prepare_unit(adapter, clock)
     claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
     stale = claimed.model_copy(update={"dispatch_id": "b" * 16})
@@ -484,7 +485,6 @@ def test_commit_rejeita_dispatch_da_unidade_obsoleto(
             _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token),
             _event("stale-unit-dispatch"),
         )
-
 def test_validador_rejeita_lease_corrompido_sem_prazo() -> None:
     unit = _unit("unit-a").model_copy(
         update={

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -58,12 +58,14 @@ class ClientSpy:
         self.client = client
         self.transactions: list[list[dict[str, Any]]] = []
         self.calls: list[str] = []
+        self.query_limits: list[int | None] = []
     def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("transact_write_items")
         self.transactions.append(kwargs["TransactItems"])
         return self.client.transact_write_items(**kwargs)
     def query(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("query")
+        self.query_limits.append(kwargs.get("Limit"))
         kwargs.setdefault("Limit", getattr(self, "query_limit", 100))
         return self.client.query(**kwargs)
     def __getattr__(self, name: str) -> Any:
@@ -303,10 +305,8 @@ def test_rejeita_transacao_com_chaves_duplicadas_ou_mais_de_100_acoes(
         execute_transaction(spy, actions)
     assert spy.calls == []
 
-def test_moto_cancela_transacao_inteira_quando_condicao_falha(
-    dynamodb_adapter: tuple[DynamoDBControlPlane, MutableClock],
-) -> None:
-    adapter, _ = dynamodb_adapter
+def test_moto_cancela_transacao_inteira_quando_condicao_falha(ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
     original = _run("run-a")
     adapter.put_run(original)
     existing_event = _event("existing")

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_completion_retries.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_completion_retries.py
@@ -9,6 +9,7 @@ from cnes_domain.control_plane.commands import CompleteJob
 from cnes_domain.control_plane.enums import JobState, RunState
 from cnes_domain.control_plane.errors import Conflict
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
+from cnes_infra.control_plane.dynamodb_keys import item_key, run_entity_key
 from packages.cnes_infra.tests.contracts.clock import (
     _NOW,
     _TENANT,
@@ -98,6 +99,17 @@ def test_complete_tenta_tres_vezes_sem_mutar_em_contencao(
     assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1) == ()
 
 
+def test_latest_job_preserva_marcador_mais_recente(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
+    newest = _job("z-newest").model_copy(update={"created_at": clock.now()})
+    older = _job("a-older").model_copy(update={"created_at": clock.now()})
+    adapter._transact((adapter._latest_job_action(newest),))
+    adapter._transact((adapter._latest_job_action(older),))
+    latest = adapter.latest_succeeded_job(_TENANT, "agent-a", "CNES", "ST", "2026-07")
+    assert latest is not None
+    assert latest.job_id == newest.job_id
+
+
 def test_publicacao_aceita_replay_identico_apos_conflito_com_leitura_forte(
     ctx: _DynamoContext,
 ) -> None:
@@ -132,3 +144,35 @@ def test_publicacao_rejeita_winner_divergente_apos_conflito(ctx: _DynamoContext)
     with pytest.raises(Conflict, match="publication_replay_conflict"):
         adapter.publish_dataset(command)
     assert adapter.get_outbox_event(command.event.event_id) is None
+
+
+def test_publicacao_propaga_conflito_sem_run_vencedor(ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
+    command = _publish("run-a", "published", None, False)
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+
+    def remove_run_then_report_conflict(_: list[dict[str, Any]]) -> None:
+        adapter._client.client.delete_item(
+            TableName=_TABLE_NAME,
+            Key=item_key(*run_entity_key(_TENANT, "run-a")),
+        )
+        _lose_transaction_response(())
+
+    adapter._client = ClientSpy(
+        adapter._client,
+        before_transaction=remove_run_then_report_conflict,
+    )
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.publish_dataset(command)
+
+
+def test_publicacao_propaga_conflito_com_run_ainda_publicando(ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
+    command = _publish("run-a", "published", None, False)
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    adapter._client = ClientSpy(
+        adapter._client,
+        before_transaction=_raise_transaction_canceled,
+    )
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.publish_dataset(command)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_completion_retries.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_completion_retries.py
@@ -1,0 +1,134 @@
+from collections.abc import Iterator
+from typing import Any
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from cnes_domain.control_plane.commands import CompleteJob
+from cnes_domain.control_plane.enums import JobState, RunState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
+from packages.cnes_infra.tests.contracts.clock import (
+    _NOW,
+    _TENANT,
+    MutableClock,
+    _agent,
+    _claim_job,
+    _event,
+    _job,
+    _raw_record,
+    _run,
+)
+from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
+from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
+    _TABLE_NAME,
+    ClientSpy,
+    _create_table,
+    _lose_transaction_response,
+    _raise_transaction_canceled,
+)
+
+type _DynamoContext = tuple[DynamoDBControlPlane, MutableClock]
+
+
+@pytest.fixture
+def ctx() -> Iterator[_DynamoContext]:
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-east-1")
+        _create_table(client)
+        clock = MutableClock(_NOW)
+        yield DynamoDBControlPlane(client, _TABLE_NAME, clock.now), clock
+
+
+def _leased_job(adapter: DynamoDBControlPlane, clock: MutableClock) -> Any:
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    assert claimed is not None
+    return claimed
+
+
+def test_complete_aceita_modo_de_manifesto_diferente_do_solicitado(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, clock = ctx
+    adapter.put_agent(_agent("agent-a"))
+    job = _job("job-a").model_copy(update={"requested_snapshot_mode": "DELTA"})
+    adapter.create_job(job, _event("job-created"))
+    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    assert claimed is not None
+    manifest = _raw_record("snapshot-a", "agent-a", 1, clock.now())
+    completed = adapter.complete_job(
+        CompleteJob(
+            tenant_id=_TENANT,
+            job_id="job-a",
+            owner="worker-a",
+            fencing_token=claimed.fencing_token,
+            manifest=manifest,
+        ),
+        _event("job-completed"),
+    )
+    assert completed.state is JobState.SUCCEEDED
+    assert adapter.latest_succeeded_job(_TENANT, "agent-a", "CNES", "ST", "2026-07") == completed
+
+
+def test_complete_tenta_tres_vezes_sem_mutar_em_contencao(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, clock = ctx
+    claimed = _leased_job(adapter, clock)
+    manifest = _raw_record("snapshot-a", "agent-a", 1, clock.now())
+    adapter._client = failing = ClientSpy(
+        adapter._client,
+        before_transaction=_raise_transaction_canceled,
+    )
+    command = CompleteJob(
+        tenant_id=_TENANT,
+        job_id="job-a",
+        owner="worker-a",
+        fencing_token=claimed.fencing_token,
+        manifest=manifest,
+    )
+    with pytest.raises(TimeoutError, match=r"^transaction_contention$"):
+        adapter.complete_job(command, _event("job-completed"))
+    assert len(failing.transactions) == 3
+    assert adapter.get_job(_TENANT, "job-a") == claimed
+    assert adapter.get_outbox_event("job-completed") is None
+    assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1) == ()
+
+
+def test_publicacao_aceita_replay_identico_apos_conflito_com_leitura_forte(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, _ = ctx
+    command = _publish("run-a", "published", None, False)
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    adapter._client = spy = ClientSpy(
+        adapter._client,
+        after_transaction=_lose_transaction_response,
+    )
+    pointer = adapter.publish_dataset(command)
+    get_requests = [request for name, request in spy.requests if name == "get_item"]
+    assert pointer.version_id == "run-a"
+    assert get_requests[-1]["ConsistentRead"] is True
+
+
+def test_publicacao_rejeita_winner_divergente_apos_conflito(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
+    command = _publish("run-a", "published", None, False)
+    winner = command.model_copy(update={"event": _event("winner-published", aggregate_id="run-a")})
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    contender = DynamoDBControlPlane(adapter._client, _TABLE_NAME, clock.now)
+
+    def publish_winner_then_report_conflict(actions: list[dict[str, Any]]) -> None:
+        contender.publish_dataset(winner)
+        _lose_transaction_response(actions)
+
+    adapter._client = ClientSpy(
+        adapter._client,
+        before_transaction=publish_winner_then_report_conflict,
+    )
+    with pytest.raises(Conflict, match="publication_replay_conflict"):
+        adapter.publish_dataset(command)
+    assert adapter.get_outbox_event(command.event.event_id) is None

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_completion_retries.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_completion_retries.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from datetime import timedelta
 from typing import Any
 
 import boto3
@@ -99,15 +100,53 @@ def test_complete_tenta_tres_vezes_sem_mutar_em_contencao(
     assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1) == ()
 
 
+def test_complete_retorna_replay_apos_resposta_transacional_perdida(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, clock = ctx
+    claimed = _leased_job(adapter, clock)
+    command = CompleteJob(
+        tenant_id=_TENANT,
+        job_id="job-a",
+        owner="worker-a",
+        fencing_token=claimed.fencing_token,
+        manifest=_raw_record("snapshot-a", "agent-a", 1, clock.now()),
+    )
+    adapter._client = ClientSpy(adapter._client, after_transaction=_lose_transaction_response)
+    completed = adapter.complete_job(command, _event("job-completed"))
+    assert completed.state is JobState.SUCCEEDED
+    assert adapter.get_job(_TENANT, "job-a") == completed
+
+
 def test_latest_job_preserva_marcador_mais_recente(ctx: _DynamoContext) -> None:
     adapter, clock = ctx
-    newest = _job("z-newest").model_copy(update={"created_at": clock.now()})
-    older = _job("a-older").model_copy(update={"created_at": clock.now()})
-    adapter._transact((adapter._latest_job_action(newest),))
-    adapter._transact((adapter._latest_job_action(older),))
+    newest = _job("z-newest").model_copy(update={"created_at": clock.now() + timedelta(1)})
+    older = _job("a-older")
+    newest_manifest = _raw_record("base-agent-a", "agent-a", 1, clock.now())
+    _complete_raw_job(adapter, clock, newest, newest_manifest)
+    _complete_raw_job(adapter, clock, older, _raw_record("delta", "agent-a", 2, clock.now()))
     latest = adapter.latest_succeeded_job(_TENANT, "agent-a", "CNES", "ST", "2026-07")
     assert latest is not None
     assert latest.job_id == newest.job_id
+
+
+def _complete_raw_job(
+    adapter: DynamoDBControlPlane, clock: MutableClock, job: Any, manifest: Any
+) -> None:
+    adapter.put_agent(_agent(job.agent_id))
+    adapter.create_job(job, _event(f"created-{job.job_id}"))
+    claimed = adapter.claim_job(_claim_job(job.job_id, "worker-a", clock))
+    assert claimed is not None
+    adapter.complete_job(
+        CompleteJob(
+            tenant_id=_TENANT,
+            job_id=job.job_id,
+            owner="worker-a",
+            fencing_token=claimed.fencing_token,
+            manifest=manifest,
+        ),
+        _event(f"completed-{job.job_id}"),
+    )
 
 
 def test_publicacao_aceita_replay_identico_apos_conflito_com_leitura_forte(

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_outbox.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_outbox.py
@@ -1,0 +1,320 @@
+from datetime import timedelta
+from typing import Any
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from cnes_domain.control_plane.commands import (
+    BeginIdempotency,
+    CompleteJob,
+    RenewJobLease,
+)
+from cnes_domain.control_plane.entities import AccessRequest
+from cnes_domain.control_plane.enums import AccessRequestState, AgentState, RunState
+from cnes_domain.control_plane.errors import Conflict, LeaseLost, NotFound
+from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
+from cnes_infra.control_plane.dynamodb_codec import encode_marker, execute_transaction
+from cnes_infra.control_plane.dynamodb_keys import (
+    entity_key,
+    outbox_key,
+)
+from packages.cnes_infra.tests.contracts.clock import (
+    _HASH_A,
+    _NOW,
+    _TENANT,
+    MutableClock,
+    _agent,
+    _claim_job,
+    _event,
+    _fail_job,
+    _job,
+    _raw_record,
+    _run,
+)
+from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
+    _TABLE_NAME,
+    ClientSpy,
+    _create_table,
+)
+
+_HASH_B = "b" * 64
+type _DynamoContext = tuple[Any, MutableClock, DynamoDBControlPlane]
+
+
+class OneItemPageClient(ClientSpy):
+    def query(self, **kwargs: Any) -> dict[str, Any]:
+        kwargs.setdefault("Limit", 1)
+        response = super().query(**kwargs)
+        if kwargs.get("IndexName") == "gsi6":
+            response["Items"] *= 2
+        if kwargs.get("IndexName") == "gsi2" and (hidden := getattr(self, "hidden_gsi2sk", None)):
+            response["Items"] = [item for item in response["Items"] if item["gsi2sk"] != hidden]
+        return response
+
+
+def _raise_transaction_conflict(_: list[dict[str, Any]]) -> None:
+    raise ClientError(
+        {
+            "Error": {"Code": "TransactionCanceledException", "Message": "cancelled"},
+            "CancellationReasons": [{"Code": "ConditionalCheckFailed"}],
+        },
+        "TransactWriteItems",
+    )
+
+
+def _lose_transaction_response(_: list[dict[str, Any]]) -> None:
+    raise Conflict("transaction_conflict")
+
+
+@pytest.fixture
+def ctx() -> Any:
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-east-1")
+        _create_table(client)
+        clock = MutableClock(_NOW)
+        yield client, clock, DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
+
+
+def _access_request(state: AccessRequestState = AccessRequestState.PENDING) -> AccessRequest:
+    decided = state is not AccessRequestState.PENDING
+    return AccessRequest(
+        tenant_id=_TENANT,
+        request_id="request-a",
+        user_id="user-a",
+        state=state,
+        decided_by="admin-a" if decided else None,
+        decided_at=_NOW if decided else None,
+    )
+
+
+def _foreign_event(adapter: DynamoDBControlPlane) -> Any:
+    adapter.create_job(
+        _job("foreign-job", tenant_id="other"), event := _event("foreign-event", tenant_id="other")
+    )
+    return event
+
+
+def test_access_request_tem_criacao_decisao_e_replays_atomicos(ctx: _DynamoContext) -> None:
+    _, _, adapter = ctx
+    pending = _access_request()
+    with pytest.raises(NotFound, match="access_request_missing"):
+        adapter.decide_access_request(
+            _access_request(AccessRequestState.APPROVED), _event("missing-access")
+        )
+    event = _event("access-created")
+    client = adapter._client
+    adapter._client = ClientSpy(client, after_transaction=_lose_transaction_response)
+    adapter.put_access_request(pending, event)
+    adapter._client = client
+    adapter.put_access_request(pending, event)
+    foreign = _foreign_event(adapter)
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.put_access_request(pending, foreign)
+    with pytest.raises(Conflict, match="access_request_conflict"):
+        adapter.put_access_request(
+            pending.model_copy(update={"user_id": "user-b"}), _event("divergent-access")
+        )
+    approved = _access_request(AccessRequestState.APPROVED)
+    changed_user = approved.model_copy(update={"user_id": "user-b"})
+    with pytest.raises(Conflict, match="access_request_conflict"):
+        adapter.decide_access_request(changed_user, _event("changed-user"))
+    assert adapter.get_access_request(_TENANT, "request-a") == pending
+    assert adapter.get_outbox_event("changed-user") is None
+    assert adapter.decide_access_request(approved, _event("access-approved")) == approved
+    assert adapter.decide_access_request(approved, _event("access-approved")) == approved
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.decide_access_request(approved, foreign)
+    with pytest.raises(Conflict, match="access_request_conflict"):
+        adapter.decide_access_request(
+            _access_request(AccessRequestState.REJECTED), _event("access-rejected")
+        )
+
+
+def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(ctx: _DynamoContext) -> None:
+    client, clock, adapter = ctx
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    delivered_at = clock.now() + timedelta(seconds=1)
+    adapter.mark_outbox_delivered("job-created", delivered_at)
+    assert adapter.pending_outbox(10) == ()
+    assert adapter.create_job(_job("job-a"), _event("job-created")) == _job("job-a")
+    divergent = _event("job-created").model_copy(update={"payload": {"changed": True}})
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.create_job(_job("job-a"), divergent)
+    adapter.mark_outbox_delivered("job-created", delivered_at)
+    with pytest.raises(Conflict, match="outbox_delivery_conflict"):
+        adapter.mark_outbox_delivered("job-created", delivered_at + timedelta(seconds=1))
+    with pytest.raises(NotFound, match="outbox_event_missing"):
+        adapter.mark_outbox_delivered("missing", delivered_at)
+    events = tuple(
+        _event(f"event-{index}").model_copy(
+            update={"created_at": clock.now() + timedelta(seconds=index)}
+        )
+        for index in range(3)
+    )
+    for index, event in enumerate(events):
+        adapter.create_job(_job(f"job-{index}"), event)
+    markers = (("missing", "missing", 3), ("stale", "job-created", 2), ("newer", "event-1", 1))
+    for marker_id, base_id, minutes in markers:
+        marker = encode_marker(
+            "STALE_OUTBOX",
+            entity_key(_TENANT, "STALE_OUTBOX", marker_id),
+            outbox_key(base_id),
+            {
+                "gsi6pk": "OUTBOX#PENDING",
+                "gsi6sk": f"{(clock.now() - timedelta(minutes=minutes)).isoformat()}#{marker_id}",
+            },
+        )
+        client.put_item(TableName=_TABLE_NAME, Item=marker)
+    paginated = OneItemPageClient(client)
+    adapter._client = paginated
+    assert (adapter.pending_outbox(0), adapter.pending_outbox(1)) == ((), events[:1])
+    paginated = OneItemPageClient(client)
+    adapter._client = paginated
+    assert adapter.pending_outbox(2) == events[:2]
+    assert [request.get("Limit") for request in paginated.query_requests] == [2, 2, 1]
+
+
+def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
+    assert adapter.claim_job(_claim_job("missing", "worker-a", clock)) is None
+    renewal = RenewJobLease(
+        tenant_id=_TENANT,
+        job_id="missing",
+        owner="worker-a",
+        fencing_token=1,
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    with pytest.raises(NotFound, match="job_missing"):
+        adapter.renew_job_lease(renewal)
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    with pytest.raises(LeaseLost, match="job_not_leased"):
+        adapter.renew_job_lease(renewal.model_copy(update={"job_id": "job-a"}))
+    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    client = adapter._client
+    contender = DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
+
+    def revoke_then_renew(_: list[dict[str, Any]]) -> None:
+        contender.put_agent(_agent("agent-a", AgentState.REVOKED))
+
+    adapter._client = ClientSpy(client, before_transaction=revoke_then_renew)
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.renew_job_lease(renewal.model_copy(update={"job_id": "job-a"}))
+    adapter._client = client
+    assert adapter.get_job(_TENANT, "job-a") == claimed
+    adapter.put_agent(_agent("agent-a"))
+    adapter._client = ClientSpy(client, before_transaction=revoke_then_renew)
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.fail_job(
+            _fail_job("worker-a", claimed.fencing_token, "failed"), _event("failed-after-revoke")
+        )
+    adapter._client = client
+    assert adapter.get_job(_TENANT, "job-a") == claimed
+    assert adapter.get_outbox_event("failed-after-revoke") is None
+    adapter.put_agent(_agent("agent-a"))
+    complete = CompleteJob(
+        tenant_id=_TENANT,
+        job_id="job-a",
+        owner="worker-a",
+        fencing_token=claimed.fencing_token,
+        manifest=_raw_record("result", "agent-b", 1, clock.now()),
+    )
+    with pytest.raises(Conflict, match="manifest_identity_conflict"):
+        adapter.complete_job(complete, _event("invalid-manifest"))
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"dataset_name": "silver"},
+        {"run_manifest_key": f"reconciliation/{_TENANT}/2026-06/run-a/run-manifest.json"},
+    ],
+)
+def test_publicacao_valida_run_e_replay(changes: dict[str, str], ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
+    from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
+
+    command = _publish("run-a", "published", None, False)
+    with pytest.raises(NotFound, match="run_missing"):
+        adapter.publish_dataset(command)
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    invalid = command.model_copy(update={"version": command.version.model_copy(update=changes)})
+    with pytest.raises(Conflict, match="publication_run_conflict"):
+        adapter.publish_dataset(invalid)
+    named = command.model_copy(update={"pointer_name": "candidate"})
+    client = adapter._client
+    adapter._client = ClientSpy(client, after_transaction=_lose_transaction_response)
+    pointer = adapter.publish_dataset(named)
+    adapter._client = client
+    assert pointer.pointer_name == "candidate"
+    assert adapter.publish_dataset(named) == pointer
+    adapter.mark_outbox_delivered(named.event.event_id, clock.now())
+    assert adapter.publish_dataset(named) == pointer
+    changed = named.model_copy(
+        update={"event": named.event.model_copy(update={"payload": {"changed": True}})}
+    )
+    with pytest.raises(Conflict, match="publication_replay_conflict"):
+        adapter.publish_dataset(changed)
+
+
+def test_codec_propaga_erro_dynamodb_nao_condicional() -> None:
+    class InvalidClient:
+        @staticmethod
+        def transact_write_items(**kwargs: Any) -> None:
+            raise ClientError(
+                {"Error": {"Code": "ValidationException", "Message": "invalid"}},
+                "TransactWriteItems",
+            )
+
+    with pytest.raises(ClientError):
+        execute_transaction(InvalidClient(), ())
+
+
+@pytest.mark.parametrize(
+    "reason", [None, "ThrottlingError", "ProvisionedThroughputExceeded", "TransactionConflict"]
+)
+def test_codec_propaga_cancelamento_sem_falha_condicional(reason: str | None) -> None:
+    class CanceledClient:
+        @staticmethod
+        def transact_write_items(**kwargs: Any) -> None:
+            reasons = [] if reason is None else [{"Code": reason}]
+            raise ClientError(
+                {"Error": {"Code": "TransactionCanceledException"}, "CancellationReasons": reasons},
+                "TransactWriteItems",
+            )
+
+    with pytest.raises(ClientError):
+        execute_transaction(CanceledClient(), ())
+
+
+def test_idempotencia_recupera_resultado_de_corrida_confirmada(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
+    command = BeginIdempotency(
+        tenant_id=_TENANT,
+        scope="jobs",
+        key="race",
+        request_hash=_HASH_A,
+        resource_id="resource-a",
+        now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5),
+    )
+    client = adapter._client
+    adapter._client = ClientSpy(client, after_transaction=_lose_transaction_response)
+    outcome = adapter.begin_idempotency(command)
+    assert not outcome.created
+    assert outcome.record.resource_id == "resource-a"
+    adapter._client = ClientSpy(client, before_transaction=_raise_transaction_conflict)
+    command = BeginIdempotency(
+        tenant_id=_TENANT,
+        scope="jobs",
+        key="lost-race",
+        request_hash=_HASH_A,
+        resource_id="resource-a",
+        now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5),
+    )
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.begin_idempotency(command)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_outbox.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_outbox.py
@@ -176,6 +176,16 @@ def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(ctx: _DynamoContext
     assert [request.get("Limit") for request in paginated.query_requests] == [2, 2, 1]
 
 
+def test_replay_de_evento_entregue_rejeita_timestamp_forjado(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
+    job, event = _job("job-a"), _event("job-created")
+    adapter.create_job(job, event)
+    adapter.mark_outbox_delivered(event.event_id, clock.now())
+    forged = event.model_copy(update={"delivered_at": clock.now() + timedelta(seconds=1)})
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.create_job(job, forged)
+
+
 def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     assert adapter.claim_job(_claim_job("missing", "worker-a", clock)) is None

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -62,6 +62,10 @@ class OneItemPageClient(ClientSpy):
         if kwargs.get("IndexName") == "gsi2" and (hidden := getattr(self, "hidden_gsi2sk", None)):
             response["Items"] = [item for item in response["Items"] if item["gsi2sk"] != hidden]
         return response
+class EmptyPageClient(ClientSpy):
+    def query(self, **kwargs: Any) -> dict[str, Any]:
+        return self.query_requests.append(dict(kwargs)) or {
+            "Items": [], "LastEvaluatedKey": {"pk": {"S": "next"}}}
 @pytest.fixture
 def ctx() -> Any:
     with mock_aws():
@@ -120,16 +124,44 @@ def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) 
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 3)
     assert tuple(ref.manifest_id for ref in chain) == (
         full.manifest_id, sibling_b.manifest_id, head.manifest_id)
+    partition = "TENANT#333534313330#RAW#434e4553#5354#323032362d3037"
+    assert 1 <= len(stale.query_requests) <= 31
+    assert all(request.get("ConsistentRead") is True and "IndexName" not in request
+               and request["ExpressionAttributeValues"][":partition"]["S"] == partition
+               and 1 <= request["Limit"] <= 31 for request in stale.query_requests)
+    assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 0) == ()
+    for index in range(7):
+        record = _raw_record(f"extra-{index}", f"agent-{index}", 1, clock.now())
+        adapter._put_direct(adapter._raw_item(record))
+    before = len(stale.query_requests)
+    assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1) == ()
+    assert len(stale.query_requests) - before == 1
+    adapter._client = empty = EmptyPageClient(adapter._client)
+    assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1) == ()
+    assert len(empty.query_requests) == 11
+def test_latest_succeeded_ignora_omissao_do_gsi(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
+    adapter._client = spy = ClientSpy(adapter._client)
+    old = _raw_record("old", "agent-a", 1, clock.now())
+    new = _raw_record("new", "agent-a", 1, clock.now() + timedelta(seconds=1))
+    for record in (old, new):
+        _store_record_matching_mode(adapter, record, clock)
+    requests = [next(iter(action.values())) for action in spy.transactions[-1]]
+    items = [request["Item" if "Item" in request else "Key"] for request in requests]
+    assert len(requests) == len({(item["pk"]["S"], item["sk"]["S"]) for item in items}) == 5
+    completed = adapter.get_job(_TENANT, "job-agent-a-new")
+    adapter._client = stale = OneItemPageClient(spy.client)
+    stale.hidden_gsi2sk = adapter._job_item(completed)["gsi2sk"]
+    result = adapter.latest_succeeded_job(_TENANT, "agent-a", "CNES", "ST", "2026-07")
+    assert (result, stale.query_requests) == (completed, [])
 def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     adapter.put_agent(_agent("agent-a"))
     job = _job("job-a").model_copy(update={"state": JobState.FAILED_FINAL})
     adapter._put_direct(adapter._job_item(job))
     base_key = entity_key(_TENANT, "JOB", "job-a")
-    attrs = {
-        "gsi1pk": f"JOB_CLAIM#{key_component(_TENANT)}#{key_component('agent-a')}",
-        "gsi1sk": f"{_NOW.isoformat()}#PENDING#job-a",
-    }
+    attrs = {"gsi1pk": f"JOB_CLAIM#{key_component(_TENANT)}#{key_component('agent-a')}",
+             "gsi1sk": f"{_NOW.isoformat()}#PENDING#job-a"}
     marker = encode_marker("STALE_JOB", entity_key(_TENANT, "STALE_JOB", "job-a"), base_key, attrs)
     client.put_item(TableName=_TABLE_NAME, Item=marker)
     assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
@@ -138,15 +170,9 @@ def test_candidato_gsi_obsoleto_nao_recupera_run_terminal(ctx: _DynamoContext) -
     client, clock, adapter = ctx
     run = _run("run-a", RunState.PUBLISHED)
     adapter.put_run(run)
-    marker = encode_marker(
-        "STALE_RUN",
-        entity_key(_TENANT, "STALE_RUN", "run-a"),
-        run_entity_key(_TENANT, "run-a"),
-        {
-            "gsi4pk": "RUN_RECOVERABLE",
-            "gsi4sk": f"{_NOW.isoformat()}#{_TENANT}#run-a",
-        },
-    )
+    marker = encode_marker("STALE_RUN", entity_key(_TENANT, "STALE_RUN", "run-a"),
+        run_entity_key(_TENANT, "run-a"), {"gsi4pk": "RUN_RECOVERABLE",
+        "gsi4sk": f"{_NOW.isoformat()}#{_TENANT}#run-a"})
     client.put_item(TableName=_TABLE_NAME, Item=marker)
     assert adapter.list_recoverable_runs(clock.now(), 10) == ()
     tenant_z = _run("run-a").model_copy(update={"tenant_id": "z"})
@@ -164,14 +190,9 @@ def test_expiracao_logica_substitui_item_ttl_ainda_presente(ctx: _DynamoContext)
     clock.advance(timedelta(minutes=6))
     retained = client.scan(TableName=_TABLE_NAME)["Items"]
     assert any(item.get("expires_at") for item in retained)
-    replacement = first.model_copy(
-        update={
-            "request_hash": _HASH_B,
-            "resource_id": "resource-b",
-            "now": clock.now(),
-            "expires_at": clock.now() + timedelta(minutes=5),
-        }
-    )
+    replacement = first.model_copy(update={
+        "request_hash": _HASH_B, "resource_id": "resource-b", "now": clock.now(),
+        "expires_at": clock.now() + timedelta(minutes=5)})
     outcome = adapter.begin_idempotency(replacement)
     assert outcome.created
     assert outcome.record.resource_id == "resource-b"
@@ -196,12 +217,10 @@ def test_chaves_compostas_isolam_componentes_com_delimitador(ctx: _DynamoContext
         run = _run(run_id).model_copy(update={"tenant_id": tenant_id})
         unit = _unit("shared").model_copy(update={"tenant_id": tenant_id, "run_id": run_id})
         adapter.put_run(run)
-        adapter.put_run_units(PutRunUnits(
-            tenant_id=tenant_id, run_id=run_id,
+        adapter.put_run_units(PutRunUnits(tenant_id=tenant_id, run_id=run_id,
             expected_run_state=RunState.PROCESSING, units=(unit,)))
-        adapter.reserve_run_dispatch(ReserveRunDispatch(
-            tenant_id=tenant_id, run_id=run_id, wave_id="a" * 16,
-            unit_ids=("shared",), now=_NOW, lease_seconds=30))
+        adapter.reserve_run_dispatch(ReserveRunDispatch(tenant_id=tenant_id, run_id=run_id,
+            wave_id="a" * 16, unit_ids=("shared",), now=_NOW, lease_seconds=30))
         expected.append(unit)
     for identity, unit in zip(identities, expected, strict=True):
         assert adapter.list_run_units(*identity) == (unit,)
@@ -261,10 +280,8 @@ def test_create_job_retorna_replay_e_rejeita_divergencia(ctx: _DynamoContext) ->
         adapter.create_job(job, event)
 def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(ctx: _DynamoContext) -> None:
     _, _, adapter = ctx
-    transition = TransitionRun(
-        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.PLANNED,
-        new_state=RunState.WAITING_INPUTS,
-    )
+    transition = TransitionRun(tenant_id=_TENANT, run_id="run-a",
+        expected_state=RunState.PLANNED, new_state=RunState.WAITING_INPUTS)
     with pytest.raises(NotFound, match="run_missing"):
         adapter.transition_run(transition, _event("missing-run"))
     with pytest.raises(NotFound, match="run_missing"):
@@ -295,10 +312,8 @@ def test_cancel_job_exige_lease_e_e_idempotente(ctx: _DynamoContext) -> None:
     assert adapter.get_job(_TENANT, "job-a") == canceled
 def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
-    command = FinalizeRunCancellation(
-        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.CANCEL_REQUESTED,
-        canceled_at=clock.now(),
-    )
+    command = FinalizeRunCancellation(tenant_id=_TENANT, run_id="run-a",
+        expected_state=RunState.CANCEL_REQUESTED, canceled_at=clock.now())
     with pytest.raises(NotFound, match="run_missing"):
         adapter.finalize_run_cancellation(command, _event("missing-run"))
     adapter.put_run(_run("run-a", RunState.CANCEL_REQUESTED))
@@ -310,10 +325,9 @@ def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(ctx: _DynamoCo
     assert adapter.get_run(_TENANT, "run-a") == canceled
 def _access_request(state: AccessRequestState = AccessRequestState.PENDING) -> AccessRequest:
     decided = state is not AccessRequestState.PENDING
-    return AccessRequest(
-        tenant_id=_TENANT, request_id="request-a", user_id="user-a", state=state,
-        decided_by="admin-a" if decided else None, decided_at=_NOW if decided else None,
-    )
+    return AccessRequest(tenant_id=_TENANT, request_id="request-a", user_id="user-a",
+        state=state, decided_by="admin-a" if decided else None,
+        decided_at=_NOW if decided else None)
 def _foreign_event(adapter: DynamoDBControlPlane) -> Any:
     event = _event("foreign-event", tenant_id="other")
     adapter.create_job(_job("foreign-job", tenant_id="other"), event)
@@ -365,19 +379,16 @@ def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(ctx: _DynamoContext
         adapter.mark_outbox_delivered("job-created", delivered_at + timedelta(seconds=1))
     with pytest.raises(NotFound, match="outbox_event_missing"):
         adapter.mark_outbox_delivered("missing", delivered_at)
-    events = tuple(_event(f"event-{index}").model_copy(
-        update={"created_at": clock.now() + timedelta(seconds=index)}
-    ) for index in range(3)
-    )
+    events = tuple(_event(f"event-{index}").model_copy(update={
+        "created_at": clock.now() + timedelta(seconds=index)}) for index in range(3))
     for index, event in enumerate(events):
         adapter.create_job(_job(f"job-{index}"), event)
     markers = (("missing", "missing", 3), ("stale", "job-created", 2), ("newer", "event-1", 1))
     for marker_id, base_id, minutes in markers:
-        marker = encode_marker(
-            "STALE_OUTBOX", entity_key(_TENANT, "STALE_OUTBOX", marker_id),
-            outbox_key(base_id), {"gsi6pk": "OUTBOX#PENDING", "gsi6sk":
-                f"{(clock.now() - timedelta(minutes=minutes)).isoformat()}#{marker_id}"},
-        )
+        marker = encode_marker("STALE_OUTBOX",
+            entity_key(_TENANT, "STALE_OUTBOX", marker_id), outbox_key(base_id),
+            {"gsi6pk": "OUTBOX#PENDING", "gsi6sk":
+             f"{(clock.now() - timedelta(minutes=minutes)).isoformat()}#{marker_id}"})
         client.put_item(TableName=_TABLE_NAME, Item=marker)
     paginated = OneItemPageClient(client)
     adapter._client = paginated
@@ -385,14 +396,12 @@ def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(ctx: _DynamoContext
     paginated = OneItemPageClient(client)
     adapter._client = paginated
     assert adapter.pending_outbox(2) == events[:2]
-    assert paginated.query_limits == [2, 2, 1]
+    assert [request.get("Limit") for request in paginated.query_requests] == [2, 2, 1]
 def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     assert adapter.claim_job(_claim_job("missing", "worker-a", clock)) is None
-    renewal = RenewJobLease(
-        tenant_id=_TENANT, job_id="missing", owner="worker-a", fencing_token=1,
-        now=clock.now(), lease_seconds=30,
-    )
+    renewal = RenewJobLease(tenant_id=_TENANT, job_id="missing", owner="worker-a",
+        fencing_token=1, now=clock.now(), lease_seconds=30)
     with pytest.raises(NotFound, match="job_missing"):
         adapter.renew_job_lease(renewal)
     adapter.put_agent(_agent("agent-a"))
@@ -453,10 +462,8 @@ def test_codec_propaga_erro_dynamodb_nao_condicional() -> None:
     class InvalidClient:
         @staticmethod
         def transact_write_items(**kwargs: Any) -> None:
-            raise ClientError(
-                {"Error": {"Code": "ValidationException", "Message": "invalid"}},
-                "TransactWriteItems",
-            )
+            raise ClientError({"Error": {
+                "Code": "ValidationException", "Message": "invalid"}}, "TransactWriteItems")
     with pytest.raises(ClientError):
         execute_transaction(InvalidClient(), ())
 @pytest.mark.parametrize("reason", [None, "ThrottlingError", "ProvisionedThroughputExceeded",
@@ -466,19 +473,15 @@ def test_codec_propaga_cancelamento_sem_falha_condicional(reason: str | None) ->
         @staticmethod
         def transact_write_items(**kwargs: Any) -> None:
             reasons = [] if reason is None else [{"Code": reason}]
-            raise ClientError(
-                {"Error": {"Code": "TransactionCanceledException"},
-                 "CancellationReasons": reasons}, "TransactWriteItems",
-            )
+            raise ClientError({"Error": {"Code": "TransactionCanceledException"},
+                "CancellationReasons": reasons}, "TransactWriteItems")
     with pytest.raises(ClientError):
         execute_transaction(CanceledClient(), ())
 def test_idempotencia_recupera_resultado_de_corrida_confirmada(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
-    command = BeginIdempotency(
-        tenant_id=_TENANT, scope="jobs", key="race", request_hash=_HASH_A,
-        resource_id="resource-a", now=clock.now(),
-        expires_at=clock.now() + timedelta(minutes=5),
-    )
+    command = BeginIdempotency(tenant_id=_TENANT, scope="jobs", key="race",
+        request_hash=_HASH_A, resource_id="resource-a", now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5))
     transact = adapter._transact
     def wins_then_reports_conflict(actions: Any) -> None:
         transact(actions)
@@ -490,11 +493,8 @@ def test_idempotencia_recupera_resultado_de_corrida_confirmada(ctx: _DynamoConte
 def test_idempotencia_propaga_conflito_sem_vencedor_visivel(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     adapter._client = FailingTransactionClient(adapter._client)
-    command = BeginIdempotency(
-        tenant_id=_TENANT, scope="jobs", key="lost-race", request_hash=_HASH_A,
-        resource_id="resource-a",
-        now=clock.now(),
-        expires_at=clock.now() + timedelta(minutes=5),
-    )
+    command = BeginIdempotency(tenant_id=_TENANT, scope="jobs", key="lost-race",
+        request_hash=_HASH_A, resource_id="resource-a", now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5))
     with pytest.raises(Conflict, match="transaction_conflict"):
         adapter.begin_idempotency(command)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -10,6 +10,7 @@ from moto import mock_aws
 from cnes_domain.control_plane.commands import (
     BeginIdempotency,
     CancelJob,
+    CompleteJob,
     FinalizeRunCancellation,
     PutRunUnits,
     ReserveRunDispatch,
@@ -71,9 +72,24 @@ def _raise_transaction_conflict(_: list[dict[str, Any]]) -> None:
         "TransactWriteItems",
     )
 
-
 def _lose_transaction_response(_: list[dict[str, Any]]) -> None:
     raise Conflict("transaction_conflict")
+
+
+def _submit_raw_record(adapter: DynamoDBControlPlane, record: Any, clock: MutableClock) -> None:
+    job = _job(f"job-{record.agent_id}-{record.snapshot_id}", record.agent_id).model_copy(
+        update={"source_type": record.source_type, "file_subtype": record.file_subtype,
+                "competencia": record.competencia}
+    )
+    adapter.put_agent(_agent(record.agent_id))
+    adapter.create_job(job, _event(f"created-{job.job_id}"))
+    claimed = adapter.claim_job(_claim_job(job.job_id, "raw-worker", clock))
+    assert claimed is not None
+    adapter.complete_job(
+        CompleteJob(tenant_id=_TENANT, job_id=job.job_id, owner="raw-worker",
+                    fencing_token=claimed.fencing_token, manifest=record),
+        _event(f"completed-{job.job_id}"),
+    )
 
 
 @pytest.fixture
@@ -83,7 +99,6 @@ def ctx() -> Any:
         _create_table(client)
         clock = MutableClock(_NOW)
         yield client, clock, DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
-
 
 def test_deduplica_candidatos_e_rele_base_antes_do_claim(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
@@ -120,7 +135,6 @@ def test_deduplica_candidatos_e_rele_base_antes_do_claim(ctx: _DynamoContext) ->
     )
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
 
-
 def test_cadeia_raw_serializa_corrida(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     full = _raw_record("base", "agent-a", 1, clock.now() + timedelta(minutes=4))
@@ -144,13 +158,10 @@ def test_cadeia_raw_serializa_corrida(ctx: _DynamoContext) -> None:
         calls += 1
         if calls in (3, 4):
             record = (sibling_b, sibling_c)[calls - 3]
-            contender._transact(contender._raw_actions(record))
+            _submit_raw_record(contender, record, clock)
 
     adapter._client = ClientSpy(client, before_transaction=contend)
-    _store_record(adapter, full, clock)
-    adapter._raw_actions(full)
-    with pytest.raises(Conflict, match="raw_ancestry_conflict"):
-        adapter._raw_actions(full.model_copy(update={"manifest_id": "duplicate-full"}))
+    _submit_raw_record(adapter, full, clock)
     for record in (head, sibling_a):
         _store_record(adapter, record, clock)
     assert adapter.get_job(_TENANT, "job-agent-a-base").state is JobState.SUCCEEDED
@@ -355,7 +366,6 @@ def test_claim_cas_perdedor_nao_desfaz_vencedor_persistido(ctx: _DynamoContext) 
     assert loser.claim_job(_claim_job("job-a", "worker-a", clock)) is None
     assert winners[0] is not None
     assert adapter.get_job(_TENANT, "job-a") == winners[0]
-
 
 def test_codec_nao_introduz_decimal_nos_itens(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -162,6 +162,7 @@ def test_cadeia_raw_serializa_corrida(ctx: _DynamoContext) -> None:
 
     adapter._client = ClientSpy(client, before_transaction=contend)
     _submit_raw_record(adapter, full, clock)
+    adapter._raw_actions(full)
     for record in (head, sibling_a):
         _store_record(adapter, record, clock)
     assert adapter.get_job(_TENANT, "job-agent-a-base").state is JobState.SUCCEEDED
@@ -206,7 +207,6 @@ def test_latest_succeeded_ignora_omissao_do_gsi_e_historico(ctx: _DynamoContext)
         _store_record(adapter, record, clock)
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1)
     assert tuple(ref.manifest_id for ref in chain) == (records[-1].manifest_id,)
-
 def test_reparo_raw_rejeita_ancestry_ausente_e_excesso(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     _store_record(adapter, _raw_record("delta-pending", "agent-a", 2, clock.now()), clock)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -1,28 +1,56 @@
-from datetime import timedelta  # noqa: I001
+from datetime import timedelta
 from decimal import Decimal
 from typing import Any
+
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 from moto import mock_aws
+
 from cnes_domain.control_plane.commands import (
-    BeginIdempotency, CancelJob, CompleteJob, FinalizeRunCancellation, PutRunUnits,
-    RenewJobLease, ReserveRunDispatch, TransitionRun)
+    BeginIdempotency,
+    CancelJob,
+    FinalizeRunCancellation,
+    PutRunUnits,
+    ReserveRunDispatch,
+    TransitionRun,
+)
 from cnes_domain.control_plane.entities import AccessRequest, Tenant
-from cnes_domain.control_plane.enums import AccessRequestState, AgentState, JobState, RunState
-from cnes_domain.control_plane.errors import Conflict, LeaseLost, NotFound
+from cnes_domain.control_plane.enums import AccessRequestState, JobState, RunState
+from cnes_domain.control_plane.errors import Conflict, NotFound
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
-from cnes_infra.control_plane.dynamodb_codec import encode_marker, execute_transaction
+from cnes_infra.control_plane.dynamodb_codec import encode_marker
 from cnes_infra.control_plane.dynamodb_keys import (
-    entity_key, key_component, outbox_key, run_entity_key)
+    entity_key,
+    key_component,
+    outbox_key,
+    run_entity_key,
+)
 from packages.cnes_infra.tests.contracts.clock import (
-    _HASH_A, _NOW, _TENANT, MutableClock, _agent, _claim_job, _event, _fail_job,
-    _job, _raw_record, _run, _unit)
+    _HASH_A,
+    _NOW,
+    _TENANT,
+    MutableClock,
+    _agent,
+    _claim_job,
+    _event,
+    _job,
+    _raw_record,
+    _run,
+    _store_record,
+    _unit,
+)
 from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
-    _TABLE_NAME, ClientSpy, FailingTransactionClient, _create_table, _put_many_units,
-    _store_record_matching_mode)
+    _TABLE_NAME,
+    ClientSpy,
+    _create_table,
+    _put_many_units,
+)
+
 _HASH_B = "b" * 64
 type _DynamoContext = tuple[Any, MutableClock, DynamoDBControlPlane]
+
+
 class OneItemPageClient(ClientSpy):
     def query(self, **kwargs: Any) -> dict[str, Any]:
         kwargs.setdefault("Limit", 1)
@@ -32,6 +60,22 @@ class OneItemPageClient(ClientSpy):
         if kwargs.get("IndexName") == "gsi2" and (hidden := getattr(self, "hidden_gsi2sk", None)):
             response["Items"] = [item for item in response["Items"] if item["gsi2sk"] != hidden]
         return response
+
+
+def _raise_transaction_conflict(_: list[dict[str, Any]]) -> None:
+    raise ClientError(
+        {
+            "Error": {"Code": "TransactionCanceledException", "Message": "cancelled"},
+            "CancellationReasons": [{"Code": "ConditionalCheckFailed"}],
+        },
+        "TransactWriteItems",
+    )
+
+
+def _lose_transaction_response(_: list[dict[str, Any]]) -> None:
+    raise Conflict("transaction_conflict")
+
+
 @pytest.fixture
 def ctx() -> Any:
     with mock_aws():
@@ -39,6 +83,8 @@ def ctx() -> Any:
         _create_table(client)
         clock = MutableClock(_NOW)
         yield client, clock, DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
+
+
 def test_deduplica_candidatos_e_rele_base_antes_do_claim(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     adapter.put_agent(_agent("agent-a"))
@@ -50,9 +96,11 @@ def test_deduplica_candidatos_e_rele_base_antes_do_claim(ctx: _DynamoContext) ->
     }
     for suffix in ("a", "b", "missing"):
         marker = encode_marker(
-            "STALE_JOB", entity_key(_TENANT, "STALE_JOB", suffix),
+            "STALE_JOB",
+            entity_key(_TENANT, "STALE_JOB", suffix),
             entity_key(_TENANT, "JOB", suffix) if suffix == "missing" else base_key,
-            attributes)
+            attributes,
+        )
         client.put_item(TableName=_TABLE_NAME, Item=marker)
     adapter._client = spy = ClientSpy(client)
     jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 10)
@@ -63,103 +111,142 @@ def test_deduplica_candidatos_e_rele_base_antes_do_claim(ctx: _DynamoContext) ->
         adapter.create_job(_job(job_id), _event(f"created-{job_id}"))
     paginated = OneItemPageClient(adapter._client)
     adapter._client = paginated
-    assert tuple(job.job_id for job in adapter.list_claimable_jobs(
-        _TENANT, "agent-a", 1)) == ("job-a",)
-    assert (adapter.list_claimable_jobs(_TENANT, "agent-a", 0),
-            paginated.calls.count("query")) == ((), 4)
+    assert tuple(job.job_id for job in adapter.list_claimable_jobs(_TENANT, "agent-a", 1)) == (
+        "job-a",
+    )
+    assert (adapter.list_claimable_jobs(_TENANT, "agent-a", 0), paginated.calls.count("query")) == (
+        (),
+        4,
+    )
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
+
+
 def test_cadeia_raw_serializa_corrida(ctx: _DynamoContext) -> None:
-    _, clock, adapter = ctx
+    client, clock, adapter = ctx
     full = _raw_record("base", "agent-a", 1, clock.now() + timedelta(minutes=4))
-    sibling_a = _raw_record("delta-a", "agent-a", 2, clock.now() + timedelta(minutes=1))
+    sibling_a = _raw_record("zeta", "agent-a", 2, clock.now() + timedelta(minutes=1))
     sibling_b = _raw_record("delta-b", "agent-a", 2, clock.now() + timedelta(minutes=2))
+    sibling_c = _raw_record("delta-c", "agent-a", 2, clock.now())
     head = _raw_record("head", "agent-a", 3, clock.now() + timedelta(minutes=3))
+
     def linked(record: Any, **updates: Any) -> Any:
         return record.model_copy(update={"base_snapshot_id": "base", **updates})
+
     sibling_a = linked(sibling_a, manifest_sha256=_HASH_B)
     sibling_b = linked(sibling_b, manifest_sha256="c" * 64)
+    sibling_c = linked(sibling_c, manifest_sha256="d" * 64)
     head = linked(head, previous_manifest_sha256="c" * 64)
-    transact, calls = adapter._transact, 0
-    def contend(actions: Any) -> None:
+    contender = DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
+    calls = 0
+
+    def contend(_: list[dict[str, Any]]) -> None:
         nonlocal calls
-        if (calls := calls + 1) == 3:
-            transact(adapter._raw_actions(sibling_b))
-        transact(actions)
-    adapter._transact = contend
-    _store_record_matching_mode(adapter, full, clock)
+        calls += 1
+        if calls in (3, 4):
+            record = (sibling_b, sibling_c)[calls - 3]
+            contender._transact(contender._raw_actions(record))
+
+    adapter._client = ClientSpy(client, before_transaction=contend)
+    _store_record(adapter, full, clock)
     adapter._raw_actions(full)
     with pytest.raises(Conflict, match="raw_ancestry_conflict"):
         adapter._raw_actions(full.model_copy(update={"manifest_id": "duplicate-full"}))
     for record in (head, sibling_a):
-        _store_record_matching_mode(adapter, record, clock)
+        _store_record(adapter, record, clock)
+    assert adapter.get_job(_TENANT, "job-agent-a-base").state is JobState.SUCCEEDED
     adapter._client = stale = OneItemPageClient(adapter._client)
     stale.hidden_gsi2sk = adapter._raw_item(head)["gsi2sk"]
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 3)
     assert tuple(ref.manifest_id for ref in chain) == (
-        full.manifest_id, sibling_b.manifest_id, head.manifest_id)
+        full.manifest_id,
+        sibling_b.manifest_id,
+        head.manifest_id,
+    )
     gets = [request for name, request in stale.requests if name == "get_item"]
     assert (stale.query_requests, len(gets), gets[0].get("ConsistentRead")) == ([], 1, True)
     assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 0) == ()
+
+
 def test_latest_succeeded_ignora_omissao_do_gsi_e_historico(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     adapter._client = spy = ClientSpy(adapter._client)
-    old = _raw_record("old", "agent-a", 1, clock.now())
-    new = _raw_record("new", "agent-a", 1, clock.now() + timedelta(seconds=1))
+    old = _raw_record("base", "agent-a", 1, clock.now())
+    new = _raw_record("zeta", "agent-a", 1, clock.now() + timedelta(seconds=1))
     for record in (old, new):
-        _store_record_matching_mode(adapter, record, clock)
+        _store_record(adapter, record, clock)
     requests = [next(iter(action.values())) for action in spy.transactions[-1]]
     items = [request["Item" if "Item" in request else "Key"] for request in requests]
     assert len(requests) == len({(item["pk"]["S"], item["sk"]["S"]) for item in items}) == 8
-    head = next(request for request in requests
-                if request.get("Item", {}).get("entity") == {"S": "RAWHEAD"})
+    head = next(
+        request for request in requests if request.get("Item", {}).get("entity") == {"S": "RAWHEAD"}
+    )
     assert head["ConditionExpression"] == "payload = :expected"
-    completed = adapter.get_job(_TENANT, "job-agent-a-new")
+    completed = adapter.get_job(_TENANT, "job-agent-a-zeta")
     adapter._client = stale = OneItemPageClient(spy.client)
     stale.hidden_gsi2sk = adapter._job_item(completed)["gsi2sk"]
     result = adapter.latest_succeeded_job(_TENANT, "agent-a", "CNES", "ST", "2026-07")
     assert (result, stale.query_requests) == (completed, [])
     adapter._client = spy.client
-    records = tuple(_raw_record(f"full-{index}", f"agent-{index}", 1,
-        clock.now() + timedelta(seconds=index)) for index in range(11))
+    records = tuple(
+        _raw_record(f"full-{index:02}", f"agent-{index}", 1, clock.now() + timedelta(seconds=index))
+        for index in range(11)
+    )
     for record in records:
-        _store_record_matching_mode(adapter, record, clock)
+        _store_record(adapter, record, clock)
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1)
     assert tuple(ref.manifest_id for ref in chain) == (records[-1].manifest_id,)
+
+
 def test_reparo_raw_rejeita_ancestry_ausente_e_excesso(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
-    _store_record_matching_mode(
-        adapter, _raw_record("delta-pending", "agent-a", 2, clock.now()), clock)
-    waiting = next(item for item in client.scan(TableName=_TABLE_NAME)["Items"]
-                   if item.get("entity", {}).get("S") == "RAWWAITING")
+    _store_record(adapter, _raw_record("delta-pending", "agent-a", 2, clock.now()), clock)
+    waiting = next(
+        item
+        for item in client.scan(TableName=_TABLE_NAME)["Items"]
+        if item.get("entity", {}).get("S") == "RAWWAITING"
+    )
     ancestry_key = {"pk": waiting["base_pk"], "sk": waiting["base_sk"]}
     client.delete_item(TableName=_TABLE_NAME, Key=ancestry_key)
     base = _raw_record("base-agent-a", "agent-a", 1, clock.now())
     with pytest.raises(Conflict, match="raw_ancestry_conflict"):
         adapter._raw_actions(base)
-    client.put_item(TableName=_TABLE_NAME, Item={**waiting,
-        "pk": waiting["base_pk"], "sk": waiting["base_sk"],
-        "entity": {"S": "RAWANCESTRY"}})
+    client.put_item(
+        TableName=_TABLE_NAME,
+        Item={
+            **waiting,
+            "pk": waiting["base_pk"],
+            "sk": waiting["base_sk"],
+            "entity": {"S": "RAWANCESTRY"},
+        },
+    )
     for index in range(95):
         clone = {**waiting, "sk": {"S": f"{waiting['sk']['S']}#{index:03d}"}}
         client.put_item(TableName=_TABLE_NAME, Item=clone)
     with pytest.raises(Conflict, match="transaction_limit"):
         adapter._raw_actions(base)
+
+
 def test_candidato_gsi_obsoleto_nao_reivindica_job_ou_run_terminal(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     adapter.put_agent(_agent("agent-a"))
     job = _job("job-a").model_copy(update={"state": JobState.FAILED_FINAL})
     adapter._put_direct(adapter._job_item(job))
     base_key = entity_key(_TENANT, "JOB", "job-a")
-    attrs = {"gsi1pk": f"JOB_CLAIM#{key_component(_TENANT)}#{key_component('agent-a')}",
-             "gsi1sk": f"{_NOW.isoformat()}#PENDING#job-a"}
+    attrs = {
+        "gsi1pk": f"JOB_CLAIM#{key_component(_TENANT)}#{key_component('agent-a')}",
+        "gsi1sk": f"{_NOW.isoformat()}#PENDING#job-a",
+    }
     marker = encode_marker("STALE_JOB", entity_key(_TENANT, "STALE_JOB", "job-a"), base_key, attrs)
     client.put_item(TableName=_TABLE_NAME, Item=marker)
     assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
     adapter.put_run(_run("run-a", RunState.PUBLISHED))
-    marker = encode_marker("STALE_RUN", entity_key(_TENANT, "STALE_RUN", "run-a"),
-        run_entity_key(_TENANT, "run-a"), {"gsi4pk": "RUN_RECOVERABLE",
-        "gsi4sk": f"{_NOW.isoformat()}#{_TENANT}#run-a"})
+    marker = encode_marker(
+        "STALE_RUN",
+        entity_key(_TENANT, "STALE_RUN", "run-a"),
+        run_entity_key(_TENANT, "run-a"),
+        {"gsi4pk": "RUN_RECOVERABLE", "gsi4sk": f"{_NOW.isoformat()}#{_TENANT}#run-a"},
+    )
     client.put_item(TableName=_TABLE_NAME, Item=marker)
     assert adapter.list_recoverable_runs(clock.now(), 10) == ()
     tenant_z = _run("run-a").model_copy(update={"tenant_id": "z"})
@@ -167,27 +254,43 @@ def test_candidato_gsi_obsoleto_nao_reivindica_job_ou_run_terminal(ctx: _DynamoC
     adapter.put_run(tenant_z)
     adapter.put_run(tenant_a)
     assert adapter.list_recoverable_runs(clock.now(), 1) == (tenant_a,)
+
+
 def test_expiracao_logica_substitui_item_ttl_ainda_presente(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     first = BeginIdempotency(
-        tenant_id=_TENANT, scope="jobs", key="key-a", request_hash=_HASH_A,
-        resource_id="resource-a", now=clock.now(),
-        expires_at=clock.now() + timedelta(minutes=5))
+        tenant_id=_TENANT,
+        scope="jobs",
+        key="key-a",
+        request_hash=_HASH_A,
+        resource_id="resource-a",
+        now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5),
+    )
     adapter.begin_idempotency(first)
     clock.advance(timedelta(minutes=6))
     retained = client.scan(TableName=_TABLE_NAME)["Items"]
     assert any(item.get("expires_at") for item in retained)
-    replacement = first.model_copy(update={
-        "request_hash": _HASH_B, "resource_id": "resource-b", "now": clock.now(),
-        "expires_at": clock.now() + timedelta(minutes=5)})
+    replacement = first.model_copy(
+        update={
+            "request_hash": _HASH_B,
+            "resource_id": "resource-b",
+            "now": clock.now(),
+            "expires_at": clock.now() + timedelta(minutes=5),
+        }
+    )
     outcome = adapter.begin_idempotency(replacement)
     assert outcome.created
     assert outcome.record.resource_id == "resource-b"
+
+
 def test_colisao_global_de_evento_rejeita_segundo_tenant_sem_mutacao(ctx: _DynamoContext) -> None:
     _, _, adapter = ctx
     adapter.create_job(_job("job-a"), _event("shared-event"))
-    other_job, other_event = _job("job-b", tenant_id="other"), _event(
-        "shared-event", tenant_id="other")
+    other_job, other_event = (
+        _job("job-b", tenant_id="other"),
+        _event("shared-event", tenant_id="other"),
+    )
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.create_job(other_job, other_event)
     assert adapter.get_job("other", "job-b") is None
@@ -196,6 +299,8 @@ def test_colisao_global_de_evento_rejeita_segundo_tenant_sem_mutacao(ctx: _Dynam
         adapter.create_job(_job("job-c"), _event("fresh-other", tenant_id="other"))
     assert adapter.get_job(_TENANT, "job-c") is None
     assert adapter.get_outbox_event("fresh-other") is None
+
+
 def test_chaves_compostas_isolam_componentes_com_delimitador(ctx: _DynamoContext) -> None:
     _, _, adapter = ctx
     identities = (("a", "b#RUN#c"), ("a#RUN#b", "c"))
@@ -204,43 +309,71 @@ def test_chaves_compostas_isolam_componentes_com_delimitador(ctx: _DynamoContext
         run = _run(run_id).model_copy(update={"tenant_id": tenant_id})
         unit = _unit("shared").model_copy(update={"tenant_id": tenant_id, "run_id": run_id})
         adapter.put_run(run)
-        adapter.put_run_units(PutRunUnits(tenant_id=tenant_id, run_id=run_id,
-            expected_run_state=RunState.PROCESSING, units=(unit,)))
-        adapter.reserve_run_dispatch(ReserveRunDispatch(tenant_id=tenant_id, run_id=run_id,
-            wave_id="a" * 16, unit_ids=("shared",), now=_NOW, lease_seconds=30))
+        adapter.put_run_units(
+            PutRunUnits(
+                tenant_id=tenant_id,
+                run_id=run_id,
+                expected_run_state=RunState.PROCESSING,
+                units=(unit,),
+            )
+        )
+        adapter.reserve_run_dispatch(
+            ReserveRunDispatch(
+                tenant_id=tenant_id,
+                run_id=run_id,
+                wave_id="a" * 16,
+                unit_ids=("shared",),
+                now=_NOW,
+                lease_seconds=30,
+            )
+        )
         expected.append(unit)
     for identity, unit in zip(identities, expected, strict=True):
         assert adapter.list_run_units(*identity) == (unit,)
-    partitions = {item["gsi5pk"]["S"] for item in adapter._client.scan(
-        TableName=_TABLE_NAME)["Items"] if "gsi5pk" in item}
+    partitions = {
+        item["gsi5pk"]["S"]
+        for item in adapter._client.scan(TableName=_TABLE_NAME)["Items"]
+        if "gsi5pk" in item
+    }
     assert len(partitions) == 2
+
+
 def test_claim_cas_perdedor_nao_desfaz_vencedor_persistido(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     adapter.put_agent(_agent("agent-a"))
     adapter.create_job(_job("job-a"), _event("job-created"))
-    loser = DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
-    transact = loser._transact
-    winners = []
-    def win_before_stale_cas(actions: Any) -> None:
+    winners: list[Any] = []
+
+    def win_before_stale_cas(_: list[dict[str, Any]]) -> None:
         winners.append(adapter.claim_job(_claim_job("job-a", "worker-b", clock)))
-        transact(actions)
-    loser._transact = win_before_stale_cas
+
+    loser = DynamoDBControlPlane(
+        ClientSpy(client, before_transaction=win_before_stale_cas),
+        _TABLE_NAME,
+        clock.now,
+    )
     assert loser.claim_job(_claim_job("job-a", "worker-a", clock)) is None
     assert winners[0] is not None
     assert adapter.get_job(_TENANT, "job-a") == winners[0]
+
+
 def test_codec_nao_introduz_decimal_nos_itens(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     adapter.create_job(_job("job-a"), _event("job-created"))
     tenant = Tenant(tenant_id=_TENANT, municipality_name="Epitácio", created_at=clock.now())
     adapter.put_tenant(tenant)
     assert adapter.get_tenant(_TENANT) == tenant
+
     def contains_decimal(value: Any) -> bool:
         if isinstance(value, dict):
             return any(contains_decimal(item) for item in value.values())
         if isinstance(value, list):
             return any(contains_decimal(item) for item in value)
         return isinstance(value, Decimal)
+
     assert not contains_decimal(client.scan(TableName=_TABLE_NAME)["Items"])
+
+
 def test_create_job_retorna_replay_e_rejeita_divergencia(ctx: _DynamoContext) -> None:
     _, _, adapter = ctx
     adapter._client = spy = ClientSpy(adapter._client)
@@ -249,26 +382,24 @@ def test_create_job_retorna_replay_e_rejeita_divergencia(ctx: _DynamoContext) ->
         adapter.create_job(_job("delivered"), delivered)
     assert "transact_write_items" not in spy.calls
     job, event = _job("job-a"), _event("job-created")
-    transact = adapter._transact
-    def commit_then_lose_response(actions: Any) -> None:
-        transact(actions)
-        raise Conflict("transaction_conflict")
-    adapter._transact = commit_then_lose_response
+    adapter._client = ClientSpy(spy, after_transaction=_lose_transaction_response)
     assert adapter.create_job(job, event) == job
-    adapter._transact = transact
+    adapter._client = spy
     assert adapter.create_job(job, event) == job
-    adapter._client = FailingTransactionClient(spy.client)
+    adapter._client = ClientSpy(spy.client, before_transaction=_raise_transaction_conflict)
     with pytest.raises(Conflict, match="transaction_conflict"):
         adapter.create_job(_job("no-winner"), _event("no-winner-created"))
     adapter._client = spy
     candidate = _job("divergent-winner")
-    def divergent_wins(actions: Any) -> None:
+
+    def divergent_wins(_: list[dict[str, Any]]) -> None:
         adapter._put_direct(adapter._job_item(candidate.model_copy(update={"agent_id": "agent-b"})))
         raise Conflict("transaction_conflict")
-    adapter._transact = divergent_wins
+
+    adapter._client = ClientSpy(spy, before_transaction=divergent_wins)
     with pytest.raises(Conflict, match="job_conflict"):
         adapter.create_job(candidate, _event("divergent-winner-created"))
-    adapter._transact = transact
+    adapter._client = spy
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.create_job(job, _foreign_event(adapter))
     divergent = event.model_copy(update={"payload": {"event_id": "divergent"}})
@@ -277,15 +408,23 @@ def test_create_job_retorna_replay_e_rejeita_divergencia(ctx: _DynamoContext) ->
     assert adapter.get_job(_TENANT, "job-a") == job
     with pytest.raises(Conflict, match="job_conflict"):
         adapter.create_job(job.model_copy(update={"agent_id": "agent-b"}), event)
-    key = {name: {"S": value} for name, value in
-           zip(("pk", "sk"), outbox_key("job-created"), strict=True)}
+    key = {
+        name: {"S": value}
+        for name, value in zip(("pk", "sk"), outbox_key("job-created"), strict=True)
+    }
     adapter._client.delete_item(TableName=_TABLE_NAME, Key=key)
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.create_job(job, event)
+
+
 def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(ctx: _DynamoContext) -> None:
     _, _, adapter = ctx
-    transition = TransitionRun(tenant_id=_TENANT, run_id="run-a",
-        expected_state=RunState.PLANNED, new_state=RunState.WAITING_INPUTS)
+    transition = TransitionRun(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        expected_state=RunState.PLANNED,
+        new_state=RunState.WAITING_INPUTS,
+    )
     with pytest.raises(NotFound, match="run_missing"):
         adapter.transition_run(transition, _event("missing-run"))
     with pytest.raises(NotFound, match="run_missing"):
@@ -297,6 +436,8 @@ def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(ctx: _Dyna
     assert (waiting, adapter.get_outbox_event("stale-run")) == ((), None)
     with pytest.raises(Conflict, match="run_state_conflict"):
         _put_many_units(adapter, 1)
+
+
 def test_cancel_job_exige_lease_e_e_idempotente(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     command = CancelJob(tenant_id=_TENANT, job_id="job-a", requested_by="user-a")
@@ -314,8 +455,12 @@ def test_cancel_job_exige_lease_e_e_idempotente(ctx: _DynamoContext) -> None:
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.cancel_job(command, _foreign_event(adapter))
     assert adapter.get_job(_TENANT, "job-a") == canceled
-    command = FinalizeRunCancellation(tenant_id=_TENANT, run_id="run-a",
-        expected_state=RunState.CANCEL_REQUESTED, canceled_at=clock.now())
+    command = FinalizeRunCancellation(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        expected_state=RunState.CANCEL_REQUESTED,
+        canceled_at=clock.now(),
+    )
     with pytest.raises(NotFound, match="run_missing"):
         adapter.finalize_run_cancellation(command, _event("missing-run"))
     adapter.put_run(_run("run-a", RunState.CANCEL_REQUESTED))
@@ -324,177 +469,22 @@ def test_cancel_job_exige_lease_e_e_idempotente(ctx: _DynamoContext) -> None:
     assert adapter.finalize_run_cancellation(command, event) == canceled
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.finalize_run_cancellation(command, _foreign_event(adapter))
+
+
 def _access_request(state: AccessRequestState = AccessRequestState.PENDING) -> AccessRequest:
     decided = state is not AccessRequestState.PENDING
-    return AccessRequest(tenant_id=_TENANT, request_id="request-a", user_id="user-a", state=state,
+    return AccessRequest(
+        tenant_id=_TENANT,
+        request_id="request-a",
+        user_id="user-a",
+        state=state,
         decided_by="admin-a" if decided else None,
-        decided_at=_NOW if decided else None)
+        decided_at=_NOW if decided else None,
+    )
+
+
 def _foreign_event(adapter: DynamoDBControlPlane) -> Any:
-    adapter.create_job(_job("foreign-job", tenant_id="other"),
-                       event := _event("foreign-event", tenant_id="other"))
+    adapter.create_job(
+        _job("foreign-job", tenant_id="other"), event := _event("foreign-event", tenant_id="other")
+    )
     return event
-def test_access_request_tem_criacao_decisao_e_replays_atomicos(ctx: _DynamoContext) -> None:
-    _, _, adapter = ctx
-    pending = _access_request()
-    with pytest.raises(NotFound, match="access_request_missing"):
-        adapter.decide_access_request(_access_request(AccessRequestState.APPROVED),
-                                      _event("missing-access"))
-    event, transact = _event("access-created"), adapter._transact
-    def commit_then_lose_response(actions: Any) -> None:
-        transact(actions)
-        raise Conflict("transaction_conflict")
-    adapter._transact = commit_then_lose_response
-    adapter.put_access_request(pending, event)
-    adapter._transact = transact
-    adapter.put_access_request(pending, event)
-    foreign = _foreign_event(adapter)
-    with pytest.raises(Conflict, match="event_id_conflict"):
-        adapter.put_access_request(pending, foreign)
-    with pytest.raises(Conflict, match="access_request_conflict"):
-        adapter.put_access_request(pending.model_copy(update={"user_id": "user-b"}),
-                                   _event("divergent-access"))
-    approved = _access_request(AccessRequestState.APPROVED)
-    changed_user = approved.model_copy(update={"user_id": "user-b"})
-    with pytest.raises(Conflict, match="access_request_conflict"):
-        adapter.decide_access_request(changed_user, _event("changed-user"))
-    assert adapter.get_access_request(_TENANT, "request-a") == pending
-    assert adapter.get_outbox_event("changed-user") is None
-    assert adapter.decide_access_request(approved, _event("access-approved")) == approved
-    assert adapter.decide_access_request(approved, _event("access-approved")) == approved
-    with pytest.raises(Conflict, match="event_id_conflict"):
-        adapter.decide_access_request(approved, foreign)
-    with pytest.raises(Conflict, match="access_request_conflict"):
-        adapter.decide_access_request(_access_request(AccessRequestState.REJECTED),
-                                      _event("access-rejected"))
-def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(ctx: _DynamoContext) -> None:
-    client, clock, adapter = ctx
-    adapter.create_job(_job("job-a"), _event("job-created"))
-    delivered_at = clock.now() + timedelta(seconds=1)
-    adapter.mark_outbox_delivered("job-created", delivered_at)
-    assert adapter.pending_outbox(10) == ()
-    assert adapter.create_job(_job("job-a"), _event("job-created")) == _job("job-a")
-    divergent = _event("job-created").model_copy(update={"payload": {"changed": True}})
-    with pytest.raises(Conflict, match="event_id_conflict"):
-        adapter.create_job(_job("job-a"), divergent)
-    adapter.mark_outbox_delivered("job-created", delivered_at)
-    with pytest.raises(Conflict, match="outbox_delivery_conflict"):
-        adapter.mark_outbox_delivered("job-created", delivered_at + timedelta(seconds=1))
-    with pytest.raises(NotFound, match="outbox_event_missing"):
-        adapter.mark_outbox_delivered("missing", delivered_at)
-    events = tuple(_event(f"event-{index}").model_copy(update={
-        "created_at": clock.now() + timedelta(seconds=index)}) for index in range(3))
-    for index, event in enumerate(events):
-        adapter.create_job(_job(f"job-{index}"), event)
-    markers = (("missing", "missing", 3), ("stale", "job-created", 2), ("newer", "event-1", 1))
-    for marker_id, base_id, minutes in markers:
-        marker = encode_marker("STALE_OUTBOX",
-            entity_key(_TENANT, "STALE_OUTBOX", marker_id), outbox_key(base_id),
-            {"gsi6pk": "OUTBOX#PENDING", "gsi6sk":
-             f"{(clock.now() - timedelta(minutes=minutes)).isoformat()}#{marker_id}"})
-        client.put_item(TableName=_TABLE_NAME, Item=marker)
-    paginated = OneItemPageClient(client)
-    adapter._client = paginated
-    assert (adapter.pending_outbox(0), adapter.pending_outbox(1)) == ((), events[:1])
-    paginated = OneItemPageClient(client)
-    adapter._client = paginated
-    assert adapter.pending_outbox(2) == events[:2]
-    assert [request.get("Limit") for request in paginated.query_requests] == [2, 2, 1]
-def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(ctx: _DynamoContext) -> None:
-    _, clock, adapter = ctx
-    assert adapter.claim_job(_claim_job("missing", "worker-a", clock)) is None
-    renewal = RenewJobLease(tenant_id=_TENANT, job_id="missing", owner="worker-a",
-        fencing_token=1, now=clock.now(), lease_seconds=30)
-    with pytest.raises(NotFound, match="job_missing"):
-        adapter.renew_job_lease(renewal)
-    adapter.put_agent(_agent("agent-a"))
-    adapter.create_job(_job("job-a"), _event("job-created"))
-    with pytest.raises(LeaseLost, match="job_not_leased"):
-        adapter.renew_job_lease(renewal.model_copy(update={"job_id": "job-a"}))
-    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
-    contender = DynamoDBControlPlane(adapter._client, _TABLE_NAME, clock.now)
-    transact = adapter._transact
-    def revoke_then_renew(actions: Any) -> None:
-        contender.put_agent(_agent("agent-a", AgentState.REVOKED))
-        transact(actions)
-    adapter._transact = revoke_then_renew
-    with pytest.raises(Conflict, match="transaction_conflict"):
-        adapter.renew_job_lease(renewal.model_copy(update={"job_id": "job-a"}))
-    adapter._transact = transact
-    assert adapter.get_job(_TENANT, "job-a") == claimed
-    adapter.put_agent(_agent("agent-a"))
-    adapter._transact = revoke_then_renew
-    with pytest.raises(Conflict, match="transaction_conflict"):
-        adapter.fail_job(_fail_job("worker-a", claimed.fencing_token, "failed"),
-                         _event("failed-after-revoke"))
-    adapter._transact = transact
-    assert adapter.get_job(_TENANT, "job-a") == claimed
-    assert adapter.get_outbox_event("failed-after-revoke") is None
-    adapter.put_agent(_agent("agent-a"))
-    manifests = (_raw_record("result", "agent-b", 1, clock.now()),
-                 _raw_record("result", "agent-a", 2, clock.now()))
-    for index, manifest in enumerate(manifests):
-        complete = CompleteJob(tenant_id=_TENANT, job_id="job-a", owner="worker-a",
-            fencing_token=claimed.fencing_token, manifest=manifest)
-        with pytest.raises(Conflict, match="manifest_identity_conflict"):
-            adapter.complete_job(complete, _event(f"invalid-manifest-{index}"))
-@pytest.mark.parametrize("changes", [
-    {"dataset_name": "silver"},
-    {"run_manifest_key": f"reconciliation/{_TENANT}/2026-06/run-a/run-manifest.json"}])
-def test_publicacao_valida_run_e_replay(changes: dict[str, str], ctx: _DynamoContext) -> None:
-    _, clock, adapter = ctx
-    from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
-    command = _publish("run-a", "published", None, False)
-    with pytest.raises(NotFound, match="run_missing"):
-        adapter.publish_dataset(command)
-    adapter.put_run(_run("run-a", RunState.PUBLISHING))
-    invalid = command.model_copy(update={"version": command.version.model_copy(update=changes)})
-    with pytest.raises(Conflict, match="publication_run_conflict"):
-        adapter.publish_dataset(invalid)
-    named = command.model_copy(update={"pointer_name": "candidate"})
-    pointer = adapter.publish_dataset(named)
-    assert pointer.pointer_name == "candidate"
-    assert adapter.publish_dataset(named) == pointer
-    adapter.mark_outbox_delivered(named.event.event_id, clock.now())
-    assert adapter.publish_dataset(named) == pointer
-    changed = named.model_copy(update={"event": named.event.model_copy(
-        update={"payload": {"changed": True}})})
-    with pytest.raises(Conflict, match="publication_replay_conflict"):
-        adapter.publish_dataset(changed)
-def test_codec_propaga_erro_dynamodb_nao_condicional() -> None:
-    class InvalidClient:
-        @staticmethod
-        def transact_write_items(**kwargs: Any) -> None:
-            raise ClientError({"Error": {
-                "Code": "ValidationException", "Message": "invalid"}}, "TransactWriteItems")
-    with pytest.raises(ClientError):
-        execute_transaction(InvalidClient(), ())
-@pytest.mark.parametrize("reason", [None, "ThrottlingError", "ProvisionedThroughputExceeded",
-                                    "TransactionConflict"])
-def test_codec_propaga_cancelamento_sem_falha_condicional(reason: str | None) -> None:
-    class CanceledClient:
-        @staticmethod
-        def transact_write_items(**kwargs: Any) -> None:
-            reasons = [] if reason is None else [{"Code": reason}]
-            raise ClientError({"Error": {"Code": "TransactionCanceledException"},
-                "CancellationReasons": reasons}, "TransactWriteItems")
-    with pytest.raises(ClientError):
-        execute_transaction(CanceledClient(), ())
-def test_idempotencia_recupera_resultado_de_corrida_confirmada(ctx: _DynamoContext) -> None:
-    _, clock, adapter = ctx
-    command = BeginIdempotency(tenant_id=_TENANT, scope="jobs", key="race",
-        request_hash=_HASH_A, resource_id="resource-a", now=clock.now(),
-        expires_at=clock.now() + timedelta(minutes=5))
-    transact = adapter._transact
-    def wins_then_reports_conflict(actions: Any) -> None:
-        transact(actions)
-        raise Conflict("transaction_conflict")
-    adapter._transact = wins_then_reports_conflict
-    outcome = adapter.begin_idempotency(command)
-    assert not outcome.created
-    assert outcome.record.resource_id == "resource-a"
-    adapter._client = FailingTransactionClient(adapter._client)
-    command = BeginIdempotency(tenant_id=_TENANT, scope="jobs", key="lost-race",
-        request_hash=_HASH_A, resource_id="resource-a", now=clock.now(),
-        expires_at=clock.now() + timedelta(minutes=5))
-    with pytest.raises(Conflict, match="transaction_conflict"):
-        adapter.begin_idempotency(command)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -85,8 +85,7 @@ def test_deduplica_candidatos_e_rele_base_antes_do_claim(dynamodb_context: _Dyna
             entity_key(_TENANT, "JOB", suffix) if suffix == "missing" else base_key,
             attributes)
         client.put_item(TableName=_TABLE_NAME, Item=marker)
-    spy = ClientSpy(client)
-    adapter._client = spy
+    adapter._client = spy = ClientSpy(client)
     jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 10)
     assert tuple(job.job_id for job in jobs) == ("job-a",)
     consistent_reads = [call for call in spy.calls if call == "get_item"]
@@ -103,9 +102,10 @@ def test_query_limitada_para_apos_primeiro_candidato_valido(ctx: _DynamoContext)
     assert tuple(job.job_id for job in jobs) == ("job-a",)
     assert (adapter.list_claimable_jobs(_TENANT, "agent-a", 0),
             paginated.calls.count("query")) == ((), 1)
-def test_cadeia_raw_segue_ancestralidade_sem_mesclar_deltas_irmaos(ctx: _DynamoContext) -> None:
+@pytest.mark.parametrize("base_minutes", [3, 4])
+def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
-    full = _raw_record("base", "agent-a", 1, clock.now())
+    full = _raw_record("base", "agent-a", 1, clock.now() + timedelta(minutes=base_minutes))
     sibling_a = _raw_record("delta-a", "agent-a", 2, clock.now() + timedelta(minutes=1))
     sibling_b = _raw_record("delta-b", "agent-a", 2, clock.now() + timedelta(minutes=2))
     head = _raw_record("head", "agent-a", 3, clock.now() + timedelta(minutes=3))
@@ -245,6 +245,11 @@ def test_codec_nao_introduz_decimal_nos_itens(dynamodb_context: _DynamoContext) 
     assert not contains_decimal(client.scan(TableName=_TABLE_NAME)["Items"])
 def test_create_job_retorna_replay_e_rejeita_divergencia(ctx: _DynamoContext) -> None:
     _, _, adapter = ctx
+    adapter._client = spy = ClientSpy(adapter._client)
+    delivered = _event("already-delivered").model_copy(update={"delivered_at": _NOW})
+    with pytest.raises(Conflict, match="event_delivery_conflict"):
+        adapter.create_job(_job("delivered"), delivered)
+    assert "transact_write_items" not in spy.calls
     job = _job("job-a")
     event = _event("job-created")
     adapter.create_job(job, event)
@@ -427,9 +432,7 @@ def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(ctx: _DynamoCo
     )
     with pytest.raises(Conflict, match="manifest_identity_conflict"):
         adapter.complete_job(complete, _event("invalid-manifest"))
-def test_publicacao_rejeita_run_ausente_e_reproduz_ponteiro_nomeado(
-    ctx: _DynamoContext,
-) -> None:
+def test_publicacao_rejeita_run_ausente_e_reproduz_ponteiro(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
     command = _publish("run-a", "published", None, False)
@@ -484,10 +487,8 @@ def test_idempotencia_recupera_resultado_de_corrida_confirmada(ctx: _DynamoConte
     outcome = adapter.begin_idempotency(command)
     assert not outcome.created
     assert outcome.record.resource_id == "resource-a"
-def test_idempotencia_propaga_conflito_sem_vencedor_visivel(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, clock, adapter = dynamodb_context
+def test_idempotencia_propaga_conflito_sem_vencedor_visivel(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
     adapter._client = FailingTransactionClient(adapter._client)
     command = BeginIdempotency(
         tenant_id=_TENANT, scope="jobs", key="lost-race", request_hash=_HASH_A,

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -1,0 +1,453 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+from decimal import Decimal
+from threading import Barrier
+from typing import Any
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from cnes_domain.control_plane.commands import (
+    BeginIdempotency,
+    CancelJob,
+    CompleteJob,
+    FinalizeRunCancellation,
+    RenewJobLease,
+    TransitionRun,
+)
+from cnes_domain.control_plane.entities import AccessRequest, Tenant
+from cnes_domain.control_plane.enums import AccessRequestState, JobState, RunState
+from cnes_domain.control_plane.errors import Conflict, LeaseLost, NotFound
+from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
+from cnes_infra.control_plane.dynamodb_codec import encode_marker, execute_transaction
+from cnes_infra.control_plane.dynamodb_keys import entity_key, run_entity_key
+from packages.cnes_infra.tests.contracts.clock import (
+    _HASH_A,
+    _NOW,
+    _TENANT,
+    MutableClock,
+    _agent,
+    _claim_job,
+    _event,
+    _job,
+    _raw_record,
+    _run,
+)
+from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
+    _TABLE_NAME,
+    ClientSpy,
+    FailingTransactionClient,
+    _create_table,
+    _put_many_units,
+)
+
+_HASH_B = "b" * 64
+
+
+@pytest.fixture
+def dynamodb_context() -> Any:
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-east-1")
+        _create_table(client)
+        clock = MutableClock(_NOW)
+        yield client, clock, DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
+
+
+def test_deduplica_candidatos_e_rele_base_antes_do_claim(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    client, clock, adapter = dynamodb_context
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    base_key = entity_key(_TENANT, "JOB", "job-a")
+    attributes = {
+        "gsi1pk": f"JOB_CLAIM#{_TENANT}#agent-a",
+        "gsi1sk": f"{_NOW.isoformat()}#PENDING#duplicate",
+    }
+    for suffix in ("a", "b"):
+        marker = encode_marker(
+            "STALE_JOB",
+            entity_key(_TENANT, "STALE_JOB", suffix),
+            base_key,
+            attributes,
+        )
+        client.put_item(TableName=_TABLE_NAME, Item=marker)
+    spy = ClientSpy(client)
+    adapter._client = spy
+
+    jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 10)
+
+    assert tuple(job.job_id for job in jobs) == ("job-a",)
+    consistent_reads = [call for call in spy.calls if call == "get_item"]
+    assert len(consistent_reads) == 2
+    assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
+
+
+def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    client, clock, adapter = dynamodb_context
+    adapter.put_agent(_agent("agent-a"))
+    job = _job("job-a").model_copy(update={"state": JobState.FAILED_FINAL})
+    adapter._put_direct(adapter._job_item(job))
+    base_key = entity_key(_TENANT, "JOB", "job-a")
+    marker = encode_marker(
+        "STALE_JOB",
+        entity_key(_TENANT, "STALE_JOB", "job-a"),
+        base_key,
+        {
+            "gsi1pk": f"JOB_CLAIM#{_TENANT}#agent-a",
+            "gsi1sk": f"{_NOW.isoformat()}#PENDING#job-a",
+        },
+    )
+    client.put_item(TableName=_TABLE_NAME, Item=marker)
+
+    assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
+    assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
+
+
+def test_candidato_gsi_obsoleto_nao_recupera_run_terminal(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    client, clock, adapter = dynamodb_context
+    run = _run("run-a", RunState.PUBLISHED)
+    adapter.put_run(run)
+    marker = encode_marker(
+        "STALE_RUN",
+        entity_key(_TENANT, "STALE_RUN", "run-a"),
+        run_entity_key(_TENANT, "run-a"),
+        {
+            "gsi4pk": "RUN_RECOVERABLE",
+            "gsi4sk": f"{_NOW.isoformat()}#{_TENANT}#run-a",
+        },
+    )
+    client.put_item(TableName=_TABLE_NAME, Item=marker)
+
+    assert adapter.list_recoverable_runs(clock.now(), 10) == ()
+
+
+def test_expiracao_logica_substitui_item_ttl_ainda_presente(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    client, clock, adapter = dynamodb_context
+    first = BeginIdempotency(
+        tenant_id=_TENANT,
+        scope="jobs",
+        key="key-a",
+        request_hash=_HASH_A,
+        resource_id="resource-a",
+        now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5),
+    )
+    adapter.begin_idempotency(first)
+    clock.advance(timedelta(minutes=6))
+    retained = client.scan(TableName=_TABLE_NAME)["Items"]
+    assert any(item.get("expires_at") for item in retained)
+    replacement = first.model_copy(
+        update={
+            "request_hash": _HASH_B,
+            "resource_id": "resource-b",
+            "now": clock.now(),
+            "expires_at": clock.now() + timedelta(minutes=5),
+        }
+    )
+
+    outcome = adapter.begin_idempotency(replacement)
+
+    assert outcome.created
+    assert outcome.record.resource_id == "resource-b"
+
+
+def test_colisao_global_de_evento_rejeita_segundo_tenant_sem_mutacao(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, _, adapter = dynamodb_context
+    adapter.create_job(_job("job-a"), _event("shared-event"))
+    other_job = _job("job-b", tenant_id="other")
+    other_event = _event("shared-event", tenant_id="other")
+
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.create_job(other_job, other_event)
+
+    assert adapter.get_job("other", "job-b") is None
+    assert adapter.get_outbox_event("shared-event").tenant_id == _TENANT
+
+
+def test_claim_concorrente_produz_um_unico_vencedor(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    client, clock, adapter = dynamodb_context
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    barrier = Barrier(2)
+
+    def claim(owner: str) -> Any:
+        contender = DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
+        command = _claim_job("job-a", owner, clock)
+        barrier.wait()
+        return contender.claim_job(command)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(executor.map(claim, ("worker-a", "worker-b")))
+
+    winners = tuple(outcome for outcome in outcomes if outcome is not None)
+    assert len(winners) == 1
+    assert winners[0].fencing_token == 1
+    assert adapter.get_job(_TENANT, "job-a") == winners[0]
+
+
+def test_codec_nao_introduz_decimal_nos_itens(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    client, _, adapter = dynamodb_context
+    adapter.create_job(_job("job-a"), _event("job-created"))
+
+    def contains_decimal(value: Any) -> bool:
+        if isinstance(value, dict):
+            return any(contains_decimal(item) for item in value.values())
+        if isinstance(value, list):
+            return any(contains_decimal(item) for item in value)
+        return isinstance(value, Decimal)
+
+    assert not contains_decimal(client.scan(TableName=_TABLE_NAME)["Items"])
+
+
+def test_persiste_tenant_com_isolamento(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, clock, adapter = dynamodb_context
+    tenant = Tenant(tenant_id=_TENANT, municipality_name="Epitácio", created_at=clock.now())
+
+    adapter.put_tenant(tenant)
+
+    assert adapter.get_tenant(_TENANT) == tenant
+    assert adapter.get_tenant("other") is None
+
+
+def test_create_job_retorna_replay_e_rejeita_divergencia(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, _, adapter = dynamodb_context
+    job = _job("job-a")
+    event = _event("job-created")
+    adapter.create_job(job, event)
+
+    assert adapter.create_job(job, event) == job
+    with pytest.raises(Conflict, match="job_conflict"):
+        adapter.create_job(job.model_copy(update={"agent_id": "agent-b"}), event)
+
+
+def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, _, adapter = dynamodb_context
+    transition = TransitionRun(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        expected_state=RunState.PROCESSING,
+        new_state=RunState.FAILED,
+    )
+    with pytest.raises(NotFound, match="run_missing"):
+        adapter.transition_run(transition, _event("missing-run"))
+    with pytest.raises(NotFound, match="run_missing"):
+        _put_many_units(adapter, 1)
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    with pytest.raises(Conflict, match="run_state_conflict"):
+        adapter.transition_run(transition, _event("stale-run"))
+    with pytest.raises(Conflict, match="run_state_conflict"):
+        _put_many_units(adapter, 1)
+
+
+def test_cancel_job_exige_lease_e_e_idempotente(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, clock, adapter = dynamodb_context
+    command = CancelJob(tenant_id=_TENANT, job_id="job-a", requested_by="user-a")
+    with pytest.raises(NotFound, match="job_missing"):
+        adapter.cancel_job(command, _event("missing-cancel"))
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    with pytest.raises(Conflict, match="job_state_conflict"):
+        adapter.cancel_job(command, _event("pending-cancel"))
+    assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
+    event = _event("job-cancel-requested")
+
+    canceled = adapter.cancel_job(command, event)
+
+    assert canceled.state is JobState.CANCEL_REQUESTED
+    assert adapter.cancel_job(command, event) == canceled
+
+
+def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, clock, adapter = dynamodb_context
+    command = FinalizeRunCancellation(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        expected_state=RunState.CANCEL_REQUESTED,
+        canceled_at=clock.now(),
+    )
+    with pytest.raises(NotFound, match="run_missing"):
+        adapter.finalize_run_cancellation(command, _event("missing-run"))
+    canceled = _run("run-a", RunState.CANCELED)
+    adapter.put_run(canceled)
+    assert adapter.finalize_run_cancellation(command, _event("unused")) == canceled
+
+
+def _access_request(state: AccessRequestState = AccessRequestState.PENDING) -> AccessRequest:
+    decided = state is not AccessRequestState.PENDING
+    return AccessRequest(
+        tenant_id=_TENANT,
+        request_id="request-a",
+        user_id="user-a",
+        state=state,
+        decided_by="admin-a" if decided else None,
+        decided_at=_NOW if decided else None,
+    )
+
+
+def test_access_request_tem_criacao_decisao_e_replays_atomicos(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, _, adapter = dynamodb_context
+    pending = _access_request()
+    with pytest.raises(NotFound, match="access_request_missing"):
+        adapter.decide_access_request(
+            _access_request(AccessRequestState.APPROVED), _event("missing-access")
+        )
+    adapter.put_access_request(pending, _event("access-created"))
+    adapter.put_access_request(pending, _event("access-created"))
+    assert adapter.get_access_request(_TENANT, "request-a") == pending
+    with pytest.raises(Conflict, match="access_request_conflict"):
+        adapter.put_access_request(
+            pending.model_copy(update={"user_id": "user-b"}), _event("divergent-access")
+        )
+    approved = _access_request(AccessRequestState.APPROVED)
+
+    assert adapter.decide_access_request(approved, _event("access-approved")) == approved
+    assert adapter.decide_access_request(approved, _event("access-approved")) == approved
+    with pytest.raises(Conflict, match="access_request_conflict"):
+        adapter.decide_access_request(
+            _access_request(AccessRequestState.REJECTED), _event("access-rejected")
+        )
+
+
+def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, clock, adapter = dynamodb_context
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    delivered_at = clock.now() + timedelta(seconds=1)
+
+    adapter.mark_outbox_delivered("job-created", delivered_at)
+
+    assert adapter.pending_outbox(10) == ()
+    adapter.mark_outbox_delivered("job-created", delivered_at)
+    with pytest.raises(Conflict, match="outbox_delivery_conflict"):
+        adapter.mark_outbox_delivered("job-created", delivered_at + timedelta(seconds=1))
+    with pytest.raises(NotFound, match="outbox_event_missing"):
+        adapter.mark_outbox_delivered("missing", delivered_at)
+
+
+def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, clock, adapter = dynamodb_context
+    assert adapter.claim_job(_claim_job("missing", "worker-a", clock)) is None
+    renewal = RenewJobLease(
+        tenant_id=_TENANT,
+        job_id="missing",
+        owner="worker-a",
+        fencing_token=1,
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    with pytest.raises(NotFound, match="job_missing"):
+        adapter.renew_job_lease(renewal)
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    with pytest.raises(LeaseLost, match="job_not_leased"):
+        adapter.renew_job_lease(renewal.model_copy(update={"job_id": "job-a"}))
+    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    manifest = _raw_record("result", "agent-b", 1, clock.now())
+    complete = CompleteJob(
+        tenant_id=_TENANT,
+        job_id="job-a",
+        owner="worker-a",
+        fencing_token=claimed.fencing_token,
+        manifest=manifest,
+    )
+    with pytest.raises(Conflict, match="manifest_identity_conflict"):
+        adapter.complete_job(complete, _event("invalid-manifest"))
+
+
+def test_publicacao_rejeita_run_ausente(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, _, adapter = dynamodb_context
+    from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
+
+    with pytest.raises(NotFound, match="run_missing"):
+        adapter.publish_dataset(_publish("run-a", "published", None, False))
+
+
+def test_codec_propaga_erro_dynamodb_nao_condicional() -> None:
+    class InvalidClient:
+        @staticmethod
+        def transact_write_items(**kwargs: Any) -> None:
+            raise ClientError(
+                {"Error": {"Code": "ValidationException", "Message": "invalid"}},
+                "TransactWriteItems",
+            )
+
+    with pytest.raises(ClientError):
+        execute_transaction(InvalidClient(), ())
+
+
+def test_idempotencia_recupera_resultado_de_corrida_confirmada(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, clock, adapter = dynamodb_context
+    command = BeginIdempotency(
+        tenant_id=_TENANT,
+        scope="jobs",
+        key="race",
+        request_hash=_HASH_A,
+        resource_id="resource-a",
+        now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5),
+    )
+    transact = adapter._transact
+
+    def wins_then_reports_conflict(actions: Any) -> None:
+        transact(actions)
+        raise Conflict("transaction_conflict")
+
+    adapter._transact = wins_then_reports_conflict
+
+    outcome = adapter.begin_idempotency(command)
+
+    assert not outcome.created
+    assert outcome.record.resource_id == "resource-a"
+
+
+def test_idempotencia_propaga_conflito_sem_vencedor_visivel(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, clock, adapter = dynamodb_context
+    adapter._client = FailingTransactionClient(adapter._client)
+    command = BeginIdempotency(
+        tenant_id=_TENANT,
+        scope="jobs",
+        key="lost-race",
+        request_hash=_HASH_A,
+        resource_id="resource-a",
+        now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5),
+    )
+
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.begin_idempotency(command)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -68,10 +68,9 @@ def test_deduplica_candidatos_e_rele_base_antes_do_claim(ctx: _DynamoContext) ->
     assert (adapter.list_claimable_jobs(_TENANT, "agent-a", 0),
             paginated.calls.count("query")) == ((), 4)
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
-@pytest.mark.parametrize("base_minutes", [3, 4])
-def test_cadeia_raw_serializa_corrida(base_minutes: int, ctx: _DynamoContext) -> None:
+def test_cadeia_raw_serializa_corrida(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
-    full = _raw_record("base", "agent-a", 1, clock.now() + timedelta(minutes=base_minutes))
+    full = _raw_record("base", "agent-a", 1, clock.now() + timedelta(minutes=4))
     sibling_a = _raw_record("delta-a", "agent-a", 2, clock.now() + timedelta(minutes=1))
     sibling_b = _raw_record("delta-b", "agent-a", 2, clock.now() + timedelta(minutes=2))
     head = _raw_record("head", "agent-a", 3, clock.now() + timedelta(minutes=3))
@@ -80,13 +79,14 @@ def test_cadeia_raw_serializa_corrida(base_minutes: int, ctx: _DynamoContext) ->
     sibling_a = linked(sibling_a, manifest_sha256=_HASH_B)
     sibling_b = linked(sibling_b, manifest_sha256="c" * 64)
     head = linked(head, previous_manifest_sha256="c" * 64)
-    parent_actions = adapter._raw_actions(full)
-    adapter._transact(adapter._raw_actions(sibling_b))
-    with pytest.raises(Conflict, match="transaction_conflict"):
-        adapter._transact(parent_actions)
-    adapter._transact(adapter._raw_actions(full))
-    repaired = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 2)
-    assert tuple(ref.manifest_id for ref in repaired) == (full.manifest_id, sibling_b.manifest_id)
+    transact, calls = adapter._transact, 0
+    def contend(actions: Any) -> None:
+        nonlocal calls
+        if (calls := calls + 1) == 3:
+            transact(adapter._raw_actions(sibling_b))
+        transact(actions)
+    adapter._transact = contend
+    _store_record_matching_mode(adapter, full, clock)
     adapter._raw_actions(full)
     with pytest.raises(Conflict, match="raw_ancestry_conflict"):
         adapter._raw_actions(full.model_copy(update={"manifest_id": "duplicate-full"}))

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -62,10 +62,6 @@ class OneItemPageClient(ClientSpy):
         if kwargs.get("IndexName") == "gsi2" and (hidden := getattr(self, "hidden_gsi2sk", None)):
             response["Items"] = [item for item in response["Items"] if item["gsi2sk"] != hidden]
         return response
-class EmptyPageClient(ClientSpy):
-    def query(self, **kwargs: Any) -> dict[str, Any]:
-        return self.query_requests.append(dict(kwargs)) or {
-            "Items": [], "LastEvaluatedKey": {"pk": {"S": "next"}}}
 @pytest.fixture
 def ctx() -> Any:
     with mock_aws():
@@ -124,21 +120,11 @@ def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) 
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 3)
     assert tuple(ref.manifest_id for ref in chain) == (
         full.manifest_id, sibling_b.manifest_id, head.manifest_id)
-    partition = "TENANT#333534313330#RAW#434e4553#5354#323032362d3037"
-    assert 1 <= len(stale.query_requests) <= 31
-    assert all(request.get("ConsistentRead") is True and "IndexName" not in request
-               and request["ExpressionAttributeValues"][":partition"]["S"] == partition
-               and 1 <= request["Limit"] <= 31 for request in stale.query_requests)
+    gets = [request for name, request in stale.requests if name == "get_item"]
+    assert stale.query_requests == []
+    assert len(gets) == 1
+    assert gets[0].get("ConsistentRead") is True
     assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 0) == ()
-    for index in range(7):
-        record = _raw_record(f"extra-{index}", f"agent-{index}", 1, clock.now())
-        adapter._put_direct(adapter._raw_item(record))
-    before = len(stale.query_requests)
-    assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1) == ()
-    assert len(stale.query_requests) - before == 1
-    adapter._client = empty = EmptyPageClient(adapter._client)
-    assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1) == ()
-    assert len(empty.query_requests) == 11
 def test_latest_succeeded_ignora_omissao_do_gsi(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     adapter._client = spy = ClientSpy(adapter._client)
@@ -148,12 +134,23 @@ def test_latest_succeeded_ignora_omissao_do_gsi(ctx: _DynamoContext) -> None:
         _store_record_matching_mode(adapter, record, clock)
     requests = [next(iter(action.values())) for action in spy.transactions[-1]]
     items = [request["Item" if "Item" in request else "Key"] for request in requests]
-    assert len(requests) == len({(item["pk"]["S"], item["sk"]["S"]) for item in items}) == 5
+    assert len(requests) == len({(item["pk"]["S"], item["sk"]["S"]) for item in items}) == 7
+    head = next(request for request in requests
+                if request.get("Item", {}).get("entity") == {"S": "RAWHEAD"})
+    assert head["ConditionExpression"] == "payload = :expected"
     completed = adapter.get_job(_TENANT, "job-agent-a-new")
     adapter._client = stale = OneItemPageClient(spy.client)
     stale.hidden_gsi2sk = adapter._job_item(completed)["gsi2sk"]
     result = adapter.latest_succeeded_job(_TENANT, "agent-a", "CNES", "ST", "2026-07")
     assert (result, stale.query_requests) == (completed, [])
+def test_cadeia_raw_retorna_full_mais_novo_apos_historico_longo(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
+    records = tuple(_raw_record(f"full-{index}", f"agent-{index}", 1,
+        clock.now() + timedelta(seconds=index)) for index in range(11))
+    for record in records:
+        _store_record_matching_mode(adapter, record, clock)
+    chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1)
+    assert tuple(ref.manifest_id for ref in chain) == (records[-1].manifest_id,)
 def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     adapter.put_agent(_agent("agent-a"))

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -69,7 +69,7 @@ def test_deduplica_candidatos_e_rele_base_antes_do_claim(ctx: _DynamoContext) ->
             paginated.calls.count("query")) == ((), 4)
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
 @pytest.mark.parametrize("base_minutes", [3, 4])
-def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) -> None:
+def test_cadeia_raw_serializa_corrida(base_minutes: int, ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     full = _raw_record("base", "agent-a", 1, clock.now() + timedelta(minutes=base_minutes))
     sibling_a = _raw_record("delta-a", "agent-a", 2, clock.now() + timedelta(minutes=1))
@@ -80,15 +80,17 @@ def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) 
     sibling_a = linked(sibling_a, manifest_sha256=_HASH_B)
     sibling_b = linked(sibling_b, manifest_sha256="c" * 64)
     head = linked(head, previous_manifest_sha256="c" * 64)
-    for record in (sibling_b, full):
-        _store_record_matching_mode(adapter, record, clock)
+    parent_actions = adapter._raw_actions(full)
+    adapter._transact(adapter._raw_actions(sibling_b))
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter._transact(parent_actions)
+    adapter._transact(adapter._raw_actions(full))
     repaired = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 2)
     assert tuple(ref.manifest_id for ref in repaired) == (full.manifest_id, sibling_b.manifest_id)
-    assert len(adapter._raw_actions(full)) == 3
-    duplicate = full.model_copy(update={"manifest_id": "duplicate-full"})
+    adapter._raw_actions(full)
     with pytest.raises(Conflict, match="raw_ancestry_conflict"):
-        adapter._raw_actions(duplicate)
-    for record in (sibling_a, head):
+        adapter._raw_actions(full.model_copy(update={"manifest_id": "duplicate-full"}))
+    for record in (head, sibling_a):
         _store_record_matching_mode(adapter, record, clock)
     adapter._client = stale = OneItemPageClient(adapter._client)
     stale.hidden_gsi2sk = adapter._raw_item(head)["gsi2sk"]
@@ -96,9 +98,7 @@ def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) 
     assert tuple(ref.manifest_id for ref in chain) == (
         full.manifest_id, sibling_b.manifest_id, head.manifest_id)
     gets = [request for name, request in stale.requests if name == "get_item"]
-    assert stale.query_requests == []
-    assert len(gets) == 1
-    assert gets[0].get("ConsistentRead") is True
+    assert (stale.query_requests, len(gets), gets[0].get("ConsistentRead")) == ([], 1, True)
     assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 0) == ()
 def test_latest_succeeded_ignora_omissao_do_gsi_e_historico(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
@@ -109,7 +109,7 @@ def test_latest_succeeded_ignora_omissao_do_gsi_e_historico(ctx: _DynamoContext)
         _store_record_matching_mode(adapter, record, clock)
     requests = [next(iter(action.values())) for action in spy.transactions[-1]]
     items = [request["Item" if "Item" in request else "Key"] for request in requests]
-    assert len(requests) == len({(item["pk"]["S"], item["sk"]["S"]) for item in items}) == 7
+    assert len(requests) == len({(item["pk"]["S"], item["sk"]["S"]) for item in items}) == 8
     head = next(request for request in requests
                 if request.get("Item", {}).get("entity") == {"S": "RAWHEAD"})
     assert head["ConditionExpression"] == "payload = :expected"

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -12,7 +12,9 @@ from cnes_domain.control_plane.commands import (
     CancelJob,
     CompleteJob,
     FinalizeRunCancellation,
+    PutRunUnits,
     RenewJobLease,
+    ReserveRunDispatch,
     TransitionRun,
 )
 from cnes_domain.control_plane.entities import AccessRequest, Tenant
@@ -20,7 +22,12 @@ from cnes_domain.control_plane.enums import AccessRequestState, AgentState, JobS
 from cnes_domain.control_plane.errors import Conflict, LeaseLost, NotFound
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
 from cnes_infra.control_plane.dynamodb_codec import encode_marker, execute_transaction
-from cnes_infra.control_plane.dynamodb_keys import entity_key, outbox_key, run_entity_key
+from cnes_infra.control_plane.dynamodb_keys import (
+    entity_key,
+    key_component,
+    outbox_key,
+    run_entity_key,
+)
 from packages.cnes_infra.tests.contracts.clock import (
     _HASH_A,
     _NOW,
@@ -34,6 +41,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _raw_record,
     _run,
     _store_record,
+    _unit,
 )
 from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
     _TABLE_NAME,
@@ -44,10 +52,15 @@ from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
 )
 
 _HASH_B = "b" * 64
+type _DynamoContext = tuple[Any, MutableClock, DynamoDBControlPlane]
+@pytest.fixture
+def ctx(dynamodb_context: _DynamoContext) -> _DynamoContext:
+    return dynamodb_context
 class OneItemPageClient(ClientSpy):
     def query(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("query")
-        response = self.client.query(**kwargs, Limit=1)
+        kwargs.setdefault("Limit", 1)
+        response = self.client.query(**kwargs)
         if kwargs.get("IndexName") == "gsi6":
             response["Items"] *= 2
         return response
@@ -58,48 +71,41 @@ def dynamodb_context() -> Any:
         _create_table(client)
         clock = MutableClock(_NOW)
         yield client, clock, DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
-def test_deduplica_candidatos_e_rele_base_antes_do_claim(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
+def test_deduplica_candidatos_e_rele_base_antes_do_claim(dynamodb_context: _DynamoContext) -> None:
     client, clock, adapter = dynamodb_context
     adapter.put_agent(_agent("agent-a"))
     adapter.create_job(_job("job-a"), _event("job-created"))
     base_key = entity_key(_TENANT, "JOB", "job-a")
     attributes = {
-        "gsi1pk": f"JOB_CLAIM#{_TENANT}#agent-a",
+        "gsi1pk": f"JOB_CLAIM#{key_component(_TENANT)}#{key_component('agent-a')}",
         "gsi1sk": f"{_NOW.isoformat()}#PENDING#duplicate",
     }
-    for suffix in ("a", "b"):
+    for suffix in ("a", "b", "missing"):
         marker = encode_marker(
-            "STALE_JOB",
-            entity_key(_TENANT, "STALE_JOB", suffix),
-            base_key,
-            attributes,
-        )
+            "STALE_JOB", entity_key(_TENANT, "STALE_JOB", suffix),
+            entity_key(_TENANT, "JOB", suffix) if suffix == "missing" else base_key,
+            attributes)
         client.put_item(TableName=_TABLE_NAME, Item=marker)
     spy = ClientSpy(client)
     adapter._client = spy
     jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 10)
     assert tuple(job.job_id for job in jobs) == ("job-a",)
     consistent_reads = [call for call in spy.calls if call == "get_item"]
-    assert len(consistent_reads) == 2
+    assert len(consistent_reads) == 3
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
-def test_query_percorre_todas_as_paginas_antes_de_ordenar_e_limitar(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, _, adapter = dynamodb_context
+def test_query_limitada_para_apos_primeiro_candidato_valido(ctx: _DynamoContext) -> None:
+    _, _, adapter = ctx
     adapter.put_agent(_agent("agent-a"))
-    for job_id in ("job-b", "job-a"):
+    for job_id in ("job-c", "job-b", "job-a"):
         adapter.create_job(_job(job_id), _event(f"created-{job_id}"))
     paginated = OneItemPageClient(adapter._client)
     adapter._client = paginated
-    jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 2)
-    assert tuple(job.job_id for job in jobs) == ("job-a", "job-b")
-    assert paginated.calls.count("query") == 2
-def test_cadeia_raw_segue_ancestralidade_sem_mesclar_deltas_irmaos(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, clock, adapter = dynamodb_context
+    jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 1)
+    assert tuple(job.job_id for job in jobs) == ("job-a",)
+    assert (adapter.list_claimable_jobs(_TENANT, "agent-a", 0),
+            paginated.calls.count("query")) == ((), 1)
+def test_cadeia_raw_segue_ancestralidade_sem_mesclar_deltas_irmaos(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
     full = _raw_record("base", "agent-a", 1, clock.now())
     sibling_a = _raw_record("delta-a", "agent-a", 2, clock.now() + timedelta(minutes=1))
     sibling_b = _raw_record("delta-b", "agent-a", 2, clock.now() + timedelta(minutes=2))
@@ -119,10 +125,8 @@ def test_cadeia_raw_segue_ancestralidade_sem_mesclar_deltas_irmaos(
     assert tuple(ref.manifest_id for ref in chain) == (
         full.manifest_id, sibling_b.manifest_id, head.manifest_id,
     )
-def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    client, clock, adapter = dynamodb_context
+def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(ctx: _DynamoContext) -> None:
+    client, clock, adapter = ctx
     adapter.put_agent(_agent("agent-a"))
     job = _job("job-a").model_copy(update={"state": JobState.FAILED_FINAL})
     adapter._put_direct(adapter._job_item(job))
@@ -132,17 +136,15 @@ def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(
         entity_key(_TENANT, "STALE_JOB", "job-a"),
         base_key,
         {
-            "gsi1pk": f"JOB_CLAIM#{_TENANT}#agent-a",
+            "gsi1pk": f"JOB_CLAIM#{key_component(_TENANT)}#{key_component('agent-a')}",
             "gsi1sk": f"{_NOW.isoformat()}#PENDING#job-a",
         },
     )
     client.put_item(TableName=_TABLE_NAME, Item=marker)
     assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
-def test_candidato_gsi_obsoleto_nao_recupera_run_terminal(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    client, clock, adapter = dynamodb_context
+def test_candidato_gsi_obsoleto_nao_recupera_run_terminal(ctx: _DynamoContext) -> None:
+    client, clock, adapter = ctx
     run = _run("run-a", RunState.PUBLISHED)
     adapter.put_run(run)
     marker = encode_marker(
@@ -156,19 +158,17 @@ def test_candidato_gsi_obsoleto_nao_recupera_run_terminal(
     )
     client.put_item(TableName=_TABLE_NAME, Item=marker)
     assert adapter.list_recoverable_runs(clock.now(), 10) == ()
-def test_expiracao_logica_substitui_item_ttl_ainda_presente(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    client, clock, adapter = dynamodb_context
+    tenant_z = _run("run-a").model_copy(update={"tenant_id": "z"})
+    tenant_a = _run("run-z").model_copy(update={"tenant_id": "a"})
+    adapter.put_run(tenant_z)
+    adapter.put_run(tenant_a)
+    assert adapter.list_recoverable_runs(clock.now(), 1) == (tenant_a,)
+def test_expiracao_logica_substitui_item_ttl_ainda_presente(ctx: _DynamoContext) -> None:
+    client, clock, adapter = ctx
     first = BeginIdempotency(
-        tenant_id=_TENANT,
-        scope="jobs",
-        key="key-a",
-        request_hash=_HASH_A,
-        resource_id="resource-a",
-        now=clock.now(),
-        expires_at=clock.now() + timedelta(minutes=5),
-    )
+        tenant_id=_TENANT, scope="jobs", key="key-a", request_hash=_HASH_A,
+        resource_id="resource-a", now=clock.now(),
+        expires_at=clock.now() + timedelta(minutes=5))
     adapter.begin_idempotency(first)
     clock.advance(timedelta(minutes=6))
     retained = client.scan(TableName=_TABLE_NAME)["Items"]
@@ -184,10 +184,8 @@ def test_expiracao_logica_substitui_item_ttl_ainda_presente(
     outcome = adapter.begin_idempotency(replacement)
     assert outcome.created
     assert outcome.record.resource_id == "resource-b"
-def test_colisao_global_de_evento_rejeita_segundo_tenant_sem_mutacao(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, _, adapter = dynamodb_context
+def test_colisao_global_de_evento_rejeita_segundo_tenant_sem_mutacao(ctx: _DynamoContext) -> None:
+    _, _, adapter = ctx
     adapter.create_job(_job("job-a"), _event("shared-event"))
     other_job = _job("job-b", tenant_id="other")
     other_event = _event("shared-event", tenant_id="other")
@@ -199,10 +197,28 @@ def test_colisao_global_de_evento_rejeita_segundo_tenant_sem_mutacao(
         adapter.create_job(_job("job-c"), _event("fresh-other", tenant_id="other"))
     assert adapter.get_job(_TENANT, "job-c") is None
     assert adapter.get_outbox_event("fresh-other") is None
-def test_claim_cas_perdedor_nao_desfaz_vencedor_persistido(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    client, clock, adapter = dynamodb_context
+def test_chaves_compostas_isolam_componentes_com_delimitador(ctx: _DynamoContext) -> None:
+    _, _, adapter = ctx
+    identities = (("a", "b#RUN#c"), ("a#RUN#b", "c"))
+    expected = []
+    for tenant_id, run_id in identities:
+        run = _run(run_id).model_copy(update={"tenant_id": tenant_id})
+        unit = _unit("shared").model_copy(update={"tenant_id": tenant_id, "run_id": run_id})
+        adapter.put_run(run)
+        adapter.put_run_units(PutRunUnits(
+            tenant_id=tenant_id, run_id=run_id,
+            expected_run_state=RunState.PROCESSING, units=(unit,)))
+        adapter.reserve_run_dispatch(ReserveRunDispatch(
+            tenant_id=tenant_id, run_id=run_id, wave_id="a" * 16,
+            unit_ids=("shared",), now=_NOW, lease_seconds=30))
+        expected.append(unit)
+    for identity, unit in zip(identities, expected, strict=True):
+        assert adapter.list_run_units(*identity) == (unit,)
+    partitions = {item["gsi5pk"]["S"] for item in adapter._client.scan(
+        TableName=_TABLE_NAME)["Items"] if "gsi5pk" in item}
+    assert len(partitions) == 2
+def test_claim_cas_perdedor_nao_desfaz_vencedor_persistido(ctx: _DynamoContext) -> None:
+    client, clock, adapter = ctx
     adapter.put_agent(_agent("agent-a"))
     adapter.create_job(_job("job-a"), _event("job-created"))
     loser = DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
@@ -215,9 +231,7 @@ def test_claim_cas_perdedor_nao_desfaz_vencedor_persistido(
     assert loser.claim_job(_claim_job("job-a", "worker-a", clock)) is None
     assert winners[0] is not None
     assert adapter.get_job(_TENANT, "job-a") == winners[0]
-def test_codec_nao_introduz_decimal_nos_itens(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
+def test_codec_nao_introduz_decimal_nos_itens(dynamodb_context: _DynamoContext) -> None:
     client, clock, adapter = dynamodb_context
     adapter.create_job(_job("job-a"), _event("job-created"))
     tenant = Tenant(tenant_id=_TENANT, municipality_name="Epitácio", created_at=clock.now())
@@ -230,10 +244,8 @@ def test_codec_nao_introduz_decimal_nos_itens(
             return any(contains_decimal(item) for item in value)
         return isinstance(value, Decimal)
     assert not contains_decimal(client.scan(TableName=_TABLE_NAME)["Items"])
-def test_create_job_retorna_replay_e_rejeita_divergencia(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, _, adapter = dynamodb_context
+def test_create_job_retorna_replay_e_rejeita_divergencia(ctx: _DynamoContext) -> None:
+    _, _, adapter = ctx
     job = _job("job-a")
     event = _event("job-created")
     adapter.create_job(job, event)
@@ -246,14 +258,13 @@ def test_create_job_retorna_replay_e_rejeita_divergencia(
     assert adapter.get_job(_TENANT, "job-a") == job
     with pytest.raises(Conflict, match="job_conflict"):
         adapter.create_job(job.model_copy(update={"agent_id": "agent-b"}), event)
-    key = {"pk": {"S": "TENANT#_GLOBAL"}, "sk": {"S": "OUTBOX#job-created"}}
+    key = {name: {"S": value} for name, value in
+           zip(("pk", "sk"), outbox_key("job-created"), strict=True)}
     adapter._client.delete_item(TableName=_TABLE_NAME, Key=key)
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.create_job(job, event)
-def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, _, adapter = dynamodb_context
+def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(ctx: _DynamoContext) -> None:
+    _, _, adapter = ctx
     transition = TransitionRun(
         tenant_id=_TENANT, run_id="run-a", expected_state=RunState.PROCESSING,
         new_state=RunState.FAILED,
@@ -267,9 +278,7 @@ def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(
         adapter.transition_run(transition, _event("stale-run"))
     with pytest.raises(Conflict, match="run_state_conflict"):
         _put_many_units(adapter, 1)
-def test_cancel_job_exige_lease_e_e_idempotente(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
+def test_cancel_job_exige_lease_e_e_idempotente(dynamodb_context: _DynamoContext) -> None:
     _, clock, adapter = dynamodb_context
     command = CancelJob(tenant_id=_TENANT, job_id="job-a", requested_by="user-a")
     with pytest.raises(NotFound, match="job_missing"):
@@ -286,10 +295,8 @@ def test_cancel_job_exige_lease_e_e_idempotente(
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.cancel_job(command, _foreign_event(adapter))
     assert adapter.get_job(_TENANT, "job-a") == canceled
-def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, clock, adapter = dynamodb_context
+def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
     command = FinalizeRunCancellation(
         tenant_id=_TENANT, run_id="run-a", expected_state=RunState.CANCEL_REQUESTED,
         canceled_at=clock.now(),
@@ -313,10 +320,8 @@ def _foreign_event(adapter: DynamoDBControlPlane) -> Any:
     event = _event("foreign-event", tenant_id="other")
     adapter.create_job(_job("foreign-job", tenant_id="other"), event)
     return event
-def test_access_request_tem_criacao_decisao_e_replays_atomicos(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, _, adapter = dynamodb_context
+def test_access_request_tem_criacao_decisao_e_replays_atomicos(ctx: _DynamoContext) -> None:
+    _, _, adapter = ctx
     pending = _access_request()
     with pytest.raises(NotFound, match="access_request_missing"):
         adapter.decide_access_request(
@@ -347,10 +352,8 @@ def test_access_request_tem_criacao_decisao_e_replays_atomicos(
         adapter.decide_access_request(
             _access_request(AccessRequestState.REJECTED), _event("access-rejected")
         )
-def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    client, clock, adapter = dynamodb_context
+def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(ctx: _DynamoContext) -> None:
+    client, clock, adapter = ctx
     adapter.create_job(_job("job-a"), _event("job-created"))
     delivered_at = clock.now() + timedelta(seconds=1)
     adapter.mark_outbox_delivered("job-created", delivered_at)
@@ -384,10 +387,8 @@ def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(
     paginated.calls.clear()
     assert adapter.pending_outbox(2) == events[:2]
     assert paginated.calls.count("query") == 5
-def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, clock, adapter = dynamodb_context
+def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
     assert adapter.claim_job(_claim_job("missing", "worker-a", clock)) is None
     renewal = RenewJobLease(
         tenant_id=_TENANT, job_id="missing", owner="worker-a", fencing_token=1,
@@ -427,9 +428,9 @@ def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(
     with pytest.raises(Conflict, match="manifest_identity_conflict"):
         adapter.complete_job(complete, _event("invalid-manifest"))
 def test_publicacao_rejeita_run_ausente_e_reproduz_ponteiro_nomeado(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+    ctx: _DynamoContext,
 ) -> None:
-    _, clock, adapter = dynamodb_context
+    _, clock, adapter = ctx
     from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
     command = _publish("run-a", "published", None, False)
     with pytest.raises(NotFound, match="run_missing"):
@@ -468,10 +469,8 @@ def test_codec_propaga_cancelamento_sem_falha_condicional(reason: str | None) ->
             )
     with pytest.raises(ClientError):
         execute_transaction(CanceledClient(), ())
-def test_idempotencia_recupera_resultado_de_corrida_confirmada(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, clock, adapter = dynamodb_context
+def test_idempotencia_recupera_resultado_de_corrida_confirmada(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
     command = BeginIdempotency(
         tenant_id=_TENANT, scope="jobs", key="race", request_hash=_HASH_A,
         resource_id="resource-a", now=clock.now(),

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -119,8 +119,7 @@ def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) 
     stale.hidden_gsi2sk = adapter._raw_item(head)["gsi2sk"]
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 3)
     assert tuple(ref.manifest_id for ref in chain) == (
-        full.manifest_id, sibling_b.manifest_id, head.manifest_id,
-    )
+        full.manifest_id, sibling_b.manifest_id, head.manifest_id)
 def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     adapter.put_agent(_agent("agent-a"))
@@ -263,8 +262,8 @@ def test_create_job_retorna_replay_e_rejeita_divergencia(ctx: _DynamoContext) ->
 def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(ctx: _DynamoContext) -> None:
     _, _, adapter = ctx
     transition = TransitionRun(
-        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.PROCESSING,
-        new_state=RunState.FAILED,
+        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.PLANNED,
+        new_state=RunState.WAITING_INPUTS,
     )
     with pytest.raises(NotFound, match="run_missing"):
         adapter.transition_run(transition, _event("missing-run"))
@@ -273,6 +272,8 @@ def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(ctx: _Dyna
     adapter.put_run(_run("run-a", RunState.PUBLISHING))
     with pytest.raises(Conflict, match="run_state_conflict"):
         adapter.transition_run(transition, _event("stale-run"))
+    waiting = adapter.list_waiting_runs_for_dependency(_TENANT, "CNES", "ST", "2026-07", 10)
+    assert (waiting, adapter.get_outbox_event("stale-run")) == ((), None)
     with pytest.raises(Conflict, match="run_state_conflict"):
         _put_many_units(adapter, 1)
 def test_cancel_job_exige_lease_e_e_idempotente(ctx: _DynamoContext) -> None:
@@ -427,8 +428,7 @@ def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(ctx: _DynamoCo
         adapter.complete_job(complete, _event("invalid-manifest"))
 @pytest.mark.parametrize("changes", [
     {"dataset_name": "silver"},
-    {"run_manifest_key": f"reconciliation/{_TENANT}/2026-06/run-a/run-manifest.json"},
-])
+    {"run_manifest_key": f"reconciliation/{_TENANT}/2026-06/run-a/run-manifest.json"}])
 def test_publicacao_valida_run_e_replay(changes: dict[str, str], ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     from packages.cnes_infra.tests.contracts.control_plane_contract import _publish

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -46,7 +46,10 @@ _HASH_B = "b" * 64
 class OneItemPageClient(ClientSpy):
     def query(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("query")
-        return self.client.query(**kwargs, Limit=1)
+        response = self.client.query(**kwargs, Limit=1)
+        if kwargs.get("IndexName") == "gsi6":
+            response["Items"] *= 2
+        return response
 @pytest.fixture
 def dynamodb_context() -> Any:
     with mock_aws():
@@ -363,13 +366,11 @@ def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(
     events = tuple(
         _event(f"event-{index}").model_copy(
             update={"created_at": clock.now() + timedelta(seconds=index)}
-        )
-        for index in range(3)
+        ) for index in range(3)
     )
     for index, event in enumerate(events):
         adapter.create_job(_job(f"job-{index}"), event)
-    markers = (("missing", "missing", 3), ("stale", "job-created", 2),
-               ("duplicate", "event-0", 1))
+    markers = (("missing", "missing", 3), ("stale", "job-created", 2), ("newer", "event-1", 1))
     for marker_id, base_id, minutes in markers:
         marker = encode_marker(
             "STALE_OUTBOX", entity_key(_TENANT, "STALE_OUTBOX", marker_id),
@@ -379,7 +380,8 @@ def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(
         client.put_item(TableName=_TABLE_NAME, Item=marker)
     paginated = OneItemPageClient(client)
     adapter._client = paginated
-    assert adapter.pending_outbox(0) == ()
+    assert (adapter.pending_outbox(0), adapter.pending_outbox(1)) == ((), events[:1])
+    paginated.calls.clear()
     assert adapter.pending_outbox(2) == events[:2]
     assert paginated.calls.count("query") == 5
 def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(
@@ -478,7 +480,6 @@ def test_idempotencia_recupera_resultado_de_corrida_confirmada(
         raise Conflict("transaction_conflict")
     adapter._transact = wins_then_reports_conflict
     outcome = adapter.begin_idempotency(command)
-
     assert not outcome.created
     assert outcome.record.resource_id == "resource-a"
 def test_idempotencia_propaga_conflito_sem_vencedor_visivel(
@@ -495,6 +496,5 @@ def test_idempotencia_propaga_conflito_sem_vencedor_visivel(
         now=clock.now(),
         expires_at=clock.now() + timedelta(minutes=5),
     )
-
     with pytest.raises(Conflict, match="transaction_conflict"):
         adapter.begin_idempotency(command)

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -16,11 +16,11 @@ from cnes_domain.control_plane.commands import (
     TransitionRun,
 )
 from cnes_domain.control_plane.entities import AccessRequest, Tenant
-from cnes_domain.control_plane.enums import AccessRequestState, JobState, RunState
+from cnes_domain.control_plane.enums import AccessRequestState, AgentState, JobState, RunState
 from cnes_domain.control_plane.errors import Conflict, LeaseLost, NotFound
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
 from cnes_infra.control_plane.dynamodb_codec import encode_marker, execute_transaction
-from cnes_infra.control_plane.dynamodb_keys import entity_key, run_entity_key
+from cnes_infra.control_plane.dynamodb_keys import entity_key, outbox_key, run_entity_key
 from packages.cnes_infra.tests.contracts.clock import (
     _HASH_A,
     _NOW,
@@ -43,14 +43,10 @@ from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
 )
 
 _HASH_B = "b" * 64
-
-
 class OneItemPageClient(ClientSpy):
     def query(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append("query")
         return self.client.query(**kwargs, Limit=1)
-
-
 @pytest.fixture
 def dynamodb_context() -> Any:
     with mock_aws():
@@ -58,8 +54,6 @@ def dynamodb_context() -> Any:
         _create_table(client)
         clock = MutableClock(_NOW)
         yield client, clock, DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
-
-
 def test_deduplica_candidatos_e_rele_base_antes_do_claim(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -86,8 +80,6 @@ def test_deduplica_candidatos_e_rele_base_antes_do_claim(
     consistent_reads = [call for call in spy.calls if call == "get_item"]
     assert len(consistent_reads) == 2
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
-
-
 def test_query_percorre_todas_as_paginas_antes_de_ordenar_e_limitar(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -100,8 +92,6 @@ def test_query_percorre_todas_as_paginas_antes_de_ordenar_e_limitar(
     jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 2)
     assert tuple(job.job_id for job in jobs) == ("job-a", "job-b")
     assert paginated.calls.count("query") == 2
-
-
 def test_cadeia_raw_segue_ancestralidade_sem_mesclar_deltas_irmaos(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -125,8 +115,6 @@ def test_cadeia_raw_segue_ancestralidade_sem_mesclar_deltas_irmaos(
     assert tuple(ref.manifest_id for ref in chain) == (
         full.manifest_id, sibling_b.manifest_id, head.manifest_id,
     )
-
-
 def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -147,8 +135,6 @@ def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(
     client.put_item(TableName=_TABLE_NAME, Item=marker)
     assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
-
-
 def test_candidato_gsi_obsoleto_nao_recupera_run_terminal(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -166,8 +152,6 @@ def test_candidato_gsi_obsoleto_nao_recupera_run_terminal(
     )
     client.put_item(TableName=_TABLE_NAME, Item=marker)
     assert adapter.list_recoverable_runs(clock.now(), 10) == ()
-
-
 def test_expiracao_logica_substitui_item_ttl_ainda_presente(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -196,8 +180,6 @@ def test_expiracao_logica_substitui_item_ttl_ainda_presente(
     outcome = adapter.begin_idempotency(replacement)
     assert outcome.created
     assert outcome.record.resource_id == "resource-b"
-
-
 def test_colisao_global_de_evento_rejeita_segundo_tenant_sem_mutacao(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -213,8 +195,6 @@ def test_colisao_global_de_evento_rejeita_segundo_tenant_sem_mutacao(
         adapter.create_job(_job("job-c"), _event("fresh-other", tenant_id="other"))
     assert adapter.get_job(_TENANT, "job-c") is None
     assert adapter.get_outbox_event("fresh-other") is None
-
-
 def test_claim_cas_perdedor_nao_desfaz_vencedor_persistido(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -227,13 +207,10 @@ def test_claim_cas_perdedor_nao_desfaz_vencedor_persistido(
     def win_before_stale_cas(actions: Any) -> None:
         winners.append(adapter.claim_job(_claim_job("job-a", "worker-b", clock)))
         transact(actions)
-
     loser._transact = win_before_stale_cas
     assert loser.claim_job(_claim_job("job-a", "worker-a", clock)) is None
     assert winners[0] is not None
     assert adapter.get_job(_TENANT, "job-a") == winners[0]
-
-
 def test_codec_nao_introduz_decimal_nos_itens(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -249,8 +226,6 @@ def test_codec_nao_introduz_decimal_nos_itens(
             return any(contains_decimal(item) for item in value)
         return isinstance(value, Decimal)
     assert not contains_decimal(client.scan(TableName=_TABLE_NAME)["Items"])
-
-
 def test_create_job_retorna_replay_e_rejeita_divergencia(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -267,8 +242,6 @@ def test_create_job_retorna_replay_e_rejeita_divergencia(
     assert adapter.get_job(_TENANT, "job-a") == job
     with pytest.raises(Conflict, match="job_conflict"):
         adapter.create_job(job.model_copy(update={"agent_id": "agent-b"}), event)
-
-
 def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -288,8 +261,6 @@ def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(
         adapter.transition_run(transition, _event("stale-run"))
     with pytest.raises(Conflict, match="run_state_conflict"):
         _put_many_units(adapter, 1)
-
-
 def test_cancel_job_exige_lease_e_e_idempotente(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -309,8 +280,6 @@ def test_cancel_job_exige_lease_e_e_idempotente(
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.cancel_job(command, _foreign_event(adapter))
     assert adapter.get_job(_TENANT, "job-a") == canceled
-
-
 def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -330,8 +299,6 @@ def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.finalize_run_cancellation(command, _foreign_event(adapter))
     assert adapter.get_run(_TENANT, "run-a") == canceled
-
-
 def _access_request(state: AccessRequestState = AccessRequestState.PENDING) -> AccessRequest:
     decided = state is not AccessRequestState.PENDING
     return AccessRequest(
@@ -342,14 +309,10 @@ def _access_request(state: AccessRequestState = AccessRequestState.PENDING) -> A
         decided_by="admin-a" if decided else None,
         decided_at=_NOW if decided else None,
     )
-
-
 def _foreign_event(adapter: DynamoDBControlPlane) -> Any:
     event = _event("foreign-event", tenant_id="other")
     adapter.create_job(_job("foreign-job", tenant_id="other"), event)
     return event
-
-
 def test_access_request_tem_criacao_decisao_e_replays_atomicos(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -370,6 +333,11 @@ def test_access_request_tem_criacao_decisao_e_replays_atomicos(
             pending.model_copy(update={"user_id": "user-b"}), _event("divergent-access")
         )
     approved = _access_request(AccessRequestState.APPROVED)
+    changed_user = approved.model_copy(update={"user_id": "user-b"})
+    with pytest.raises(Conflict, match="access_request_conflict"):
+        adapter.decide_access_request(changed_user, _event("changed-user"))
+    assert adapter.get_access_request(_TENANT, "request-a") == pending
+    assert adapter.get_outbox_event("changed-user") is None
     assert adapter.decide_access_request(approved, _event("access-approved")) == approved
     assert adapter.decide_access_request(approved, _event("access-approved")) == approved
     with pytest.raises(Conflict, match="event_id_conflict"):
@@ -379,12 +347,10 @@ def test_access_request_tem_criacao_decisao_e_replays_atomicos(
         adapter.decide_access_request(
             _access_request(AccessRequestState.REJECTED), _event("access-rejected")
         )
-
-
 def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
-    _, clock, adapter = dynamodb_context
+    client, clock, adapter = dynamodb_context
     adapter.create_job(_job("job-a"), _event("job-created"))
     delivered_at = clock.now() + timedelta(seconds=1)
     adapter.mark_outbox_delivered("job-created", delivered_at)
@@ -394,8 +360,28 @@ def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(
         adapter.mark_outbox_delivered("job-created", delivered_at + timedelta(seconds=1))
     with pytest.raises(NotFound, match="outbox_event_missing"):
         adapter.mark_outbox_delivered("missing", delivered_at)
-
-
+    events = tuple(
+        _event(f"event-{index}").model_copy(
+            update={"created_at": clock.now() + timedelta(seconds=index)}
+        )
+        for index in range(3)
+    )
+    for index, event in enumerate(events):
+        adapter.create_job(_job(f"job-{index}"), event)
+    markers = (("missing", "missing", 3), ("stale", "job-created", 2),
+               ("duplicate", "event-0", 1))
+    for marker_id, base_id, minutes in markers:
+        marker = encode_marker(
+            "STALE_OUTBOX", entity_key(_TENANT, "STALE_OUTBOX", marker_id),
+            outbox_key(base_id), {"gsi6pk": "OUTBOX#PENDING", "gsi6sk":
+                f"{(clock.now() - timedelta(minutes=minutes)).isoformat()}#{marker_id}"},
+        )
+        client.put_item(TableName=_TABLE_NAME, Item=marker)
+    paginated = OneItemPageClient(client)
+    adapter._client = paginated
+    assert adapter.pending_outbox(0) == ()
+    assert adapter.pending_outbox(2) == events[:2]
+    assert paginated.calls.count("query") == 5
 def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -416,6 +402,17 @@ def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(
     with pytest.raises(LeaseLost, match="job_not_leased"):
         adapter.renew_job_lease(renewal.model_copy(update={"job_id": "job-a"}))
     claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    contender = DynamoDBControlPlane(adapter._client, _TABLE_NAME, clock.now)
+    transact = adapter._transact
+    def revoke_then_renew(actions: Any) -> None:
+        contender.put_agent(_agent("agent-a", AgentState.REVOKED))
+        transact(actions)
+    adapter._transact = revoke_then_renew
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.renew_job_lease(renewal.model_copy(update={"job_id": "job-a"}))
+    adapter._transact = transact
+    assert adapter.get_job(_TENANT, "job-a") == claimed
+    adapter.put_agent(_agent("agent-a"))
     manifest = _raw_record("result", "agent-b", 1, clock.now())
     complete = CompleteJob(
         tenant_id=_TENANT,
@@ -426,8 +423,6 @@ def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(
     )
     with pytest.raises(Conflict, match="manifest_identity_conflict"):
         adapter.complete_job(complete, _event("invalid-manifest"))
-
-
 def test_publicacao_rejeita_run_ausente_e_reproduz_ponteiro_nomeado(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -441,8 +436,6 @@ def test_publicacao_rejeita_run_ausente_e_reproduz_ponteiro_nomeado(
     pointer = adapter.publish_dataset(named)
     assert pointer.pointer_name == "candidate"
     assert adapter.publish_dataset(named) == pointer
-
-
 def test_codec_propaga_erro_dynamodb_nao_condicional() -> None:
     class InvalidClient:
         @staticmethod
@@ -453,8 +446,19 @@ def test_codec_propaga_erro_dynamodb_nao_condicional() -> None:
             )
     with pytest.raises(ClientError):
         execute_transaction(InvalidClient(), ())
-
-
+@pytest.mark.parametrize("reason", [None, "ThrottlingError", "ProvisionedThroughputExceeded",
+                                    "TransactionConflict"])
+def test_codec_propaga_cancelamento_sem_falha_condicional(reason: str | None) -> None:
+    class CanceledClient:
+        @staticmethod
+        def transact_write_items(**kwargs: Any) -> None:
+            reasons = [] if reason is None else [{"Code": reason}]
+            raise ClientError(
+                {"Error": {"Code": "TransactionCanceledException"},
+                 "CancellationReasons": reasons}, "TransactWriteItems",
+            )
+    with pytest.raises(ClientError):
+        execute_transaction(CanceledClient(), ())
 def test_idempotencia_recupera_resultado_de_corrida_confirmada(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -472,15 +476,11 @@ def test_idempotencia_recupera_resultado_de_corrida_confirmada(
     def wins_then_reports_conflict(actions: Any) -> None:
         transact(actions)
         raise Conflict("transaction_conflict")
-
     adapter._transact = wins_then_reports_conflict
-
     outcome = adapter.begin_idempotency(command)
 
     assert not outcome.created
     assert outcome.record.resource_id == "resource-a"
-
-
 def test_idempotencia_propaga_conflito_sem_vencedor_visivel(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -207,7 +207,6 @@ def test_latest_succeeded_ignora_omissao_do_gsi_e_historico(ctx: _DynamoContext)
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1)
     assert tuple(ref.manifest_id for ref in chain) == (records[-1].manifest_id,)
 
-
 def test_reparo_raw_rejeita_ancestry_ausente_e_excesso(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     _store_record(adapter, _raw_record("delta-pending", "agent-a", 2, clock.now()), clock)
@@ -228,14 +227,16 @@ def test_reparo_raw_rejeita_ancestry_ausente_e_excesso(ctx: _DynamoContext) -> N
             "pk": waiting["base_pk"],
             "sk": waiting["base_sk"],
             "entity": {"S": "RAWANCESTRY"},
+            "chain": {"S": "[]"},
         },
     )
+    with pytest.raises(Conflict, match="raw_ancestry_conflict"):
+        adapter._raw_actions(base)
     for index in range(95):
         clone = {**waiting, "sk": {"S": f"{waiting['sk']['S']}#{index:03d}"}}
         client.put_item(TableName=_TABLE_NAME, Item=clone)
     with pytest.raises(Conflict, match="transaction_limit"):
         adapter._raw_actions(base)
-
 
 def test_candidato_gsi_obsoleto_nao_reivindica_job_ou_run_terminal(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
@@ -265,7 +266,6 @@ def test_candidato_gsi_obsoleto_nao_reivindica_job_ou_run_terminal(ctx: _DynamoC
     adapter.put_run(tenant_z)
     adapter.put_run(tenant_a)
     assert adapter.list_recoverable_runs(clock.now(), 1) == (tenant_a,)
-
 
 def test_expiracao_logica_substitui_item_ttl_ainda_presente(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -29,6 +29,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _agent,
     _claim_job,
     _event,
+    _fail_job,
     _job,
     _raw_record,
     _run,
@@ -245,14 +246,16 @@ def test_create_job_retorna_replay_e_rejeita_divergencia(
     assert adapter.get_job(_TENANT, "job-a") == job
     with pytest.raises(Conflict, match="job_conflict"):
         adapter.create_job(job.model_copy(update={"agent_id": "agent-b"}), event)
+    key = {"pk": {"S": "TENANT#_GLOBAL"}, "sk": {"S": "OUTBOX#job-created"}}
+    adapter._client.delete_item(TableName=_TABLE_NAME, Key=key)
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.create_job(job, event)
 def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
     _, _, adapter = dynamodb_context
     transition = TransitionRun(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        expected_state=RunState.PROCESSING,
+        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.PROCESSING,
         new_state=RunState.FAILED,
     )
     with pytest.raises(NotFound, match="run_missing"):
@@ -288,9 +291,7 @@ def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(
 ) -> None:
     _, clock, adapter = dynamodb_context
     command = FinalizeRunCancellation(
-        tenant_id=_TENANT,
-        run_id="run-a",
-        expected_state=RunState.CANCEL_REQUESTED,
+        tenant_id=_TENANT, run_id="run-a", expected_state=RunState.CANCEL_REQUESTED,
         canceled_at=clock.now(),
     )
     with pytest.raises(NotFound, match="run_missing"):
@@ -305,12 +306,8 @@ def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(
 def _access_request(state: AccessRequestState = AccessRequestState.PENDING) -> AccessRequest:
     decided = state is not AccessRequestState.PENDING
     return AccessRequest(
-        tenant_id=_TENANT,
-        request_id="request-a",
-        user_id="user-a",
-        state=state,
-        decided_by="admin-a" if decided else None,
-        decided_at=_NOW if decided else None,
+        tenant_id=_TENANT, request_id="request-a", user_id="user-a", state=state,
+        decided_by="admin-a" if decided else None, decided_at=_NOW if decided else None,
     )
 def _foreign_event(adapter: DynamoDBControlPlane) -> Any:
     event = _event("foreign-event", tenant_id="other")
@@ -358,15 +355,18 @@ def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(
     delivered_at = clock.now() + timedelta(seconds=1)
     adapter.mark_outbox_delivered("job-created", delivered_at)
     assert adapter.pending_outbox(10) == ()
+    assert adapter.create_job(_job("job-a"), _event("job-created")) == _job("job-a")
+    divergent = _event("job-created").model_copy(update={"payload": {"changed": True}})
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.create_job(_job("job-a"), divergent)
     adapter.mark_outbox_delivered("job-created", delivered_at)
     with pytest.raises(Conflict, match="outbox_delivery_conflict"):
         adapter.mark_outbox_delivered("job-created", delivered_at + timedelta(seconds=1))
     with pytest.raises(NotFound, match="outbox_event_missing"):
         adapter.mark_outbox_delivered("missing", delivered_at)
-    events = tuple(
-        _event(f"event-{index}").model_copy(
-            update={"created_at": clock.now() + timedelta(seconds=index)}
-        ) for index in range(3)
+    events = tuple(_event(f"event-{index}").model_copy(
+        update={"created_at": clock.now() + timedelta(seconds=index)}
+    ) for index in range(3)
     )
     for index, event in enumerate(events):
         adapter.create_job(_job(f"job-{index}"), event)
@@ -390,12 +390,8 @@ def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(
     _, clock, adapter = dynamodb_context
     assert adapter.claim_job(_claim_job("missing", "worker-a", clock)) is None
     renewal = RenewJobLease(
-        tenant_id=_TENANT,
-        job_id="missing",
-        owner="worker-a",
-        fencing_token=1,
-        now=clock.now(),
-        lease_seconds=30,
+        tenant_id=_TENANT, job_id="missing", owner="worker-a", fencing_token=1,
+        now=clock.now(), lease_seconds=30,
     )
     with pytest.raises(NotFound, match="job_missing"):
         adapter.renew_job_lease(renewal)
@@ -415,20 +411,25 @@ def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(
     adapter._transact = transact
     assert adapter.get_job(_TENANT, "job-a") == claimed
     adapter.put_agent(_agent("agent-a"))
+    adapter._transact = revoke_then_renew
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.fail_job(_fail_job("worker-a", claimed.fencing_token, "failed"),
+                         _event("failed-after-revoke"))
+    adapter._transact = transact
+    assert adapter.get_job(_TENANT, "job-a") == claimed
+    assert adapter.get_outbox_event("failed-after-revoke") is None
+    adapter.put_agent(_agent("agent-a"))
     manifest = _raw_record("result", "agent-b", 1, clock.now())
     complete = CompleteJob(
-        tenant_id=_TENANT,
-        job_id="job-a",
-        owner="worker-a",
-        fencing_token=claimed.fencing_token,
-        manifest=manifest,
+        tenant_id=_TENANT, job_id="job-a", owner="worker-a",
+        fencing_token=claimed.fencing_token, manifest=manifest,
     )
     with pytest.raises(Conflict, match="manifest_identity_conflict"):
         adapter.complete_job(complete, _event("invalid-manifest"))
 def test_publicacao_rejeita_run_ausente_e_reproduz_ponteiro_nomeado(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
-    _, _, adapter = dynamodb_context
+    _, clock, adapter = dynamodb_context
     from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
     command = _publish("run-a", "published", None, False)
     with pytest.raises(NotFound, match="run_missing"):
@@ -438,6 +439,12 @@ def test_publicacao_rejeita_run_ausente_e_reproduz_ponteiro_nomeado(
     pointer = adapter.publish_dataset(named)
     assert pointer.pointer_name == "candidate"
     assert adapter.publish_dataset(named) == pointer
+    adapter.mark_outbox_delivered(named.event.event_id, clock.now())
+    assert adapter.publish_dataset(named) == pointer
+    changed = named.model_copy(update={"event": named.event.model_copy(
+        update={"payload": {"changed": True}})})
+    with pytest.raises(Conflict, match="publication_replay_conflict"):
+        adapter.publish_dataset(changed)
 def test_codec_propaga_erro_dynamodb_nao_condicional() -> None:
     class InvalidClient:
         @staticmethod
@@ -466,12 +473,8 @@ def test_idempotencia_recupera_resultado_de_corrida_confirmada(
 ) -> None:
     _, clock, adapter = dynamodb_context
     command = BeginIdempotency(
-        tenant_id=_TENANT,
-        scope="jobs",
-        key="race",
-        request_hash=_HASH_A,
-        resource_id="resource-a",
-        now=clock.now(),
+        tenant_id=_TENANT, scope="jobs", key="race", request_hash=_HASH_A,
+        resource_id="resource-a", now=clock.now(),
         expires_at=clock.now() + timedelta(minutes=5),
     )
     transact = adapter._transact
@@ -488,10 +491,7 @@ def test_idempotencia_propaga_conflito_sem_vencedor_visivel(
     _, clock, adapter = dynamodb_context
     adapter._client = FailingTransactionClient(adapter._client)
     command = BeginIdempotency(
-        tenant_id=_TENANT,
-        scope="jobs",
-        key="lost-race",
-        request_hash=_HASH_A,
+        tenant_id=_TENANT, scope="jobs", key="lost-race", request_hash=_HASH_A,
         resource_id="resource-a",
         now=clock.now(),
         expires_at=clock.now() + timedelta(minutes=5),

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -58,9 +58,8 @@ def ctx(dynamodb_context: _DynamoContext) -> _DynamoContext:
     return dynamodb_context
 class OneItemPageClient(ClientSpy):
     def query(self, **kwargs: Any) -> dict[str, Any]:
-        self.calls.append("query")
         kwargs.setdefault("Limit", 1)
-        response = self.client.query(**kwargs)
+        response = super().query(**kwargs)
         if kwargs.get("IndexName") == "gsi6":
             response["Items"] *= 2
         return response
@@ -384,9 +383,10 @@ def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(ctx: _DynamoContext
     paginated = OneItemPageClient(client)
     adapter._client = paginated
     assert (adapter.pending_outbox(0), adapter.pending_outbox(1)) == ((), events[:1])
-    paginated.calls.clear()
+    paginated = OneItemPageClient(client)
+    adapter._client = paginated
     assert adapter.pending_outbox(2) == events[:2]
-    assert paginated.calls.count("query") == 5
+    assert paginated.query_limits == [2, 2, 1]
 def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     assert adapter.claim_job(_claim_job("missing", "worker-a", clock)) is None

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -324,33 +324,35 @@ def test_cancel_job_exige_lease_e_e_idempotente(ctx: _DynamoContext) -> None:
     assert adapter.finalize_run_cancellation(command, event) == canceled
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.finalize_run_cancellation(command, _foreign_event(adapter))
-    assert adapter.get_run(_TENANT, "run-a") == canceled
 def _access_request(state: AccessRequestState = AccessRequestState.PENDING) -> AccessRequest:
     decided = state is not AccessRequestState.PENDING
-    return AccessRequest(tenant_id=_TENANT, request_id="request-a", user_id="user-a",
-        state=state, decided_by="admin-a" if decided else None,
+    return AccessRequest(tenant_id=_TENANT, request_id="request-a", user_id="user-a", state=state,
+        decided_by="admin-a" if decided else None,
         decided_at=_NOW if decided else None)
 def _foreign_event(adapter: DynamoDBControlPlane) -> Any:
-    event = _event("foreign-event", tenant_id="other")
-    adapter.create_job(_job("foreign-job", tenant_id="other"), event)
+    adapter.create_job(_job("foreign-job", tenant_id="other"),
+                       event := _event("foreign-event", tenant_id="other"))
     return event
 def test_access_request_tem_criacao_decisao_e_replays_atomicos(ctx: _DynamoContext) -> None:
     _, _, adapter = ctx
     pending = _access_request()
     with pytest.raises(NotFound, match="access_request_missing"):
-        adapter.decide_access_request(
-            _access_request(AccessRequestState.APPROVED), _event("missing-access")
-        )
-    adapter.put_access_request(pending, _event("access-created"))
-    adapter.put_access_request(pending, _event("access-created"))
-    assert adapter.get_access_request(_TENANT, "request-a") == pending
+        adapter.decide_access_request(_access_request(AccessRequestState.APPROVED),
+                                      _event("missing-access"))
+    event, transact = _event("access-created"), adapter._transact
+    def commit_then_lose_response(actions: Any) -> None:
+        transact(actions)
+        raise Conflict("transaction_conflict")
+    adapter._transact = commit_then_lose_response
+    adapter.put_access_request(pending, event)
+    adapter._transact = transact
+    adapter.put_access_request(pending, event)
     foreign = _foreign_event(adapter)
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.put_access_request(pending, foreign)
     with pytest.raises(Conflict, match="access_request_conflict"):
-        adapter.put_access_request(
-            pending.model_copy(update={"user_id": "user-b"}), _event("divergent-access")
-        )
+        adapter.put_access_request(pending.model_copy(update={"user_id": "user-b"}),
+                                   _event("divergent-access"))
     approved = _access_request(AccessRequestState.APPROVED)
     changed_user = approved.model_copy(update={"user_id": "user-b"})
     with pytest.raises(Conflict, match="access_request_conflict"):
@@ -361,11 +363,9 @@ def test_access_request_tem_criacao_decisao_e_replays_atomicos(ctx: _DynamoConte
     assert adapter.decide_access_request(approved, _event("access-approved")) == approved
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.decide_access_request(approved, foreign)
-    assert adapter.get_access_request(_TENANT, "request-a") == approved
     with pytest.raises(Conflict, match="access_request_conflict"):
-        adapter.decide_access_request(
-            _access_request(AccessRequestState.REJECTED), _event("access-rejected")
-        )
+        adapter.decide_access_request(_access_request(AccessRequestState.REJECTED),
+                                      _event("access-rejected"))
 def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     adapter.create_job(_job("job-a"), _event("job-created"))

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -46,6 +46,12 @@ from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
 _HASH_B = "b" * 64
 
 
+class OneItemPageClient(ClientSpy):
+    def query(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append("query")
+        return self.client.query(**kwargs, Limit=1)
+
+
 @pytest.fixture
 def dynamodb_context() -> Any:
     with mock_aws():
@@ -83,6 +89,22 @@ def test_deduplica_candidatos_e_rele_base_antes_do_claim(
     consistent_reads = [call for call in spy.calls if call == "get_item"]
     assert len(consistent_reads) == 2
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
+
+
+def test_query_percorre_todas_as_paginas_antes_de_ordenar_e_limitar(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, _, adapter = dynamodb_context
+    adapter.put_agent(_agent("agent-a"))
+    for job_id in ("job-b", "job-a"):
+        adapter.create_job(_job(job_id), _event(f"created-{job_id}"))
+    paginated = OneItemPageClient(adapter._client)
+    adapter._client = paginated
+
+    jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 2)
+
+    assert tuple(job.job_id for job in jobs) == ("job-a", "job-b")
+    assert paginated.calls.count("query") == 2
 
 
 def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(
@@ -235,6 +257,12 @@ def test_create_job_retorna_replay_e_rejeita_divergencia(
     adapter.create_job(job, event)
 
     assert adapter.create_job(job, event) == job
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.create_job(job, _foreign_event(adapter))
+    divergent = event.model_copy(update={"payload": {"event_id": "divergent"}})
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.create_job(job, divergent)
+    assert adapter.get_job(_TENANT, "job-a") == job
     with pytest.raises(Conflict, match="job_conflict"):
         adapter.create_job(job.model_copy(update={"agent_id": "agent-b"}), event)
 
@@ -278,6 +306,9 @@ def test_cancel_job_exige_lease_e_e_idempotente(
 
     assert canceled.state is JobState.CANCEL_REQUESTED
     assert adapter.cancel_job(command, event) == canceled
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.cancel_job(command, _foreign_event(adapter))
+    assert adapter.get_job(_TENANT, "job-a") == canceled
 
 
 def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(
@@ -292,9 +323,13 @@ def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(
     )
     with pytest.raises(NotFound, match="run_missing"):
         adapter.finalize_run_cancellation(command, _event("missing-run"))
-    canceled = _run("run-a", RunState.CANCELED)
-    adapter.put_run(canceled)
-    assert adapter.finalize_run_cancellation(command, _event("unused")) == canceled
+    adapter.put_run(_run("run-a", RunState.CANCEL_REQUESTED))
+    event = _event("run-canceled")
+    canceled = adapter.finalize_run_cancellation(command, event)
+    assert adapter.finalize_run_cancellation(command, event) == canceled
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.finalize_run_cancellation(command, _foreign_event(adapter))
+    assert adapter.get_run(_TENANT, "run-a") == canceled
 
 
 def _access_request(state: AccessRequestState = AccessRequestState.PENDING) -> AccessRequest:
@@ -309,6 +344,12 @@ def _access_request(state: AccessRequestState = AccessRequestState.PENDING) -> A
     )
 
 
+def _foreign_event(adapter: DynamoDBControlPlane) -> Any:
+    event = _event("foreign-event", tenant_id="other")
+    adapter.create_job(_job("foreign-job", tenant_id="other"), event)
+    return event
+
+
 def test_access_request_tem_criacao_decisao_e_replays_atomicos(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
@@ -321,6 +362,9 @@ def test_access_request_tem_criacao_decisao_e_replays_atomicos(
     adapter.put_access_request(pending, _event("access-created"))
     adapter.put_access_request(pending, _event("access-created"))
     assert adapter.get_access_request(_TENANT, "request-a") == pending
+    foreign = _foreign_event(adapter)
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.put_access_request(pending, foreign)
     with pytest.raises(Conflict, match="access_request_conflict"):
         adapter.put_access_request(
             pending.model_copy(update={"user_id": "user-b"}), _event("divergent-access")
@@ -329,6 +373,9 @@ def test_access_request_tem_criacao_decisao_e_replays_atomicos(
 
     assert adapter.decide_access_request(approved, _event("access-approved")) == approved
     assert adapter.decide_access_request(approved, _event("access-approved")) == approved
+    with pytest.raises(Conflict, match="event_id_conflict"):
+        adapter.decide_access_request(approved, foreign)
+    assert adapter.get_access_request(_TENANT, "request-a") == approved
     with pytest.raises(Conflict, match="access_request_conflict"):
         adapter.decide_access_request(
             _access_request(AccessRequestState.REJECTED), _event("access-rejected")

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -53,25 +53,24 @@ from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
 
 _HASH_B = "b" * 64
 type _DynamoContext = tuple[Any, MutableClock, DynamoDBControlPlane]
-@pytest.fixture
-def ctx(dynamodb_context: _DynamoContext) -> _DynamoContext:
-    return dynamodb_context
 class OneItemPageClient(ClientSpy):
     def query(self, **kwargs: Any) -> dict[str, Any]:
         kwargs.setdefault("Limit", 1)
         response = super().query(**kwargs)
         if kwargs.get("IndexName") == "gsi6":
             response["Items"] *= 2
+        if kwargs.get("IndexName") == "gsi2" and (hidden := getattr(self, "hidden_gsi2sk", None)):
+            response["Items"] = [item for item in response["Items"] if item["gsi2sk"] != hidden]
         return response
 @pytest.fixture
-def dynamodb_context() -> Any:
+def ctx() -> Any:
     with mock_aws():
         client = boto3.client("dynamodb", region_name="us-east-1")
         _create_table(client)
         clock = MutableClock(_NOW)
         yield client, clock, DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
-def test_deduplica_candidatos_e_rele_base_antes_do_claim(dynamodb_context: _DynamoContext) -> None:
-    client, clock, adapter = dynamodb_context
+def test_deduplica_candidatos_e_rele_base_antes_do_claim(ctx: _DynamoContext) -> None:
+    client, clock, adapter = ctx
     adapter.put_agent(_agent("agent-a"))
     adapter.create_job(_job("job-a"), _event("job-created"))
     base_key = entity_key(_TENANT, "JOB", "job-a")
@@ -109,17 +108,15 @@ def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) 
     sibling_a = _raw_record("delta-a", "agent-a", 2, clock.now() + timedelta(minutes=1))
     sibling_b = _raw_record("delta-b", "agent-a", 2, clock.now() + timedelta(minutes=2))
     head = _raw_record("head", "agent-a", 3, clock.now() + timedelta(minutes=3))
-    sibling_a = sibling_a.model_copy(
-        update={"base_snapshot_id": "base", "manifest_sha256": _HASH_B}
-    )
-    sibling_b = sibling_b.model_copy(
-        update={"base_snapshot_id": "base", "manifest_sha256": "c" * 64}
-    )
-    head = head.model_copy(
-        update={"base_snapshot_id": "base", "previous_manifest_sha256": "c" * 64}
-    )
+    def linked(record: Any, **updates: Any) -> Any:
+        return record.model_copy(update={"base_snapshot_id": "base", **updates})
+    sibling_a = linked(sibling_a, manifest_sha256=_HASH_B)
+    sibling_b = linked(sibling_b, manifest_sha256="c" * 64)
+    head = linked(head, previous_manifest_sha256="c" * 64)
     for record in (full, sibling_a, sibling_b, head):
         _store_record(adapter, record, clock)
+    adapter._client = stale = OneItemPageClient(adapter._client)
+    stale.hidden_gsi2sk = adapter._raw_item(head)["gsi2sk"]
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 3)
     assert tuple(ref.manifest_id for ref in chain) == (
         full.manifest_id, sibling_b.manifest_id, head.manifest_id,
@@ -130,15 +127,11 @@ def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(ctx: _DynamoContext)
     job = _job("job-a").model_copy(update={"state": JobState.FAILED_FINAL})
     adapter._put_direct(adapter._job_item(job))
     base_key = entity_key(_TENANT, "JOB", "job-a")
-    marker = encode_marker(
-        "STALE_JOB",
-        entity_key(_TENANT, "STALE_JOB", "job-a"),
-        base_key,
-        {
-            "gsi1pk": f"JOB_CLAIM#{key_component(_TENANT)}#{key_component('agent-a')}",
-            "gsi1sk": f"{_NOW.isoformat()}#PENDING#job-a",
-        },
-    )
+    attrs = {
+        "gsi1pk": f"JOB_CLAIM#{key_component(_TENANT)}#{key_component('agent-a')}",
+        "gsi1sk": f"{_NOW.isoformat()}#PENDING#job-a",
+    }
+    marker = encode_marker("STALE_JOB", entity_key(_TENANT, "STALE_JOB", "job-a"), base_key, attrs)
     client.put_item(TableName=_TABLE_NAME, Item=marker)
     assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
@@ -230,8 +223,8 @@ def test_claim_cas_perdedor_nao_desfaz_vencedor_persistido(ctx: _DynamoContext) 
     assert loser.claim_job(_claim_job("job-a", "worker-a", clock)) is None
     assert winners[0] is not None
     assert adapter.get_job(_TENANT, "job-a") == winners[0]
-def test_codec_nao_introduz_decimal_nos_itens(dynamodb_context: _DynamoContext) -> None:
-    client, clock, adapter = dynamodb_context
+def test_codec_nao_introduz_decimal_nos_itens(ctx: _DynamoContext) -> None:
+    client, clock, adapter = ctx
     adapter.create_job(_job("job-a"), _event("job-created"))
     tenant = Tenant(tenant_id=_TENANT, municipality_name="Epitácio", created_at=clock.now())
     adapter.put_tenant(tenant)
@@ -282,8 +275,8 @@ def test_transicao_e_unidades_rejeitam_run_ausente_ou_estado_obsoleto(ctx: _Dyna
         adapter.transition_run(transition, _event("stale-run"))
     with pytest.raises(Conflict, match="run_state_conflict"):
         _put_many_units(adapter, 1)
-def test_cancel_job_exige_lease_e_e_idempotente(dynamodb_context: _DynamoContext) -> None:
-    _, clock, adapter = dynamodb_context
+def test_cancel_job_exige_lease_e_e_idempotente(ctx: _DynamoContext) -> None:
+    _, clock, adapter = ctx
     command = CancelJob(tenant_id=_TENANT, job_id="job-a", requested_by="user-a")
     with pytest.raises(NotFound, match="job_missing"):
         adapter.cancel_job(command, _event("missing-cancel"))
@@ -432,13 +425,20 @@ def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(ctx: _DynamoCo
     )
     with pytest.raises(Conflict, match="manifest_identity_conflict"):
         adapter.complete_job(complete, _event("invalid-manifest"))
-def test_publicacao_rejeita_run_ausente_e_reproduz_ponteiro(ctx: _DynamoContext) -> None:
+@pytest.mark.parametrize("changes", [
+    {"dataset_name": "silver"},
+    {"run_manifest_key": f"reconciliation/{_TENANT}/2026-06/run-a/run-manifest.json"},
+])
+def test_publicacao_valida_run_e_replay(changes: dict[str, str], ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
     command = _publish("run-a", "published", None, False)
     with pytest.raises(NotFound, match="run_missing"):
         adapter.publish_dataset(command)
     adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    invalid = command.model_copy(update={"version": command.version.model_copy(update=changes)})
+    with pytest.raises(Conflict, match="publication_run_conflict"):
+        adapter.publish_dataset(invalid)
     named = command.model_copy(update={"pointer_name": "candidate"})
     pointer = adapter.publish_dataset(named)
     assert pointer.pointer_name == "candidate"

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -40,7 +40,6 @@ from packages.cnes_infra.tests.contracts.clock import (
     _job,
     _raw_record,
     _run,
-    _store_record,
     _unit,
 )
 from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
@@ -49,6 +48,7 @@ from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
     FailingTransactionClient,
     _create_table,
     _put_many_units,
+    _store_record_matching_mode,
 )
 
 _HASH_B = "b" * 64
@@ -114,7 +114,7 @@ def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) 
     sibling_b = linked(sibling_b, manifest_sha256="c" * 64)
     head = linked(head, previous_manifest_sha256="c" * 64)
     for record in (full, sibling_a, sibling_b, head):
-        _store_record(adapter, record, clock)
+        _store_record_matching_mode(adapter, record, clock)
     adapter._client = stale = OneItemPageClient(adapter._client)
     stale.hidden_gsi2sk = adapter._raw_item(head)["gsi2sk"]
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 3)
@@ -419,13 +419,13 @@ def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(ctx: _DynamoCo
     assert adapter.get_job(_TENANT, "job-a") == claimed
     assert adapter.get_outbox_event("failed-after-revoke") is None
     adapter.put_agent(_agent("agent-a"))
-    manifest = _raw_record("result", "agent-b", 1, clock.now())
-    complete = CompleteJob(
-        tenant_id=_TENANT, job_id="job-a", owner="worker-a",
-        fencing_token=claimed.fencing_token, manifest=manifest,
-    )
-    with pytest.raises(Conflict, match="manifest_identity_conflict"):
-        adapter.complete_job(complete, _event("invalid-manifest"))
+    manifests = (_raw_record("result", "agent-b", 1, clock.now()),
+                 _raw_record("result", "agent-a", 2, clock.now()))
+    for index, manifest in enumerate(manifests):
+        complete = CompleteJob(tenant_id=_TENANT, job_id="job-a", owner="worker-a",
+            fencing_token=claimed.fencing_token, manifest=manifest)
+        with pytest.raises(Conflict, match="manifest_identity_conflict"):
+            adapter.complete_job(complete, _event(f"invalid-manifest-{index}"))
 @pytest.mark.parametrize("changes", [
     {"dataset_name": "silver"},
     {"run_manifest_key": f"reconciliation/{_TENANT}/2026-06/run-a/run-manifest.json"}])

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -1,56 +1,26 @@
-from datetime import timedelta
+from datetime import timedelta  # noqa: I001
 from decimal import Decimal
 from typing import Any
-
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 from moto import mock_aws
-
 from cnes_domain.control_plane.commands import (
-    BeginIdempotency,
-    CancelJob,
-    CompleteJob,
-    FinalizeRunCancellation,
-    PutRunUnits,
-    RenewJobLease,
-    ReserveRunDispatch,
-    TransitionRun,
-)
+    BeginIdempotency, CancelJob, CompleteJob, FinalizeRunCancellation, PutRunUnits,
+    RenewJobLease, ReserveRunDispatch, TransitionRun)
 from cnes_domain.control_plane.entities import AccessRequest, Tenant
 from cnes_domain.control_plane.enums import AccessRequestState, AgentState, JobState, RunState
 from cnes_domain.control_plane.errors import Conflict, LeaseLost, NotFound
 from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
 from cnes_infra.control_plane.dynamodb_codec import encode_marker, execute_transaction
 from cnes_infra.control_plane.dynamodb_keys import (
-    entity_key,
-    key_component,
-    outbox_key,
-    run_entity_key,
-)
+    entity_key, key_component, outbox_key, run_entity_key)
 from packages.cnes_infra.tests.contracts.clock import (
-    _HASH_A,
-    _NOW,
-    _TENANT,
-    MutableClock,
-    _agent,
-    _claim_job,
-    _event,
-    _fail_job,
-    _job,
-    _raw_record,
-    _run,
-    _unit,
-)
+    _HASH_A, _NOW, _TENANT, MutableClock, _agent, _claim_job, _event, _fail_job,
+    _job, _raw_record, _run, _unit)
 from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
-    _TABLE_NAME,
-    ClientSpy,
-    FailingTransactionClient,
-    _create_table,
-    _put_many_units,
-    _store_record_matching_mode,
-)
-
+    _TABLE_NAME, ClientSpy, FailingTransactionClient, _create_table, _put_many_units,
+    _store_record_matching_mode)
 _HASH_B = "b" * 64
 type _DynamoContext = tuple[Any, MutableClock, DynamoDBControlPlane]
 class OneItemPageClient(ClientSpy):
@@ -89,18 +59,15 @@ def test_deduplica_candidatos_e_rele_base_antes_do_claim(ctx: _DynamoContext) ->
     assert tuple(job.job_id for job in jobs) == ("job-a",)
     consistent_reads = [call for call in spy.calls if call == "get_item"]
     assert len(consistent_reads) == 3
-    assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
-def test_query_limitada_para_apos_primeiro_candidato_valido(ctx: _DynamoContext) -> None:
-    _, _, adapter = ctx
-    adapter.put_agent(_agent("agent-a"))
-    for job_id in ("job-c", "job-b", "job-a"):
+    for job_id in ("job-c", "job-b"):
         adapter.create_job(_job(job_id), _event(f"created-{job_id}"))
     paginated = OneItemPageClient(adapter._client)
     adapter._client = paginated
-    jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 1)
-    assert tuple(job.job_id for job in jobs) == ("job-a",)
+    assert tuple(job.job_id for job in adapter.list_claimable_jobs(
+        _TENANT, "agent-a", 1)) == ("job-a",)
     assert (adapter.list_claimable_jobs(_TENANT, "agent-a", 0),
-            paginated.calls.count("query")) == ((), 1)
+            paginated.calls.count("query")) == ((), 4)
+    assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
 @pytest.mark.parametrize("base_minutes", [3, 4])
 def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
@@ -113,7 +80,15 @@ def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) 
     sibling_a = linked(sibling_a, manifest_sha256=_HASH_B)
     sibling_b = linked(sibling_b, manifest_sha256="c" * 64)
     head = linked(head, previous_manifest_sha256="c" * 64)
-    for record in (full, sibling_a, sibling_b, head):
+    for record in (sibling_b, full):
+        _store_record_matching_mode(adapter, record, clock)
+    repaired = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 2)
+    assert tuple(ref.manifest_id for ref in repaired) == (full.manifest_id, sibling_b.manifest_id)
+    assert len(adapter._raw_actions(full)) == 3
+    duplicate = full.model_copy(update={"manifest_id": "duplicate-full"})
+    with pytest.raises(Conflict, match="raw_ancestry_conflict"):
+        adapter._raw_actions(duplicate)
+    for record in (sibling_a, head):
         _store_record_matching_mode(adapter, record, clock)
     adapter._client = stale = OneItemPageClient(adapter._client)
     stale.hidden_gsi2sk = adapter._raw_item(head)["gsi2sk"]
@@ -125,7 +100,7 @@ def test_cadeia_raw_prefere_descendente(base_minutes: int, ctx: _DynamoContext) 
     assert len(gets) == 1
     assert gets[0].get("ConsistentRead") is True
     assert adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 0) == ()
-def test_latest_succeeded_ignora_omissao_do_gsi(ctx: _DynamoContext) -> None:
+def test_latest_succeeded_ignora_omissao_do_gsi_e_historico(ctx: _DynamoContext) -> None:
     _, clock, adapter = ctx
     adapter._client = spy = ClientSpy(adapter._client)
     old = _raw_record("old", "agent-a", 1, clock.now())
@@ -143,15 +118,33 @@ def test_latest_succeeded_ignora_omissao_do_gsi(ctx: _DynamoContext) -> None:
     stale.hidden_gsi2sk = adapter._job_item(completed)["gsi2sk"]
     result = adapter.latest_succeeded_job(_TENANT, "agent-a", "CNES", "ST", "2026-07")
     assert (result, stale.query_requests) == (completed, [])
-def test_cadeia_raw_retorna_full_mais_novo_apos_historico_longo(ctx: _DynamoContext) -> None:
-    _, clock, adapter = ctx
+    adapter._client = spy.client
     records = tuple(_raw_record(f"full-{index}", f"agent-{index}", 1,
         clock.now() + timedelta(seconds=index)) for index in range(11))
     for record in records:
         _store_record_matching_mode(adapter, record, clock)
     chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 1)
     assert tuple(ref.manifest_id for ref in chain) == (records[-1].manifest_id,)
-def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(ctx: _DynamoContext) -> None:
+def test_reparo_raw_rejeita_ancestry_ausente_e_excesso(ctx: _DynamoContext) -> None:
+    client, clock, adapter = ctx
+    _store_record_matching_mode(
+        adapter, _raw_record("delta-pending", "agent-a", 2, clock.now()), clock)
+    waiting = next(item for item in client.scan(TableName=_TABLE_NAME)["Items"]
+                   if item.get("entity", {}).get("S") == "RAWWAITING")
+    ancestry_key = {"pk": waiting["base_pk"], "sk": waiting["base_sk"]}
+    client.delete_item(TableName=_TABLE_NAME, Key=ancestry_key)
+    base = _raw_record("base-agent-a", "agent-a", 1, clock.now())
+    with pytest.raises(Conflict, match="raw_ancestry_conflict"):
+        adapter._raw_actions(base)
+    client.put_item(TableName=_TABLE_NAME, Item={**waiting,
+        "pk": waiting["base_pk"], "sk": waiting["base_sk"],
+        "entity": {"S": "RAWANCESTRY"}})
+    for index in range(95):
+        clone = {**waiting, "sk": {"S": f"{waiting['sk']['S']}#{index:03d}"}}
+        client.put_item(TableName=_TABLE_NAME, Item=clone)
+    with pytest.raises(Conflict, match="transaction_limit"):
+        adapter._raw_actions(base)
+def test_candidato_gsi_obsoleto_nao_reivindica_job_ou_run_terminal(ctx: _DynamoContext) -> None:
     client, clock, adapter = ctx
     adapter.put_agent(_agent("agent-a"))
     job = _job("job-a").model_copy(update={"state": JobState.FAILED_FINAL})
@@ -163,10 +156,7 @@ def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(ctx: _DynamoContext)
     client.put_item(TableName=_TABLE_NAME, Item=marker)
     assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
-def test_candidato_gsi_obsoleto_nao_recupera_run_terminal(ctx: _DynamoContext) -> None:
-    client, clock, adapter = ctx
-    run = _run("run-a", RunState.PUBLISHED)
-    adapter.put_run(run)
+    adapter.put_run(_run("run-a", RunState.PUBLISHED))
     marker = encode_marker("STALE_RUN", entity_key(_TENANT, "STALE_RUN", "run-a"),
         run_entity_key(_TENANT, "run-a"), {"gsi4pk": "RUN_RECOVERABLE",
         "gsi4sk": f"{_NOW.isoformat()}#{_TENANT}#run-a"})
@@ -196,8 +186,8 @@ def test_expiracao_logica_substitui_item_ttl_ainda_presente(ctx: _DynamoContext)
 def test_colisao_global_de_evento_rejeita_segundo_tenant_sem_mutacao(ctx: _DynamoContext) -> None:
     _, _, adapter = ctx
     adapter.create_job(_job("job-a"), _event("shared-event"))
-    other_job = _job("job-b", tenant_id="other")
-    other_event = _event("shared-event", tenant_id="other")
+    other_job, other_event = _job("job-b", tenant_id="other"), _event(
+        "shared-event", tenant_id="other")
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.create_job(other_job, other_event)
     assert adapter.get_job("other", "job-b") is None
@@ -258,10 +248,27 @@ def test_create_job_retorna_replay_e_rejeita_divergencia(ctx: _DynamoContext) ->
     with pytest.raises(Conflict, match="event_delivery_conflict"):
         adapter.create_job(_job("delivered"), delivered)
     assert "transact_write_items" not in spy.calls
-    job = _job("job-a")
-    event = _event("job-created")
-    adapter.create_job(job, event)
+    job, event = _job("job-a"), _event("job-created")
+    transact = adapter._transact
+    def commit_then_lose_response(actions: Any) -> None:
+        transact(actions)
+        raise Conflict("transaction_conflict")
+    adapter._transact = commit_then_lose_response
     assert adapter.create_job(job, event) == job
+    adapter._transact = transact
+    assert adapter.create_job(job, event) == job
+    adapter._client = FailingTransactionClient(spy.client)
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.create_job(_job("no-winner"), _event("no-winner-created"))
+    adapter._client = spy
+    candidate = _job("divergent-winner")
+    def divergent_wins(actions: Any) -> None:
+        adapter._put_direct(adapter._job_item(candidate.model_copy(update={"agent_id": "agent-b"})))
+        raise Conflict("transaction_conflict")
+    adapter._transact = divergent_wins
+    with pytest.raises(Conflict, match="job_conflict"):
+        adapter.create_job(candidate, _event("divergent-winner-created"))
+    adapter._transact = transact
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.create_job(job, _foreign_event(adapter))
     divergent = event.model_copy(update={"payload": {"event_id": "divergent"}})
@@ -307,8 +314,6 @@ def test_cancel_job_exige_lease_e_e_idempotente(ctx: _DynamoContext) -> None:
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.cancel_job(command, _foreign_event(adapter))
     assert adapter.get_job(_TENANT, "job-a") == canceled
-def test_finalizacao_ausente_e_replay_cancelado_sao_deterministas(ctx: _DynamoContext) -> None:
-    _, clock, adapter = ctx
     command = FinalizeRunCancellation(tenant_id=_TENANT, run_id="run-a",
         expected_state=RunState.CANCEL_REQUESTED, canceled_at=clock.now())
     with pytest.raises(NotFound, match="run_missing"):
@@ -487,8 +492,6 @@ def test_idempotencia_recupera_resultado_de_corrida_confirmada(ctx: _DynamoConte
     outcome = adapter.begin_idempotency(command)
     assert not outcome.created
     assert outcome.record.resource_id == "resource-a"
-def test_idempotencia_propaga_conflito_sem_vencedor_visivel(ctx: _DynamoContext) -> None:
-    _, clock, adapter = ctx
     adapter._client = FailingTransactionClient(adapter._client)
     command = BeginIdempotency(tenant_id=_TENANT, scope="jobs", key="lost-race",
         request_hash=_HASH_A, resource_id="resource-a", now=clock.now(),

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py
@@ -1,7 +1,5 @@
-from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 from decimal import Decimal
-from threading import Barrier
 from typing import Any
 
 import boto3
@@ -34,6 +32,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _job,
     _raw_record,
     _run,
+    _store_record,
 )
 from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
     _TABLE_NAME,
@@ -82,9 +81,7 @@ def test_deduplica_candidatos_e_rele_base_antes_do_claim(
         client.put_item(TableName=_TABLE_NAME, Item=marker)
     spy = ClientSpy(client)
     adapter._client = spy
-
     jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 10)
-
     assert tuple(job.job_id for job in jobs) == ("job-a",)
     consistent_reads = [call for call in spy.calls if call == "get_item"]
     assert len(consistent_reads) == 2
@@ -100,11 +97,34 @@ def test_query_percorre_todas_as_paginas_antes_de_ordenar_e_limitar(
         adapter.create_job(_job(job_id), _event(f"created-{job_id}"))
     paginated = OneItemPageClient(adapter._client)
     adapter._client = paginated
-
     jobs = adapter.list_claimable_jobs(_TENANT, "agent-a", 2)
-
     assert tuple(job.job_id for job in jobs) == ("job-a", "job-b")
     assert paginated.calls.count("query") == 2
+
+
+def test_cadeia_raw_segue_ancestralidade_sem_mesclar_deltas_irmaos(
+    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
+) -> None:
+    _, clock, adapter = dynamodb_context
+    full = _raw_record("base", "agent-a", 1, clock.now())
+    sibling_a = _raw_record("delta-a", "agent-a", 2, clock.now() + timedelta(minutes=1))
+    sibling_b = _raw_record("delta-b", "agent-a", 2, clock.now() + timedelta(minutes=2))
+    head = _raw_record("head", "agent-a", 3, clock.now() + timedelta(minutes=3))
+    sibling_a = sibling_a.model_copy(
+        update={"base_snapshot_id": "base", "manifest_sha256": _HASH_B}
+    )
+    sibling_b = sibling_b.model_copy(
+        update={"base_snapshot_id": "base", "manifest_sha256": "c" * 64}
+    )
+    head = head.model_copy(
+        update={"base_snapshot_id": "base", "previous_manifest_sha256": "c" * 64}
+    )
+    for record in (full, sibling_a, sibling_b, head):
+        _store_record(adapter, record, clock)
+    chain = adapter.list_raw_manifest_chain(_TENANT, "CNES", "ST", "2026-07", 3)
+    assert tuple(ref.manifest_id for ref in chain) == (
+        full.manifest_id, sibling_b.manifest_id, head.manifest_id,
+    )
 
 
 def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(
@@ -125,7 +145,6 @@ def test_candidato_gsi_obsoleto_nao_reivindica_job_terminal(
         },
     )
     client.put_item(TableName=_TABLE_NAME, Item=marker)
-
     assert adapter.list_claimable_jobs(_TENANT, "agent-a", 10) == ()
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is None
 
@@ -146,7 +165,6 @@ def test_candidato_gsi_obsoleto_nao_recupera_run_terminal(
         },
     )
     client.put_item(TableName=_TABLE_NAME, Item=marker)
-
     assert adapter.list_recoverable_runs(clock.now(), 10) == ()
 
 
@@ -175,9 +193,7 @@ def test_expiracao_logica_substitui_item_ttl_ainda_presente(
             "expires_at": clock.now() + timedelta(minutes=5),
         }
     )
-
     outcome = adapter.begin_idempotency(replacement)
-
     assert outcome.created
     assert outcome.record.resource_id == "resource-b"
 
@@ -189,63 +205,50 @@ def test_colisao_global_de_evento_rejeita_segundo_tenant_sem_mutacao(
     adapter.create_job(_job("job-a"), _event("shared-event"))
     other_job = _job("job-b", tenant_id="other")
     other_event = _event("shared-event", tenant_id="other")
-
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.create_job(other_job, other_event)
-
     assert adapter.get_job("other", "job-b") is None
     assert adapter.get_outbox_event("shared-event").tenant_id == _TENANT
+    with pytest.raises(Conflict, match="event_tenant_conflict"):
+        adapter.create_job(_job("job-c"), _event("fresh-other", tenant_id="other"))
+    assert adapter.get_job(_TENANT, "job-c") is None
+    assert adapter.get_outbox_event("fresh-other") is None
 
 
-def test_claim_concorrente_produz_um_unico_vencedor(
+def test_claim_cas_perdedor_nao_desfaz_vencedor_persistido(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
     client, clock, adapter = dynamodb_context
     adapter.put_agent(_agent("agent-a"))
     adapter.create_job(_job("job-a"), _event("job-created"))
-    barrier = Barrier(2)
+    loser = DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
+    transact = loser._transact
+    winners = []
+    def win_before_stale_cas(actions: Any) -> None:
+        winners.append(adapter.claim_job(_claim_job("job-a", "worker-b", clock)))
+        transact(actions)
 
-    def claim(owner: str) -> Any:
-        contender = DynamoDBControlPlane(client, _TABLE_NAME, clock.now)
-        command = _claim_job("job-a", owner, clock)
-        barrier.wait()
-        return contender.claim_job(command)
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        outcomes = tuple(executor.map(claim, ("worker-a", "worker-b")))
-
-    winners = tuple(outcome for outcome in outcomes if outcome is not None)
-    assert len(winners) == 1
-    assert winners[0].fencing_token == 1
+    loser._transact = win_before_stale_cas
+    assert loser.claim_job(_claim_job("job-a", "worker-a", clock)) is None
+    assert winners[0] is not None
     assert adapter.get_job(_TENANT, "job-a") == winners[0]
 
 
 def test_codec_nao_introduz_decimal_nos_itens(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
-    client, _, adapter = dynamodb_context
+    client, clock, adapter = dynamodb_context
     adapter.create_job(_job("job-a"), _event("job-created"))
-
+    tenant = Tenant(tenant_id=_TENANT, municipality_name="Epitácio", created_at=clock.now())
+    adapter.put_tenant(tenant)
+    assert adapter.get_tenant(_TENANT) == tenant
     def contains_decimal(value: Any) -> bool:
         if isinstance(value, dict):
             return any(contains_decimal(item) for item in value.values())
         if isinstance(value, list):
             return any(contains_decimal(item) for item in value)
         return isinstance(value, Decimal)
-
     assert not contains_decimal(client.scan(TableName=_TABLE_NAME)["Items"])
-
-
-def test_persiste_tenant_com_isolamento(
-    dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
-) -> None:
-    _, clock, adapter = dynamodb_context
-    tenant = Tenant(tenant_id=_TENANT, municipality_name="Epitácio", created_at=clock.now())
-
-    adapter.put_tenant(tenant)
-
-    assert adapter.get_tenant(_TENANT) == tenant
-    assert adapter.get_tenant("other") is None
 
 
 def test_create_job_retorna_replay_e_rejeita_divergencia(
@@ -255,7 +258,6 @@ def test_create_job_retorna_replay_e_rejeita_divergencia(
     job = _job("job-a")
     event = _event("job-created")
     adapter.create_job(job, event)
-
     assert adapter.create_job(job, event) == job
     with pytest.raises(Conflict, match="event_id_conflict"):
         adapter.create_job(job, _foreign_event(adapter))
@@ -301,9 +303,7 @@ def test_cancel_job_exige_lease_e_e_idempotente(
         adapter.cancel_job(command, _event("pending-cancel"))
     assert adapter.claim_job(_claim_job("job-a", "worker-a", clock)) is not None
     event = _event("job-cancel-requested")
-
     canceled = adapter.cancel_job(command, event)
-
     assert canceled.state is JobState.CANCEL_REQUESTED
     assert adapter.cancel_job(command, event) == canceled
     with pytest.raises(Conflict, match="event_id_conflict"):
@@ -370,7 +370,6 @@ def test_access_request_tem_criacao_decisao_e_replays_atomicos(
             pending.model_copy(update={"user_id": "user-b"}), _event("divergent-access")
         )
     approved = _access_request(AccessRequestState.APPROVED)
-
     assert adapter.decide_access_request(approved, _event("access-approved")) == approved
     assert adapter.decide_access_request(approved, _event("access-approved")) == approved
     with pytest.raises(Conflict, match="event_id_conflict"):
@@ -388,9 +387,7 @@ def test_outbox_entrega_remove_pendencia_e_rejeita_redecisao(
     _, clock, adapter = dynamodb_context
     adapter.create_job(_job("job-a"), _event("job-created"))
     delivered_at = clock.now() + timedelta(seconds=1)
-
     adapter.mark_outbox_delivered("job-created", delivered_at)
-
     assert adapter.pending_outbox(10) == ()
     adapter.mark_outbox_delivered("job-created", delivered_at)
     with pytest.raises(Conflict, match="outbox_delivery_conflict"):
@@ -431,14 +428,19 @@ def test_claims_rejeitam_ausencia_e_manifesto_de_outra_identidade(
         adapter.complete_job(complete, _event("invalid-manifest"))
 
 
-def test_publicacao_rejeita_run_ausente(
+def test_publicacao_rejeita_run_ausente_e_reproduz_ponteiro_nomeado(
     dynamodb_context: tuple[Any, MutableClock, DynamoDBControlPlane],
 ) -> None:
     _, _, adapter = dynamodb_context
     from packages.cnes_infra.tests.contracts.control_plane_contract import _publish
-
+    command = _publish("run-a", "published", None, False)
     with pytest.raises(NotFound, match="run_missing"):
-        adapter.publish_dataset(_publish("run-a", "published", None, False))
+        adapter.publish_dataset(command)
+    adapter.put_run(_run("run-a", RunState.PUBLISHING))
+    named = command.model_copy(update={"pointer_name": "candidate"})
+    pointer = adapter.publish_dataset(named)
+    assert pointer.pointer_name == "candidate"
+    assert adapter.publish_dataset(named) == pointer
 
 
 def test_codec_propaga_erro_dynamodb_nao_condicional() -> None:
@@ -449,7 +451,6 @@ def test_codec_propaga_erro_dynamodb_nao_condicional() -> None:
                 {"Error": {"Code": "ValidationException", "Message": "invalid"}},
                 "TransactWriteItems",
             )
-
     with pytest.raises(ClientError):
         execute_transaction(InvalidClient(), ())
 
@@ -468,7 +469,6 @@ def test_idempotencia_recupera_resultado_de_corrida_confirmada(
         expires_at=clock.now() + timedelta(minutes=5),
     )
     transact = adapter._transact
-
     def wins_then_reports_conflict(actions: Any) -> None:
         transact(actions)
         raise Conflict("transaction_conflict")

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_transaction_limits.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_transaction_limits.py
@@ -1,0 +1,231 @@
+from collections.abc import Iterator
+from datetime import timedelta
+from typing import Any
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from cnes_domain.control_plane.commands import FinalizeRunCancellation, ReserveRunDispatch
+from cnes_domain.control_plane.enums import RunState, RunUnitState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
+from cnes_infra.control_plane.dynamodb_codec import execute_transaction
+from cnes_infra.control_plane.dynamodb_keys import (
+    dependency_marker_key,
+    item_key,
+    key_component,
+    outbox_key,
+    run_entity_key,
+)
+from packages.cnes_infra.tests.contracts.clock import _NOW, _TENANT, MutableClock, _event, _run
+from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import (
+    _TABLE_NAME,
+    ClientSpy,
+    _create_table,
+    _dependency_run,
+    _DynamoContext,
+    _expected_item,
+    _expected_put,
+    _expected_unit_action,
+    _hide_unit_from_gsi,
+    _lose_transaction_response,
+    _many_units,
+    _put_many_units,
+    _raise_transaction_canceled,
+    _store_waiting,
+    _transaction_action,
+)
+
+
+@pytest.fixture
+def ctx() -> Iterator[_DynamoContext]:
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-east-1")
+        _create_table(client)
+        clock = MutableClock(_NOW)
+        yield DynamoDBControlPlane(client, _TABLE_NAME, clock.now), clock
+
+
+def test_grava_99_unidades_em_ate_100_acoes_unicas(ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
+    adapter.put_run(_run("run-a"))
+    adapter._client = spy = ClientSpy(adapter._client)
+    _put_many_units(adapter, 99)
+    assert _put_many_units(adapter, 99) == _many_units(99)
+    actions = spy.transactions[-1]
+    run = _run("run-a")
+    expected_check = {
+        "ConditionCheck": {
+            "TableName": _TABLE_NAME,
+            "Key": item_key(*run_entity_key(_TENANT, "run-a")),
+            "ConditionExpression": "payload = :expected",
+            "ExpressionAttributeValues": {":expected": {"S": run.model_dump_json()}},
+        }
+    }
+    assert actions == [
+        expected_check,
+        *(_expected_unit_action(index, RunUnitState.PENDING) for index in range(99)),
+    ]
+    with pytest.raises(Conflict, match="run_units_conflict"):
+        _put_many_units(adapter, 98)
+    assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
+
+
+def test_rejeita_100_unidades_antes_de_chamar_boto3(ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
+    adapter._client = spy = ClientSpy(adapter._client)
+    with pytest.raises(Conflict, match="transaction_limit"):
+        _put_many_units(adapter, 100)
+    assert spy.calls == []
+
+
+def test_rejeita_uniao_de_99_unidades_antes_de_transacao(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
+    adapter.put_run(_run("run-a"))
+    units = _put_many_units(adapter, 99)
+    first = ReserveRunDispatch(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        wave_id="a" * 16,
+        unit_ids=tuple(unit.unit_id for unit in units[:98]),
+        now=clock.now(),
+        lease_seconds=30,
+    )
+    adapter.reserve_run_dispatch(first)
+    clock.advance(timedelta(seconds=31))
+    adapter._client = spy = ClientSpy(adapter._client)
+    replacement = first.model_copy(
+        update={"wave_id": "b" * 16, "unit_ids": ("unit-098",), "now": clock.now()}
+    )
+    with pytest.raises(Conflict, match="transaction_limit"):
+        adapter.reserve_run_dispatch(replacement)
+    assert spy.transactions == []
+
+
+def _prepare_cancellation(adapter: DynamoDBControlPlane, amount: int) -> None:
+    adapter.put_run(_run("run-a"))
+    _put_many_units(adapter, amount)
+    adapter.put_run(_run("run-a", RunState.CANCEL_REQUESTED))
+
+
+def _finalize(adapter: DynamoDBControlPlane, clock: MutableClock) -> Any:
+    command = FinalizeRunCancellation(
+        tenant_id=_TENANT,
+        run_id="run-a",
+        expected_state=RunState.CANCEL_REQUESTED,
+        canceled_at=clock.now(),
+    )
+    return adapter.finalize_run_cancellation(command, _event("run-canceled"))
+
+
+def test_cancela_98_unidades_em_100_acoes_unicas(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
+    _prepare_cancellation(adapter, 98)
+    _hide_unit_from_gsi(adapter, "unit-097")
+    adapter._client = spy = ClientSpy(adapter._client)
+    assert _finalize(adapter, clock).state is RunState.CANCELED
+    actions = spy.transactions[-1]
+    canceled = _run("run-a", RunState.CANCELED)
+    run_item = _expected_item(canceled, "RUN", run_entity_key(_TENANT, "run-a"), {})
+    original_payload = _run("run-a", RunState.CANCEL_REQUESTED).model_dump_json()
+    event = _event("run-canceled")
+    indexes = {
+        "gsi6pk": "OUTBOX#PENDING",
+        "gsi6sk": f"{_NOW.isoformat(timespec='microseconds')}#{key_component('run-canceled')}",
+    }
+    event_item = _expected_item(event, "OUTBOXEVENT", outbox_key("run-canceled"), indexes)
+    assert actions == [
+        _expected_put(run_item, original_payload),
+        *(_expected_unit_action(index, RunUnitState.CANCELED) for index in range(98)),
+        _expected_put(event_item, None),
+    ]
+
+
+def test_rejeita_cancelamento_de_99_unidades_sem_transacao(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
+    _prepare_cancellation(adapter, 99)
+    _hide_unit_from_gsi(adapter, "unit-098")
+    adapter._client = spy = ClientSpy(adapter._client)
+    with pytest.raises(Conflict, match="transaction_limit"):
+        _finalize(adapter, clock)
+    assert spy.transactions == []
+    assert adapter.get_run(_TENANT, "run-a").state is RunState.CANCEL_REQUESTED
+    spy.calls.clear()
+    spy.query_limit = 1
+    assert adapter.list_run_units(_TENANT, "run-a") == _many_units(99)
+    assert spy.calls.count("query") == 99
+    assert adapter.get_outbox_event("run-canceled") is None
+
+
+@pytest.mark.parametrize(
+    ("state", "count"), [(RunState.WAITING_INPUTS, 99), (RunState.PLANNED, 98)]
+)
+def test_waiting_limita_acoes_e_chaves(state: RunState, count: int, ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
+    run = _dependency_run(count, state, "run-limit")
+    if state is RunState.PLANNED:
+        adapter.put_run(run)
+    adapter._client = spy = ClientSpy(adapter._client)
+    overflow = _dependency_run(count + 1, state, "run-overflow")
+    if state is RunState.PLANNED:
+        adapter.put_run(overflow)
+    mutations = (len(spy.transactions), spy.calls.count("put_item"))
+    with pytest.raises(Conflict, match="transaction_limit"):
+        _store_waiting(adapter, overflow, "waiting-overflow")
+    assert (len(spy.transactions), spy.calls.count("put_item")) == mutations
+    _store_waiting(adapter, run, "waiting-limit")
+    actions = spy.transactions[-1]
+    keys = {
+        (action["Put"]["Item"]["pk"]["S"], action["Put"]["Item"]["sk"]["S"]) for action in actions
+    }
+    assert len(actions) == len(keys) == 100
+    action = _transaction_action("same")
+    with pytest.raises(Conflict, match="duplicate_transaction_key"):
+        execute_transaction(spy, (action, action))
+
+
+@pytest.mark.parametrize("state", [RunState.WAITING_INPUTS, RunState.PLANNED])
+def test_waiting_reverte_run_quando_marcador_falha(state: RunState, ctx: _DynamoContext) -> None:
+    adapter, _ = ctx
+    run = _dependency_run(1, state, "run-a")
+    if state is RunState.PLANNED:
+        adapter.put_run(run)
+    identity = "RUN_DEP#" + "#".join(map(key_component, (_TENANT, "SOURCE-0", "ST", "2026-07")))
+    marker_key = dependency_marker_key(_TENANT, "run-a", identity)
+    adapter._client.put_item(TableName=_TABLE_NAME, Item=item_key(*marker_key))
+    error = "transaction_conflict" if state is RunState.PLANNED else "run_dependency_conflict"
+    with pytest.raises(Conflict, match=error):
+        _store_waiting(adapter, run, "waiting-rollback")
+    expected = run if state is RunState.PLANNED else None
+    assert adapter.get_run(_TENANT, "run-a") == expected
+    assert adapter.get_outbox_event("waiting-rollback") is None
+
+
+def test_put_waiting_recupera_resposta_perdida_e_rejeita_divergencias(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, _ = ctx
+    run = _dependency_run(2, RunState.WAITING_INPUTS, "run-replay")
+    adapter._client = ClientSpy(adapter._client, after_transaction=_lose_transaction_response)
+    adapter.put_run(run)
+    adapter._client = spy = ClientSpy(adapter._client.client)
+    adapter.put_run(run)
+    assert any(request.get("ConsistentRead") is True for request in spy.query_requests)
+    before = spy.scan(TableName=_TABLE_NAME)["Items"]
+    divergent = run.model_copy(update={"created_at": _NOW + timedelta(seconds=1)})
+    with pytest.raises(Conflict, match="run_conflict"):
+        adapter.put_run(divergent)
+    assert spy.scan(TableName=_TABLE_NAME)["Items"] == before
+    marker = next(item for item in before if item.get("entity", {}).get("S") == "RUN_DEP")
+    marker["gsi3sk"] = {"S": "divergent"}
+    spy.put_item(TableName=_TABLE_NAME, Item=marker)
+    changed = spy.scan(TableName=_TABLE_NAME)["Items"]
+    with pytest.raises(Conflict, match="run_dependency_conflict"):
+        adapter.put_run(run)
+    assert spy.scan(TableName=_TABLE_NAME)["Items"] == changed
+    fresh = _dependency_run(1, RunState.WAITING_INPUTS, "run-loser")
+    adapter._client = ClientSpy(spy.client, before_transaction=_raise_transaction_canceled)
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.put_run(fresh)
+    assert adapter.get_run(_TENANT, "run-loser") is None


### PR DESCRIPTION
## Objetivo

Implementar `DynamoDBControlPlane` completo, com single-table tenant-prefixed, seis GSIs,
releituras fortes, transações condicionais e limites físicos explícitos.

## Allowlist alterada

- `packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_keys.py`
- `packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py`
- `packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py`
- `packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py`
- `packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_publication.py`
- `packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py`
- `packages/cnes_infra/tests/control_plane/test_dynamodb_stale_gsi.py`

## Decisões e riscos

- GSIs são apenas descoberta eventual; candidatos são paginados, deduplicados e relidos na
  base com consistência forte antes de decisões.
- Cancelamento descobre todas as unidades por query forte na partição-base, preservando
  fronteira 98/99 e zero chamadas transacionais no overflow.
- Todas as transações passam por builder que rejeita mais de 100 ações e chaves repetidas.
- `event_id` é global; replay exige tenant e evento canônico idênticos.
- TTL é cleanup-only e nunca verdade síncrona.
- Eventos novos precisam pertencer ao tenant do agregado; recuperação de dispatch relê todo
  o conjunto anterior e admite `RESERVED`/`STARTED` expirados somente sem leases vivos.
- Ancestralidade de manifests segue hashes, replay de unidades compara o grafo completo por
  leitura forte e replay de publicação respeita o alias solicitado.
- Substituição de dispatch condiciona também os payloads de todas as unidades da geração
  anterior, deduplicados contra a nova onda, fechando a janela TOCTOU.
- Renovação condiciona agente ativo; decisões preservam a identidade do pedido; replay de
  unidades canonicaliza ordem; outbox limita descoberta útil; throttling Dynamo permanece
  retryable em vez de virar conflito de domínio.
- Candidatos outbox só contam após seus atributos GSI atuais coincidirem com a releitura
  forte, impedindo marcadores stale de alterar a ordem limitada.
- Bind condiciona o run PROCESSING, fail condiciona agente ativo, listagem de unidades lê a
  partição-base forte e replay aceita diferença apenas em `delivered_at` persistido.
- Componentes de chave usam encoding hexadecimal UTF-8 em base e GSIs; discovery bounded
  pagina e revalida incrementalmente até preencher o limite, com ordem canônica de recovery.
- Context7 estava sem quota; a verificação usou o service model lockado do botocore 1.43.82.

## Evidência RED/GREEN

- RED inicial: módulo DynamoDB ausente.
- REDs regressivos: GSI omitindo unidade no cancelamento, paginação truncada, colisões globais
  em fast paths e rollback transacional inconclusivo.
- GREEN final do controller: `55 passed`; 100% branch nos novos módulos; Ruff focado/global.
- Re-revisão confirmou paginação, ConsistentRead base, ações exatas e rollback Moto real.
- O race não determinístico do Moto foi substituído por interleaving CAS determinístico;
  `891 passed, 6 skipped` no gate de packages com 100% e `1022 passed, 10 skipped` na rápida.
- Gate rápido final: `1028 passed, 10 skipped`; colisão cross-tenant, paginação bounded e
  desempate de recoverable foram comprovados RED antes da correção.
- `pending_outbox` envia `Limit` pelo saldo em cada página e continua somente quando candidatos
  stale não preenchem o batch; o request shape foi comprovado RED/GREEN.
- Cadeias preferem endpoints descendentes mesmo com timestamps não monotônicos; eventos fresh
  com `delivered_at` são rejeitados antes de qualquer transação. Gate rápido: `1029 passed`.
- Publicação vincula dataset e manifest key ao Run carregado; raw chains usam partição base
  forte; Run WAITING_INPUTS e markers são uma transação de até 100 ações. Fast: `1031 passed`.
- A transição PLANNED→WAITING_INPUTS grava Run, markers e evento atomicamente; 98 dependências
  ocupam 100 ações e 99 são rejeitadas antes de qualquer mutação. Fast final: `1032 passed`.
- Replacement relê e condiciona unidades mesmo após dispatch TERMINAL; completion exige que
  snapshot mode solicitado e produzido coincidam, com shared case adaptado no teste local.
- Latest succeeded usa marcador-base forte atualizado por CAS na completion; raw manifests têm
  partição-base por identidade e budget fechado de `10 * limit`, sem depender de GSI eventual.
- `put_run(WAITING_INPUTS)` relê Run e markers fortemente; replay exato retorna, divergência ou
  marker órfão conflita, e corrida aceita apenas vencedor canonicamente idêntico.
- Completion materializa HEAD raw por identidade, protegido por CAS, e ancestry imutável; chain
  lookup é um GetItem forte do HEAD e não desaparece com histórico maior que o budget.
- Predecessor RAW tardio repara descendentes candidatos por markers tenant-prefixed com orçamento
  transacional fechado; corrida de `create_job` relê fortemente e aceita somente o vencedor
  canônico exato após conflito condicional.
- Um CAS de versão RAW tenant-prefixed acompanha a descoberta e o commit: qualquer predecessor
  concorrente invalida ações stale, impedindo DELTA de permanecer em `RAWWAITING` sem novo gatilho.
- Perda desse CAS reconstrói uma vez toda a completion a partir de releituras fortes; nova perda
  é propagada, sem loop, e job/outbox só persistem na transação vencedora.
- Falha opcional de unidade e criação concorrente de access request aplicam o mesmo retry/reload
  forte e limitado, aceitando somente vencedor canônico exato.

## SHA testado

`116ed012565ebae6eed91182c1da36d6f785371d`

Refs #123
