### PR TITLE
test(infra): gate phase 2 adapter conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [main, develop]
     paths:
       - 'packages/**'
+      - 'tests/**'
       - 'apps/central_api/**'
       - 'apps/data_processor/**'
       - 'apps/cnes_db_migrator/**'
@@ -14,11 +15,14 @@ on:
       - 'docs/contracts/openapi.json'
       - 'docs/contracts/schemas/**'
       - '.github/workflows/ci.yml'
+      - 'docker-compose.yml'
       - 'scripts/ci_python_gate.sh'
+      - 'scripts/ci_phase2_adapters.sh'
   push:
     branches: [main, develop]
     paths:
       - 'packages/**'
+      - 'tests/**'
       - 'apps/central_api/**'
       - 'apps/data_processor/**'
       - 'apps/cnes_db_migrator/**'
@@ -27,7 +31,9 @@ on:
       - 'docs/contracts/openapi.json'
       - 'docs/contracts/schemas/**'
       - '.github/workflows/ci.yml'
+      - 'docker-compose.yml'
       - 'scripts/ci_python_gate.sh'
+      - 'scripts/ci_phase2_adapters.sh'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -73,3 +79,6 @@ jobs:
 
       - name: Run Python gate
         run: bash scripts/ci_python_gate.sh
+
+      - name: Run Phase 2 adapter conformance
+        run: bash scripts/ci_phase2_adapters.sh

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -31,6 +31,20 @@ env:
   COMPETENCIA_MES: "1"
 
 jobs:
+  phase2-adapter-conformance:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.13" }
+      - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          version: "0.9.26"
+      - run: uv sync --locked --all-packages
+      - name: Run Phase 2 adapter conformance
+        run: bash scripts/ci_phase2_adapters.sh
+
   n-plus-1:
     runs-on: ubuntu-latest
     services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,6 +232,34 @@ services:
     - ./docker-compose.keycloak:/opt/keycloak/data/import:ro
     profiles:
     - dev
+  dynamodb-local:
+    image: amazon/dynamodb-local:3.3.1@sha256:ff89bd48ff32cd8d9be5fee8873b65b8854dc408f1afe881be6eb00247bc0dab
+    command: -jar DynamoDBLocal.jar -inMemory -sharedDb
+    ports:
+    - "127.0.0.1:18000:8000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:8000 >/dev/null || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 5s
+    profiles:
+    - aws-test
+  localstack:
+    image: localstack/localstack:4.11.1@sha256:3071c9c72a1e9dbc23ad33540617ad7825ffeba80a8f421eff798b97850f9de5
+    environment:
+      AWS_DEFAULT_REGION: us-east-1
+      SERVICES: s3
+    ports:
+    - "127.0.0.1:4566:4566"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 5s
+    profiles:
+    - aws-test
 volumes:
   pgdata_test: null
   minio_data: null

--- a/packages/cnes_infra/src/cnes_infra/__init__.py
+++ b/packages/cnes_infra/src/cnes_infra/__init__.py
@@ -1,0 +1,3 @@
+"""Namespaces públicos da infraestrutura."""
+
+__all__ = ("audit", "control_plane", "object_store")

--- a/packages/cnes_infra/src/cnes_infra/audit/__init__.py
+++ b/packages/cnes_infra/src/cnes_infra/audit/__init__.py
@@ -1,0 +1,6 @@
+"""Adapters públicos de auditoria."""
+
+from cnes_infra.audit.local_sink import LocalAuditSink
+from cnes_infra.audit.s3_object_lock_sink import S3ObjectLockAuditSink
+
+__all__ = ("LocalAuditSink", "S3ObjectLockAuditSink")

--- a/packages/cnes_infra/src/cnes_infra/control_plane/__init__.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/__init__.py
@@ -1,0 +1,6 @@
+"""Adapters públicos do plano de controle."""
+
+from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
+from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
+
+__all__ = ("DynamoDBControlPlane", "SQLiteControlPlane")

