### PR TITLE
fix(control-plane): harden dynamodb lease replays

### DIFF
--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -107,8 +107,10 @@ class DynamoDBControlPlane(DynamoDBClaims, DynamoDBPublication):
             "ExpressionAttributeValues": {":partition": {"S": partition}},
         }
         return bounded_candidates(self._client, request, query)
-    def _transact(self, actions: tuple[Action, ...]) -> None:
-        execute_transaction(self._client, actions)
+    def _transact(
+        self, actions: tuple[Action, ...], client_request_token: str | None = None
+    ) -> None:
+        execute_transaction(self._client, actions, client_request_token)
     def _put_direct(self, item: Item) -> None:
         self._client.put_item(TableName=self._table_name, Item=item)
     def _job_item(self, job: Job) -> Item:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
-from botocore.exceptions import ConnectionClosedError, ReadTimeoutError
+from botocore.exceptions import ClientError, ConnectionClosedError, ReadTimeoutError
 
 from cnes_domain.control_plane.entities import Agent, Job, Run, RunDispatch, RunUnit
 from cnes_domain.control_plane.enums import (
@@ -278,10 +278,18 @@ class DynamoDBClaims:
         token = self._commit_client_request_token(command, event)
         try:
             self._transact(actions, token)
-        except (ConnectionClosedError, ReadTimeoutError):
+        except (ConnectionClosedError, ReadTimeoutError, ClientError) as error:
+            if isinstance(error, ClientError) and not self._is_server_error(error):
+                raise
             try:
                 self._transact(actions, token)
-            except (Conflict, ConnectionClosedError, ReadTimeoutError):
+            except (ConnectionClosedError, ReadTimeoutError, ClientError) as retry_error:
+                if isinstance(retry_error, ClientError) and not self._is_server_error(retry_error):
+                    raise
+                if self._commit_run_unit_replay(command, event, updated):
+                    return updated
+                raise
+            except Conflict:
                 if self._commit_run_unit_replay(command, event, updated):
                     return updated
                 raise
@@ -295,6 +303,11 @@ class DynamoDBClaims:
     def _commit_client_request_token(command: CommitRunUnit, event: Any) -> str:
         values = (command.tenant_id, command.run_id, command.unit_id, event.event_id)
         return sha256("\x1f".join(values).encode()).hexdigest()[:36]
+
+    @staticmethod
+    def _is_server_error(error: ClientError) -> bool:
+        status = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        return isinstance(status, int) and 500 <= status < 600
 
     def _commit_run_unit_replay(
         self, command: CommitRunUnit, event: Any, updated: RunUnit

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -6,6 +6,8 @@ from datetime import timedelta
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
+from botocore.exceptions import ConnectionClosedError, ReadTimeoutError
+
 from cnes_domain.control_plane.entities import Agent, Job, Run, RunDispatch, RunUnit
 from cnes_domain.control_plane.enums import (
     AgentState,
@@ -275,7 +277,7 @@ class DynamoDBClaims:
         )
         try:
             self._transact(actions)
-        except Conflict:
+        except (Conflict, ConnectionClosedError, ReadTimeoutError):
             if self._commit_run_unit_replay(command, event, updated):
                 return updated
             raise

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -299,9 +299,14 @@ class DynamoDBClaims:
             raise
         return updated
 
-    @staticmethod
-    def _commit_client_request_token(command: CommitRunUnit, event: Any) -> str:
-        values = (command.tenant_id, command.run_id, command.unit_id, event.event_id)
+    def _commit_client_request_token(self, command: CommitRunUnit, event: Any) -> str:
+        values = (
+            self._table_name,
+            command.tenant_id,
+            command.run_id,
+            command.unit_id,
+            event.event_id,
+        )
         return sha256("\x1f".join(values).encode()).hexdigest()[:36]
 
     @staticmethod

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from hashlib import sha256
+from time import sleep
 from typing import TYPE_CHECKING, Any
 
 from botocore.exceptions import ClientError, ConnectionClosedError, ReadTimeoutError
@@ -279,12 +280,14 @@ class DynamoDBClaims:
         try:
             self._transact(actions, token)
         except (ConnectionClosedError, ReadTimeoutError, ClientError) as error:
-            if isinstance(error, ClientError) and not self._is_server_error(error):
+            if isinstance(error, ClientError) and not self._is_retryable_client_error(error):
                 raise
             try:
-                self._transact(actions, token)
+                self._retry_commit_transaction(actions, token)
             except (ConnectionClosedError, ReadTimeoutError, ClientError) as retry_error:
-                if isinstance(retry_error, ClientError) and not self._is_server_error(retry_error):
+                if isinstance(retry_error, ClientError) and not self._is_retryable_client_error(
+                    retry_error
+                ):
                     raise
                 if self._commit_run_unit_replay(command, event, updated):
                     return updated
@@ -313,6 +316,23 @@ class DynamoDBClaims:
     def _is_server_error(error: ClientError) -> bool:
         status = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
         return isinstance(status, int) and 500 <= status < 600
+
+    def _retry_commit_transaction(self, actions: tuple[Action, ...], token: str) -> None:
+        try:
+            self._transact(actions, token)
+        except ClientError as error:
+            if not self._is_transaction_in_progress(error):
+                raise
+            sleep(5)
+            self._transact(actions, token)
+
+    @classmethod
+    def _is_retryable_client_error(cls, error: ClientError) -> bool:
+        return cls._is_server_error(error) or cls._is_transaction_in_progress(error)
+
+    @staticmethod
+    def _is_transaction_in_progress(error: ClientError) -> bool:
+        return error.response.get("Error", {}).get("Code") == "TransactionInProgressException"
 
     def _commit_run_unit_replay(
         self, command: CommitRunUnit, event: Any, updated: RunUnit

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -275,13 +275,26 @@ class DynamoDBClaims:
             put_action(self._table_name, self._unit_item(updated), payload(unit_item)),
             self._event_action(command.tenant_id, event),
         )
+        token = self._commit_client_request_token(command, event)
         try:
-            self._transact(actions)
-        except (Conflict, ConnectionClosedError, ReadTimeoutError):
+            self._transact(actions, token)
+        except (ConnectionClosedError, ReadTimeoutError):
+            try:
+                self._transact(actions, token)
+            except (Conflict, ConnectionClosedError, ReadTimeoutError):
+                if self._commit_run_unit_replay(command, event, updated):
+                    return updated
+                raise
+        except Conflict:
             if self._commit_run_unit_replay(command, event, updated):
                 return updated
             raise
         return updated
+
+    @staticmethod
+    def _commit_client_request_token(command: CommitRunUnit, event: Any) -> str:
+        values = (command.tenant_id, command.run_id, command.unit_id, event.event_id)
+        return sha256("\x1f".join(values).encode()).hexdigest()[:36]
 
     def _commit_run_unit_replay(
         self, command: CommitRunUnit, event: Any, updated: RunUnit

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from hashlib import sha256
+from json import dumps
 from time import sleep
 from typing import TYPE_CHECKING, Any
 
@@ -310,7 +311,7 @@ class DynamoDBClaims:
             command.unit_id,
             event.event_id,
         )
-        return sha256("\x1f".join(values).encode()).hexdigest()[:36]
+        return sha256(dumps(values, separators=(",", ":")).encode()).hexdigest()[:36]
 
     @staticmethod
     def _is_server_error(error: ClientError) -> bool:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -283,6 +283,8 @@ class DynamoDBClaims:
         except (ConnectionClosedError, ReadTimeoutError, ClientError) as error:
             if isinstance(error, ClientError) and not self._is_retryable_client_error(error):
                 raise
+            if isinstance(error, ClientError) and self._is_transaction_in_progress(error):
+                sleep(5)
             try:
                 self._retry_commit_transaction(actions, token)
             except (ConnectionClosedError, ReadTimeoutError, ClientError) as retry_error:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -62,6 +62,7 @@ class DynamoDBClaims:
         return encode_model(dispatch, "RUNDISPATCH", key, attributes)
     def claim_job(self, command: ClaimJob) -> Job | None:
         """Reivindica um job elegível com novo fence."""
+        now = self._clock()
         key = entity_key(command.tenant_id, "JOB", command.job_id)
         item = self._get_item(key)
         if item is None:
@@ -70,7 +71,7 @@ class DynamoDBClaims:
         agent_item = self._get_item(entity_key(command.tenant_id, "AGENT", job.agent_id))
         if agent_item is None or decode_model(agent_item, Agent).state is not AgentState.ACTIVE:
             return None
-        if not self._job_is_claimable(job, command.now):
+        if not self._job_is_claimable(job, now):
             return None
         leased = transition_job(job, JobState.LEASED) if job.state is not JobState.LEASED else job
         updated = leased.model_copy(
@@ -78,7 +79,7 @@ class DynamoDBClaims:
                 "attempt": job.attempt + 1,
                 "fencing_token": job.fencing_token + 1,
                 "lease_owner": command.owner,
-                "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+                "lease_until": now + timedelta(seconds=command.lease_seconds),
                 "error_code": None,
             }
         )
@@ -93,11 +94,12 @@ class DynamoDBClaims:
         return updated
     def renew_job_lease(self, command: RenewJobLease) -> Job:
         """Renova o lease de um job fenced."""
+        now = self._clock()
         item, job = self._leased_job(command.tenant_id, command.job_id)
-        self._validate_job_fence(job, command.owner, command.fencing_token, command.now)
+        self._validate_job_fence(job, command.owner, command.fencing_token, now)
         agent_item = self._active_agent_item(job)
         updated = job.model_copy(
-            update={"lease_until": command.now + timedelta(seconds=command.lease_seconds)}
+            update={"lease_until": now + timedelta(seconds=command.lease_seconds)}
         )
         self._transact(
             (
@@ -271,8 +273,23 @@ class DynamoDBClaims:
             put_action(self._table_name, self._unit_item(updated), payload(unit_item)),
             self._event_action(command.tenant_id, event),
         )
-        self._transact(actions)
+        try:
+            self._transact(actions)
+        except Conflict:
+            if self._commit_run_unit_replay(command, event, updated):
+                return updated
+            raise
         return updated
+
+    def _commit_run_unit_replay(
+        self, command: CommitRunUnit, event: Any, updated: RunUnit
+    ) -> bool:
+        winner = self._get_model(
+            unit_key(command.tenant_id, command.run_id, command.unit_id), RunUnit
+        )
+        return winner == updated and self._event_replay_matches(
+            self._get_outbox_event(event.event_id), event
+        )
     def _fail_run_unit_actions(
         self, command: FailRunUnit, event: Any
     ) -> tuple[RunUnit, tuple[Action, ...]]:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -445,12 +445,17 @@ def _validate_actions(actions: tuple[Action, ...]) -> None:
         raise Conflict("duplicate_transaction_key")
 
 
-def execute_transaction(client: Any, actions: Iterable[Action]) -> None:
+def execute_transaction(
+    client: Any, actions: Iterable[Action], client_request_token: str | None = None
+) -> None:
     """Valida e envia uma transação de chaves únicas."""
     normalized = tuple(actions)
     _validate_actions(normalized)
+    request = {"TransactItems": list(normalized)}
+    if client_request_token is not None:
+        request["ClientRequestToken"] = client_request_token
     try:
-        client.transact_write_items(TransactItems=list(normalized))
+        client.transact_write_items(**request)
     except ClientError as error:
         code = error.response.get("Error", {}).get("Code")
         reasons = error.response.get("CancellationReasons") or ()

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -381,6 +381,38 @@ def test_commit_repete_transacao_com_token_estavel_apos_timeout_antes_da_respost
     assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
 
 
+def test_commit_propaga_conflito_se_repeticao_apos_timeout_nao_encontra_replay(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    event = _event("unit-completed")
+    attempts = 0
+
+    def timeout_then_persist_incompatible(_: list[dict[str, Any]]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ReadTimeoutError(endpoint_url="https://dynamodb.us-east-1.amazonaws.com")
+        winner = claimed.model_copy(
+            update={
+                "state": RunUnitState.SUCCEEDED,
+                "lease_owner": None,
+                "lease_until": None,
+                "output_manifests": command.output_manifests,
+            }
+        )
+        adapter._put_direct(adapter._unit_item(winner))
+
+    adapter._client = ClientSpy(
+        adapter._client, before_transaction=timeout_then_persist_incompatible
+    )
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.commit_run_unit(command, event)
+
+
 def test_commit_propaga_conflito_quando_evento_persistido_nao_corresponde(
     ctx: _DynamoContext,
 ) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -76,6 +76,7 @@ class ClientSpy:
         self.before_transaction = before_transaction
         self.after_transaction = after_transaction
         self.transactions: list[list[dict[str, Any]]] = []
+        self.transaction_requests: list[dict[str, Any]] = []
         self.calls: list[str] = []
         self.query_requests: list[dict[str, Any]] = []
         self.requests: list[tuple[str, dict[str, Any]]] = []
@@ -84,6 +85,7 @@ class ClientSpy:
         actions: list[dict[str, Any]] = kwargs["TransactItems"]
         self.calls.append("transact_write_items")
         self.transactions.append(actions)
+        self.transaction_requests.append(dict(kwargs))
         if self.before_transaction is not None:
             self.before_transaction(actions)
         response = self.client.transact_write_items(**kwargs)
@@ -350,6 +352,33 @@ def test_commit_reconhece_resposta_de_transporte_perdida_apos_transacao_confirma
 
     assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
     assert adapter.get_outbox_event(event.event_id) == event
+
+
+def test_commit_repete_transacao_com_token_estavel_apos_timeout_antes_da_resposta(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    event = _event("unit-completed")
+    attempts = 0
+
+    def lose_first_response(_: list[dict[str, Any]]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ReadTimeoutError(endpoint_url="https://dynamodb.us-east-1.amazonaws.com")
+
+    spy = ClientSpy(adapter._client, before_transaction=lose_first_response)
+    adapter._client = spy
+
+    completed = adapter.commit_run_unit(command, event)
+
+    tokens = [request["ClientRequestToken"] for request in spy.transaction_requests]
+    assert tokens[0] == tokens[1]
+    assert adapter.get_outbox_event(event.event_id) == event
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
 
 
 def test_commit_propaga_conflito_quando_evento_persistido_nao_corresponde(

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -364,6 +364,18 @@ def test_token_de_commit_diferencia_tabelas(ctx: _DynamoContext) -> None:
     assert other._commit_client_request_token(command, event) != token
 
 
+def test_token_de_commit_nao_colide_com_separador_em_identificadores(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, _ = ctx
+    command = _commit_command("a" * 16, "worker-a", 1).model_copy(update={"unit_id": "a"})
+    first = adapter._commit_client_request_token(command, _event("b\x1fc"))
+    colliding = command.model_copy(update={"unit_id": "a\x1fb"})
+    second = adapter._commit_client_request_token(colliding, _event("c"))
+
+    assert second != first
+
+
 @pytest.mark.parametrize("error_type", [ReadTimeoutError, ConnectionClosedError])
 def test_commit_reconhece_resposta_de_transporte_perdida_apos_transacao_confirmada(
     ctx: _DynamoContext, error_type: type[Exception]

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -456,6 +456,49 @@ def test_commit_repete_apos_transacao_em_progresso(
     assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
 
 
+def test_commit_aguarda_transacao_em_progresso_inicial(
+    ctx: _DynamoContext, monkeypatch: Any
+) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    event = _event("unit-completed")
+    delays: list[int] = []
+    attempts = 0
+
+    def finish_original_transaction(delay: int) -> None:
+        delays.append(delay)
+        winner = claimed.model_copy(
+            update={
+                "state": RunUnitState.SUCCEEDED,
+                "lease_owner": None,
+                "lease_until": None,
+                "output_manifests": command.output_manifests,
+            }
+        )
+        adapter._put_direct(adapter._unit_item(winner))
+        adapter._put_direct(adapter._outbox_item(event))
+
+    def in_progress_then_timeout(_: list[dict[str, Any]]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _transaction_in_progress_error()
+        raise ReadTimeoutError(endpoint_url="https://dynamodb.us-east-1.amazonaws.com")
+
+    monkeypatch.setattr(
+        "cnes_infra.control_plane.dynamodb_claims.sleep", finish_original_transaction
+    )
+    adapter._client = ClientSpy(adapter._client, before_transaction=in_progress_then_timeout)
+
+    completed = adapter.commit_run_unit(command, event)
+
+    assert delays == [5]
+    assert adapter.get_outbox_event(event.event_id) == event
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
+
+
 @pytest.mark.parametrize("status", [500, 503])
 def test_commit_repete_transacao_com_token_estavel_apos_erro_dynamodb_5xx(
     ctx: _DynamoContext, status: int

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -45,6 +45,7 @@ from packages.cnes_infra.tests.contracts.clock import (
     _event,
     _job,
     _prepare_unit,
+    _renew_job,
     _run,
     _unit,
 )
@@ -278,6 +279,83 @@ def test_claims_retornam_none_quando_cas_perde_corrida(ctx: _DynamoContext) -> N
         lease_seconds=30,
     )
     assert adapter.claim_run_unit(command) is None
+
+
+def test_claim_job_com_relogio_futuro_nao_toma_lease_vivo(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    leased = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    assert leased is not None
+    future_claim = _claim_job("job-a", "worker-b", clock).model_copy(
+        update={"now": clock.now() + timedelta(seconds=31)}
+    )
+
+    assert adapter.claim_job(future_claim) is None
+    assert adapter.get_job(_TENANT, "job-a") == leased
+
+
+@pytest.mark.parametrize(
+    "reported_now", [(_NOW - timedelta(hours=1),), (_NOW + timedelta(hours=1),)]
+)
+def test_renovacao_de_job_usa_relogio_autoritativo(
+    ctx: _DynamoContext, reported_now: Any
+) -> None:
+    adapter, clock = ctx
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    assert claimed is not None
+    renewal = _renew_job(clock).model_copy(update={"now": reported_now})
+
+    renewed = adapter.renew_job_lease(renewal)
+
+    assert renewed.lease_until == clock.now() + timedelta(seconds=renewal.lease_seconds)
+    assert adapter.get_job(_TENANT, "job-a") == renewed
+
+
+def test_commit_retorna_sucesso_quando_resposta_da_transacao_confirmada_se_perde(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    event = _event("unit-completed")
+    adapter._client = ClientSpy(adapter._client, after_transaction=_lose_transaction_response)
+
+    completed = adapter.commit_run_unit(command, event)
+
+    assert completed.state is RunUnitState.SUCCEEDED
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
+    assert adapter.get_outbox_event(event.event_id) == event
+
+
+def test_commit_propaga_conflito_quando_evento_persistido_nao_corresponde(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    event = _event("unit-completed")
+
+    def persist_winner_incompativel(_: list[dict[str, Any]]) -> None:
+        winner = claimed.model_copy(
+            update={
+                "state": RunUnitState.SUCCEEDED,
+                "lease_owner": None,
+                "lease_until": None,
+                "output_manifests": command.output_manifests,
+            }
+        )
+        different_event = event.model_copy(update={"payload": {"event_id": "different"}})
+        adapter._put_direct(adapter._unit_item(winner))
+        adapter._put_direct(adapter._outbox_item(different_event))
+
+    adapter._client = ClientSpy(adapter._client, before_transaction=persist_winner_incompativel)
+    with pytest.raises(Conflict, match="transaction_conflict"):
+        adapter.commit_run_unit(command, event)
 
 
 def test_falha_opcional_rele_parent_apos_cas_concorrente(ctx: _DynamoContext) -> None:

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -343,6 +343,17 @@ def test_commit_retorna_sucesso_quando_resposta_da_transacao_confirmada_se_perde
     assert adapter.get_outbox_event(event.event_id) == event
 
 
+def test_token_de_commit_diferencia_tabelas(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
+    command = _commit_command("a" * 16, "worker-a", 1)
+    event = _event("unit-completed")
+    other = DynamoDBControlPlane(adapter._client, "another-control-plane", clock.now)
+
+    token = adapter._commit_client_request_token(command, event)
+
+    assert other._commit_client_request_token(command, event) != token
+
+
 @pytest.mark.parametrize("error_type", [ReadTimeoutError, ConnectionClosedError])
 def test_commit_reconhece_resposta_de_transporte_perdida_apos_transacao_confirmada(
     ctx: _DynamoContext, error_type: type[Exception]

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -126,6 +126,16 @@ def _lose_transaction_response(_: list[dict[str, Any]]) -> None:
     raise Conflict("transaction_conflict")
 
 
+def _dynamodb_client_error(status: int) -> ClientError:
+    return ClientError(
+        {
+            "Error": {"Code": "InternalServerError"},
+            "ResponseMetadata": {"HTTPStatusCode": status},
+        },
+        "TransactWriteItems",
+    )
+
+
 def _create_table(client: object) -> None:
     index_attributes = tuple(f"{index}{suffix}" for index in _INDEXES for suffix in ("pk", "sk"))
     attribute_definitions = [
@@ -377,6 +387,102 @@ def test_commit_repete_transacao_com_token_estavel_apos_timeout_antes_da_respost
 
     tokens = [request["ClientRequestToken"] for request in spy.transaction_requests]
     assert tokens[0] == tokens[1]
+    assert adapter.get_outbox_event(event.event_id) == event
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
+
+
+@pytest.mark.parametrize("status", [500, 503])
+def test_commit_repete_transacao_com_token_estavel_apos_erro_dynamodb_5xx(
+    ctx: _DynamoContext, status: int
+) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    event = _event("unit-completed")
+    attempts = 0
+
+    def fail_first_response(_: list[dict[str, Any]]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _dynamodb_client_error(status)
+
+    spy = ClientSpy(adapter._client, before_transaction=fail_first_response)
+    adapter._client = spy
+
+    completed = adapter.commit_run_unit(command, event)
+
+    tokens = [request["ClientRequestToken"] for request in spy.transaction_requests]
+    assert tokens[0] == tokens[1]
+    assert adapter.get_outbox_event(event.event_id) == event
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
+
+
+def test_commit_propaga_erro_dynamodb_4xx(ctx: _DynamoContext) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+
+    def fail_request(_: list[dict[str, Any]]) -> None:
+        raise _dynamodb_client_error(400)
+
+    adapter._client = ClientSpy(adapter._client, before_transaction=fail_request)
+
+    with pytest.raises(ClientError, match="InternalServerError"):
+        adapter.commit_run_unit(command, _event("unit-completed"))
+
+
+@pytest.mark.parametrize("status", [400, 500])
+def test_commit_propaga_segundo_erro_dynamodb_apos_timeout(
+    ctx: _DynamoContext, status: int
+) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    attempts = 0
+
+    def timeout_then_fail(_: list[dict[str, Any]]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ReadTimeoutError(endpoint_url="https://dynamodb.us-east-1.amazonaws.com")
+        raise _dynamodb_client_error(status)
+
+    adapter._client = ClientSpy(adapter._client, before_transaction=timeout_then_fail)
+    with pytest.raises(ClientError, match="InternalServerError"):
+        adapter.commit_run_unit(command, _event("unit-completed"))
+
+
+def test_commit_reconhece_erro_dynamodb_5xx_apos_repeticao_confirmada(
+    ctx: _DynamoContext,
+) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    event = _event("unit-completed")
+    attempts = 0
+
+    def fail_first_request(_: list[dict[str, Any]]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ReadTimeoutError(endpoint_url="https://dynamodb.us-east-1.amazonaws.com")
+
+    def fail_second_response(_: list[dict[str, Any]]) -> None:
+        raise _dynamodb_client_error(500)
+
+    adapter._client = ClientSpy(
+        adapter._client,
+        before_transaction=fail_first_request,
+        after_transaction=fail_second_response,
+    )
+
+    completed = adapter.commit_run_unit(command, event)
+
     assert adapter.get_outbox_event(event.event_id) == event
     assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
 

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -136,6 +136,16 @@ def _dynamodb_client_error(status: int) -> ClientError:
     )
 
 
+def _transaction_in_progress_error() -> ClientError:
+    return ClientError(
+        {
+            "Error": {"Code": "TransactionInProgressException"},
+            "ResponseMetadata": {"HTTPStatusCode": 400},
+        },
+        "TransactWriteItems",
+    )
+
+
 def _create_table(client: object) -> None:
     index_attributes = tuple(f"{index}{suffix}" for index in _INDEXES for suffix in ("pk", "sk"))
     attribute_definitions = [
@@ -398,6 +408,38 @@ def test_commit_repete_transacao_com_token_estavel_apos_timeout_antes_da_respost
 
     tokens = [request["ClientRequestToken"] for request in spy.transaction_requests]
     assert tokens[0] == tokens[1]
+    assert adapter.get_outbox_event(event.event_id) == event
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
+
+
+def test_commit_repete_apos_transacao_em_progresso(
+    ctx: _DynamoContext, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(
+        "cnes_infra.control_plane.dynamodb_claims.sleep", lambda _: None, raising=False
+    )
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    event = _event("unit-completed")
+    attempts = 0
+
+    def timeout_then_in_progress(_: list[dict[str, Any]]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ReadTimeoutError(endpoint_url="https://dynamodb.us-east-1.amazonaws.com")
+        if attempts == 2:
+            raise _transaction_in_progress_error()
+
+    spy = ClientSpy(adapter._client, before_transaction=timeout_then_in_progress)
+    adapter._client = spy
+
+    completed = adapter.commit_run_unit(command, event)
+
+    tokens = [request["ClientRequestToken"] for request in spy.transaction_requests]
+    assert tokens == [tokens[0]] * 3
     assert adapter.get_outbox_event(event.event_id) == event
     assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
 

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_adapter.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import boto3
 import pytest
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ConnectionClosedError, ReadTimeoutError
 from moto import mock_aws
 
 from cnes_domain.control_plane.commands import (
@@ -327,6 +327,27 @@ def test_commit_retorna_sucesso_quando_resposta_da_transacao_confirmada_se_perde
     completed = adapter.commit_run_unit(command, event)
 
     assert completed.state is RunUnitState.SUCCEEDED
+    assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
+    assert adapter.get_outbox_event(event.event_id) == event
+
+
+@pytest.mark.parametrize("error_type", [ReadTimeoutError, ConnectionClosedError])
+def test_commit_reconhece_resposta_de_transporte_perdida_apos_transacao_confirmada(
+    ctx: _DynamoContext, error_type: type[Exception]
+) -> None:
+    adapter, clock = ctx
+    dispatch = _prepare_unit(adapter, clock)
+    claimed = _claim_unit(adapter, clock, dispatch.dispatch_id, "worker-a")
+    command = _commit_command(dispatch.dispatch_id, "worker-a", claimed.fencing_token)
+    event = _event("unit-completed")
+
+    def lose_response(_: list[dict[str, Any]]) -> None:
+        raise error_type(endpoint_url="https://dynamodb.us-east-1.amazonaws.com")
+
+    adapter._client = ClientSpy(adapter._client, after_transaction=lose_response)
+
+    completed = adapter.commit_run_unit(command, event)
+
     assert adapter.list_run_units(_TENANT, "run-a")[0] == completed
     assert adapter.get_outbox_event(event.event_id) == event
 


### PR DESCRIPTION
Corrige o relógio autoritativo de leases e o replay idempotente da conclusão de unidade.\n\nVerificado com ruff, suíte de control plane e suíte rápida.