### PR TITLE
feat(audit): add local and object lock sinks

### DIFF
--- a/packages/cnes_infra/src/cnes_infra/audit/local_sink.py
+++ b/packages/cnes_infra/src/cnes_infra/audit/local_sink.py
@@ -12,7 +12,7 @@ from hashlib import sha256
 from itertools import groupby
 from pathlib import Path
 from secrets import token_hex
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, BinaryIO
 
 import polars as pl
 
@@ -108,6 +108,15 @@ def _batch_group(entry: _BatchEntry) -> tuple[str, str]:
     return entry.tenant_id, entry.log_path
 
 
+def _write_all(stream: BinaryIO, record: bytes) -> None:
+    remaining = memoryview(record)
+    while remaining:
+        written = stream.write(remaining)
+        if written is None or written <= 0:
+            raise OSError("audit_write=incomplete")
+        remaining = remaining[written:]
+
+
 class LocalAuditSink:
     """Entrega ao menos uma vez baseada em ``event_id`` estável, não exactly-once."""
 
@@ -160,6 +169,7 @@ class LocalAuditSink:
         ).fetchone()
         offset = int(row[0])
         with path.open("r+b") as stream:
+            recovered = False
             stream.seek(offset)
             while record := stream.readline():
                 if not record.endswith(b"\n"):
@@ -172,7 +182,11 @@ class LocalAuditSink:
                     event.event_id, event.tenant_id, relative, offset, len(record), digest
                 )
                 self._index(database, entry)
+                recovered = True
                 offset += len(record)
+            if recovered:
+                stream.flush()
+                os.fsync(stream.fileno())
 
     def _validate_record(self, relative: str, record: bytes) -> tuple[OutboxEvent, str]:
         body = record.removesuffix(b"\n")
@@ -257,7 +271,7 @@ class LocalAuditSink:
         with pending.path.open("a+b", buffering=0) as stream:
             stream.seek(0, os.SEEK_END)
             offset = stream.tell()
-            stream.write(pending.record)
+            _write_all(stream, pending.record)
             self._fault("after_file_write")
             stream.flush()
             os.fsync(stream.fileno())

--- a/packages/cnes_infra/src/cnes_infra/audit/local_sink.py
+++ b/packages/cnes_infra/src/cnes_infra/audit/local_sink.py
@@ -14,8 +14,7 @@ from pathlib import Path
 from secrets import token_hex
 from typing import TYPE_CHECKING
 
-import pyarrow as pa
-import pyarrow.parquet as pq
+import polars as pl
 
 from cnes_domain.control_plane.entities import OutboxEvent
 from cnes_domain.control_plane.errors import Conflict