--- a/packages/cnes_infra/src/cnes_infra/object_store/__init__.py
+++ b/packages/cnes_infra/src/cnes_infra/object_store/__init__.py
@@ -1,0 +1,6 @@
+"""Adapters públicos de armazenamento de objetos."""
+
+from cnes_infra.object_store.filesystem import FilesystemObjectStore
+from cnes_infra.object_store.s3 import S3ObjectStore, S3Retention
+
+__all__ = ("FilesystemObjectStore", "S3ObjectStore", "S3Retention")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ markers = [
     "chaos: fault injection resilience tests",
     "chaos_infra: testcontainers infra chaos tests",
     "negative: hypothesis-driven negative input tests",
+    "local_profile: matriz integrada dos adapters locais Phase 2",
+    "dynamodb_local: testes que requerem DynamoDB Local",
+    "s3_integration: testes que requerem S3 compatível",
 ]
 
 [tool.ruff]

--- a/pytest.ini
+++ b/pytest.ini
@@ -26,4 +26,7 @@ markers =
     chaos: fault injection resilience tests
     chaos_infra: testcontainers infra chaos tests
     negative: hypothesis-driven negative input tests
+    local_profile: matriz integrada dos adapters locais Phase 2
+    dynamodb_local: testes que requerem DynamoDB Local
+    s3_integration: testes que requerem S3 compatível
 asyncio_mode = auto

--- a/scripts/ci_phase2_adapters.sh
+++ b/scripts/ci_phase2_adapters.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+phase2_project="${PHASE2_COMPOSE_PROJECT:-cnesdata-phase2}"
+compose=(docker compose --project-name "$phase2_project" --profile aws-test)
+
+cleanup() {
+  phase2_status=$?
+  trap - EXIT INT TERM
+  set +e
+  "${compose[@]}" down -v --remove-orphans
+  phase2_cleanup_status=$?
+  if (( phase2_status != 0 )); then
+    exit "$phase2_status"
+  fi
+  exit "$phase2_cleanup_status"
+}
+
+trap cleanup EXIT INT TERM
+
+"${compose[@]}" config --images
+"${compose[@]}" up -d --wait --wait-timeout 120 dynamodb-local localstack
+
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+export DYNAMODB_ENDPOINT=http://127.0.0.1:18000
+export S3_ENDPOINT=http://127.0.0.1:4566
+
+uv run python - <<'PY'
+import os
+
+import boto3
+from botocore.config import Config
+
+TABLE_NAME = "cnesdata-control-plane"
+INDEXES = tuple(f"gsi{number}" for number in range(1, 7))
+
+
+def dynamodb_client():
+    return boto3.client(
+        "dynamodb",
+        endpoint_url=os.environ["DYNAMODB_ENDPOINT"],
+        region_name="us-east-1",
+    )
+
+
+def s3_client():
+    return boto3.client(
+        "s3",
+        endpoint_url=os.environ["S3_ENDPOINT"],
+        region_name="us-east-1",
+        config=Config(s3={"addressing_style": "path"}),
+    )
+
+
+def create_control_plane_table(client):
+    names = ("pk", "sk", *(f"{index}{suffix}" for index in INDEXES for suffix in ("pk", "sk")))
+    throughput = {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5}
+    client.create_table(
+        TableName=TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": name, "AttributeType": "S"} for name in names
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": index,
+                "KeySchema": [
+                    {"AttributeName": f"{index}pk", "KeyType": "HASH"},
+                    {"AttributeName": f"{index}sk", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+                "ProvisionedThroughput": throughput,
+            }
+            for index in INDEXES
+        ],
+        ProvisionedThroughput=throughput,
+    )
+    client.get_waiter("table_exists").wait(TableName=TABLE_NAME)
+    client.update_time_to_live(
+        TableName=TABLE_NAME,
+        TimeToLiveSpecification={"Enabled": True, "AttributeName": "expires_at"},
+    )
+
+
+def create_buckets(client):
+    client.create_bucket(Bucket="cnesdata-test")
+    client.create_bucket(
+        Bucket="cnesdata-audit-test",
+        ObjectLockEnabledForBucket=True,
+    )
+
+
+create_control_plane_table(dynamodb_client())
+create_buckets(s3_client())
+PY
+
+uv run pytest -q tests/integration/test_local_adapter_matrix.py -m local_profile
+uv run pytest -q tests/integration/test_aws_adapter_matrix.py \
+  -m "dynamodb_local and s3_integration"

--- a/tests/integration/test_aws_adapter_matrix.py
+++ b/tests/integration/test_aws_adapter_matrix.py
@@ -95,6 +95,23 @@ def _assert_provisioned_resources(dynamodb: Any, s3: Any) -> None:
     assert lock["ObjectLockConfiguration"]["ObjectLockEnabled"] == "Enabled"
 
 
+def _publish_object(store: Any) -> Any:
+    body = b"phase-2-aws"
+    digest = sha256(body).hexdigest()
+    store.put("staging/job-aws.parquet", BytesIO(body), digest)
+    published = store.promote(
+        "staging/job-aws.parquet", "raw/354130/job-aws.parquet", digest
+    )
+    assert store.put("raw/354130/job-aws.parquet", BytesIO(body), digest) == published
+    with pytest.raises(Conflict, match="object=immutable"):
+        store.put(
+            "raw/354130/job-aws.parquet",
+            BytesIO(b"divergente"),
+            sha256(b"divergente").hexdigest(),
+        )
+    return published
+
+
 @pytest.mark.dynamodb_local
 @pytest.mark.s3_integration
 def test_replay_integrado_preserva_objetos_e_evidencia_de_retencao() -> None:
@@ -111,20 +128,7 @@ def test_replay_integrado_preserva_objetos_e_evidencia_de_retencao() -> None:
     created = control_plane.create_job(_job(), _event())
     assert control_plane.create_job(_job(), _event()) == created
 
-    body = b"phase-2-aws"
-    digest = sha256(body).hexdigest()
-    store = S3ObjectStore(s3, OBJECT_BUCKET)
-    store.put("staging/job-aws.parquet", BytesIO(body), digest)
-    published = store.promote(
-        "staging/job-aws.parquet", "raw/354130/job-aws.parquet", digest
-    )
-    assert store.put("raw/354130/job-aws.parquet", BytesIO(body), digest) == published
-    with pytest.raises(Conflict, match="object=immutable"):
-        store.put(
-            "raw/354130/job-aws.parquet",
-            BytesIO(b"divergente"),
-            sha256(b"divergente").hexdigest(),
-        )
+    published = _publish_object(S3ObjectStore(s3, OBJECT_BUCKET))
 
     sink = S3ObjectLockAuditSink(s3, AUDIT_BUCKET, retention_days=30)
     first = dispatch_once(_InterruptedControlPlane(control_plane), sink, DELIVERED_AT)