@@ -34,17 +33,15 @@ CREATE TABLE IF NOT EXISTS events (
     batch_path TEXT
 )
 """
-_PARQUET_SCHEMA = pa.schema(
-    [
-        pa.field("tenant_id", pa.string()),
-        pa.field("event_id", pa.string()),
-        pa.field("event_type", pa.string()),
-        pa.field("aggregate_id", pa.string()),
-        pa.field("payload_json", pa.string()),
-        pa.field("created_at", pa.string()),
-        pa.field("delivered_at", pa.string()),
-    ]
-)
+_PARQUET_SCHEMA = {
+    "tenant_id": pl.String,
+    "event_id": pl.String,
+    "event_type": pl.String,
+    "aggregate_id": pl.String,
+    "payload_json": pl.String,
+    "created_at": pl.String,
+    "delivered_at": pl.String,
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,6 +68,7 @@ class _BatchEntry:
     log_path: str
     offset: int
     length: int
+    digest: str
 
 
 def _canonical_event(event: OutboxEvent) -> bytes:
@@ -239,20 +237,32 @@ class LocalAuditSink:
                 self._materialize_batches(database)
                 return
             path = self._root / relative
-            path.parent.mkdir(parents=True, exist_ok=True)
+            self._ensure_log_directory(path.parent)
             self._append_record(database, _PendingAppend(event, path, record))
             self._materialize_batches(database)
+
+    def _ensure_log_directory(self, directory: Path) -> None:
+        current = self._audit_root
+        for part in directory.relative_to(self._audit_root).parts:
+            child = current / part
+            if not child.exists():
+                child.mkdir()
+                self._fsync_directory(current)
+            current = child
 
     def _append_record(
         self, database: sqlite3.Connection, pending: _PendingAppend
     ) -> None:
-        with pending.path.open("a+b") as stream:
+        created = not pending.path.exists()
+        with pending.path.open("a+b", buffering=0) as stream:
             stream.seek(0, os.SEEK_END)
             offset = stream.tell()
             stream.write(pending.record)
             self._fault("after_file_write")
             stream.flush()
             os.fsync(stream.fileno())
+            if created:
+                self._fsync_directory(pending.path.parent)
             self._fault("after_file_fsync")
         digest = sha256(pending.record.removesuffix(b"\n")).hexdigest()
         entry = _IndexEntry(
@@ -270,7 +280,7 @@ class LocalAuditSink:
 
     def _materialize_batches(self, database: sqlite3.Connection) -> None:
         rows = database.execute(
-            "SELECT event_id, tenant_id, log_path, offset, length FROM events "
+            "SELECT event_id, tenant_id, log_path, offset, length, sha256 FROM events "
             "WHERE batch_path IS NULL ORDER BY tenant_id, log_path, offset"
         ).fetchall()
         entries = [_BatchEntry(*row) for row in rows]
@@ -283,10 +293,7 @@ class LocalAuditSink:
     def _materialize_batch(
         self, database: sqlite3.Connection, entries: list[_BatchEntry]
     ) -> None:
-        records = [
-            self._read_record(entry.log_path, entry.offset, entry.length)
-            for entry in entries
-        ]
+        records = [self._read_record(entry) for entry in entries]
         digest = sha256(b"".join(records)).hexdigest()
         relative = Path(entries[0].log_path).parent / f"batch-{digest}.parquet"
         table = self._parquet_table(records)
@@ -297,16 +304,20 @@ class LocalAuditSink:
         )
         database.commit()
 
-    def _read_record(self, relative: str, offset: int, length: int) -> bytes:
-        with (self._root / relative).open("rb") as stream:
-            stream.seek(offset)
-            record = stream.read(length)
-        if len(record) != length or not record.endswith(b"\n"):
+    def _read_record(self, entry: _BatchEntry) -> bytes:
+        with (self._root / entry.log_path).open("rb") as stream:
+            stream.seek(entry.offset)
+            record = stream.read(entry.length)
+        if len(record) != entry.length or not record.endswith(b"\n"):
             raise ValueError("audit_record=missing")
+        event, digest = self._validate_record(entry.log_path, record)
+        valid = event.event_id == entry.event_id and event.tenant_id == entry.tenant_id
+        if not valid or digest != entry.digest:
+            raise ValueError("audit_record=invalid")
         return record
 
     @staticmethod
-    def _parquet_table(records: list[bytes]) -> pa.Table:
+    def _parquet_table(records: list[bytes]) -> pl.DataFrame:
         serialized = [json.loads(record) for record in records]
         rows = [
             {
@@ -322,13 +333,13 @@ class LocalAuditSink:
             }
             for item in serialized
         ]
-        return pa.Table.from_pylist(rows, schema=_PARQUET_SCHEMA)
+        return pl.DataFrame(rows, schema=_PARQUET_SCHEMA)
 
-    def _publish_parquet(self, destination: Path, table: pa.Table) -> None:
+    def _publish_parquet(self, destination: Path, table: pl.DataFrame) -> None:
         temporary = destination.with_name(f".{destination.name}.{token_hex(8)}.tmp")
         try:
             with temporary.open("xb") as stream:
-                pq.write_table(table, stream)
+                table.write_parquet(stream)
                 stream.flush()
                 os.fsync(stream.fileno())
             expected = _file_digest(temporary)

--- a/packages/cnes_infra/src/cnes_infra/audit/local_sink.py
+++ b/packages/cnes_infra/src/cnes_infra/audit/local_sink.py
@@ -142,7 +142,7 @@ class LocalAuditSink:
             missing.append(current)
             current = current.parent
         for directory in reversed(missing):
-            directory.mkdir()
+            directory.mkdir(exist_ok=True)
             self._fsync_directory(directory.parent)
 
     @contextmanager

--- a/packages/cnes_infra/src/cnes_infra/audit/local_sink.py
+++ b/packages/cnes_infra/src/cnes_infra/audit/local_sink.py
@@ -1,0 +1,350 @@
+"""Sink de auditoria local recuperável em JSONL e Parquet."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from hashlib import sha256
+from itertools import groupby
+from pathlib import Path
+from secrets import token_hex
+from typing import TYPE_CHECKING
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from cnes_domain.control_plane.entities import OutboxEvent
+from cnes_domain.control_plane.errors import Conflict
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS events (
+    event_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    log_path TEXT NOT NULL,
+    offset INTEGER NOT NULL,
+    length INTEGER NOT NULL,
+    sha256 TEXT NOT NULL,
+    batch_path TEXT
+)
+"""
+_PARQUET_SCHEMA = pa.schema(
+    [
+        pa.field("tenant_id", pa.string()),
+        pa.field("event_id", pa.string()),
+        pa.field("event_type", pa.string()),
+        pa.field("aggregate_id", pa.string()),
+        pa.field("payload_json", pa.string()),
+        pa.field("created_at", pa.string()),
+        pa.field("delivered_at", pa.string()),
+    ]
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _IndexEntry:
+    event_id: str
+    tenant_id: str
+    log_path: str
+    offset: int
+    length: int
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingAppend:
+    event: OutboxEvent
+    path: Path
+    record: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _BatchEntry:
+    event_id: str
+    tenant_id: str
+    log_path: str
+    offset: int
+    length: int
+
+
+def _canonical_event(event: OutboxEvent) -> bytes:
+    return json.dumps(
+        event.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
+    ).encode()
+
+
+def _safe_component(value: str) -> str:
+    invalid = value in {"", ".", ".."} or any(char in value for char in "#/\\\0")
+    if invalid:
+        raise ValueError("audit_path=invalid")
+    return value
+
+
+def _log_path(event: OutboxEvent) -> Path:
+    tenant = _safe_component(event.tenant_id)
+    return Path(
+        "audit",
+        tenant,
+        f"{event.created_at:%Y}",
+        f"{event.created_at:%m}",
+        f"{event.created_at:%d}",
+        "events.jsonl",
+    )
+
+
+def _file_digest(path: Path) -> str:
+    digest = sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _batch_group(entry: _BatchEntry) -> tuple[str, str]:
+    return entry.tenant_id, entry.log_path
+
+
+class LocalAuditSink:
+    """Entrega ao menos uma vez baseada em ``event_id`` estável, não exactly-once."""
+
+    def __init__(self, root: Path, parquet_batch_size: int = 1000) -> None:
+        if parquet_batch_size <= 0:
+            raise ValueError("parquet_batch_size=invalid")
+        self._root = Path(root).absolute()
+        self._audit_root = self._root / "audit"
+        self._batch_size = parquet_batch_size
+        self._audit_root.mkdir(parents=True, exist_ok=True)
+        self._lock_path = self._audit_root / ".sink.lock"
+        self._database_path = self._audit_root / "index.sqlite3"
+        with self._locked(), self._connect() as database:
+            database.execute(_SCHEMA)
+            database.commit()
+            self._recover(database)
+            self._materialize_batches(database)
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        with self._lock_path.open("a+b") as stream:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        database = sqlite3.connect(self._database_path)
+        try:
+            database.execute("PRAGMA synchronous=FULL")
+            yield database
+        finally:
+            database.close()
+
+    def _fault(self, boundary: str) -> None:
+        pass
+
+    def _recover(self, database: sqlite3.Connection) -> None:
+        for path in sorted(self._audit_root.glob("*/*/*/*/events.jsonl")):
+            self._recover_log(database, path)
+        database.commit()
+
+    def _recover_log(self, database: sqlite3.Connection, path: Path) -> None:
+        relative = path.relative_to(self._root).as_posix()
+        row = database.execute(
+            "SELECT COALESCE(MAX(offset + length), 0) FROM events WHERE log_path = ?",
+            (relative,),
+        ).fetchone()
+        offset = int(row[0])
+        with path.open("r+b") as stream:
+            stream.seek(offset)
+            while record := stream.readline():
+                if not record.endswith(b"\n"):
+                    stream.truncate(offset)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                    break
+                event, digest = self._validate_record(relative, record)
+                entry = _IndexEntry(
+                    event.event_id, event.tenant_id, relative, offset, len(record), digest
+                )
+                self._index(database, entry)
+                offset += len(record)
+
+    def _validate_record(self, relative: str, record: bytes) -> tuple[OutboxEvent, str]:
+        body = record.removesuffix(b"\n")
+        try:
+            event = OutboxEvent.model_validate_json(body)
+            valid = _canonical_event(event) == body and _log_path(event).as_posix() == relative
+        except (ValueError, TypeError):
+            valid = False
+        if not valid:
+            raise ValueError("audit_record=invalid")
+        return event, sha256(body).hexdigest()
+
+    def _index(self, database: sqlite3.Connection, entry: _IndexEntry) -> None:
+        existing = database.execute(
+            "SELECT 1 FROM events WHERE event_id = ?",
+            (entry.event_id,),
+        ).fetchone()
+        if existing is not None:
+            raise Conflict("event_id=immutable")
+        database.execute(
+            "INSERT INTO events VALUES (?, ?, ?, ?, ?, ?, NULL)",
+            (
+                entry.event_id,
+                entry.tenant_id,
+                entry.log_path,
+                entry.offset,
+                entry.length,
+                entry.digest,
+            ),
+        )
+
+    def _existing_matches(
+        self, database: sqlite3.Connection, event: OutboxEvent, record: bytes
+    ) -> bool | None:
+        row = database.execute(
+            "SELECT log_path, offset, length FROM events WHERE event_id = ?",
+            (event.event_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        relative, offset, length = row
+        with (self._root / relative).open("rb") as stream:
+            stream.seek(offset)
+            existing = stream.read(length)
+        return existing == record
+
+    def append(self, event: OutboxEvent) -> None:
+        """Persiste um evento completo antes de indexá-lo.
+
+        Args:
+            event: Evento validado com identidade estável.
+        """
+        relative = _log_path(event).as_posix()
+        body = _canonical_event(event)
+        record = body + b"\n"
+        with self._locked(), self._connect() as database:
+            self._recover(database)
+            existing = self._existing_matches(database, event, record)
+            if existing is not None:
+                if not existing:
+                    raise Conflict("event_id=immutable")
+                self._materialize_batches(database)
+                return
+            path = self._root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._append_record(database, _PendingAppend(event, path, record))
+            self._materialize_batches(database)
+
+    def _append_record(
+        self, database: sqlite3.Connection, pending: _PendingAppend
+    ) -> None:
+        with pending.path.open("a+b") as stream:
+            stream.seek(0, os.SEEK_END)
+            offset = stream.tell()
+            stream.write(pending.record)
+            self._fault("after_file_write")
+            stream.flush()
+            os.fsync(stream.fileno())
+            self._fault("after_file_fsync")
+        digest = sha256(pending.record.removesuffix(b"\n")).hexdigest()
+        entry = _IndexEntry(
+            pending.event.event_id,
+            pending.event.tenant_id,
+            pending.path.relative_to(self._root).as_posix(),
+            offset,
+            len(pending.record),
+            digest,
+        )
+        self._index(database, entry)
+        self._fault("before_index_commit")
+        database.commit()
+        self._fault("after_index_commit")
+
+    def _materialize_batches(self, database: sqlite3.Connection) -> None:
+        rows = database.execute(
+            "SELECT event_id, tenant_id, log_path, offset, length FROM events "
+            "WHERE batch_path IS NULL ORDER BY tenant_id, log_path, offset"
+        ).fetchall()
+        entries = [_BatchEntry(*row) for row in rows]
+        for _, grouped in groupby(entries, key=_batch_group):
+            pending = list(grouped)
+            while len(pending) >= self._batch_size:
+                batch, pending = pending[: self._batch_size], pending[self._batch_size :]
+                self._materialize_batch(database, batch)
+
+    def _materialize_batch(
+        self, database: sqlite3.Connection, entries: list[_BatchEntry]
+    ) -> None:
+        records = [
+            self._read_record(entry.log_path, entry.offset, entry.length)
+            for entry in entries
+        ]
+        digest = sha256(b"".join(records)).hexdigest()
+        relative = Path(entries[0].log_path).parent / f"batch-{digest}.parquet"
+        table = self._parquet_table(records)
+        self._publish_parquet(self._root / relative, table)
+        database.executemany(
+            "UPDATE events SET batch_path = ? WHERE event_id = ?",
+            [(relative.as_posix(), entry.event_id) for entry in entries],
+        )
+        database.commit()
+
+    def _read_record(self, relative: str, offset: int, length: int) -> bytes:
+        with (self._root / relative).open("rb") as stream:
+            stream.seek(offset)
+            record = stream.read(length)
+        if len(record) != length or not record.endswith(b"\n"):
+            raise ValueError("audit_record=missing")
+        return record
+
+    @staticmethod
+    def _parquet_table(records: list[bytes]) -> pa.Table:
+        serialized = [json.loads(record) for record in records]
+        rows = [
+            {
+                "tenant_id": item["tenant_id"],
+                "event_id": item["event_id"],
+                "event_type": item["event_type"],
+                "aggregate_id": item["aggregate_id"],
+                "payload_json": json.dumps(
+                    item["payload"], sort_keys=True, separators=(",", ":")
+                ),
+                "created_at": item["created_at"],
+                "delivered_at": item["delivered_at"],
+            }
+            for item in serialized
+        ]
+        return pa.Table.from_pylist(rows, schema=_PARQUET_SCHEMA)
+
+    def _publish_parquet(self, destination: Path, table: pa.Table) -> None:
+        temporary = destination.with_name(f".{destination.name}.{token_hex(8)}.tmp")
+        try:
+            with temporary.open("xb") as stream:
+                pq.write_table(table, stream)
+                stream.flush()
+                os.fsync(stream.fileno())
+            expected = _file_digest(temporary)
+            try:
+                os.link(temporary, destination)
+            except FileExistsError as error:
+                if _file_digest(destination) != expected:
+                    raise Conflict("batch=immutable") from error
+            self._fsync_directory(destination.parent)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)

--- a/packages/cnes_infra/src/cnes_infra/audit/local_sink.py
+++ b/packages/cnes_infra/src/cnes_infra/audit/local_sink.py
@@ -126,7 +126,7 @@ class LocalAuditSink:
         self._root = Path(root).absolute()
         self._audit_root = self._root / "audit"
         self._batch_size = parquet_batch_size
-        self._audit_root.mkdir(parents=True, exist_ok=True)
+        self._ensure_audit_root()
         self._lock_path = self._audit_root / ".sink.lock"
         self._database_path = self._audit_root / "index.sqlite3"
         with self._locked(), self._connect() as database:
@@ -134,6 +134,16 @@ class LocalAuditSink:
             database.commit()
             self._recover(database)
             self._materialize_batches(database)
+
+    def _ensure_audit_root(self) -> None:
+        missing = []
+        current = self._audit_root
+        while not current.exists():
+            missing.append(current)
+            current = current.parent
+        for directory in reversed(missing):
+            directory.mkdir()
+            self._fsync_directory(directory.parent)
 
     @contextmanager
     def _locked(self) -> Iterator[None]:

--- a/packages/cnes_infra/src/cnes_infra/audit/s3_object_lock_sink.py
+++ b/packages/cnes_infra/src/cnes_infra/audit/s3_object_lock_sink.py
@@ -63,4 +63,6 @@ class S3ObjectLockAuditSink:
             "COMPLIANCE", event.created_at + timedelta(days=self._retention_days)
         )
         store = S3ObjectStore(self._client, self._bucket, retention=retention)
+        identity_key = f"audit/.event-id/{event_id}.json"
+        store.put(identity_key, BytesIO(body), digest)
         store.put(key, BytesIO(body), digest)

--- a/packages/cnes_infra/src/cnes_infra/audit/s3_object_lock_sink.py
+++ b/packages/cnes_infra/src/cnes_infra/audit/s3_object_lock_sink.py
@@ -1,0 +1,66 @@
+"""Sink de auditoria com retenção S3 Object Lock."""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from hashlib import sha256
+from io import BytesIO
+from typing import TYPE_CHECKING
+
+from cnes_infra.object_store.s3 import S3ObjectStore, S3Retention
+
+if TYPE_CHECKING:
+    from botocore.client import BaseClient
+
+    from cnes_domain.control_plane.entities import OutboxEvent
+
+
+def _safe_component(value: str) -> str:
+    invalid = value in {"", ".", ".."} or any(char in value for char in "#/\\\0")
+    if invalid:
+        raise ValueError("audit_path=invalid")
+    return value
+
+
+def _canonical_event(event: OutboxEvent) -> bytes:
+    return json.dumps(
+        event.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
+    ).encode()
+
+
+class S3ObjectLockAuditSink:
+    """Entrega ao menos uma vez por ``event_id`` estável, sem validar WORM."""
+
+    def __init__(self, client: BaseClient, bucket: str, retention_days: int) -> None:
+        if not bucket or "/" in bucket or "\\" in bucket:
+            raise ValueError("bucket=invalid")
+        if retention_days <= 0:
+            raise ValueError("retention_days=invalid")
+        response = client.get_object_lock_configuration(Bucket=bucket)
+        configuration = response.get("ObjectLockConfiguration", {})
+        if configuration.get("ObjectLockEnabled") != "Enabled":
+            raise ValueError("object_lock=disabled")
+        self._client = client
+        self._bucket = bucket
+        self._retention_days = retention_days
+
+    def append(self, event: OutboxEvent) -> None:
+        """Armazena o evento com retenção COMPLIANCE.
+
+        Args:
+            event: Evento validado com identidade estável.
+        """
+        tenant_id = _safe_component(event.tenant_id)
+        event_id = _safe_component(event.event_id)
+        key = (
+            f"audit/{tenant_id}/{event.created_at:%Y}/{event.created_at:%m}/"
+            f"{event.created_at:%d}/{event_id}.json"
+        )
+        body = _canonical_event(event)
+        digest = sha256(body).hexdigest()
+        retention = S3Retention(
+            "COMPLIANCE", event.created_at + timedelta(days=self._retention_days)
+        )
+        store = S3ObjectStore(self._client, self._bucket, retention=retention)
+        store.put(key, BytesIO(body), digest)

--- a/packages/cnes_infra/tests/audit/test_local_sink.py
+++ b/packages/cnes_infra/tests/audit/test_local_sink.py
@@ -253,22 +253,37 @@ def test_importa_sink_sem_dependencia_opcional_pyarrow(
 def test_sincroniza_hierarquia_nova_antes_de_confirmar_indice(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    sink = LocalAuditSink(tmp_path)
     synchronized: list[Path] = []
     monkeypatch.setattr(
         LocalAuditSink, "_fsync_directory", staticmethod(synchronized.append)
     )
+    sink = LocalAuditSink(tmp_path)
 
     sink.append(audit_event())
 
     audit = tmp_path / "audit"
     assert synchronized == [
+        tmp_path,
         audit,
         audit / "tenant-a",
         audit / "tenant-a" / "2026",
         audit / "tenant-a" / "2026" / "07",
         audit / "tenant-a" / "2026" / "07" / "15",
     ]
+
+
+def test_sincroniza_ancestrais_novos_da_raiz(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    synchronized: list[Path] = []
+    monkeypatch.setattr(
+        LocalAuditSink, "_fsync_directory", staticmethod(synchronized.append)
+    )
+    root = tmp_path / "nested" / "root"
+
+    LocalAuditSink(root)
+
+    assert synchronized == [tmp_path, tmp_path / "nested", root]
 
 
 def test_materializa_lote_parquet_textual_e_deterministico(tmp_path: Path) -> None:

--- a/packages/cnes_infra/tests/audit/test_local_sink.py
+++ b/packages/cnes_infra/tests/audit/test_local_sink.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import builtins
+import importlib
 import json
 import multiprocessing
+import os
 import sqlite3
+import sys
 from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pyarrow.parquet as pq
+import polars as pl
 import pytest
 
 from cnes_domain.control_plane.errors import Conflict
@@ -63,6 +67,26 @@ class _FaultSink(LocalAuditSink):
             raise OSError("audit_write=denied")
 
 
+class _CrashSink(LocalAuditSink):
+    def __init__(self, root: Path, boundary: str) -> None:
+        self.boundary = boundary
+        super().__init__(root)
+
+    def _fault(self, boundary: str) -> None:
+        if boundary == self.boundary:
+            os._exit(91)
+
+
+class _BlockPyArrowImport:
+    def __init__(self) -> None:
+        self._original = builtins.__import__
+
+    def __call__(self, name: str, *args: object, **kwargs: object) -> object:
+        if name == "pyarrow" or name.startswith("pyarrow."):
+            raise ModuleNotFoundError(name)
+        return self._original(name, *args, **kwargs)
+
+
 @pytest.mark.parametrize("case", audit_sink_cases(), ids=lambda case: case.name)
 def test_cumpre_contrato_compartilhado(tmp_path: Path, case: AuditSinkCase) -> None:
     case.run(_LocalProbe(tmp_path))
@@ -74,10 +98,15 @@ def test_cumpre_contrato_compartilhado(tmp_path: Path, case: AuditSinkCase) -> N
 )
 def test_recupera_evento_completo_apos_falha(tmp_path: Path, boundary: str) -> None:
     event = audit_event()
-    sink = _FaultSink(tmp_path)
-    sink.boundary = boundary
-    with pytest.raises(OSError, match="audit_write=denied"):
-        sink.append(event)
+    context = multiprocessing.get_context("spawn")
+    process = context.Process(
+        target=_crash_append_in_process, args=(str(tmp_path), boundary)
+    )
+    process.start()
+    process.join(timeout=10)
+
+    assert process.exitcode == 91
+    assert _log_path(tmp_path).read_bytes() == canonical_body(event) + b"\n"
 
     reopened = LocalAuditSink(tmp_path)
     reopened.append(event)
@@ -140,6 +169,10 @@ def _append_in_process(root: str, event_id: str) -> None:
     LocalAuditSink(Path(root)).append(audit_event(event_id))
 
 
+def _crash_append_in_process(root: str, boundary: str) -> None:
+    _CrashSink(Path(root), boundary).append(audit_event())
+
+
 def test_serializa_append_entre_processos(tmp_path: Path) -> None:
     context = multiprocessing.get_context("spawn")
     processes = [
@@ -156,6 +189,38 @@ def test_serializa_append_entre_processos(tmp_path: Path) -> None:
     assert len(_log_path(tmp_path).read_bytes().splitlines()) == 12
 
 
+def test_importa_sink_sem_dependencia_opcional_pyarrow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delitem(sys.modules, "cnes_infra.audit.local_sink")
+    monkeypatch.setattr(builtins, "__import__", _BlockPyArrowImport())
+
+    module = importlib.import_module("cnes_infra.audit.local_sink")
+
+    assert module.LocalAuditSink
+
+
+def test_sincroniza_hierarquia_nova_antes_de_confirmar_indice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sink = LocalAuditSink(tmp_path)
+    synchronized: list[Path] = []
+    monkeypatch.setattr(
+        LocalAuditSink, "_fsync_directory", staticmethod(synchronized.append)
+    )
+
+    sink.append(audit_event())
+
+    audit = tmp_path / "audit"
+    assert synchronized == [
+        audit,
+        audit / "tenant-a",
+        audit / "tenant-a" / "2026",
+        audit / "tenant-a" / "2026" / "07",
+        audit / "tenant-a" / "2026" / "07" / "15",
+    ]
+
+
 def test_materializa_lote_parquet_textual_e_deterministico(tmp_path: Path) -> None:
     events = (audit_event("event-001"), audit_event("event-002", payload={"n": 2}))
     sink = LocalAuditSink(tmp_path, parquet_batch_size=2)
@@ -165,9 +230,9 @@ def test_materializa_lote_parquet_textual_e_deterministico(tmp_path: Path) -> No
     jsonl = b"".join(canonical_body(event) + b"\n" for event in events)
     digest = sha256(jsonl).hexdigest()
     parquet = _log_path(tmp_path).parent / f"batch-{digest}.parquet"
-    table = pq.read_table(parquet)
+    table = pl.read_parquet(parquet)
 
-    assert table.schema.names == [
+    assert table.columns == [
         "tenant_id",
         "event_id",
         "event_type",
@@ -176,9 +241,9 @@ def test_materializa_lote_parquet_textual_e_deterministico(tmp_path: Path) -> No
         "created_at",
         "delivered_at",
     ]
-    assert all(str(field.type) == "string" for field in table.schema)
-    assert table.column("event_id").to_pylist() == ["event-001", "event-002"]
-    assert table.column("payload_json").to_pylist()[1] == '{"n":2}'
+    assert all(value == pl.String for value in table.schema.values())
+    assert table.get_column("event_id").to_list() == ["event-001", "event-002"]
+    assert table.get_column("payload_json").to_list()[1] == '{"n":2}'
     assert _log_path(tmp_path).read_bytes() == jsonl
 
     _clear_batch_associations(tmp_path)
@@ -210,6 +275,18 @@ def test_rejeita_lote_quando_registro_indexado_foi_truncado(tmp_path: Path) -> N
 
     with pytest.raises(ValueError, match="audit_record=missing"):
         LocalAuditSink(tmp_path, parquet_batch_size=2)
+
+
+def test_rejeita_lote_quando_registro_indexado_muda_sem_alterar_tamanho(
+    tmp_path: Path,
+) -> None:
+    sink = LocalAuditSink(tmp_path, parquet_batch_size=2)
+    sink.append(audit_event("event-001"))
+    log = _log_path(tmp_path)
+    log.write_bytes(log.read_bytes().replace(b"event-001", b"event-009"))
+
+    with pytest.raises(ValueError, match="audit_record=invalid"):
+        LocalAuditSink(tmp_path, parquet_batch_size=1)
 
 
 def test_rejeita_parametros_e_componentes_inseguros(tmp_path: Path) -> None:

--- a/packages/cnes_infra/tests/audit/test_local_sink.py
+++ b/packages/cnes_infra/tests/audit/test_local_sink.py
@@ -9,8 +9,10 @@ import multiprocessing
 import os
 import sqlite3
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from hashlib import sha256
 from pathlib import Path
+from threading import Barrier
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -284,6 +286,27 @@ def test_sincroniza_ancestrais_novos_da_raiz(
     LocalAuditSink(root)
 
     assert synchronized == [tmp_path, tmp_path / "nested", root]
+
+
+def test_tolera_criacao_concorrente_da_raiz(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "nested" / "root"
+    first_directory = tmp_path / "nested"
+    barrier = Barrier(2)
+    original_mkdir = Path.mkdir
+
+    def synchronized_mkdir(path: Path, *args: object, **kwargs: object) -> None:
+        if path == first_directory:
+            barrier.wait(timeout=5)
+        original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", synchronized_mkdir)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        sinks = list(executor.map(lambda _: LocalAuditSink(root), range(2)))
+
+    assert len(sinks) == 2
 
 
 def test_materializa_lote_parquet_textual_e_deterministico(tmp_path: Path) -> None:

--- a/packages/cnes_infra/tests/audit/test_local_sink.py
+++ b/packages/cnes_infra/tests/audit/test_local_sink.py
@@ -1,0 +1,241 @@
+"""Conformidade do sink de auditoria local."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import sqlite3
+from hashlib import sha256
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pyarrow.parquet as pq
+import pytest
+
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.audit.local_sink import LocalAuditSink
+from packages.cnes_infra.tests.contracts.audit_sink_contract import (
+    AuditSinkCase,
+    StoredAuditEvent,
+    audit_event,
+    audit_sink_cases,
+    canonical_body,
+)
+
+if TYPE_CHECKING:
+    from cnes_domain.control_plane.entities import OutboxEvent
+
+
+class _LocalProbe:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.sink = _FaultSink(root)
+
+    def expected_location(self, event: OutboxEvent) -> str:
+        return f"audit/{event.tenant_id}/2026/07/15/events.jsonl"
+
+    def stored(self) -> tuple[StoredAuditEvent, ...]:
+        database = sqlite3.connect(self.root / "audit" / "index.sqlite3")
+        rows = database.execute(
+            "SELECT log_path, offset, length, sha256 FROM events ORDER BY log_path, offset"
+        ).fetchall()
+        database.close()
+        result = []
+        for log_path, offset, length, digest in rows:
+            with (self.root / log_path).open("rb") as stream:
+                stream.seek(offset)
+                body = stream.read(length).removesuffix(b"\n")
+            result.append(StoredAuditEvent(log_path, body, digest))
+        return tuple(result)
+
+    def fail_next(self) -> None:
+        self.sink.boundary = "after_file_write"
+
+
+class _FaultSink(LocalAuditSink):
+    def __init__(self, root: Path, parquet_batch_size: int = 1000) -> None:
+        self.boundary: str | None = None
+        super().__init__(root, parquet_batch_size)
+
+    def _fault(self, boundary: str) -> None:
+        if boundary == self.boundary:
+            self.boundary = None
+            raise OSError("audit_write=denied")
+
+
+@pytest.mark.parametrize("case", audit_sink_cases(), ids=lambda case: case.name)
+def test_cumpre_contrato_compartilhado(tmp_path: Path, case: AuditSinkCase) -> None:
+    case.run(_LocalProbe(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    ["after_file_write", "after_file_fsync", "before_index_commit", "after_index_commit"],
+)
+def test_recupera_evento_completo_apos_falha(tmp_path: Path, boundary: str) -> None:
+    event = audit_event()
+    sink = _FaultSink(tmp_path)
+    sink.boundary = boundary
+    with pytest.raises(OSError, match="audit_write=denied"):
+        sink.append(event)
+
+    reopened = LocalAuditSink(tmp_path)
+    reopened.append(event)
+
+    log = tmp_path / "audit" / "tenant-a" / "2026" / "07" / "15" / "events.jsonl"
+    assert log.read_bytes() == canonical_body(event) + b"\n"
+    assert _index_count(tmp_path) == 1
+
+
+def test_recupera_orfao_antes_do_append_de_sink_ja_instanciado(tmp_path: Path) -> None:
+    first = _FaultSink(tmp_path)
+    second = LocalAuditSink(tmp_path)
+    first.boundary = "before_index_commit"
+    with pytest.raises(OSError, match="audit_write=denied"):
+        first.append(audit_event("event-001"))
+
+    second.append(audit_event("event-002"))
+
+    assert _index_count(tmp_path) == 2
+    assert len(_log_path(tmp_path).read_bytes().splitlines()) == 2
+
+
+def test_trunca_somente_cauda_parcial(tmp_path: Path) -> None:
+    event = audit_event()
+    LocalAuditSink(tmp_path).append(event)
+    log = _log_path(tmp_path)
+    with log.open("ab") as stream:
+        stream.write(b'{"event_id":"incompleto"')
+
+    LocalAuditSink(tmp_path)
+
+    assert log.read_bytes() == canonical_body(event) + b"\n"
+
+
+@pytest.mark.parametrize(
+    "record",
+    [b"{}\n", json.dumps(audit_event().model_dump(mode="json"), indent=2).encode() + b"\n"],
+    ids=["invalido", "nao_canonico"],
+)
+def test_rejeita_registro_completo_invalido(tmp_path: Path, record: bytes) -> None:
+    log = _log_path(tmp_path)
+    log.parent.mkdir(parents=True)
+    log.write_bytes(record)
+
+    with pytest.raises(ValueError, match="audit_record=invalid"):
+        LocalAuditSink(tmp_path)
+
+
+def test_rejeita_evento_duplicado_na_cauda_nao_indexada(tmp_path: Path) -> None:
+    event = audit_event()
+    LocalAuditSink(tmp_path).append(event)
+    with _log_path(tmp_path).open("ab") as stream:
+        stream.write(canonical_body(event) + b"\n")
+
+    with pytest.raises(Conflict, match="event_id=immutable"):
+        LocalAuditSink(tmp_path)
+
+
+def _append_in_process(root: str, event_id: str) -> None:
+    LocalAuditSink(Path(root)).append(audit_event(event_id))
+
+
+def test_serializa_append_entre_processos(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    processes = [
+        context.Process(target=_append_in_process, args=(str(tmp_path), f"event-{index:03d}"))
+        for index in range(12)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=10)
+
+    assert all(process.exitcode == 0 for process in processes)
+    assert _index_count(tmp_path) == 12
+    assert len(_log_path(tmp_path).read_bytes().splitlines()) == 12
+
+
+def test_materializa_lote_parquet_textual_e_deterministico(tmp_path: Path) -> None:
+    events = (audit_event("event-001"), audit_event("event-002", payload={"n": 2}))
+    sink = LocalAuditSink(tmp_path, parquet_batch_size=2)
+    for event in events:
+        sink.append(event)
+
+    jsonl = b"".join(canonical_body(event) + b"\n" for event in events)
+    digest = sha256(jsonl).hexdigest()
+    parquet = _log_path(tmp_path).parent / f"batch-{digest}.parquet"
+    table = pq.read_table(parquet)
+
+    assert table.schema.names == [
+        "tenant_id",
+        "event_id",
+        "event_type",
+        "aggregate_id",
+        "payload_json",
+        "created_at",
+        "delivered_at",
+    ]
+    assert all(str(field.type) == "string" for field in table.schema)
+    assert table.column("event_id").to_pylist() == ["event-001", "event-002"]
+    assert table.column("payload_json").to_pylist()[1] == '{"n":2}'
+    assert _log_path(tmp_path).read_bytes() == jsonl
+
+    _clear_batch_associations(tmp_path)
+    original_digest = sha256(parquet.read_bytes()).hexdigest()
+    LocalAuditSink(tmp_path, parquet_batch_size=2).append(events[0])
+    assert list(parquet.parent.glob("batch-*.parquet")) == [parquet]
+    assert sha256(parquet.read_bytes()).hexdigest() == original_digest
+
+
+def test_rejeita_lote_preexistente_com_conteudo_divergente(tmp_path: Path) -> None:
+    events = (audit_event("event-001"), audit_event("event-002"))
+    sink = LocalAuditSink(tmp_path, parquet_batch_size=3)
+    for event in events:
+        sink.append(event)
+    jsonl = b"".join(canonical_body(event) + b"\n" for event in events)
+    parquet = _log_path(tmp_path).parent / f"batch-{sha256(jsonl).hexdigest()}.parquet"
+    parquet.write_bytes(b"divergente")
+
+    with pytest.raises(Conflict, match="batch=immutable"):
+        LocalAuditSink(tmp_path, parquet_batch_size=2)
+
+
+def test_rejeita_lote_quando_registro_indexado_foi_truncado(tmp_path: Path) -> None:
+    sink = LocalAuditSink(tmp_path, parquet_batch_size=3)
+    sink.append(audit_event("event-001"))
+    sink.append(audit_event("event-002"))
+    log = _log_path(tmp_path)
+    log.write_bytes(log.read_bytes()[:-1])
+
+    with pytest.raises(ValueError, match="audit_record=missing"):
+        LocalAuditSink(tmp_path, parquet_batch_size=2)
+
+
+def test_rejeita_parametros_e_componentes_inseguros(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="parquet_batch_size=invalid"):
+        LocalAuditSink(tmp_path, parquet_batch_size=0)
+    unsafe = audit_event().model_copy()
+    object.__setattr__(unsafe, "tenant_id", "../tenant")
+    with pytest.raises(ValueError, match="audit_path=invalid"):
+        LocalAuditSink(tmp_path).append(unsafe)
+
+
+def _log_path(root: Path) -> Path:
+    return root / "audit" / "tenant-a" / "2026" / "07" / "15" / "events.jsonl"
+
+
+def _index_count(root: Path) -> int:
+    database = sqlite3.connect(root / "audit" / "index.sqlite3")
+    count = database.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    database.close()
+    return int(count)
+
+
+def _clear_batch_associations(root: Path) -> None:
+    database = sqlite3.connect(root / "audit" / "index.sqlite3")
+    try:
+        database.execute("UPDATE events SET batch_path = NULL")
+        database.commit()
+    finally:
+        database.close()

--- a/packages/cnes_infra/tests/audit/test_local_sink.py
+++ b/packages/cnes_infra/tests/audit/test_local_sink.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
+import cnes_infra.audit.local_sink as local_sink_module
 from cnes_domain.control_plane.errors import Conflict
 from cnes_infra.audit.local_sink import LocalAuditSink
 from packages.cnes_infra.tests.contracts.audit_sink_contract import (
@@ -87,6 +88,21 @@ class _BlockPyArrowImport:
         return self._original(name, *args, **kwargs)
 
 
+class _ShortWriter:
+    def __init__(self) -> None:
+        self.content = bytearray()
+
+    def write(self, content: bytes | memoryview) -> int:
+        chunk = bytes(content[:3])
+        self.content.extend(chunk)
+        return len(chunk)
+
+
+class _StoppedWriter:
+    def write(self, content: bytes | memoryview) -> int:
+        return 0
+
+
 @pytest.mark.parametrize("case", audit_sink_cases(), ids=lambda case: case.name)
 def test_cumpre_contrato_compartilhado(tmp_path: Path, case: AuditSinkCase) -> None:
     case.run(_LocalProbe(tmp_path))
@@ -127,6 +143,40 @@ def test_recupera_orfao_antes_do_append_de_sink_ja_instanciado(tmp_path: Path) -
 
     assert _index_count(tmp_path) == 2
     assert len(_log_path(tmp_path).read_bytes().splitlines()) == 2
+
+
+def test_repete_escrita_curta_ate_persistir_registro_completo() -> None:
+    writer = _ShortWriter()
+
+    local_sink_module._write_all(writer, b"registro-completo")
+
+    assert writer.content == b"registro-completo"
+
+
+def test_rejeita_escrita_sem_progresso() -> None:
+    with pytest.raises(OSError, match="audit_write=incomplete"):
+        local_sink_module._write_all(_StoppedWriter(), b"registro")
+
+
+def test_sincroniza_orfao_recuperado_antes_do_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    LocalAuditSink(tmp_path)
+    log = _log_path(tmp_path)
+    log.parent.mkdir(parents=True)
+    log.write_bytes(canonical_body(audit_event()) + b"\n")
+    synchronized: list[Path] = []
+    original_fsync = os.fsync
+
+    def record_fsync(descriptor: int) -> None:
+        synchronized.append(Path(os.readlink(f"/proc/self/fd/{descriptor}")))
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", record_fsync)
+
+    LocalAuditSink(tmp_path)
+
+    assert log in synchronized
 
 
 def test_trunca_somente_cauda_parcial(tmp_path: Path) -> None:

--- a/packages/cnes_infra/tests/audit/test_s3_object_lock_sink.py
+++ b/packages/cnes_infra/tests/audit/test_s3_object_lock_sink.py
@@ -73,6 +73,7 @@ class _S3Probe:
         return tuple(
             StoredAuditEvent(key, body, metadata["sha256"])
             for key, (body, metadata, _) in self.client.objects.items()
+            if not key.startswith("audit/.event-id/")
         )
 
     def fail_next(self) -> None:
@@ -82,6 +83,17 @@ class _S3Probe:
 @pytest.mark.parametrize("case", audit_sink_cases(), ids=lambda case: case.name)
 def test_cumpre_contrato_compartilhado(case: AuditSinkCase) -> None:
     case.run(_S3Probe())
+
+
+def test_rejeita_mesmo_event_id_em_particao_s3_divergente() -> None:
+    client = _MemoryS3()
+    sink = S3ObjectLockAuditSink(client, "audit-bucket", 30)
+    event = audit_event()
+    sink.append(event)
+    changed = event.model_copy(update={"tenant_id": "tenant-b"})
+
+    with pytest.raises(Conflict, match="object=immutable"):
+        sink.append(changed)
 
 
 def _client_error(code: str, status: int, operation: str) -> ClientError:
@@ -115,12 +127,24 @@ def _put_params(event: Any) -> dict[str, Any]:
     }
 
 
+def _identity_params(event: Any) -> dict[str, Any]:
+    params = _put_params(event)
+    params["Key"] = f"audit/.event-id/{event.event_id}.json"
+    return params
+
+
+def _identity(stubber: Stubber, event: Any) -> None:
+    params = _identity_params(event)
+    stubber.add_response("put_object", {"ChecksumSHA256": params["ChecksumSHA256"]}, params)
+
+
 def test_envia_requisicao_exata_sem_newline() -> None:
     event = audit_event()
     params = _put_params(event)
     client = _client()
     with Stubber(client) as stubber:
         _enabled(stubber)
+        _identity(stubber, event)
         stubber.add_response(
             "put_object", {"ChecksumSHA256": params["ChecksumSHA256"]}, params
         )
@@ -164,6 +188,7 @@ def test_rejeita_checksum_ausente_ou_divergente(
     event, client = audit_event(), _client()
     with Stubber(client) as stubber:
         _enabled(stubber)
+        _identity(stubber, event)
         stubber.add_response("put_object", response, _put_params(event))
         sink = S3ObjectLockAuditSink(client, "audit-bucket", 30)
         with pytest.raises(ValueError, match=f"checksum_response={message}"):
@@ -174,6 +199,7 @@ def test_rejeita_baddigest() -> None:
     event, client = audit_event(), _client()
     with Stubber(client) as stubber:
         _enabled(stubber)
+        _identity(stubber, event)
         stubber.add_client_error(
             "put_object",
             service_error_code="BadDigest",
@@ -199,6 +225,7 @@ def test_aceita_replay_412_com_conteudo_e_retencao_integrais() -> None:
     digest = sha256(body).hexdigest()
     with Stubber(client) as stubber:
         _enabled(stubber)
+        _identity(stubber, event)
         stubber.add_client_error(
             "put_object", service_error_code="PreconditionFailed", http_status_code=412,
             expected_params=params)
@@ -224,6 +251,7 @@ def test_rejeita_replay_412_com_conteudo_divergente() -> None:
     different = b"divergente"
     with Stubber(client) as stubber:
         _enabled(stubber)
+        _identity(stubber, event)
         stubber.add_client_error(
             "put_object", service_error_code="PreconditionFailed", http_status_code=412,
             expected_params=params)
@@ -241,6 +269,7 @@ def test_limita_retry_409_e_releitura(attempts: int) -> None:
     params = _put_params(event)
     with Stubber(client) as stubber:
         _enabled(stubber)
+        _identity(stubber, event)
         for _ in range(attempts):
             stubber.add_client_error(
                 "put_object", service_error_code="ConditionalRequestConflict",

--- a/packages/cnes_infra/tests/audit/test_s3_object_lock_sink.py
+++ b/packages/cnes_infra/tests/audit/test_s3_object_lock_sink.py
@@ -1,0 +1,272 @@
+"""Conformidade do sink de auditoria S3 Object Lock."""
+
+from __future__ import annotations
+
+from base64 import b64encode
+from datetime import timedelta
+from hashlib import sha256
+from io import BytesIO
+from typing import Any
+
+import boto3
+import pytest
+from botocore import UNSIGNED
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from botocore.stub import ANY, Stubber
+
+from cnes_domain.control_plane.errors import Conflict
+from cnes_infra.audit.s3_object_lock_sink import S3ObjectLockAuditSink
+from packages.cnes_infra.tests.contracts.audit_sink_contract import (
+    AuditSinkCase,
+    StoredAuditEvent,
+    audit_event,
+    audit_sink_cases,
+    canonical_body,
+)
+
+
+def _client() -> Any:
+    return boto3.client(
+        "s3", region_name="us-east-1", config=Config(signature_version=UNSIGNED)
+    )
+
+
+class _MemoryS3:
+    def __init__(self) -> None:
+        self.objects: dict[str, tuple[bytes, dict[str, str], Any]] = {}
+        self.fail = False
+
+    def get_object_lock_configuration(self, **kwargs: Any) -> dict[str, Any]:
+        return {"ObjectLockConfiguration": {"ObjectLockEnabled": "Enabled"}}
+
+    def put_object(self, **kwargs: Any) -> dict[str, str]:
+        if self.fail:
+            self.fail = False
+            raise OSError("s3=unavailable")
+        key = kwargs["Key"]
+        body = kwargs["Body"].read()
+        current = self.objects.get(key)
+        if current is not None:
+            raise _client_error("PreconditionFailed", 412, "PutObject")
+        self.objects[key] = (body, kwargs["Metadata"], kwargs["ObjectLockRetainUntilDate"])
+        return {"ChecksumSHA256": kwargs["ChecksumSHA256"]}
+
+    def get_object(self, **kwargs: Any) -> dict[str, Any]:
+        body, metadata, _ = self.objects[kwargs["Key"]]
+        return {"Body": BytesIO(body), "Metadata": metadata, "VersionId": "version-1"}
+
+    def get_object_retention(self, **kwargs: Any) -> dict[str, Any]:
+        _, _, retain_until = self.objects[kwargs["Key"]]
+        return {"Retention": {"Mode": "COMPLIANCE", "RetainUntilDate": retain_until}}
+
+
+class _S3Probe:
+    def __init__(self) -> None:
+        self.client = _MemoryS3()
+        self.sink = S3ObjectLockAuditSink(self.client, "audit-bucket", 30)
+
+    def expected_location(self, event: Any) -> str:
+        return f"audit/{event.tenant_id}/2026/07/15/{event.event_id}.json"
+
+    def stored(self) -> tuple[StoredAuditEvent, ...]:
+        return tuple(
+            StoredAuditEvent(key, body, metadata["sha256"])
+            for key, (body, metadata, _) in self.client.objects.items()
+        )
+
+    def fail_next(self) -> None:
+        self.client.fail = True
+
+
+@pytest.mark.parametrize("case", audit_sink_cases(), ids=lambda case: case.name)
+def test_cumpre_contrato_compartilhado(case: AuditSinkCase) -> None:
+    case.run(_S3Probe())
+
+
+def _client_error(code: str, status: int, operation: str) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": code, "Message": code}, "ResponseMetadata": {"HTTPStatusCode": status}},
+        operation,
+    )
+
+
+def _enabled(stubber: Stubber) -> None:
+    stubber.add_response(
+        "get_object_lock_configuration",
+        {"ObjectLockConfiguration": {"ObjectLockEnabled": "Enabled"}},
+        {"Bucket": "audit-bucket"},
+    )
+
+
+def _put_params(event: Any) -> dict[str, Any]:
+    body = canonical_body(event)
+    digest = sha256(body).hexdigest()
+    return {
+        "Body": ANY,
+        "Bucket": "audit-bucket",
+        "IfNoneMatch": "*",
+        "Key": f"audit/tenant-a/2026/07/15/{event.event_id}.json",
+        "Metadata": {"sha256": digest},
+        "ChecksumAlgorithm": "SHA256",
+        "ChecksumSHA256": b64encode(bytes.fromhex(digest)).decode(),
+        "ObjectLockMode": "COMPLIANCE",
+        "ObjectLockRetainUntilDate": event.created_at + timedelta(days=30),
+    }
+
+
+def test_envia_requisicao_exata_sem_newline() -> None:
+    event = audit_event()
+    params = _put_params(event)
+    client = _client()
+    with Stubber(client) as stubber:
+        _enabled(stubber)
+        stubber.add_response(
+            "put_object", {"ChecksumSHA256": params["ChecksumSHA256"]}, params
+        )
+        S3ObjectLockAuditSink(client, "audit-bucket", 30).append(event)
+        stubber.assert_no_pending_responses()
+
+
+@pytest.mark.parametrize("configuration", [{}, {"ObjectLockEnabled": "Disabled"}])
+def test_rejeita_bucket_sem_object_lock(configuration: dict[str, str]) -> None:
+    client = _client()
+    with Stubber(client) as stubber:
+        stubber.add_response(
+            "get_object_lock_configuration",
+            {"ObjectLockConfiguration": configuration},
+            {"Bucket": "audit-bucket"},
+        )
+        with pytest.raises(ValueError, match="object_lock=disabled"):
+            S3ObjectLockAuditSink(client, "audit-bucket", 30)
+
+
+def test_propaga_erro_ao_consultar_object_lock() -> None:
+    client = _client()
+    with Stubber(client) as stubber:
+        stubber.add_client_error(
+            "get_object_lock_configuration",
+            service_error_code="AccessDenied",
+            http_status_code=403,
+            expected_params={"Bucket": "audit-bucket"},
+        )
+        with pytest.raises(ClientError, match="AccessDenied"):
+            S3ObjectLockAuditSink(client, "audit-bucket", 30)
+
+
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [({}, "missing"), ({"ChecksumSHA256": "AAAA"}, "mismatch")],
+)
+def test_rejeita_checksum_ausente_ou_divergente(
+    response: dict[str, str], message: str
+) -> None:
+    event, client = audit_event(), _client()
+    with Stubber(client) as stubber:
+        _enabled(stubber)
+        stubber.add_response("put_object", response, _put_params(event))
+        sink = S3ObjectLockAuditSink(client, "audit-bucket", 30)
+        with pytest.raises(ValueError, match=f"checksum_response={message}"):
+            sink.append(event)
+
+
+def test_rejeita_baddigest() -> None:
+    event, client = audit_event(), _client()
+    with Stubber(client) as stubber:
+        _enabled(stubber)
+        stubber.add_client_error(
+            "put_object",
+            service_error_code="BadDigest",
+            http_status_code=400,
+            expected_params=_put_params(event),
+        )
+        sink = S3ObjectLockAuditSink(client, "audit-bucket", 30)
+        with pytest.raises(ValueError, match="checksum=rejected"):
+            sink.append(event)
+
+
+def _object_response(body: bytes, digest: str) -> dict[str, Any]:
+    return {
+        "Body": BytesIO(body),
+        "Metadata": {"sha256": digest},
+        "VersionId": "version-1",
+    }
+
+
+def test_aceita_replay_412_com_conteudo_e_retencao_integrais() -> None:
+    event, client = audit_event(), _client()
+    body, params = canonical_body(event), _put_params(event)
+    digest = sha256(body).hexdigest()
+    with Stubber(client) as stubber:
+        _enabled(stubber)
+        stubber.add_client_error(
+            "put_object", service_error_code="PreconditionFailed", http_status_code=412,
+            expected_params=params)
+        stubber.add_response(
+            "get_object", _object_response(body, digest),
+            {"Bucket": "audit-bucket", "Key": params["Key"]})
+        stubber.add_response(
+            "get_object_retention",
+            {
+                "Retention": {
+                    "Mode": "COMPLIANCE",
+                    "RetainUntilDate": params["ObjectLockRetainUntilDate"],
+                }
+            },
+            {"Bucket": "audit-bucket", "Key": params["Key"], "VersionId": "version-1"},
+        )
+        S3ObjectLockAuditSink(client, "audit-bucket", 30).append(event)
+
+
+def test_rejeita_replay_412_com_conteudo_divergente() -> None:
+    event, client = audit_event(), _client()
+    params = _put_params(event)
+    different = b"divergente"
+    with Stubber(client) as stubber:
+        _enabled(stubber)
+        stubber.add_client_error(
+            "put_object", service_error_code="PreconditionFailed", http_status_code=412,
+            expected_params=params)
+        stubber.add_response(
+            "get_object", _object_response(different, sha256(different).hexdigest()),
+            {"Bucket": "audit-bucket", "Key": params["Key"]})
+        sink = S3ObjectLockAuditSink(client, "audit-bucket", 30)
+        with pytest.raises(Conflict, match="object=immutable"):
+            sink.append(event)
+
+
+@pytest.mark.parametrize("attempts", [1, 3])
+def test_limita_retry_409_e_releitura(attempts: int) -> None:
+    event, client = audit_event(), _client()
+    params = _put_params(event)
+    with Stubber(client) as stubber:
+        _enabled(stubber)
+        for _ in range(attempts):
+            stubber.add_client_error(
+                "put_object", service_error_code="ConditionalRequestConflict",
+                http_status_code=409, expected_params=params)
+            stubber.add_client_error(
+                "get_object", service_error_code="NoSuchKey", http_status_code=404,
+                expected_params={"Bucket": "audit-bucket", "Key": params["Key"]})
+        if attempts == 1:
+            stubber.add_response(
+                "put_object", {"ChecksumSHA256": params["ChecksumSHA256"]}, params)
+        sink = S3ObjectLockAuditSink(client, "audit-bucket", 30)
+        if attempts == 1:
+            sink.append(event)
+        else:
+            with pytest.raises(Conflict, match="conditional_request=conflict"):
+                sink.append(event)
+
+
+def test_rejeita_parametros_e_componentes_inseguros() -> None:
+    client = _MemoryS3()
+    with pytest.raises(ValueError, match="retention_days=invalid"):
+        S3ObjectLockAuditSink(client, "audit-bucket", 0)
+    with pytest.raises(ValueError, match="bucket=invalid"):
+        S3ObjectLockAuditSink(client, "", 30)
+    unsafe = audit_event().model_copy()
+    object.__setattr__(unsafe, "event_id", "../event")
+    sink = S3ObjectLockAuditSink(client, "audit-bucket", 30)
+    with pytest.raises(ValueError, match="audit_path=invalid"):
+        sink.append(unsafe)

--- a/packages/cnes_infra/tests/contracts/audit_sink_contract.py
+++ b/packages/cnes_infra/tests/contracts/audit_sink_contract.py
@@ -1,0 +1,139 @@
+"""Casos reutilizáveis de conformidade dos sinks de auditoria."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from hashlib import sha256
+from typing import Any, Protocol
+
+from cnes_domain.control_plane.entities import OutboxEvent
+from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.ports.audit import AuditSinkPort
+
+
+@dataclass(frozen=True, slots=True)
+class StoredAuditEvent:
+    location: str
+    body: bytes
+    sha256: str
+
+
+class AuditSinkProbe(Protocol):
+    sink: Any
+
+    def stored(self) -> tuple[StoredAuditEvent, ...]: ...
+
+    def expected_location(self, event: OutboxEvent) -> str: ...
+
+    def fail_next(self) -> None: ...
+
+
+_Runner = Callable[[AuditSinkProbe], None]
+
+
+@dataclass(frozen=True, slots=True)
+class AuditSinkCase:
+    """Executa uma invariável contra um sink e seu probe de backend."""
+
+    name: str
+    _runner: _Runner = field(repr=False, compare=False)
+
+    def run(self, probe: AuditSinkProbe) -> None:
+        try:
+            assert isinstance(probe.sink, AuditSinkPort)
+            self._runner(probe)
+        except Exception as error:
+            raise AssertionError(f"case={self.name}") from error
+
+
+def audit_event(
+    event_id: str = "event-001",
+    *,
+    payload: dict[str, Any] | None = None,
+    created_at: datetime | None = None,
+) -> OutboxEvent:
+    return OutboxEvent(
+        tenant_id="tenant-a",
+        event_id=event_id,
+        event_type="job.created",
+        aggregate_id="job-001",
+        payload=payload if payload is not None else {"acao": "criar", "ordem": [2, 1]},
+        created_at=created_at or datetime(2026, 7, 15, 10, 30, tzinfo=UTC),
+        delivered_at=None,
+    )
+
+
+def canonical_body(event: OutboxEvent) -> bytes:
+    return json.dumps(
+        event.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
+    ).encode()
+
+
+def _case_serializacao_canonica(probe: AuditSinkProbe) -> None:
+    event = audit_event(payload={"z": 1, "nested": {"b": 2, "a": "ação"}})
+    probe.sink.append(event)
+    assert probe.stored()[0].body == canonical_body(event)
+
+
+def _case_identidade_e_metadados(probe: AuditSinkProbe) -> None:
+    event = audit_event()
+    probe.sink.append(event)
+    stored = probe.stored()[0]
+    assert stored.location == probe.expected_location(event)
+    assert stored.sha256 == sha256(canonical_body(event)).hexdigest()
+
+
+def _case_ordem_deterministica(probe: AuditSinkProbe) -> None:
+    events = (audit_event("event-002"), audit_event("event-001"))
+    for event in events:
+        probe.sink.append(event)
+    stored = probe.stored()
+    assert tuple(json.loads(item.body)["event_id"] for item in stored) == (
+        "event-002",
+        "event-001",
+    )
+    assert tuple(item.location for item in stored) == tuple(
+        probe.expected_location(event) for event in events
+    )
+
+
+def _case_replay_idempotente(probe: AuditSinkProbe) -> None:
+    event = audit_event()
+    probe.sink.append(event)
+    probe.sink.append(event)
+    assert len(probe.stored()) == 1
+
+
+def _case_rejeita_event_id_divergente(probe: AuditSinkProbe) -> None:
+    event = audit_event()
+    probe.sink.append(event)
+    changed = audit_event(payload={"acao": "alterar"})
+    try:
+        probe.sink.append(changed)
+    except Conflict:
+        return
+    raise AssertionError("conflict_required")
+
+
+def _case_propaga_erro_permanente(probe: AuditSinkProbe) -> None:
+    probe.fail_next()
+    try:
+        probe.sink.append(audit_event())
+    except OSError:
+        return
+    raise AssertionError("permanent_error_required")
+
+
+def audit_sink_cases() -> tuple[AuditSinkCase, ...]:
+    """Retorna o catálogo estável de invariáveis dos sinks de auditoria."""
+    return (
+        AuditSinkCase("serializacao_canonica", _case_serializacao_canonica),
+        AuditSinkCase("identidade_e_metadados", _case_identidade_e_metadados),
+        AuditSinkCase("ordem_deterministica", _case_ordem_deterministica),
+        AuditSinkCase("replay_idempotente", _case_replay_idempotente),
+        AuditSinkCase("event_id_divergente", _case_rejeita_event_id_divergente),
+        AuditSinkCase("erro_permanente", _case_propaga_erro_permanente),
+    )


### PR DESCRIPTION
## Objetivo

Implementar os adapters de `AuditSinkPort` para filesystem POSIX local e S3 Object Lock, com serialização canônica, replay idempotente e retenção explícita.

## Implementação

- JSONL local durável com `flock`, `fsync`, índice SQLite e recuperação antes de cada append.
- Lotes Parquet imutáveis com identidade derivada do JSONL canônico.
- S3 Object Lock em modo `COMPLIANCE`, checksum SHA-256 explícito e upload condicional via `S3ObjectStore`.
- Contrato compartilhado entre backends e testes de crash, concorrência, replay, conflito, 409, 412 e `BadDigest`.

## Evidências

- Focados: `38 passed`.
- Packages: `1339 passed, 7 skipped`, coverage 100% line/branch.
- Ruff global: verde.
- Suíte rápida sem `chaos_infra`: `1289 passed, 11 skipped`.
- O comando rápido literal mantém o débito externo em `test_central_api_sobrevive_pg_restart`: testcontainers recria o container com porta aleatória enquanto o teste reutiliza a URL antiga.
- Revisão pré-PR corrigiu a interleaving entre sink já instanciado e evento órfão após crash.

Closes #125
Refs #93