--- a/tests/integration/test_aws_adapter_matrix.py
+++ b/tests/integration/test_aws_adapter_matrix.py
@@ -1,0 +1,156 @@
+"""Matriz de capability smoke dos adapters AWS Phase 2."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+from io import BytesIO
+from typing import Any
+
+import boto3
+import pytest
+from botocore.config import Config
+
+from cnes_domain.control_plane.entities import Job, OutboxEvent
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.outbox_dispatcher import DispatchResult, dispatch_once
+
+NOW = datetime(2026, 9, 6, 12, tzinfo=UTC)
+DELIVERED_AT = NOW + timedelta(seconds=1)
+TABLE_NAME = "cnesdata-control-plane"
+OBJECT_BUCKET = "cnesdata-test"
+AUDIT_BUCKET = "cnesdata-audit-test"
+
+
+def _client(service: str, endpoint: str) -> Any:
+    return boto3.client(
+        service,
+        endpoint_url=endpoint,
+        region_name="us-east-1",
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID", "test"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY", "test"),
+        config=Config(retries={"max_attempts": 2}, s3={"addressing_style": "path"}),
+    )
+
+
+def _job() -> Job:
+    return Job(
+        tenant_id="354130",
+        job_id="job-aws",
+        agent_id="agent-aws",
+        source_type="CNES",
+        file_subtype="ST",
+        competencia="2026-09",
+        requested_snapshot_mode="FULL",
+        state=JobState.PENDING,
+        attempt=0,
+        fencing_token=0,
+        lease_owner=None,
+        lease_until=None,
+        result_manifest_id=None,
+        result_manifest_key=None,
+        error_code=None,
+        created_at=NOW,
+    )
+
+
+def _event() -> OutboxEvent:
+    return OutboxEvent(
+        tenant_id="354130",
+        event_id="event-aws",
+        event_type="job.created",
+        aggregate_id="job-aws",
+        payload={"job_id": "job-aws"},
+        created_at=NOW,
+        delivered_at=None,
+    )
+
+
+class _InterruptedControlPlane:
+    def __init__(self, control_plane: Any) -> None:
+        self._control_plane = control_plane
+
+    def pending_outbox(self, limit: int) -> tuple[OutboxEvent, ...]:
+        return self._control_plane.pending_outbox(limit)
+
+    def mark_outbox_delivered(self, event_id: str, delivered_at: datetime) -> None:
+        raise OSError("dispatch=interrupted")
+
+
+def _audit_keys(client: Any) -> set[str]:
+    response = client.list_objects_v2(Bucket=AUDIT_BUCKET, Prefix="audit/")
+    return {item["Key"] for item in response.get("Contents", [])}
+
+
+def _assert_provisioned_resources(dynamodb: Any, s3: Any) -> None:
+    table = dynamodb.describe_table(TableName=TABLE_NAME)["Table"]
+    ttl = dynamodb.describe_time_to_live(TableName=TABLE_NAME)["TimeToLiveDescription"]
+    lock = s3.get_object_lock_configuration(Bucket=AUDIT_BUCKET)
+    assert {index["IndexName"] for index in table["GlobalSecondaryIndexes"]} == {
+        f"gsi{number}" for number in range(1, 7)
+    }
+    assert ttl == {"TimeToLiveStatus": "ENABLED", "AttributeName": "expires_at"}
+    assert lock["ObjectLockConfiguration"]["ObjectLockEnabled"] == "Enabled"
+
+
+@pytest.mark.dynamodb_local
+@pytest.mark.s3_integration
+def test_replay_integrado_preserva_objetos_e_evidencia_de_retencao() -> None:
+    from cnes_infra.audit import S3ObjectLockAuditSink
+    from cnes_infra.control_plane import DynamoDBControlPlane
+    from cnes_infra.object_store import S3ObjectStore
+
+    dynamodb = _client(
+        "dynamodb", os.getenv("DYNAMODB_ENDPOINT", "http://127.0.0.1:18000")
+    )
+    s3 = _client("s3", os.getenv("S3_ENDPOINT", "http://127.0.0.1:4566"))
+    _assert_provisioned_resources(dynamodb, s3)
+    control_plane = DynamoDBControlPlane(dynamodb, TABLE_NAME, lambda: NOW)
+    created = control_plane.create_job(_job(), _event())
+    assert control_plane.create_job(_job(), _event()) == created
+
+    body = b"phase-2-aws"
+    digest = sha256(body).hexdigest()
+    store = S3ObjectStore(s3, OBJECT_BUCKET)
+    store.put("staging/job-aws.parquet", BytesIO(body), digest)
+    published = store.promote(
+        "staging/job-aws.parquet", "raw/354130/job-aws.parquet", digest
+    )
+    assert store.put("raw/354130/job-aws.parquet", BytesIO(body), digest) == published
+    with pytest.raises(Conflict, match="object=immutable"):
+        store.put(
+            "raw/354130/job-aws.parquet",
+            BytesIO(b"divergente"),
+            sha256(b"divergente").hexdigest(),
+        )
+
+    sink = S3ObjectLockAuditSink(s3, AUDIT_BUCKET, retention_days=30)
+    first = dispatch_once(_InterruptedControlPlane(control_plane), sink, DELIVERED_AT)
+    keys_after_interruption = _audit_keys(s3)
+
+    reopened_control_plane = DynamoDBControlPlane(dynamodb, TABLE_NAME, lambda: DELIVERED_AT)
+    reopened_store = S3ObjectStore(s3, OBJECT_BUCKET)
+    reopened_sink = S3ObjectLockAuditSink(s3, AUDIT_BUCKET, retention_days=30)
+    second = dispatch_once(reopened_control_plane, reopened_sink, DELIVERED_AT)
+    event_key = "audit/354130/2026/09/06/event-aws.json"
+    stored = s3.get_object(Bucket=AUDIT_BUCKET, Key=event_key)
+    retention = s3.get_object_retention(
+        Bucket=AUDIT_BUCKET,
+        Key=event_key,
+        VersionId=stored["VersionId"],
+    )["Retention"]
+
+    assert first == DispatchResult(delivered=0, failed=1)
+    assert second == DispatchResult(delivered=1, failed=0)
+    assert reopened_control_plane.pending_outbox(10) == ()
+    assert reopened_store.stat("raw/354130/job-aws.parquet") == published
+    assert _audit_keys(s3) == keys_after_interruption
+    assert keys_after_interruption == {
+        "audit/.event-id/event-aws.json",
+        event_key,
+    }
+    assert stored["Body"].read()
+    assert retention["Mode"] == "COMPLIANCE"
+    assert retention["RetainUntilDate"] >= NOW + timedelta(days=30)

--- a/tests/integration/test_local_adapter_matrix.py
+++ b/tests/integration/test_local_adapter_matrix.py
@@ -1,0 +1,150 @@
+"""Matriz de conformidade dos adapters locais Phase 2."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+from io import BytesIO
+from typing import TYPE_CHECKING, Any
+
+import polars as pl
+import pytest
+
+from cnes_domain.control_plane.entities import Job, OutboxEvent
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.outbox_dispatcher import DispatchResult, dispatch_once
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+NOW = datetime(2026, 9, 6, 12, tzinfo=UTC)
+DELIVERED_AT = NOW + timedelta(seconds=1)
+
+
+def _job() -> Job:
+    return Job(
+        tenant_id="354130",
+        job_id="job-local",
+        agent_id="agent-local",
+        source_type="CNES",
+        file_subtype="ST",
+        competencia="2026-09",
+        requested_snapshot_mode="FULL",
+        state=JobState.PENDING,
+        attempt=0,
+        fencing_token=0,
+        lease_owner=None,
+        lease_until=None,
+        result_manifest_id=None,
+        result_manifest_key=None,
+        error_code=None,
+        created_at=NOW,
+    )
+
+
+def _event() -> OutboxEvent:
+    return OutboxEvent(
+        tenant_id="354130",
+        event_id="event-local",
+        event_type="job.created",
+        aggregate_id="job-local",
+        payload={"job_id": "job-local"},
+        created_at=NOW,
+        delivered_at=None,
+    )
+
+
+class _InterruptedControlPlane:
+    def __init__(self, control_plane: Any) -> None:
+        self._control_plane = control_plane
+
+    def pending_outbox(self, limit: int) -> tuple[OutboxEvent, ...]:
+        return self._control_plane.pending_outbox(limit)
+
+    def mark_outbox_delivered(self, event_id: str, delivered_at: datetime) -> None:
+        raise OSError("dispatch=interrupted")
+
+
+@pytest.mark.local_profile
+def test_exports_publicos_sao_unicos_e_dispatcher_permanece_no_dominio() -> None:
+    import cnes_infra
+    from cnes_infra import audit, control_plane, object_store
+    from cnes_infra.audit import LocalAuditSink, S3ObjectLockAuditSink
+    from cnes_infra.control_plane import DynamoDBControlPlane, SQLiteControlPlane
+    from cnes_infra.object_store import FilesystemObjectStore, S3ObjectStore, S3Retention
+
+    assert cnes_infra.__all__ == ("audit", "control_plane", "object_store")
+    assert control_plane.__all__ == ("DynamoDBControlPlane", "SQLiteControlPlane")
+    assert object_store.__all__ == ("FilesystemObjectStore", "S3ObjectStore", "S3Retention")
+    assert audit.__all__ == ("LocalAuditSink", "S3ObjectLockAuditSink")
+    assert all(
+        value is not None
+        for value in (
+            SQLiteControlPlane,
+            DynamoDBControlPlane,
+            FilesystemObjectStore,
+            S3ObjectStore,
+            S3Retention,
+            LocalAuditSink,
+            S3ObjectLockAuditSink,
+        )
+    )
+    aliases = {
+        "SQLiteControlPlane",
+        "DynamoDBControlPlane",
+        "FilesystemObjectStore",
+        "S3ObjectStore",
+        "S3Retention",
+        "LocalAuditSink",
+        "S3ObjectLockAuditSink",
+        "dispatch_once",
+    }
+    assert aliases.isdisjoint(vars(cnes_infra))
+
+
+@pytest.mark.local_profile
+def test_reabre_adapters_e_conclui_replay_sem_duplicar_efeitos(tmp_path: Path) -> None:
+    from cnes_infra.audit import LocalAuditSink
+    from cnes_infra.control_plane import SQLiteControlPlane
+    from cnes_infra.object_store import FilesystemObjectStore
+
+    database_path = tmp_path / "control-plane.sqlite3"
+    object_root = tmp_path / "objects"
+    audit_root = tmp_path / "audit-root"
+    object_root.mkdir()
+    body = b"phase-2-local"
+    digest = sha256(body).hexdigest()
+    control_plane = SQLiteControlPlane(database_path, lambda: NOW)
+    control_plane.initialize()
+    control_plane.create_job(_job(), _event())
+    store = FilesystemObjectStore(object_root)
+    store.put("staging/job-local.parquet", BytesIO(body), digest)
+    published = store.promote(
+        "staging/job-local.parquet", "raw/354130/job-local.parquet", digest
+    )
+    sink = LocalAuditSink(audit_root, parquet_batch_size=1)
+
+    first = dispatch_once(_InterruptedControlPlane(control_plane), sink, DELIVERED_AT)
+
+    reopened_control_plane = SQLiteControlPlane(database_path, lambda: DELIVERED_AT)
+    reopened_control_plane.initialize()
+    reopened_store = FilesystemObjectStore(object_root)
+    reopened_sink = LocalAuditSink(audit_root, parquet_batch_size=1)
+    second = dispatch_once(reopened_control_plane, reopened_sink, DELIVERED_AT)
+    replayed = reopened_store.put("raw/354130/job-local.parquet", BytesIO(body), digest)
+
+    log_path = audit_root / "audit" / "354130" / "2026" / "09" / "06" / "events.jsonl"
+    parquet_paths = tuple((audit_root / "audit").glob("*/*/*/*/batch-*.parquet"))
+    with reopened_store.open("raw/354130/job-local.parquet") as stored:
+        stored_body = stored.read()
+
+    assert first == DispatchResult(delivered=0, failed=1)
+    assert second == DispatchResult(delivered=1, failed=0)
+    assert reopened_control_plane.pending_outbox(10) == ()
+    assert published == replayed
+    assert stored_body == body
+    assert len(log_path.read_text(encoding="utf-8").splitlines()) == 1
+    assert json.loads(log_path.read_text(encoding="utf-8"))["event_id"] == "event-local"
+    assert len(parquet_paths) == 1
+    assert pl.read_parquet(parquet_paths[0]).get_column("event_id").to_list() == ["event-local"]


### PR DESCRIPTION
## Resumo

- publica os adapters Phase 2 somente pelos namespaces de infraestrutura
- cobre replay local e AWS-emulator após interrupção entre audit append e outbox delivery
- adiciona profile aws-test pinado e um único script versionado de provisionamento, testes e cleanup
- integra o gate após o Python gate e somente em schedule/manual no python-quality
- registra os markers também em pytest.ini conforme emenda de escopo da Issue #127

## Verificação

- RED: 3 falhas de import e 4 warnings de markers desconhecidos
- Ruff global
- scripts/ci_python_gate.sh: packages 100% coverage; apps 97,55%
- scripts/baseline_matrix_test.py: 31 passed
- scripts/ci_phase2_adapters.sh: local 2 passed; AWS 1 passed; teardown limpo
- falha forçada de pytest: status não zero com teardown limpo

## Limites da evidência

A retenção é apenas capability smoke do emulador. Este PR não comprova WORM, atomicidade AWS real, exactly-once nem segurança SQLite cross-host.

Refs #127