### PR TITLE
feat(ingestion): validate raw manifests and delta chains

### DIFF
--- a/apps/central_api/src/central_api/services/delta_policy.py
+++ b/apps/central_api/src/central_api/services/delta_policy.py
@@ -1,0 +1,61 @@
+"""Política pura de aceitação de cadeias raw DELTA."""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+
+from cnes_contracts import RawManifest, manifest_sha256
+from cnes_domain.control_plane.entities import RawResyncState
+
+_MAX_BASE_AGE = timedelta(days=7)
+_MAX_CHAIN_LENGTH = 30
+
+
+class ResyncReason(StrEnum):
+    AGENT_RESYNC_REQUIRED = "AGENT_RESYNC_REQUIRED"
+    BASE_UNKNOWN = "BASE_UNKNOWN"
+    SEQUENCE_GAP = "SEQUENCE_GAP"
+    HASH_CHAIN_MISMATCH = "HASH_CHAIN_MISMATCH"
+    SCHEMA_INCOMPATIBLE = "SCHEMA_INCOMPATIBLE"
+    BASE_TOO_OLD = "BASE_TOO_OLD"
+    CHAIN_TOO_LONG = "CHAIN_TOO_LONG"
+
+
+@dataclass(frozen=True, slots=True)
+class _DeltaContext:
+    manifest: RawManifest
+    chain: tuple[RawManifest, ...]
+    resync_state: RawResyncState | None
+    now: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class DeltaPolicy:
+    max_base_age: timedelta = _MAX_BASE_AGE
+    max_chain_length: int = _MAX_CHAIN_LENGTH
+
+    def __post_init__(self) -> None:
+        valid_age = timedelta(0) < self.max_base_age <= _MAX_BASE_AGE
+        valid_length = 0 < self.max_chain_length <= _MAX_CHAIN_LENGTH
+        if not valid_age or not valid_length:
+            raise ValueError("delta_policy_limit")
+
+    def evaluate(self, context: _DeltaContext) -> ResyncReason | None:
+        manifest = context.manifest
+        chain = context.chain
+        reason = None
+        if context.resync_state is not None:
+            reason = ResyncReason.AGENT_RESYNC_REQUIRED
+        elif not chain or manifest.base_snapshot_id != chain[0].snapshot_id:
+            reason = ResyncReason.BASE_UNKNOWN
+        elif manifest.sequence != chain[-1].sequence + 1:
+            reason = ResyncReason.SEQUENCE_GAP
+        elif manifest.previous_manifest_sha256 != manifest_sha256(chain[-1]):
+            reason = ResyncReason.HASH_CHAIN_MISMATCH
+        elif manifest.schema_version != chain[-1].schema_version:
+            reason = ResyncReason.SCHEMA_INCOMPATIBLE
+        elif not timedelta(0) <= context.now - chain[0].created_at <= self.max_base_age:
+            reason = ResyncReason.BASE_TOO_OLD
+        elif len(chain) - 1 >= self.max_chain_length:
+            reason = ResyncReason.CHAIN_TOO_LONG
+        return reason

--- a/apps/central_api/src/central_api/services/raw_ingestion.py
+++ b/apps/central_api/src/central_api/services/raw_ingestion.py
@@ -1,0 +1,432 @@
+"""Registro imutável de manifestos raw."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from hashlib import sha256
+from io import BytesIO
+from itertools import pairwise
+from typing import TYPE_CHECKING
+
+from central_api.services.delta_policy import DeltaPolicy, ResyncReason, _DeltaContext
+from cnes_contracts import RawManifest, SnapshotMode, manifest_sha256
+from cnes_domain.control_plane.commands import CompleteJob, FailJob
+from cnes_domain.control_plane.entities import Job, ManifestRef, OutboxEvent, RawManifestRecord
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
+from cnes_domain.control_plane.errors import ControlPlaneErrorCode as ErrorCode
+from cnes_domain.control_plane.queries import (
+    AgentRawManifestChainQuery,
+    LatestSucceededJobQuery,
+    RawIdentity,
+    RawManifestByIdQuery,
+    RawResyncStateQuery,
+)
+
+if TYPE_CHECKING:
+    from typing import Protocol
+
+    from cnes_domain.ports.control_plane import ControlPlanePort, TypedRawQueryPort
+    from cnes_domain.ports.object_store import ObjectStorePort
+
+    class _ControlPlane(ControlPlanePort, TypedRawQueryPort, Protocol):
+        pass
+
+logger = logging.getLogger(__name__)
+type AcceptedManifest = Callable[[RawManifestRecord], None]
+
+
+def _noop(_: RawManifestRecord) -> None:
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class RawAcceptance:
+    accepted: bool
+    manifest_id: str
+    manifest_sha256: str
+    full_resync_required: bool
+    reason: ResyncReason | None
+
+
+@dataclass(frozen=True, slots=True)
+class _DeltaDecision:
+    reason: ResyncReason | None
+    expected_head_manifest_id: str | None
+    marker_observed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class RegisterRawManifest:
+    tenant_id: str
+    agent_id: str
+    job_id: str
+    owner: str
+    fencing_token: int
+    manifest: RawManifest
+    manifest_bytes: bytes
+    now: datetime
+
+    def __post_init__(self) -> None:
+        if not all((self.tenant_id, self.agent_id, self.job_id, self.owner)):
+            raise ValueError("blank_value")
+        if self.fencing_token < 0:
+            raise ValueError("negative_counter")
+        if self.now.tzinfo is None or self.now.utcoffset() != timedelta(0):
+            raise ValueError("datetime_not_utc")
+
+
+class RawIngestionService:
+    def __init__(
+        self,
+        control_plane: _ControlPlane,
+        object_store: ObjectStorePort,
+        policy: DeltaPolicy,
+        accepted_manifest: AcceptedManifest = _noop,
+    ) -> None:
+        self._control_plane = control_plane
+        self._object_store = object_store
+        self._policy = policy
+        self._accepted_manifest = accepted_manifest
+
+    def register(self, command: RegisterRawManifest) -> RawAcceptance:
+        job = self._control_plane.get_job(command.tenant_id, command.job_id)
+        if job is None:
+            raise NotFound(ErrorCode.JOB_MISSING)
+        digest = self._validate_identity_and_bytes(job, command)
+        replay = self._terminal_replay(job, command, digest)
+        if replay is not None:
+            return replay
+        self._validate_live_job(job, command)
+        self._validate_data_object(command.manifest)
+        record = _record(command.manifest, _manifest_key(command.manifest), digest)
+        decision = self._delta_decision(command)
+        if decision.reason is not None:
+            return self._reject(command, digest, decision)
+        return self._accept(command, record, decision.expected_head_manifest_id)
+
+    @staticmethod
+    def _validate_identity_and_bytes(job: Job, command: RegisterRawManifest) -> str:
+        manifest = command.manifest
+        expected = (
+            job.tenant_id,
+            job.agent_id,
+            job.source_type,
+            job.file_subtype,
+            job.competencia,
+            job.requested_snapshot_mode,
+        )
+        actual = (
+            command.tenant_id,
+            command.agent_id,
+            manifest.source_type.value,
+            manifest.file_subtype,
+            manifest.competencia,
+            manifest.snapshot_mode.value,
+        )
+        manifest_identity = (manifest.tenant_id, manifest.agent_id)
+        if actual != expected or manifest_identity != (command.tenant_id, command.agent_id):
+            raise Conflict(ErrorCode.MANIFEST_IDENTITY_CONFLICT)
+        canonical = _canonical_bytes(manifest)
+        if command.manifest_bytes != canonical:
+            raise Conflict("manifest=noncanonical")
+        return sha256(canonical).hexdigest()
+
+    def _terminal_replay(
+        self, job: Job, command: RegisterRawManifest, digest: str
+    ) -> RawAcceptance | None:
+        if job.state is JobState.SUCCEEDED:
+            self._validate_accepted_replay(job, command, digest)
+            return RawAcceptance(True, command.manifest.manifest_id, digest, False, None)
+        if job.state is not JobState.FAILED_FINAL:
+            return None
+        prefix = "RAW_RESYNC_"
+        if job.error_code is None or not job.error_code.startswith(prefix):
+            return None
+        try:
+            reason = ResyncReason(job.error_code.removeprefix(prefix))
+        except ValueError as error:
+            raise Conflict("terminal_replay=conflict") from error
+        if job.rejected_manifest_sha256 != digest:
+            raise Conflict("terminal_replay=conflict")
+        return RawAcceptance(False, command.manifest.manifest_id, digest, True, reason)
+
+    def _validate_accepted_replay(
+        self, job: Job, command: RegisterRawManifest, digest: str
+    ) -> None:
+        if job.result_manifest_id is None:
+            raise Conflict("terminal_replay=conflict")
+        query = RawManifestByIdQuery(job.tenant_id, job.result_manifest_id)
+        record = self._control_plane.query_raw_manifest_by_id(query)
+        if record is None or not _record_matches(command.manifest, record, digest):
+            raise Conflict("terminal_replay=conflict")
+        if job.result_manifest_key != record.manifest_key:
+            raise Conflict("terminal_replay=conflict")
+        self._validate_data_object(command.manifest, replay=True)
+        self._validate_sidecar(record.manifest_key, command.manifest_bytes, digest)
+
+    @staticmethod
+    def _validate_live_job(job: Job, command: RegisterRawManifest) -> None:
+        if job.state is not JobState.LEASED:
+            raise LeaseLost(ErrorCode.JOB_NOT_LEASED)
+        if job.lease_owner != command.owner:
+            raise LeaseLost(ErrorCode.JOB_OWNER_LOST)
+        if job.fencing_token != command.fencing_token:
+            raise FenceRejected(ErrorCode.JOB_FENCE_REJECTED)
+        if job.lease_until is None or job.lease_until <= command.now:
+            raise LeaseLost(ErrorCode.JOB_LEASE_EXPIRED)
+
+    def _validate_data_object(self, manifest: RawManifest, replay: bool = False) -> None:
+        if manifest.object_key != _data_key(manifest):
+            code = "terminal_replay=conflict" if replay else "object=divergent"
+            raise Conflict(code)
+        stat = self._object_store.stat(manifest.object_key)
+        if stat is None:
+            code = "terminal_replay=conflict" if replay else "object=missing"
+            raise Conflict(code)
+        expected = (manifest.object_key, manifest.size_bytes, manifest.object_sha256)
+        if (stat.key, stat.size_bytes, stat.sha256) != expected:
+            code = "terminal_replay=conflict" if replay else "object=divergent"
+            raise Conflict(code)
+
+    def _validate_sidecar(self, key: str, canonical: bytes, digest: str) -> None:
+        stat = self._object_store.stat(key)
+        if stat is None or (stat.key, stat.size_bytes, stat.sha256) != (
+            key,
+            len(canonical),
+            digest,
+        ):
+            raise Conflict("terminal_replay=conflict")
+        try:
+            with self._object_store.open(key) as stream:
+                if stream.read() != canonical:
+                    raise Conflict("terminal_replay=conflict")
+        except (FileNotFoundError, KeyError) as error:
+            raise Conflict("terminal_replay=conflict") from error
+
+    def _delta_decision(self, command: RegisterRawManifest) -> _DeltaDecision:
+        if command.manifest.snapshot_mode is SnapshotMode.FULL:
+            return _DeltaDecision(None, None, False)
+        identity = _raw_identity(command.manifest)
+        marker = self._control_plane.query_raw_resync_state(
+            RawResyncStateQuery(identity, command.agent_id)
+        )
+        if marker is not None:
+            reason = self._policy.evaluate(
+                _DeltaContext(command.manifest, (), marker, command.now)
+            )
+            return _DeltaDecision(reason, None, True)
+        latest = self._control_plane.query_latest_succeeded_job(
+            LatestSucceededJobQuery(identity, command.agent_id)
+        )
+        if latest is None:
+            reason = self._policy.evaluate(
+                _DeltaContext(command.manifest, (), None, command.now)
+            )
+            return _DeltaDecision(reason, None, False)
+        refs = self._control_plane.query_agent_raw_manifest_chain(
+            AgentRawManifestChainQuery(identity, command.agent_id, limit=31)
+        )
+        latest_ref = None if not refs else refs[-1]
+        if (
+            latest_ref is None
+            or latest_ref.manifest_id != latest.result_manifest_id
+            or latest_ref.manifest_key != latest.result_manifest_key
+        ):
+            raise Conflict("raw_history=divergent")
+        chain = self._load_chain(command, refs)
+        reason = self._policy.evaluate(
+            _DeltaContext(command.manifest, chain, None, command.now)
+        )
+        return _DeltaDecision(reason, latest_ref.manifest_id, False)
+
+    def _load_chain(
+        self, command: RegisterRawManifest, refs: tuple[ManifestRef, ...]
+    ) -> tuple[RawManifest, ...]:
+        manifests = []
+        try:
+            for reference in refs:
+                query = RawManifestByIdQuery(command.tenant_id, reference.manifest_id)
+                record = self._control_plane.query_raw_manifest_by_id(query)
+                if record is None or record.manifest_key != reference.manifest_key:
+                    raise ValueError("record_missing")
+                with self._object_store.open(record.manifest_key) as stream:
+                    payload = stream.read()
+                historical = RawManifest.model_validate_json(payload)
+                digest = manifest_sha256(historical)
+                if payload != _canonical_bytes(historical):
+                    raise ValueError("sidecar_noncanonical")
+                if not _record_matches(historical, record, digest):
+                    raise ValueError("record_divergent")
+                manifests.append(historical)
+        except Exception as error:
+            raise Conflict("raw_history=divergent") from error
+        chain = tuple(manifests)
+        if not _valid_chain(chain, command.agent_id, command.manifest):
+            raise Conflict("raw_history=divergent")
+        return chain
+
+    def _reject(
+        self, command: RegisterRawManifest, digest: str, decision: _DeltaDecision
+    ) -> RawAcceptance:
+        reason = decision.reason
+        if reason is None:
+            raise ValueError("resync_reason_required")
+        error_code = f"RAW_RESYNC_{reason.value}"
+        failure = FailJob(
+            tenant_id=command.tenant_id,
+            job_id=command.job_id,
+            owner=command.owner,
+            fencing_token=command.fencing_token,
+            error_code=error_code,
+            retryable=False,
+            rejected_manifest_sha256=digest,
+            expected_head_manifest_id=decision.expected_head_manifest_id,
+            expected_resync_marker=decision.marker_observed,
+        )
+        event = _event(command, digest, "raw.manifest.resync_required", reason=reason)
+        self._control_plane.fail_job(failure, event)
+        return RawAcceptance(False, command.manifest.manifest_id, digest, True, reason)
+
+    def _accept(
+        self, command: RegisterRawManifest, record: RawManifestRecord,
+        expected_head_manifest_id: str | None,
+    ) -> RawAcceptance:
+        digest = record.manifest_sha256
+        self._object_store.put(record.manifest_key, BytesIO(command.manifest_bytes), digest)
+        completion = CompleteJob(
+            tenant_id=command.tenant_id,
+            job_id=command.job_id,
+            owner=command.owner,
+            fencing_token=command.fencing_token,
+            manifest=record,
+            expected_head_manifest_id=expected_head_manifest_id,
+        )
+        event = _event(
+            command, digest, "raw.manifest.accepted", manifest_key=record.manifest_key
+        )
+        self._control_plane.complete_job(completion, event)
+        try:
+            self._accepted_manifest(record)
+        except Exception as error:
+            logger.error(
+                "accepted_manifest_callback_failed tenant_id=%s job_id=%s manifest_id=%s "
+                "exception_type=%s",
+                command.tenant_id,
+                command.job_id,
+                command.manifest.manifest_id,
+                type(error).__name__,
+            )
+        return RawAcceptance(True, command.manifest.manifest_id, digest, False, None)
+
+
+def _canonical_bytes(manifest: RawManifest) -> bytes:
+    return manifest.model_dump_json(exclude_none=False, by_alias=False).encode()
+
+
+def _manifest_key(manifest: RawManifest) -> str:
+    return _data_key(manifest).removesuffix("data.parquet") + "manifest.json"
+
+
+def _data_key(manifest: RawManifest) -> str:
+    return (
+        f"raw/{manifest.tenant_id}/{manifest.source_type.value}/{manifest.competencia}/"
+        f"{manifest.snapshot_id}/data.parquet"
+    )
+
+
+def _raw_identity(manifest: RawManifest) -> RawIdentity:
+    return RawIdentity(
+        manifest.tenant_id,
+        manifest.source_type.value,
+        manifest.file_subtype,
+        manifest.competencia,
+    )
+
+
+def _record(manifest: RawManifest, key: str, digest: str) -> RawManifestRecord:
+    return RawManifestRecord(
+        tenant_id=manifest.tenant_id,
+        manifest_id=manifest.manifest_id,
+        manifest_key=key,
+        agent_id=manifest.agent_id,
+        source_type=manifest.source_type.value,
+        file_subtype=manifest.file_subtype,
+        competencia=manifest.competencia,
+        snapshot_mode=manifest.snapshot_mode.value,
+        snapshot_id=manifest.snapshot_id,
+        base_snapshot_id=manifest.base_snapshot_id,
+        sequence=manifest.sequence,
+        previous_manifest_sha256=manifest.previous_manifest_sha256,
+        manifest_sha256=digest,
+        created_at=manifest.created_at,
+    )
+
+
+def _record_matches(manifest: RawManifest, record: RawManifestRecord, digest: str) -> bool:
+    return record == _record(manifest, _manifest_key(manifest), digest)
+
+
+def _valid_chain(
+    chain: tuple[RawManifest, ...], agent_id: str, expected: RawManifest
+) -> bool:
+    if (
+        not chain
+        or chain[0].snapshot_mode is not SnapshotMode.FULL
+        or _raw_identity(chain[0]) != _raw_identity(expected)
+    ):
+        return False
+    for previous, current in pairwise(chain):
+        if not _valid_link(previous, current, chain[0]):
+            return False
+    return chain[0].agent_id == agent_id
+
+
+def _valid_link(
+    previous: RawManifest,
+    current: RawManifest,
+    base: RawManifest,
+) -> bool:
+    return (
+        current.snapshot_mode is SnapshotMode.DELTA
+        and _raw_identity(current) == _raw_identity(base)
+        and current.agent_id == base.agent_id
+        and current.schema_version == base.schema_version
+        and current.base_snapshot_id == base.snapshot_id
+        and current.sequence == previous.sequence + 1
+        and current.previous_manifest_sha256 == manifest_sha256(previous)
+    )
+
+
+def _event(
+    command: RegisterRawManifest,
+    digest: str,
+    event_type: str,
+    **extra: str | ResyncReason,
+) -> OutboxEvent:
+    manifest = command.manifest
+    identity = "\x1f".join((event_type, command.tenant_id, command.job_id, digest))
+    payload = {
+        "job_id": command.job_id,
+        "agent_id": command.agent_id,
+        "manifest_id": manifest.manifest_id,
+        "manifest_sha256": digest,
+        "source_type": manifest.source_type.value,
+        "file_subtype": manifest.file_subtype,
+        "competencia": manifest.competencia,
+        "snapshot_mode": manifest.snapshot_mode.value,
+        **{key: value.value if isinstance(value, ResyncReason) else value
+           for key, value in extra.items()},
+    }
+    return OutboxEvent(
+        tenant_id=command.tenant_id,
+        event_id=sha256(identity.encode()).hexdigest(),
+        event_type=event_type,
+        aggregate_id=command.job_id,
+        payload=payload,
+        created_at=command.now,
+        delivered_at=None,
+    )

--- a/apps/central_api/tests/services/test_delta_policy.py
+++ b/apps/central_api/tests/services/test_delta_policy.py
@@ -1,0 +1,141 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from central_api.services.delta_policy import DeltaPolicy, ResyncReason, _DeltaContext
+from cnes_contracts import RawManifest, SnapshotMode, SourceType, manifest_sha256
+from cnes_domain.control_plane.entities import RawResyncState
+
+NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
+HASH = "a" * 64
+
+
+def manifest(
+    sequence: int,
+    created_at: datetime = NOW,
+    schema_version: str = "v1",
+    previous: str | None = None,
+) -> RawManifest:
+    mode = SnapshotMode.FULL if sequence == 1 else SnapshotMode.DELTA
+    snapshot_id = "base" if sequence == 1 else f"delta-{sequence}"
+    return RawManifest(
+        manifest_version=1,
+        manifest_id=f"manifest-{snapshot_id}",
+        tenant_id="354130",
+        source_type=SourceType.CNES_LOCAL,
+        file_subtype="CNES_VINCULO",
+        competencia="2026-07",
+        agent_id="agent-1",
+        agent_version="1.0",
+        schema_version=schema_version,
+        snapshot_mode=mode,
+        snapshot_id=snapshot_id,
+        base_snapshot_id=None if sequence == 1 else "base",
+        sequence=sequence,
+        previous_manifest_sha256=None if sequence == 1 else previous or HASH,
+        object_sha256=HASH,
+        row_count=1,
+        size_bytes=10,
+        object_key=f"raw/354130/CNES_LOCAL/2026-07/{snapshot_id}/data.parquet",
+        created_at=created_at,
+    )
+
+
+def context(
+    current: RawManifest,
+    chain: tuple[RawManifest, ...],
+    marker: RawResyncState | None = None,
+    now: datetime = NOW,
+) -> _DeltaContext:
+    return _DeltaContext(current, chain, marker, now)
+
+
+def linked_delta(chain: tuple[RawManifest, ...], **updates: object) -> RawManifest:
+    values = {
+        "sequence": chain[-1].sequence + 1,
+        "previous": manifest_sha256(chain[-1]),
+        "created_at": NOW,
+        "schema_version": chain[-1].schema_version,
+    } | updates
+    return manifest(**values)
+
+
+def old_base_context(_: RawManifest) -> _DeltaContext:
+    old_base = manifest(1, NOW - timedelta(days=7, microseconds=1))
+    return context(linked_delta((old_base,)), (old_base,))
+
+
+@pytest.mark.parametrize(
+    ("reason", "build"),
+    [
+        (
+            ResyncReason.AGENT_RESYNC_REQUIRED,
+            lambda base: context(
+                manifest(9),
+                (),
+                RawResyncState(
+                    tenant_id="354130",
+                    agent_id="agent-1",
+                    source_type="CNES_LOCAL",
+                    file_subtype="CNES_VINCULO",
+                    competencia="2026-07",
+                    required_since=NOW,
+                ),
+            ),
+        ),
+        (ResyncReason.BASE_UNKNOWN, lambda base: context(manifest(2), ())),
+        (ResyncReason.SEQUENCE_GAP, lambda base: context(manifest(3), (base,))),
+        (
+            ResyncReason.HASH_CHAIN_MISMATCH,
+            lambda base: context(manifest(2, previous="b" * 64), (base,)),
+        ),
+        (
+            ResyncReason.SCHEMA_INCOMPATIBLE,
+            lambda base: context(linked_delta((base,), schema_version="v2"), (base,)),
+        ),
+        (
+            ResyncReason.BASE_TOO_OLD,
+            old_base_context,
+        ),
+        (
+            ResyncReason.CHAIN_TOO_LONG,
+            lambda base: context(
+                linked_delta(tuple(manifest(index) for index in range(1, 32))),
+                tuple(manifest(index) for index in range(1, 32)),
+            ),
+        ),
+    ],
+)
+def test_delta_invalido_solicita_full(reason, build) -> None:
+    base = manifest(1)
+    assert DeltaPolicy().evaluate(build(base)) is reason
+
+
+def test_aceita_limites_exatos_de_idade_e_cadeia() -> None:
+    base = manifest(1, NOW - timedelta(days=7))
+    chain = (base, *(manifest(index) for index in range(2, 31)))
+    current = linked_delta(chain)
+
+    assert DeltaPolicy().evaluate(context(current, chain)) is None
+
+
+def test_rejeita_base_com_data_futura() -> None:
+    base = manifest(1, NOW + timedelta(microseconds=1))
+
+    assert DeltaPolicy().evaluate(context(linked_delta((base,)), (base,))) is (
+        ResyncReason.BASE_TOO_OLD
+    )
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"max_base_age": timedelta(0)},
+        {"max_base_age": timedelta(days=7, microseconds=1)},
+        {"max_chain_length": 0},
+        {"max_chain_length": 31},
+    ],
+)
+def test_rejeita_limites_fora_dos_tetos(values: dict[str, object]) -> None:
+    with pytest.raises(ValueError, match="delta_policy_limit"):
+        DeltaPolicy(**values)

--- a/apps/central_api/tests/services/test_raw_history.py
+++ b/apps/central_api/tests/services/test_raw_history.py
@@ -1,0 +1,43 @@
+from datetime import UTC, datetime
+from hashlib import sha256
+
+import pytest
+
+from central_api.services.raw_ingestion import _valid_chain
+from cnes_contracts import RawManifest, SnapshotMode, SourceType, manifest_sha256
+
+
+def _manifest(mode: SnapshotMode = SnapshotMode.FULL) -> RawManifest:
+    delta = mode is SnapshotMode.DELTA
+    snapshot_id = "delta-2" if delta else "base"
+    return RawManifest(
+        manifest_version=1, manifest_id=f"manifest-{snapshot_id}", tenant_id="354130",
+        source_type=SourceType.CNES_LOCAL, file_subtype="CNES_VINCULO",
+        competencia="2026-07", agent_id="agent-1", agent_version="1.0",
+        schema_version="v1", snapshot_mode=mode, snapshot_id=snapshot_id,
+        base_snapshot_id="base" if delta else None, sequence=2 if delta else 1,
+        previous_manifest_sha256="a" * 64 if delta else None,
+        object_sha256=sha256(b"parquet").hexdigest(), row_count=1,
+        size_bytes=7,
+        object_key=f"raw/354130/CNES_LOCAL/2026-07/{snapshot_id}/data.parquet",
+        created_at=datetime(2026, 7, 15, 12, tzinfo=UTC),
+    )
+
+
+@pytest.mark.parametrize("corruption", ["identity", "schema"])
+def test_cadeia_historica_rejeita_identidade_ou_schema_descontinuo(
+    corruption: str,
+) -> None:
+    expected = _manifest()
+    base = expected.model_copy(
+        update={"file_subtype": "divergent"} if corruption == "identity" else {}
+    )
+    updates = {
+        "previous_manifest_sha256": manifest_sha256(base),
+        "file_subtype": base.file_subtype,
+    }
+    if corruption == "schema":
+        updates["schema_version"] = "divergent"
+    delta = _manifest(SnapshotMode.DELTA).model_copy(update=updates)
+
+    assert not _valid_chain((base, delta), "agent-1", expected)

--- a/apps/central_api/tests/services/test_raw_ingestion.py
+++ b/apps/central_api/tests/services/test_raw_ingestion.py
@@ -1,0 +1,499 @@
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+from io import BytesIO
+
+import pytest
+
+from central_api.services.delta_policy import DeltaPolicy, ResyncReason
+from central_api.services.raw_ingestion import RawIngestionService, RegisterRawManifest
+from cnes_contracts import RawManifest, SnapshotMode, SourceType, manifest_sha256
+from cnes_domain.control_plane.entities import Job, ManifestRef, RawManifestRecord, RawResyncState
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.ports.object_store import ObjectStat
+
+NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
+DATA = b"parquet"
+DATA_HASH = sha256(DATA).hexdigest()
+
+
+def manifest(mode: SnapshotMode = SnapshotMode.FULL) -> RawManifest:
+    delta = mode is SnapshotMode.DELTA
+    snapshot_id = "delta-2" if delta else "base"
+    return RawManifest(
+        manifest_version=1,
+        manifest_id=f"manifest-{snapshot_id}",
+        tenant_id="354130",
+        source_type=SourceType.CNES_LOCAL,
+        file_subtype="CNES_VINCULO",
+        competencia="2026-07",
+        agent_id="agent-1",
+        agent_version="1.0",
+        schema_version="v1",
+        snapshot_mode=mode,
+        snapshot_id=snapshot_id,
+        base_snapshot_id="base" if delta else None,
+        sequence=2 if delta else 1,
+        previous_manifest_sha256="a" * 64 if delta else None,
+        object_sha256=DATA_HASH,
+        row_count=1,
+        size_bytes=len(DATA),
+        object_key=f"raw/354130/CNES_LOCAL/2026-07/{snapshot_id}/data.parquet",
+        created_at=NOW,
+    )
+
+
+def job(mode: SnapshotMode = SnapshotMode.FULL, state: JobState = JobState.LEASED) -> Job:
+    return Job(
+        tenant_id="354130",
+        job_id="job-1",
+        agent_id="agent-1",
+        source_type="CNES_LOCAL",
+        file_subtype="CNES_VINCULO",
+        competencia="2026-07",
+        requested_snapshot_mode=mode.value,
+        state=state,
+        attempt=1,
+        fencing_token=7,
+        lease_owner="worker" if state is JobState.LEASED else None,
+        lease_until=NOW + timedelta(minutes=5) if state is JobState.LEASED else None,
+        result_manifest_id=None,
+        result_manifest_key=None,
+        error_code=None,
+        created_at=NOW,
+    )
+
+
+def record(raw: RawManifest) -> RawManifestRecord:
+    return RawManifestRecord(
+        tenant_id=raw.tenant_id,
+        manifest_id=raw.manifest_id,
+        manifest_key=raw.object_key.removesuffix("data.parquet") + "manifest.json",
+        agent_id=raw.agent_id,
+        source_type=raw.source_type.value,
+        file_subtype=raw.file_subtype,
+        competencia=raw.competencia,
+        snapshot_mode=raw.snapshot_mode.value,
+        snapshot_id=raw.snapshot_id,
+        base_snapshot_id=raw.base_snapshot_id,
+        sequence=raw.sequence,
+        previous_manifest_sha256=raw.previous_manifest_sha256,
+        manifest_sha256=manifest_sha256(raw),
+        created_at=raw.created_at,
+    )
+
+
+class ObjectStore:
+    def __init__(self, raw: RawManifest) -> None:
+        self.objects = {raw.object_key: DATA}
+        self.calls: list[str] = []
+
+    def stat(self, key: str) -> ObjectStat | None:
+        self.calls.append(f"stat:{key}")
+        body = self.objects.get(key)
+        return None if body is None else ObjectStat(key, len(body), sha256(body).hexdigest())
+
+    def put(self, key: str, body, expected_sha256: str) -> ObjectStat:
+        self.calls.append(f"put:{key}")
+        value = body.read()
+        current = self.objects.setdefault(key, value)
+        if current != value:
+            raise Conflict("object=immutable")
+        return ObjectStat(key, len(value), expected_sha256)
+
+    @contextmanager
+    def open(self, key: str):
+        self.calls.append(f"open:{key}")
+        yield BytesIO(self.objects[key])
+
+
+class ControlPlane:
+    def __init__(self, current: Job) -> None:
+        self.job = current
+        self.records: dict[str, RawManifestRecord] = {}
+        self.marker = None
+        self.latest = None
+        self.chain = ()
+        self.mutations: list[str] = []
+        self.query_calls: list[str] = []
+        self.events = []
+        self.completions = []
+
+    def get_job(self, tenant_id: str, job_id: str) -> Job | None:
+        return self.job if (tenant_id, job_id) == (self.job.tenant_id, self.job.job_id) else None
+
+    def query_raw_manifest_by_id(self, query):
+        self.query_calls.append("by-id")
+        return self.records.get(query.manifest_id)
+
+    def query_latest_succeeded_job(self, query):
+        self.query_calls.append("latest")
+        return self.latest
+
+    def query_agent_raw_manifest_chain(self, query):
+        self.query_calls.append("agent-chain")
+        return self.chain
+
+    def query_raw_resync_state(self, query):
+        self.query_calls.append("resync")
+        return self.marker
+
+    def complete_job(self, command, event):
+        self.mutations.append("complete")
+        self.completions.append(command)
+        self.events.append(event)
+        self.records[command.manifest.manifest_id] = command.manifest
+        self.job = self.job.model_copy(update={
+            "state": JobState.SUCCEEDED,
+            "lease_owner": None,
+            "lease_until": None,
+            "result_manifest_id": command.manifest.manifest_id,
+            "result_manifest_key": command.manifest.manifest_key,
+        })
+        return self.job
+
+    def fail_job(self, command, event):
+        self.mutations.append("fail")
+        self.events.append(event)
+        self.job = self.job.model_copy(update={
+            "state": JobState.FAILED_FINAL,
+            "lease_owner": None,
+            "lease_until": None,
+            "error_code": command.error_code,
+            "rejected_manifest_sha256": command.rejected_manifest_sha256,
+        })
+        return self.job
+
+
+def command(raw: RawManifest, **updates: object) -> RegisterRawManifest:
+    values = {
+        "tenant_id": "354130",
+        "agent_id": "agent-1",
+        "job_id": "job-1",
+        "owner": "worker",
+        "fencing_token": 7,
+        "manifest": raw,
+        "manifest_bytes": raw.model_dump_json(exclude_none=False, by_alias=False).encode(),
+        "now": NOW,
+    }
+    return RegisterRawManifest(**(values | updates))
+
+
+def test_aceite_grava_sidecar_antes_do_commit_atomico_e_callback() -> None:
+    raw = manifest()
+    store = ObjectStore(raw)
+    control = ControlPlane(job())
+    order = []
+
+    def accepted(item: RawManifestRecord) -> None:
+        assert control.mutations == ["complete"]
+        order.append(item.manifest_id)
+
+    result = RawIngestionService(control, store, DeltaPolicy(), accepted).register(command(raw))
+
+    assert result.accepted
+    assert control.mutations == ["complete"]
+    assert store.calls[-1].startswith("put:")
+    assert order == [raw.manifest_id]
+
+
+def test_identidade_divergente_falha_antes_de_acessar_objeto() -> None:
+    raw = manifest()
+    store = ObjectStore(raw)
+    control = ControlPlane(job())
+
+    with pytest.raises(Conflict, match="manifest_identity"):
+        RawIngestionService(control, store, DeltaPolicy()).register(
+            command(raw, agent_id="other")
+        )
+
+    assert store.calls == []
+    assert control.mutations == []
+
+
+@pytest.mark.parametrize(
+    ("mode", "raw_updates", "updates", "error"),
+    [
+        (SnapshotMode.FULL, {}, {"fencing_token": 8}, "job_fence_rejected"),
+        (SnapshotMode.FULL, {}, {"manifest_bytes": b"{}"}, "manifest=noncanonical"),
+        (SnapshotMode.FULL,
+         {"object_key": "raw/354130/CNES_LOCAL/2026-07/base/other.parquet"}, {},
+         "object=divergent"),
+        (SnapshotMode.FULL, {"manifest_id": "part/id"}, {}, "invalid_key_component"),
+        (SnapshotMode.DELTA, {"manifest_id": "part/id"}, {}, "invalid_key_component"),
+    ],
+)
+def test_conflito_vivo_nao_altera_control_plane(mode, raw_updates, updates, error) -> None:
+    raw = manifest(mode).model_copy(update=raw_updates)
+    store = ObjectStore(raw)
+    control = ControlPlane(job(mode))
+
+    with pytest.raises((Conflict, ValueError), match=error):
+        RawIngestionService(control, store, DeltaPolicy()).register(command(raw, **updates))
+
+    assert control.mutations == []
+    assert all(not call.startswith("put:") for call in store.calls)
+
+
+def test_objeto_divergente_vence_rejeicao_delta_potencial() -> None:
+    raw = manifest(SnapshotMode.DELTA)
+    store = ObjectStore(raw)
+    store.objects[raw.object_key] = b"wrong"
+    control = ControlPlane(job(SnapshotMode.DELTA))
+
+    with pytest.raises(Conflict, match="object=divergent"):
+        RawIngestionService(control, store, DeltaPolicy()).register(command(raw))
+
+    assert control.query_calls == []
+    assert control.mutations == []
+
+
+def test_rejeicao_delta_finaliza_job_sem_sidecar() -> None:
+    raw = manifest(SnapshotMode.DELTA)
+    store = ObjectStore(raw)
+    control = ControlPlane(job(SnapshotMode.DELTA))
+
+    result = RawIngestionService(control, store, DeltaPolicy()).register(command(raw))
+
+    assert result.reason is ResyncReason.BASE_UNKNOWN
+    assert control.job.rejected_manifest_sha256 == manifest_sha256(raw)
+    assert control.mutations == ["fail"]
+    assert all("manifest.json" not in call for call in store.calls)
+    event = control.events[0]
+    digest = manifest_sha256(raw)
+    identity = "\x1f".join((event.event_type, "354130", "job-1", digest))
+    assert event.event_id == sha256(identity.encode()).hexdigest()
+    assert event.aggregate_id == "job-1"
+    assert event.created_at == NOW
+    assert event.payload == {
+        "job_id": "job-1", "agent_id": "agent-1", "manifest_id": raw.manifest_id,
+        "manifest_sha256": digest, "source_type": "CNES_LOCAL",
+        "file_subtype": "CNES_VINCULO", "competencia": "2026-07",
+        "snapshot_mode": "DELTA", "reason": "BASE_UNKNOWN",
+    }
+
+
+def test_replay_terminal_rejeitado_sem_lease_nao_acessa_objeto() -> None:
+    raw = manifest(SnapshotMode.DELTA)
+    digest = manifest_sha256(raw)
+    failed = job(SnapshotMode.DELTA, JobState.FAILED_FINAL).model_copy(update={
+        "error_code": "RAW_RESYNC_BASE_UNKNOWN",
+        "rejected_manifest_sha256": digest,
+    })
+    store = ObjectStore(raw)
+    control = ControlPlane(failed)
+
+    result = RawIngestionService(control, store, DeltaPolicy()).register(command(raw))
+
+    assert result.reason is ResyncReason.BASE_UNKNOWN
+    assert store.calls == []
+    assert control.query_calls == []
+
+
+def test_replay_terminal_aceito_carrega_por_id_sem_cadeia() -> None:
+    raw = manifest()
+    projection = record(raw)
+    succeeded = job().model_copy(update={
+        "state": JobState.SUCCEEDED,
+        "lease_owner": None,
+        "lease_until": None,
+        "result_manifest_id": raw.manifest_id,
+        "result_manifest_key": projection.manifest_key,
+    })
+    store = ObjectStore(raw)
+    sidecar = raw.model_dump_json(exclude_none=False, by_alias=False).encode()
+    store.objects[projection.manifest_key] = sidecar
+    control = ControlPlane(succeeded)
+    control.records[raw.manifest_id] = projection
+
+    result = RawIngestionService(control, store, DeltaPolicy()).register(command(raw))
+
+    assert result.accepted
+    assert control.query_calls == ["by-id"]
+    assert control.mutations == []
+
+
+def test_replay_terminal_divergente_nao_muta_estado() -> None:
+    raw = manifest(SnapshotMode.DELTA)
+    failed = job(SnapshotMode.DELTA, JobState.FAILED_FINAL).model_copy(update={
+        "error_code": "RAW_RESYNC_BASE_UNKNOWN",
+        "rejected_manifest_sha256": "b" * 64,
+    })
+    control = ControlPlane(failed)
+
+    with pytest.raises(Conflict, match="terminal_replay=conflict"):
+        RawIngestionService(control, ObjectStore(raw), DeltaPolicy()).register(command(raw))
+
+    assert control.mutations == []
+
+
+def test_callback_falha_depois_do_aceite_duravel(caplog) -> None:
+    raw = manifest()
+    control = ControlPlane(job())
+
+    def fail(_: RawManifestRecord) -> None:
+        raise RuntimeError("cpf=12345678900")
+
+    result = RawIngestionService(control, ObjectStore(raw), DeltaPolicy(), fail).register(
+        command(raw)
+    )
+
+    assert result.accepted
+    assert control.mutations == ["complete"]
+    assert "12345678900" not in caplog.text
+
+
+@pytest.mark.parametrize("latest_key_matches", [True, False])
+def test_delta_valida_chave_do_ultimo_job(latest_key_matches: bool) -> None:
+    base = manifest()
+    base_record = record(base)
+    current = manifest(SnapshotMode.DELTA).model_copy(
+        update={"previous_manifest_sha256": manifest_sha256(base)}
+    )
+    store = ObjectStore(current)
+    store.objects[base_record.manifest_key] = (
+        base.model_dump_json(exclude_none=False, by_alias=False).encode()
+    )
+    control = ControlPlane(job(SnapshotMode.DELTA))
+    control.records[base.manifest_id] = base_record
+    control.chain = (ManifestRef(
+        manifest_id=base.manifest_id,
+        manifest_key=base_record.manifest_key,
+    ),)
+    control.latest = job(state=JobState.LEASED).model_copy(update={
+        "state": JobState.SUCCEEDED,
+        "lease_owner": None,
+        "lease_until": None,
+        "result_manifest_id": base.manifest_id,
+        "result_manifest_key": (
+            base_record.manifest_key if latest_key_matches else "raw/x/y/manifest.json"
+        ),
+    })
+
+    if not latest_key_matches:
+        with pytest.raises(Conflict, match="raw_history=divergent"):
+            RawIngestionService(control, store, DeltaPolicy()).register(command(current))
+        return
+    result = RawIngestionService(control, store, DeltaPolicy()).register(command(current))
+
+    assert result.accepted
+    assert control.query_calls == ["resync", "latest", "agent-chain", "by-id"]
+    assert control.completions[0].expected_head_manifest_id == base.manifest_id
+
+
+def test_marcador_existente_tem_precedencia_sem_consultar_cadeia() -> None:
+    raw = manifest(SnapshotMode.DELTA)
+    control = ControlPlane(job(SnapshotMode.DELTA))
+    control.marker = RawResyncState(
+        tenant_id="354130",
+        agent_id="agent-1",
+        source_type="CNES_LOCAL",
+        file_subtype="CNES_VINCULO",
+        competencia="2026-07",
+        required_since=NOW,
+    )
+
+    result = RawIngestionService(control, ObjectStore(raw), DeltaPolicy()).register(command(raw))
+
+    assert result.reason is ResyncReason.AGENT_RESYNC_REQUIRED
+    assert control.query_calls == ["resync"]
+
+
+@pytest.mark.parametrize(
+    ("current", "updates", "error"),
+    [
+        (None, {}, "job_missing"),
+        (job(state=JobState.PENDING), {}, "job_not_leased"),
+        (job(), {"owner": "other"}, "job_owner_lost"),
+        (
+            job().model_copy(update={"lease_until": NOW}),
+            {},
+            "job_lease_expired",
+        ),
+    ],
+)
+def test_job_invalido_nao_acessa_objeto(current, updates, error) -> None:
+    raw = manifest()
+    control = ControlPlane(current or job())
+    if current is None:
+        control.job = control.job.model_copy(update={"job_id": "other"})
+    store = ObjectStore(raw)
+
+    with pytest.raises((Conflict, LookupError), match=error):
+        RawIngestionService(control, store, DeltaPolicy()).register(command(raw, **updates))
+
+    assert store.calls == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("tenant_id", "", "blank_value"),
+        ("fencing_token", -1, "negative_counter"),
+        ("now", NOW.replace(tzinfo=None), "datetime_not_utc"),
+    ],
+)
+def test_comando_rejeita_envelope_invalido(field, value, error) -> None:
+    with pytest.raises(ValueError, match=error):
+        command(manifest(), **{field: value})
+
+
+def test_objeto_ausente_nao_muta_estado() -> None:
+    raw = manifest()
+    store = ObjectStore(raw)
+    store.objects.clear()
+    control = ControlPlane(job())
+
+    with pytest.raises(Conflict, match="object=missing"):
+        RawIngestionService(control, store, DeltaPolicy()).register(command(raw))
+
+    assert control.mutations == []
+
+
+@pytest.mark.parametrize("corruption", ["record", "job-key", "sidecar-stat", "sidecar-bytes"])
+def test_replay_aceito_corrompido_falha_fechado(corruption: str) -> None:
+    raw = manifest()
+    projection = record(raw)
+    succeeded = job().model_copy(update={
+        "state": JobState.SUCCEEDED,
+        "lease_owner": None,
+        "lease_until": None,
+        "result_manifest_id": raw.manifest_id,
+        "result_manifest_key": projection.manifest_key,
+    })
+    store = ObjectStore(raw)
+    sidecar = raw.model_dump_json(exclude_none=False, by_alias=False).encode()
+    store.objects[projection.manifest_key] = sidecar
+    control = ControlPlane(succeeded)
+    control.records[raw.manifest_id] = projection
+    if corruption == "record":
+        control.records.clear()
+    elif corruption == "job-key":
+        control.job = succeeded.model_copy(update={"result_manifest_key": "raw/x/y/manifest.json"})
+    elif corruption == "sidecar-stat":
+        store.objects.pop(projection.manifest_key)
+    else:
+        store.objects[projection.manifest_key] = b"divergent"
+
+    with pytest.raises(Conflict, match="terminal_replay=conflict"):
+        RawIngestionService(control, store, DeltaPolicy()).register(command(raw))
+
+    assert control.mutations == []
+
+
+def test_historico_corrompido_nao_finaliza_job() -> None:
+    raw = manifest(SnapshotMode.DELTA)
+    control = ControlPlane(job(SnapshotMode.DELTA))
+    control.latest = job().model_copy(update={
+        "state": JobState.SUCCEEDED,
+        "lease_owner": None,
+        "lease_until": None,
+        "result_manifest_id": "missing",
+        "result_manifest_key": "raw/354130/CNES_LOCAL/2026-07/base/manifest.json",
+    })
+
+    with pytest.raises(Conflict, match="raw_history=divergent"):
+        RawIngestionService(control, ObjectStore(raw), DeltaPolicy()).register(command(raw))
+
+    assert control.mutations == []

--- a/packages/cnes_domain/src/cnes_domain/control_plane/commands.py
+++ b/packages/cnes_domain/src/cnes_domain/control_plane/commands.py
@@ -16,6 +16,7 @@ from cnes_domain.control_plane.entities import (
     _ControlPlaneModel,
     _optional_error_code,
     _optional_non_blank,
+    _optional_sha256,
     _require_dispatch_id,
     _require_non_blank,
     _require_sha256,
@@ -85,8 +86,10 @@ class CompleteJob(_ControlPlaneModel):
     owner: str
     fencing_token: int
     manifest: RawManifestRecord
+    expected_head_manifest_id: str | None = None
 
     _strings = field_validator("tenant_id", "job_id", "owner")(_require_non_blank)
+    _expected_head = field_validator("expected_head_manifest_id")(_optional_non_blank)
     _fence = field_validator("fencing_token")(_require_non_negative)
 
     @model_validator(mode="after")
@@ -103,10 +106,35 @@ class FailJob(_ControlPlaneModel):
     fencing_token: int
     error_code: str
     retryable: bool
+    rejected_manifest_sha256: str | None = None
+    expected_head_manifest_id: str | None = None
+    expected_resync_marker: bool | None = None
 
     _strings = field_validator("tenant_id", "job_id", "owner")(_require_non_blank)
     _error = field_validator("error_code")(_optional_error_code)
     _fence = field_validator("fencing_token")(_require_non_negative)
+    _rejected_hash = field_validator("rejected_manifest_sha256")(_optional_sha256)
+    _expected_head = field_validator("expected_head_manifest_id")(_optional_non_blank)
+
+    @model_validator(mode="after")
+    def _validate_rejected_hash(self) -> FailJob:
+        is_resync = not self.retryable and self.error_code.startswith("RAW_RESYNC_")
+        if is_resync and self.rejected_manifest_sha256 is None:
+            raise ValueError("resync_hash_required")
+        guarded = (
+            self.expected_head_manifest_id is not None
+            or self.expected_resync_marker is not None
+        )
+        if guarded and not is_resync:
+            raise ValueError("resync_guard_forbidden")
+        if (
+            self.expected_head_manifest_id is not None
+            and self.expected_resync_marker is not False
+        ):
+            raise ValueError("head_guard_requires_absent_marker")
+        if not is_resync and self.rejected_manifest_sha256 is not None:
+            raise ValueError("resync_hash_forbidden")
+        return self
 
 
 class CancelJob(_ControlPlaneModel):

--- a/packages/cnes_domain/src/cnes_domain/control_plane/entities.py
+++ b/packages/cnes_domain/src/cnes_domain/control_plane/entities.py
@@ -25,63 +25,41 @@ _COMPETENCIA = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
 _LOWER_HEX_16 = re.compile(r"^[0-9a-f]{16}$")
 _LOWER_HEX_64 = re.compile(r"^[0-9a-f]{64}$")
 _ERROR_CODE = re.compile(r"^[A-Za-z0-9_.:-]+$")
-
-
 def _require_non_blank(value: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError("blank_value")
     return value
-
-
 def _optional_non_blank(value: str | None) -> str | None:
     return _require_non_blank(value) if value is not None else value
-
-
 def _require_key_component(value: str) -> str:
     _require_non_blank(value)
     if value in {".", ".."} or any(char in value for char in "#/\\"):
         raise ValueError("invalid_key_component")
     return value
-
-
 def _require_competencia(value: str) -> str:
     if not isinstance(value, str) or not _COMPETENCIA.fullmatch(value):
         raise ValueError("invalid_competencia")
     return value
-
-
 def _require_utc(value: datetime) -> datetime:
     if value.tzinfo is None or value.utcoffset() != timedelta(0):
         raise ValueError("datetime_not_utc")
     return value
-
-
 def _optional_utc(value: datetime | None) -> datetime | None:
     return _require_utc(value) if value is not None else value
-
-
 def _require_sha256(value: str) -> str:
     if not _LOWER_HEX_64.fullmatch(value):
         raise ValueError("invalid_sha256")
     return value
-
-
 def _optional_sha256(value: str | None) -> str | None:
     return _require_sha256(value) if value is not None else value
-
-
 def _optional_error_code(value: str | None) -> str | None:
     if value is not None and not _ERROR_CODE.fullmatch(value):
         raise ValueError("invalid_error_code")
     return value
-
-
 def _require_dispatch_id(value: str, name: str) -> str:
     if not _LOWER_HEX_16.fullmatch(value):
         raise ValueError(f"invalid_{name}")
     return value
-
-
 def _require_sidecar_key(value: str) -> str:
     if value.startswith("/") or "//" in value or "\\" in value:
         raise ValueError("invalid_manifest_key")
@@ -90,8 +68,6 @@ def _require_sidecar_key(value: str) -> str:
     if len(parts) < 3 or parts[-1] not in {"manifest.json", "run-manifest.json"} or invalid_parts:
         raise ValueError("invalid_manifest_key")
     return value
-
-
 def _require_finite_json(value: JsonValue) -> JsonValue:
     if isinstance(value, float) and not isfinite(value):
         raise ValueError("non_finite_json_float")
@@ -102,23 +78,17 @@ def _require_finite_json(value: JsonValue) -> JsonValue:
         for item in value.values():
             _require_finite_json(item)
     return value
-
-
 def _unique_non_blank(values: tuple[str, ...], duplicate_message: str) -> tuple[str, ...]:
     for value in values:
         _require_non_blank(value)
     if len(set(values)) != len(values):
         raise ValueError(duplicate_message)
     return values
-
-
 def _require_unique_refs(refs: tuple[ManifestRef, ...]) -> None:
     ids = {ref.manifest_id for ref in refs}
     keys = {ref.manifest_key for ref in refs}
     if len(ids) != len(refs) or len(keys) != len(refs):
         raise ValueError("duplicate_manifest_ref")
-
-
 class _ControlPlaneModel(BaseModel):
     model_config = ConfigDict(frozen=True, strict=True, extra="forbid")
 
@@ -169,6 +139,7 @@ class Job(_ControlPlaneModel):
     result_manifest_id: str | None
     result_manifest_key: str | None
     error_code: str | None
+    rejected_manifest_sha256: str | None = None
     created_at: datetime
     _strings = field_validator("tenant_id", "job_id", "agent_id", "source_type", "file_subtype")(
         _require_key_component
@@ -177,6 +148,7 @@ class Job(_ControlPlaneModel):
     _datetimes = field_validator("lease_until", "created_at")(_optional_utc)
     _optional_ids = field_validator("lease_owner", "result_manifest_id")(_optional_non_blank)
     _error_value = field_validator("error_code")(_optional_error_code)
+    _rejected_hash = field_validator("rejected_manifest_sha256")(_optional_sha256)
     @model_validator(mode="after")
     def _validate_consistency(self) -> Job:
         if (self.lease_owner is None) != (self.lease_until is None):
@@ -185,6 +157,13 @@ class Job(_ControlPlaneModel):
             raise ValueError("result_manifest_pair_required")
         if self.state is JobState.SUCCEEDED and self.result_manifest_id is None:
             raise ValueError("succeeded_manifest_required")
+        is_resync = self.state is JobState.FAILED_FINAL and bool(
+            self.error_code and self.error_code.startswith("RAW_RESYNC_")
+        )
+        if is_resync and self.rejected_manifest_sha256 is None:
+            raise ValueError("resync_hash_required")
+        if not is_resync and self.rejected_manifest_sha256 is not None:
+            raise ValueError("resync_hash_forbidden")
         self._validate_result_key()
         return self
 
@@ -285,6 +264,19 @@ class RawManifestRecord(_ControlPlaneModel):
         if self.manifest_key != f"{expected}{self.snapshot_id}/manifest.json":
             raise ValueError("invalid_manifest_key")
         return self
+
+
+class RawResyncState(_ControlPlaneModel):
+    tenant_id: str
+    agent_id: str
+    source_type: str
+    file_subtype: str
+    competencia: str
+    required_since: datetime
+    _components = field_validator(
+        "tenant_id", "agent_id", "source_type", "file_subtype")(_require_key_component)
+    _competencia_value = field_validator("competencia")(_require_competencia)
+    _required_utc = field_validator("required_since")(_require_utc)
 
 
 class RunUnit(_ControlPlaneModel):

--- a/packages/cnes_domain/src/cnes_domain/control_plane/queries.py
+++ b/packages/cnes_domain/src/cnes_domain/control_plane/queries.py
@@ -35,6 +35,35 @@ class RawManifestChainQuery:
 
 
 @dataclass(frozen=True, slots=True)
+class RawManifestByIdQuery:
+    tenant_id: str
+    manifest_id: str
+
+    def __post_init__(self) -> None:
+        _require_key_component(self.tenant_id)
+        _require_key_component(self.manifest_id)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRawManifestChainQuery:
+    identity: RawIdentity
+    agent_id: str
+    limit: int = 31
+
+    def __post_init__(self) -> None:
+        _require_key_component(self.agent_id)
+
+
+@dataclass(frozen=True, slots=True)
+class RawResyncStateQuery:
+    identity: RawIdentity
+    agent_id: str
+
+    def __post_init__(self) -> None:
+        _require_key_component(self.agent_id)
+
+
+@dataclass(frozen=True, slots=True)
 class WaitingRunsForDependencyQuery:
     identity: RawIdentity
     limit: int = 100

--- a/packages/cnes_domain/src/cnes_domain/ports/control_plane.py
+++ b/packages/cnes_domain/src/cnes_domain/ports/control_plane.py
@@ -35,14 +35,19 @@ if TYPE_CHECKING:
         ManifestRef,
         Membership,
         OutboxEvent,
+        RawManifestRecord,
+        RawResyncState,
         Run,
         RunDispatch,
         RunUnit,
         Tenant,
     )
     from cnes_domain.control_plane.queries import (
+        AgentRawManifestChainQuery,
         LatestSucceededJobQuery,
+        RawManifestByIdQuery,
         RawManifestChainQuery,
+        RawResyncStateQuery,
         WaitingRunsForDependencyQuery,
     )
 
@@ -126,6 +131,21 @@ class ControlPlanePort(Protocol):
 
 @runtime_checkable
 class TypedRawQueryPort(Protocol):
+    def query_raw_manifest_by_id(
+        self, query: RawManifestByIdQuery
+    ) -> RawManifestRecord | None:
+        raise NotImplementedError
+
+    def query_agent_raw_manifest_chain(
+        self, query: AgentRawManifestChainQuery
+    ) -> tuple[ManifestRef, ...]:
+        raise NotImplementedError
+
+    def query_raw_resync_state(
+        self, query: RawResyncStateQuery
+    ) -> RawResyncState | None:
+        raise NotImplementedError
+
     def query_latest_succeeded_job(self, query: LatestSucceededJobQuery) -> Job | None:
         raise NotImplementedError
 

--- a/packages/cnes_domain/tests/control_plane/test_queries.py
+++ b/packages/cnes_domain/tests/control_plane/test_queries.py
@@ -5,17 +5,37 @@ import pytest
 
 import cnes_domain
 from cnes_domain import control_plane, ports
-from cnes_domain.control_plane.entities import Job, ManifestRef, Run
+from cnes_domain.control_plane.entities import (
+    Job,
+    ManifestRef,
+    RawManifestRecord,
+    RawResyncState,
+    Run,
+)
 from cnes_domain.control_plane.queries import (
+    AgentRawManifestChainQuery,
     LatestSucceededJobQuery,
     RawIdentity,
+    RawManifestByIdQuery,
     RawManifestChainQuery,
+    RawResyncStateQuery,
     WaitingRunsForDependencyQuery,
 )
 from cnes_domain.ports.control_plane import ControlPlanePort, TypedRawQueryPort
 
 
 class _TypedQueries:
+    def query_raw_manifest_by_id(self, query: RawManifestByIdQuery) -> RawManifestRecord | None:
+        return None
+
+    def query_agent_raw_manifest_chain(
+        self, query: AgentRawManifestChainQuery
+    ) -> tuple[ManifestRef, ...]:
+        return ()
+
+    def query_raw_resync_state(self, query: RawResyncStateQuery) -> RawResyncState | None:
+        return None
+
     def query_latest_succeeded_job(self, query: LatestSucceededJobQuery) -> Job | None:
         return None
 
@@ -33,6 +53,16 @@ class _TypedQueries:
 class _IncompleteQueries:
     def query_latest_succeeded_job(self, query: LatestSucceededJobQuery) -> Job | None:
         return None
+
+    def query_raw_manifest_chain(
+        self, query: RawManifestChainQuery
+    ) -> tuple[ManifestRef, ...]:
+        return ()
+
+    def query_waiting_runs_for_dependency(
+        self, query: WaitingRunsForDependencyQuery
+    ) -> tuple[Run, ...]:
+        return ()
 
 
 def test_identidade_raw_aceita_componentes_canonicos() -> None:
@@ -73,11 +103,17 @@ def test_consultas_raw_preservam_identidade_e_limites_padrao() -> None:
     latest = LatestSucceededJobQuery(identity, "agent-01")
     manifests = RawManifestChainQuery(identity)
     waiting = WaitingRunsForDependencyQuery(identity)
+    by_id = RawManifestByIdQuery("354130", "manifest-1")
+    agent_chain = AgentRawManifestChainQuery(identity, "agent-01")
+    resync = RawResyncStateQuery(identity, "agent-01")
 
     assert latest.identity is identity
     assert latest.agent_id == "agent-01"
     assert manifests.limit == 31
     assert waiting.limit == 100
+    assert (by_id.tenant_id, by_id.manifest_id) == ("354130", "manifest-1")
+    assert agent_chain.limit == 31
+    assert resync.identity is identity
 
 
 def test_consulta_de_job_rejeita_agente_invalido() -> None:
@@ -122,6 +158,15 @@ def test_porta_tipadas_reconhece_implementacao_em_runtime() -> None:
 
 
 def test_porta_tipadas_expoe_assinaturas_de_uma_consulta() -> None:
+    assert str(signature(TypedRawQueryPort.query_raw_manifest_by_id)) == (
+        "(self, query: 'RawManifestByIdQuery') -> 'RawManifestRecord | None'"
+    )
+    assert str(signature(TypedRawQueryPort.query_agent_raw_manifest_chain)) == (
+        "(self, query: 'AgentRawManifestChainQuery') -> 'tuple[ManifestRef, ...]'"
+    )
+    assert str(signature(TypedRawQueryPort.query_raw_resync_state)) == (
+        "(self, query: 'RawResyncStateQuery') -> 'RawResyncState | None'"
+    )
     assert str(signature(TypedRawQueryPort.query_latest_succeeded_job)) == (
         "(self, query: 'LatestSucceededJobQuery') -> 'Job | None'"
     )

--- a/packages/cnes_domain/tests/control_plane/test_raw_registration_entities.py
+++ b/packages/cnes_domain/tests/control_plane/test_raw_registration_entities.py
@@ -1,0 +1,101 @@
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from cnes_domain.control_plane.commands import FailJob
+from cnes_domain.control_plane.entities import Job, RawResyncState
+from cnes_domain.control_plane.enums import JobState
+
+NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
+HASH = "a" * 64
+
+
+def job_values(**updates: object) -> dict[str, object]:
+    values = {
+        "tenant_id": "354130", "job_id": "job-1", "agent_id": "agent-01",
+        "source_type": "CNES_LOCAL", "file_subtype": "CNES_VINCULO",
+        "competencia": "2026-07", "requested_snapshot_mode": "FULL",
+        "state": JobState.PENDING, "attempt": 0, "fencing_token": 0,
+        "lease_owner": None, "lease_until": None, "result_manifest_id": None,
+        "result_manifest_key": None, "error_code": None, "created_at": NOW,
+    }
+    return values | updates
+
+
+def test_estado_de_resync_exige_identidade_exata_e_instante_utc() -> None:
+    state = RawResyncState(
+        tenant_id="354130", agent_id="agent-01", source_type="CNES_LOCAL",
+        file_subtype="CNES_VINCULO", competencia="2026-07", required_since=NOW,
+    )
+    assert state.required_since is NOW
+    with pytest.raises(ValidationError, match="datetime_not_utc"):
+        RawResyncState.model_validate(
+            state.model_dump() | {"required_since": NOW.replace(tzinfo=None)}
+        )
+
+
+@pytest.mark.parametrize(
+    ("updates", "error"),
+    [
+        ({"state": JobState.FAILED_FINAL, "error_code": "RAW_RESYNC_BASE_UNKNOWN"},
+         "resync_hash_required"),
+        ({"rejected_manifest_sha256": HASH}, "resync_hash_forbidden"),
+        ({"state": JobState.FAILED_FINAL, "error_code": "other",
+          "rejected_manifest_sha256": HASH}, "resync_hash_forbidden"),
+        ({"state": JobState.FAILED_FINAL, "error_code": "RAW_RESYNC_BASE_UNKNOWN",
+          "rejected_manifest_sha256": "A" * 64}, "invalid_sha256"),
+    ],
+)
+def test_job_vincula_hash_rejeitado_somente_a_resync_final(
+    updates: dict[str, object], error: str
+) -> None:
+    with pytest.raises(ValidationError, match=error):
+        Job.model_validate(job_values(**updates))
+    valid = Job.model_validate(job_values(
+        state=JobState.FAILED_FINAL,
+        error_code="RAW_RESYNC_BASE_UNKNOWN",
+        rejected_manifest_sha256=HASH,
+    ))
+    assert valid.rejected_manifest_sha256 == HASH
+
+
+@pytest.mark.parametrize(
+    ("updates", "error"),
+    [
+        ({"rejected_manifest_sha256": HASH}, "resync_hash_forbidden"),
+        ({"error_code": "RAW_RESYNC_BASE_UNKNOWN", "retryable": False},
+         "resync_hash_required"),
+    ],
+)
+def test_comando_de_falha_vincula_hash_ao_resync(updates, error) -> None:
+    values = {
+        "tenant_id": "354130", "job_id": "job-1", "owner": "worker",
+        "fencing_token": 1, "error_code": "other", "retryable": True,
+    }
+    with pytest.raises(ValidationError, match=error):
+        FailJob(**(values | updates))
+
+
+@pytest.mark.parametrize(
+    ("updates", "error"),
+    [
+        ({"expected_resync_marker": False}, "resync_guard_forbidden"),
+        (
+            {
+                "error_code": "RAW_RESYNC_BASE_UNKNOWN",
+                "retryable": False,
+                "rejected_manifest_sha256": HASH,
+                "expected_head_manifest_id": "manifest-a",
+            },
+            "head_guard_requires_absent_marker",
+        ),
+    ],
+)
+def test_comando_de_falha_restringe_guarda_raw(updates, error) -> None:
+    values = {
+        "tenant_id": "354130", "job_id": "job-1", "owner": "worker",
+        "fencing_token": 1, "error_code": "other", "retryable": True,
+    }
+    with pytest.raises(ValidationError, match=error):
+        FailJob(**(values | updates))

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_adapter.py
@@ -47,7 +47,9 @@ from cnes_infra.control_plane.dynamodb_keys import (
     entity_key,
     item_key,
     key_component,
+    raw_manifest_lookup_key,
     raw_partition,
+    raw_resync_key,
     run_entity_key,
     run_partition,
     timestamp,
@@ -140,7 +142,16 @@ class DynamoDBControlPlane(
         key = partition, f"MANIFEST#{key_component(record.manifest_id)}"
         return encode_model(record, "RAWMANIFESTRECORD", key, attributes)
     def _raw_actions(self, record: RawManifestRecord) -> tuple[Action, ...]:
-        return raw_manifest_actions(self._client, self._table_name, record, self._raw_item(record))
+        lookup = encode_model(
+            record,
+            "RAWMANIFESTRECORD",
+            raw_manifest_lookup_key(record.tenant_id, record.manifest_id),
+        )
+        actions = list(
+            raw_manifest_actions(self._client, self._table_name, record, self._raw_item(record))
+        )
+        actions.append(put_action(self._table_name, lookup, None))
+        return tuple(actions)
     def _run_item(self, run: Run) -> Item:
         attributes = {}
         if run.state in _RECOVERABLE:
@@ -212,17 +223,50 @@ class DynamoDBControlPlane(
     def get_job(self, tenant_id: str, job_id: str) -> Job | None:
         """Retorna o job solicitado."""
         return self._get_model(entity_key(tenant_id, "JOB", job_id), Job)
-    def _latest_job_action(self, job: Job) -> Action:
+    def _latest_job_action(
+        self, job: Job, expected_head_manifest_id: str | None = None,
+        resync_marker_present: bool | None = None,
+    ) -> Action:
         partition = raw_partition(job.tenant_id, job.source_type, job.file_subtype, job.competencia)
         key = partition, f"LATEST_JOB#{key_component(job.agent_id)}"
         current_item = self._get_item(key)
         marker = encode_model(job, "JOB", key)
         if current_item is None:
+            if expected_head_manifest_id is not None:
+                raise Conflict(ErrorCode.TRANSACTION_CONFLICT)
             return put_action(self._table_name, marker, None)
         current = decode_model(current_item, Job)
-        if (current.created_at, current.job_id) >= (job.created_at, job.job_id):
+        if (
+            expected_head_manifest_id is not None
+            and current.result_manifest_id != expected_head_manifest_id
+        ):
+            raise Conflict(ErrorCode.TRANSACTION_CONFLICT)
+        if expected_head_manifest_id is not None:
+            return put_action(self._table_name, marker, payload(current_item))
+        if resync_marker_present is not True and (current.created_at, current.job_id) >= (
+            job.created_at, job.job_id
+        ):
             return check_action(self._table_name, current_item)
         return put_action(self._table_name, marker, payload(current_item))
+    def _raw_resync_marker_present(self, manifest: Any) -> bool | None:
+        if manifest.snapshot_mode != "FULL":
+            return None
+        partition = raw_partition(
+            manifest.tenant_id, manifest.source_type, manifest.file_subtype, manifest.competencia)
+        return self._get_item(raw_resync_key(partition, manifest.agent_id)) is not None
+    def _accepted_resync_actions(
+        self, manifest: Any, marker_present: bool | None
+    ) -> tuple[Action, ...]:
+        if marker_present is None:
+            return ()
+        partition = raw_partition(
+            manifest.tenant_id, manifest.source_type, manifest.file_subtype, manifest.competencia)
+        key = raw_resync_key(partition, manifest.agent_id)
+        existence = "exists" if marker_present else "not_exists"
+        return ({"Delete": {"TableName": self._table_name,
+            "Key": {"pk": {"S": key[0]}, "sk": {"S": key[1]}},
+            "ConditionExpression": f"attribute_{existence}(pk)",
+        }},)
     def list_claimable_jobs(self, tenant_id: str, agent_id: str, limit: int) -> tuple[Job, ...]:
         """Lista jobs elegíveis para claim."""
         agent = self.get_agent(tenant_id, agent_id)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_claims.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from botocore.exceptions import ClientError, ConnectionClosedError, ReadTimeoutError
 
-from cnes_domain.control_plane.entities import Agent, Job, Run, RunDispatch, RunUnit
+from cnes_domain.control_plane.entities import Agent, Job, RawResyncState, Run, RunDispatch, RunUnit
 from cnes_domain.control_plane.enums import (
     AgentState,
     DispatchState,
@@ -25,14 +25,20 @@ from cnes_domain.control_plane.transitions import transition_job, transition_run
 from cnes_infra.control_plane.dynamodb_codec import (
     Action,
     Item,
+    absent_check_action,
     check_action,
     decode_model,
+    encode_model,
     payload,
     put_action,
 )
 from cnes_infra.control_plane.dynamodb_keys import (
     dispatch_key,
     entity_key,
+    key_component,
+    raw_manifest_lookup_key,
+    raw_partition,
+    raw_resync_key,
     run_entity_key,
     unit_key,
 )
@@ -120,15 +126,32 @@ class DynamoDBClaims:
                 "result_manifest_key": command.manifest.manifest_key,
             }
         )
+        resync_marker = self._raw_resync_marker_present(command.manifest)
         actions = (check_action(self._table_name, agent_item),
             put_action(self._table_name, self._job_item(updated), payload(item)),
             *self._raw_actions(command.manifest),
-            self._latest_job_action(updated),
+            self._latest_job_action(
+                updated, command.expected_head_manifest_id, resync_marker),
+            *self._delta_resync_guard_actions(command),
+            *self._accepted_resync_actions(command.manifest, resync_marker),
             self._event_action(job.tenant_id, event),
         )
         return updated, actions
+
+    def _delta_resync_guard_actions(self, command: CompleteJob) -> tuple[Action, ...]:
+        if command.expected_head_manifest_id is None:
+            return ()
+        manifest = command.manifest
+        partition = raw_partition(
+            manifest.tenant_id, manifest.source_type,
+            manifest.file_subtype, manifest.competencia,
+        )
+        key = raw_resync_key(partition, manifest.agent_id)
+        if self._get_item(key) is not None:
+            raise Conflict(ErrorCode.TRANSACTION_CONFLICT)
+        return (absent_check_action(self._table_name, key),)
+
     def _complete_job_replay(self, command: CompleteJob, event: Any, updated: Job) -> bool:
-        raw_item = self._raw_item(command.manifest)
         manifest = command.manifest
         identity = RawIdentity(
             command.tenant_id, manifest.source_type, manifest.file_subtype, manifest.competencia
@@ -136,7 +159,8 @@ class DynamoDBClaims:
         return (
             self.get_job(command.tenant_id, command.job_id) == updated
             and self._get_model(
-                (raw_item["pk"]["S"], raw_item["sk"]["S"]), type(command.manifest)
+                raw_manifest_lookup_key(manifest.tenant_id, manifest.manifest_id),
+                type(command.manifest),
             ) == command.manifest
             and self.query_latest_succeeded_job(
                 LatestSucceededJobQuery(identity, manifest.agent_id)
@@ -163,21 +187,65 @@ class DynamoDBClaims:
         self._validate_job_fence(job, command.owner, command.fencing_token, self._clock())
         agent_item = self._active_agent_item(job)
         state = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
-        updated = transition_job(job, state).model_copy(
-            update={
-                "lease_owner": None,
-                "lease_until": None,
-                "error_code": command.error_code,
-            }
-        )
-        self._transact(
-            (
-                check_action(self._table_name, agent_item),
-                put_action(self._table_name, self._job_item(updated), payload(item)),
-                self._event_action(job.tenant_id, event),
-            )
-        )
+        updated = transition_job(job, state).model_copy(update={
+            "lease_owner": None,
+            "lease_until": None,
+            "error_code": command.error_code,
+            "rejected_manifest_sha256": command.rejected_manifest_sha256,
+        })
+        actions = [
+            check_action(self._table_name, agent_item),
+            put_action(self._table_name, self._job_item(updated), payload(item)),
+        ]
+        if command.rejected_manifest_sha256 is not None:
+            actions.extend(self._rejection_head_guard_actions(job, command))
+            actions.append(self._resync_action(job, command.expected_resync_marker))
+        actions.append(self._event_action(job.tenant_id, event))
+        self._transact(tuple(actions))
         return updated
+    def _rejection_head_guard_actions(self, job: Job, command: FailJob) -> tuple[Action, ...]:
+        if command.expected_resync_marker is not False:
+            return ()
+        partition = raw_partition(
+            job.tenant_id, job.source_type, job.file_subtype, job.competencia
+        )
+        key = partition, f"LATEST_JOB#{key_component(job.agent_id)}"
+        item = self._get_item(key)
+        expected = command.expected_head_manifest_id
+        if item is None:
+            if expected is not None:
+                raise Conflict(ErrorCode.TRANSACTION_CONFLICT)
+            return (absent_check_action(self._table_name, key),)
+        if expected is None or decode_model(item, Job).result_manifest_id != expected:
+            raise Conflict(ErrorCode.TRANSACTION_CONFLICT)
+        return (check_action(self._table_name, item),)
+    def _resync_action(self, job: Job, expected_marker: bool | None = None) -> Action:
+        key = self._resync_key(job)
+        state = RawResyncState(
+            tenant_id=job.tenant_id, agent_id=job.agent_id,
+            source_type=job.source_type, file_subtype=job.file_subtype,
+            competencia=job.competencia, required_since=self._clock(),
+        )
+        item = encode_model(state, "RAWRESYNCSTATE", key)
+        update: dict[str, Any] = {
+            "TableName": self._table_name,
+            "Key": {"pk": item["pk"], "sk": item["sk"]},
+            "UpdateExpression": (
+                "SET #entity = if_not_exists(#entity, :entity), "
+                "#payload = if_not_exists(#payload, :payload)"
+            ),
+            "ExpressionAttributeNames": {"#entity": "entity", "#payload": "payload"},
+            "ExpressionAttributeValues": {":entity": item["entity"], ":payload": item["payload"]},
+        }
+        if expected_marker is not None:
+            existence = "exists" if expected_marker else "not_exists"
+            update["ConditionExpression"] = f"attribute_{existence}(pk)"
+        return {"Update": update}
+    @staticmethod
+    def _resync_key(job: Job) -> tuple[str, str]:
+        partition = raw_partition(
+            job.tenant_id, job.source_type, job.file_subtype, job.competencia)
+        return raw_resync_key(partition, job.agent_id)
     def _leased_job(self, tenant_id: str, job_id: str) -> tuple[Item, Job]:
         item = self._get_item(entity_key(tenant_id, "JOB", job_id))
         if item is None:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_codec.py
@@ -300,7 +300,7 @@ def _repair_descendants(
     visited = 0
     while pending:
         parent, chain = pending.pop()
-        children = _waiting_children(client, table_name, parent, 92 - visited)
+        children = _waiting_children(client, table_name, parent, 90 - visited)
         visited += len(children)
         if not children:
             endpoints.append((parent, chain))
@@ -430,6 +430,15 @@ def check_action(table_name: str, item: Item) -> Action:
             "ExpressionAttributeValues": {":expected": item["payload"]},
         }
     }
+
+
+def absent_check_action(table_name: str, key: tuple[str, str]) -> Action:
+    """Cria uma ação ConditionCheck de ausência."""
+    return {"ConditionCheck": {
+        "TableName": table_name,
+        "Key": {"pk": {"S": key[0]}, "sk": {"S": key[1]}},
+        "ConditionExpression": "attribute_not_exists(pk)",
+    }}
 
 
 def _action_key(action: Action) -> tuple[str, str]:

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_keys.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_keys.py
@@ -29,6 +29,16 @@ def raw_partition(tenant_id: str, source_type: str, file_subtype: str, competenc
     return f"{tenant_partition(tenant_id)}#RAW#{identity}"
 
 
+def raw_manifest_lookup_key(tenant_id: str, manifest_id: str) -> tuple[str, str]:
+    """Cria a projeção forte e imutável por ID do manifesto."""
+    return entity_key(tenant_id, "RAW_MANIFEST", manifest_id)
+
+
+def raw_resync_key(partition: str, agent_id: str) -> tuple[str, str]:
+    """Cria a chave forte do marcador de resync do agente."""
+    return partition, f"RESYNC#{key_component(agent_id)}"
+
+
 def entity_key(tenant_id: str, entity: str, identifier: str) -> tuple[str, str]:
     """Cria a chave base de uma entidade do tenant."""
     return tenant_partition(tenant_id), f"{entity}#{key_component(identifier)}"

--- a/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_queries.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/dynamodb_queries.py
@@ -2,24 +2,40 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
-from cnes_domain.control_plane.entities import Job, Run
+from cnes_domain.control_plane.entities import (
+    Job,
+    ManifestRef,
+    RawManifestRecord,
+    RawResyncState,
+    Run,
+)
 from cnes_domain.control_plane.enums import RunState
+from cnes_domain.control_plane.queries import RawManifestByIdQuery
 from cnes_infra.control_plane.dynamodb_codec import (
     CandidateQuery,
+    _ancestry_prefix,
     bounded_candidates,
     raw_head_chain,
+    unique_partition_item,
 )
-from cnes_infra.control_plane.dynamodb_keys import key_component, raw_partition
+from cnes_infra.control_plane.dynamodb_keys import (
+    key_component,
+    raw_manifest_lookup_key,
+    raw_partition,
+    raw_resync_key,
+)
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
 
-    from cnes_domain.control_plane.entities import ManifestRef
     from cnes_domain.control_plane.queries import (
+        AgentRawManifestChainQuery,
         LatestSucceededJobQuery,
         RawManifestChainQuery,
+        RawResyncStateQuery,
         WaitingRunsForDependencyQuery,
     )
 
@@ -45,6 +61,49 @@ class DynamoDBQueries:
             identity.tenant_id, identity.source_type, identity.file_subtype, identity.competencia
         )
         return self._get_model((partition, f"LATEST_JOB#{key_component(query.agent_id)}"), Job)
+
+    def query_raw_manifest_by_id(
+        self, query: RawManifestByIdQuery
+    ) -> RawManifestRecord | None:
+        """Returns: Manifesto carregado fortemente pela identidade imutável."""
+        return self._get_model(
+            raw_manifest_lookup_key(query.tenant_id, query.manifest_id), RawManifestRecord
+        )
+
+    def query_agent_raw_manifest_chain(
+        self, query: AgentRawManifestChainQuery
+    ) -> tuple[ManifestRef, ...]:
+        """Returns: Cadeia materializada da cabeça forte do agente."""
+        if query.limit <= 0:
+            return ()
+        identity = query.identity
+        partition = raw_partition(
+            identity.tenant_id, identity.source_type, identity.file_subtype, identity.competencia
+        )
+        job = self._get_model((partition, f"LATEST_JOB#{key_component(query.agent_id)}"), Job)
+        if job is None or job.result_manifest_id is None:
+            return ()
+        record = self.query_raw_manifest_by_id(
+            RawManifestByIdQuery(identity.tenant_id, job.result_manifest_id)
+        )
+        if record is None or record.agent_id != query.agent_id:
+            return ()
+        prefix = _ancestry_prefix(record, record.sequence, record.manifest_sha256)
+        ancestry = unique_partition_item(self._client, self._table_name, partition, prefix)
+        if ancestry is None or "chain" not in ancestry:
+            return ()
+        chain = json.loads(ancestry["chain"]["S"])
+        if len(chain) > query.limit:
+            return ()
+        return tuple(ManifestRef.model_validate(item) for item in chain)
+
+    def query_raw_resync_state(self, query: RawResyncStateQuery) -> RawResyncState | None:
+        """Returns: Marcador forte de resync da identidade e do agente."""
+        identity = query.identity
+        partition = raw_partition(
+            identity.tenant_id, identity.source_type, identity.file_subtype, identity.competencia
+        )
+        return self._get_model(raw_resync_key(partition, query.agent_id), RawResyncState)
 
     def query_raw_manifest_chain(self, query: RawManifestChainQuery) -> tuple[ManifestRef, ...]:
         """Returns: Cadeia válida de manifestos RAW ordenados."""

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_adapter.py
@@ -1,5 +1,4 @@
 """SQLite control-plane adapter."""
-
 from __future__ import annotations
 
 import sqlite3
@@ -29,6 +28,7 @@ from cnes_infra.control_plane import (
     sqlite_publication,
 )
 from cnes_infra.control_plane.raw_query_compat import DeprecatedRawQueryMixin
+from cnes_infra.control_plane.sqlite_raw_registration import SQLiteRawRegistrationQueries
 from cnes_infra.control_plane.sqlite_schema import (
     _SQLiteWALUnavailable,
     deserialize_model,
@@ -106,7 +106,7 @@ def _is_network_filesystem(path: Path) -> bool:
     return is_network_filesystem(path)
 
 
-class SQLiteControlPlane(DeprecatedRawQueryMixin):
+class SQLiteControlPlane(SQLiteRawRegistrationQueries, DeprecatedRawQueryMixin):
     """Persiste o plano de controle em um arquivo SQLite local."""
     def __init__(self, database_path: Path, clock: Callable[[], datetime]) -> None:
         self._database_path = Path(database_path)

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_claims.py
@@ -1,5 +1,4 @@
 """SQLite lease and fencing operations."""
-
 from __future__ import annotations
 
 from datetime import timedelta
@@ -17,6 +16,7 @@ from cnes_domain.control_plane.enums import (
 from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost
 from cnes_domain.control_plane.errors import ControlPlaneErrorCode as ErrorCode
 from cnes_domain.control_plane.transitions import transition_run, transition_run_unit
+from cnes_infra.control_plane import sqlite_raw_registration
 from cnes_infra.control_plane.sqlite_dispatch import (
     put_run_dispatch_bind,
     put_run_dispatch_finish,
@@ -54,7 +54,6 @@ if TYPE_CHECKING:
         ReserveRunDispatch,
     )
     from cnes_domain.control_plane.entities import Job, OutboxEvent
-
 def _validate_job_fence(store: Any, connection: Any, command: Any) -> Job:
     job = store.get_job_record(connection, command.tenant_id, command.job_id)
     agent = None if job is None else store.get_agent_record(connection, job.tenant_id, job.agent_id)
@@ -69,7 +68,6 @@ def _validate_job_fence(store: Any, connection: Any, command: Any) -> Job:
     if job.lease_until is None or job.lease_until <= store.now():
         raise LeaseLost(ErrorCode.LEASE_EXPIRED)
     return job
-
 def claim_job(store: Any, command: ClaimJob) -> Job | None:
     with store.write_transaction() as connection:
         job = store.get_job_record(connection, command.tenant_id, command.job_id)
@@ -136,6 +134,9 @@ def complete_job(store: Any, command: CompleteJob, event: OutboxEvent) -> Job:
         store.put_outbox_event(connection, event, command.tenant_id)
         store.put_job_record(connection, completed)
         store.put_manifest_record(connection, manifest)
+        sqlite_raw_registration.advance_agent_head(connection, completed, command)
+        if manifest.snapshot_mode == "FULL":
+            sqlite_raw_registration.delete_resync_state(connection, manifest)
         put_job_terminal_write(connection, "complete", command, event)
         return completed
 def fail_job(store: Any, command: FailJob, event: OutboxEvent) -> Job:
@@ -146,6 +147,7 @@ def fail_job(store: Any, command: FailJob, event: OutboxEvent) -> Job:
             validate_job_terminal_replay(connection, job, command, event)
             return job
         job = _validate_job_fence(store, connection, command)
+        sqlite_raw_registration.validate_resync_rejection(connection, job, command)
         state = JobState.FAILED_RETRYABLE if command.retryable else JobState.FAILED_FINAL
         failed = job.model_copy(
             update={
@@ -153,10 +155,13 @@ def fail_job(store: Any, command: FailJob, event: OutboxEvent) -> Job:
                 "lease_owner": None,
                 "lease_until": None,
                 "error_code": command.error_code,
+                "rejected_manifest_sha256": command.rejected_manifest_sha256,
             }
         )
         store.put_outbox_event(connection, event, command.tenant_id)
         store.put_job_record(connection, failed)
+        if command.rejected_manifest_sha256 is not None:
+            sqlite_raw_registration.put_resync_state(store, connection, failed)
         put_job_terminal_write(connection, "fail", command, event)
         return failed
 def cancel_job(store: Any, command: CancelJob, event: OutboxEvent) -> Job:
@@ -174,7 +179,6 @@ def cancel_job(store: Any, command: CancelJob, event: OutboxEvent) -> Job:
         store.put_job_record(connection, canceled)
         put_job_cancellation(connection, command, event)
         return canceled
-
 def _list_run_units(connection: Any, tenant_id: str, run_id: str) -> tuple[RunUnit, ...]:
     rows = connection.execute(
         "SELECT data FROM run_units WHERE tenant_id = ? AND run_id = ? ORDER BY unit_id",
@@ -247,8 +251,6 @@ def _put_dispatch(connection: Any, dispatch: RunDispatch) -> None:
             serialize_model(dispatch),
         ),
     )
-
-
 def _has_live_unit_lease(connection: Any, command: Any, dispatch: RunDispatch | None) -> bool:
     units = _list_run_units(connection, command.tenant_id, command.run_id)
     affected = set(command.unit_ids) | (set(dispatch.unit_ids) if dispatch else set())
@@ -433,8 +435,6 @@ def commit_run_unit(store: Any, command: CommitRunUnit, event: OutboxEvent) -> R
         _put_run_unit(connection, completed)
         put_run_unit_terminal_write(connection, "commit", command, event)
         return completed
-
-
 def fail_run_unit(store: Any, command: FailRunUnit, event: OutboxEvent) -> RunUnit:
     with store.write_transaction() as connection:
         current = next(

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_publication.py
@@ -45,9 +45,18 @@ def query_latest_succeeded_job(store: Any, query: LatestSucceededJobQuery) -> Jo
     identity = query.identity
     with store.read_connection() as connection:
         row = connection.execute(
-            "SELECT data FROM jobs WHERE tenant_id = ? AND agent_id = ? "
-            "AND source_type = ? AND file_subtype = ? AND competencia = ? "
-            "AND state = ? ORDER BY created_at DESC, job_id DESC LIMIT 1",
+            "SELECT jobs.data FROM jobs LEFT JOIN raw_agent_heads ON "
+            "raw_agent_heads.tenant_id = jobs.tenant_id "
+            "AND raw_agent_heads.agent_id = jobs.agent_id "
+            "AND raw_agent_heads.source_type = jobs.source_type "
+            "AND raw_agent_heads.file_subtype = jobs.file_subtype "
+            "AND raw_agent_heads.competencia = jobs.competencia WHERE "
+            "jobs.tenant_id = ? AND jobs.agent_id = ? AND jobs.source_type = ? "
+            "AND jobs.file_subtype = ? AND jobs.competencia = ? AND jobs.state = ? "
+            "AND (raw_agent_heads.job_id IS NULL OR jobs.job_id = raw_agent_heads.job_id) "
+            "ORDER BY (jobs.job_id = raw_agent_heads.job_id) DESC, "
+            "CASE WHEN raw_agent_heads.job_id IS NULL THEN jobs.created_at END DESC, "
+            "CASE WHEN raw_agent_heads.job_id IS NULL THEN jobs.job_id END DESC LIMIT 1",
             (
                 identity.tenant_id,
                 query.agent_id,

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_raw_registration.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_raw_registration.py
@@ -1,0 +1,225 @@
+"""Consultas e marcadores raw do plano de controle SQLite."""
+
+from typing import Any
+
+from cnes_domain.control_plane.commands import CompleteJob, FailJob
+from cnes_domain.control_plane.entities import Job, ManifestRef, RawManifestRecord, RawResyncState
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.errors import Conflict, ControlPlaneErrorCode
+from cnes_domain.control_plane.queries import (
+    AgentRawManifestChainQuery,
+    RawManifestByIdQuery,
+    RawResyncStateQuery,
+)
+from cnes_infra.control_plane.sqlite_publication import _build_ancestry
+from cnes_infra.control_plane.sqlite_schema import deserialize_model, serialize_model
+
+
+class SQLiteRawRegistrationQueries:
+    """Expõe consultas fortes do registro raw SQLite."""
+
+    def query_raw_manifest_by_id(
+        self, query: RawManifestByIdQuery
+    ) -> RawManifestRecord | None:
+        return _query_raw_manifest_by_id(self, query)
+
+    def query_agent_raw_manifest_chain(
+        self, query: AgentRawManifestChainQuery
+    ) -> tuple[ManifestRef, ...]:
+        return _query_agent_raw_manifest_chain(self, query)
+
+    def query_raw_resync_state(self, query: RawResyncStateQuery) -> RawResyncState | None:
+        return _query_raw_resync_state(self, query)
+
+
+def _legacy_head(
+    connection: Any, identity: tuple[str, ...], current_job_id: str
+) -> tuple[str, str, str] | None:
+    row = connection.execute(
+        "SELECT data FROM jobs WHERE tenant_id = ? AND agent_id = ? AND source_type = ? "
+        "AND file_subtype = ? AND competencia = ? AND state = ? AND job_id != ? "
+        "ORDER BY created_at DESC, job_id DESC LIMIT 1",
+        (*identity, JobState.SUCCEEDED.value, current_job_id),
+    ).fetchone()
+    if row is None:
+        return None
+    job = deserialize_model(row[0], Job)
+    return job.result_manifest_id, job.created_at.isoformat(), job.job_id
+
+
+def _put_agent_head(
+    connection: Any, identity: tuple[str, ...], head: tuple[str, str, str]
+) -> None:
+    manifest_id, created_at, job_id = head
+    connection.execute(
+        "INSERT INTO raw_agent_heads (tenant_id, agent_id, source_type, file_subtype, "
+        "competencia, job_id, manifest_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT (tenant_id, agent_id, source_type, file_subtype, competencia) "
+        "DO UPDATE SET job_id = excluded.job_id, manifest_id = excluded.manifest_id, "
+        "created_at = excluded.created_at",
+        (*identity, job_id, manifest_id, created_at),
+    )
+
+
+def advance_agent_head(connection: Any, job: Job, command: CompleteJob) -> None:
+    expected = command.expected_head_manifest_id
+    manifest = command.manifest
+    identity = (
+        manifest.tenant_id, manifest.agent_id, manifest.source_type,
+        manifest.file_subtype, manifest.competencia,
+    )
+    row = connection.execute(
+        "SELECT manifest_id, created_at, job_id FROM raw_agent_heads "
+        "WHERE tenant_id = ? AND agent_id = ? AND source_type = ? "
+        "AND file_subtype = ? AND competencia = ?",
+        identity,
+    ).fetchone()
+    marker = connection.execute(
+        "SELECT 1 FROM raw_resync_states WHERE tenant_id = ? AND agent_id = ? "
+        "AND source_type = ? AND file_subtype = ? AND competencia = ?",
+        identity,
+    ).fetchone()
+    current = row if row is not None else _legacy_head(connection, identity, job.job_id)
+    if expected is not None and (
+        marker is not None or current is None or current[0] != expected
+    ):
+        raise Conflict(ControlPlaneErrorCode.TRANSACTION_CONFLICT)
+    ordering = (job.created_at.isoformat(), job.job_id)
+    if (
+        expected is None
+        and marker is None
+        and current is not None
+        and current[1:] >= ordering
+    ):
+        if row is None:
+            _put_agent_head(connection, identity, current)
+        return
+    _put_agent_head(connection, identity, (manifest.manifest_id, *ordering))
+
+
+def validate_resync_rejection(connection: Any, job: Job, command: FailJob) -> None:
+    expected_marker = command.expected_resync_marker
+    if expected_marker is None:
+        return
+    identity = (
+        job.tenant_id, job.agent_id, job.source_type,
+        job.file_subtype, job.competencia,
+    )
+    marker = connection.execute(
+        "SELECT 1 FROM raw_resync_states WHERE tenant_id = ? AND agent_id = ? "
+        "AND source_type = ? AND file_subtype = ? AND competencia = ?",
+        identity,
+    ).fetchone()
+    if (marker is not None) != expected_marker:
+        raise Conflict(ControlPlaneErrorCode.TRANSACTION_CONFLICT)
+    if expected_marker:
+        return
+    row = connection.execute(
+        "SELECT manifest_id, created_at, job_id FROM raw_agent_heads "
+        "WHERE tenant_id = ? AND agent_id = ? AND source_type = ? "
+        "AND file_subtype = ? AND competencia = ?",
+        identity,
+    ).fetchone()
+    current = row if row is not None else _legacy_head(connection, identity, job.job_id)
+    current_id = None if current is None else current[0]
+    if current_id != command.expected_head_manifest_id:
+        raise Conflict(ControlPlaneErrorCode.TRANSACTION_CONFLICT)
+
+
+def _query_raw_manifest_by_id(store: Any, query: RawManifestByIdQuery) -> RawManifestRecord | None:
+    with store.read_connection() as connection:
+        row = connection.execute(
+            "SELECT data FROM raw_manifests WHERE tenant_id = ? AND manifest_id = ?",
+            (query.tenant_id, query.manifest_id),
+        ).fetchone()
+    return None if row is None else deserialize_model(row[0], RawManifestRecord)
+
+
+def _query_agent_raw_manifest_chain(
+    store: Any, query: AgentRawManifestChainQuery
+) -> tuple[ManifestRef, ...]:
+    if query.limit <= 0:
+        return ()
+    identity = query.identity
+    with store.read_connection() as connection:
+        row = connection.execute(
+            "SELECT raw_manifests.data FROM jobs JOIN raw_manifests ON "
+            "raw_manifests.tenant_id = jobs.tenant_id AND "
+            "raw_manifests.manifest_id = json_extract(jobs.data, '$.result_manifest_id') "
+            "LEFT JOIN raw_agent_heads ON raw_agent_heads.tenant_id = jobs.tenant_id "
+            "AND raw_agent_heads.agent_id = jobs.agent_id "
+            "AND raw_agent_heads.source_type = jobs.source_type "
+            "AND raw_agent_heads.file_subtype = jobs.file_subtype "
+            "AND raw_agent_heads.competencia = jobs.competencia WHERE jobs.tenant_id = ? "
+            "AND jobs.agent_id = ? AND jobs.source_type = ? AND jobs.file_subtype = ? "
+            "AND jobs.competencia = ? AND jobs.state = ? "
+            "AND (raw_agent_heads.job_id IS NULL OR jobs.job_id = raw_agent_heads.job_id) "
+            "ORDER BY (jobs.job_id = raw_agent_heads.job_id) DESC, "
+            "CASE WHEN raw_agent_heads.job_id IS NULL THEN jobs.created_at END DESC, "
+            "CASE WHEN raw_agent_heads.job_id IS NULL THEN jobs.job_id END DESC LIMIT 1",
+            (
+                identity.tenant_id, query.agent_id, identity.source_type,
+                identity.file_subtype, identity.competencia, JobState.SUCCEEDED.value,
+            ),
+        ).fetchone()
+        if row is None:
+            return ()
+        head = deserialize_model(row[0], RawManifestRecord)
+        raw_identity = (
+            identity.tenant_id, identity.source_type,
+            identity.file_subtype, identity.competencia,
+        )
+        chain = _build_ancestry(connection, raw_identity, head, query.limit)
+    if chain is None or len(chain) != head.sequence:
+        return ()
+    return tuple(
+        ManifestRef(manifest_id=item.manifest_id, manifest_key=item.manifest_key)
+        for item in chain
+    )
+
+
+def _query_raw_resync_state(store: Any, query: RawResyncStateQuery) -> RawResyncState | None:
+    identity = query.identity
+    with store.read_connection() as connection:
+        row = connection.execute(
+            "SELECT data FROM raw_resync_states WHERE tenant_id = ? AND agent_id = ? "
+            "AND source_type = ? AND file_subtype = ? AND competencia = ?",
+            (
+                identity.tenant_id, query.agent_id, identity.source_type,
+                identity.file_subtype, identity.competencia,
+            ),
+        ).fetchone()
+    return None if row is None else deserialize_model(row[0], RawResyncState)
+
+
+def delete_resync_state(connection: Any, manifest: RawManifestRecord) -> None:
+    """Remove o marcador de resync da identidade raw."""
+    connection.execute(
+        "DELETE FROM raw_resync_states WHERE tenant_id = ? AND agent_id = ? "
+        "AND source_type = ? AND file_subtype = ? AND competencia = ?",
+        (
+            manifest.tenant_id, manifest.agent_id, manifest.source_type,
+            manifest.file_subtype, manifest.competencia,
+        ),
+    )
+
+
+def put_resync_state(store: Any, connection: Any, job: Job) -> None:
+    """Cria o primeiro marcador de resync da identidade raw."""
+    state = RawResyncState(
+        tenant_id=job.tenant_id,
+        agent_id=job.agent_id,
+        source_type=job.source_type,
+        file_subtype=job.file_subtype,
+        competencia=job.competencia,
+        required_since=store.now(),
+    )
+    connection.execute(
+        "INSERT INTO raw_resync_states "
+        "(tenant_id, agent_id, source_type, file_subtype, competencia, data) "
+        "VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING",
+        (
+            state.tenant_id, state.agent_id, state.source_type,
+            state.file_subtype, state.competencia, serialize_model(state),
+        ),
+    )

--- a/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
+++ b/packages/cnes_infra/src/cnes_infra/control_plane/sqlite_schema.py
@@ -99,6 +99,27 @@ ON raw_manifests (
     tenant_id, source_type, file_subtype, competencia, agent_id,
     sequence, manifest_sha256, base_snapshot_id, snapshot_id
 );
+CREATE TABLE IF NOT EXISTS raw_agent_heads (
+    tenant_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    file_subtype TEXT NOT NULL,
+    competencia TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    manifest_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, agent_id, source_type, file_subtype, competencia),
+    FOREIGN KEY (tenant_id, job_id) REFERENCES jobs (tenant_id, job_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS raw_resync_states (
+    tenant_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    file_subtype TEXT NOT NULL,
+    competencia TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, agent_id, source_type, file_subtype, competencia)
+);
 CREATE TABLE IF NOT EXISTS runs (
     tenant_id TEXT NOT NULL,
     run_id TEXT NOT NULL,

--- a/packages/cnes_infra/tests/contracts/control_plane_raw_contract.py
+++ b/packages/cnes_infra/tests/contracts/control_plane_raw_contract.py
@@ -2,20 +2,27 @@ from datetime import timedelta
 from typing import Any
 from warnings import catch_warnings, simplefilter
 
+import pytest
+
+from cnes_domain.control_plane.commands import CompleteJob
 from cnes_domain.control_plane.entities import RunDependency
 from cnes_domain.control_plane.enums import RunState
 from cnes_domain.control_plane.errors import Conflict
 from cnes_domain.control_plane.ids import run_dependency_key
 from cnes_domain.control_plane.queries import (
+    AgentRawManifestChainQuery,
     LatestSucceededJobQuery,
     RawIdentity,
+    RawManifestByIdQuery,
     RawManifestChainQuery,
+    RawResyncStateQuery,
     WaitingRunsForDependencyQuery,
 )
 from packages.cnes_infra.tests.contracts.clock import (
     _NOW,
     _TENANT,
     MutableClock,
+    _agent,
     _claim_job,
     _event,
     _fail_job,
@@ -26,6 +33,167 @@ from packages.cnes_infra.tests.contracts.clock import (
 )
 
 _HASH_B = "b" * 64
+
+
+def _accept_record(adapter: Any, record: Any, clock: MutableClock, job_id: str) -> None:
+    job = _job(job_id).model_copy(update={
+        "requested_snapshot_mode": record.snapshot_mode,
+        "created_at": record.created_at,
+    })
+    adapter.create_job(job, _event(f"{job_id}-created"))
+    claim = adapter.claim_job(_claim_job(job_id, "worker", clock))
+    adapter.complete_job(
+        CompleteJob(
+            tenant_id=_TENANT,
+            job_id=job_id,
+            owner="worker",
+            fencing_token=claim.fencing_token,
+            manifest=record,
+        ),
+        _event(f"{job_id}-accepted"),
+    )
+
+
+def _reject_twice(adapter: Any, clock: MutableClock, identity: RawIdentity) -> None:
+    adapter.put_agent(_agent("agent-a"))
+    rejected = _job("job-rejected")
+    adapter.create_job(rejected, _event("rejected-created"))
+    claim = adapter.claim_job(_claim_job(rejected.job_id, "worker", clock))
+    command = _fail_job("worker", claim.fencing_token, "RAW_RESYNC_BASE_UNKNOWN").model_copy(
+        update={
+            "job_id": rejected.job_id,
+            "retryable": False,
+            "rejected_manifest_sha256": _HASH_B,
+            "expected_resync_marker": False,
+        }
+    )
+    event = _event("resync-required")
+    failed = adapter.fail_job(command, event)
+    marker = adapter.query_raw_resync_state(RawResyncStateQuery(identity, "agent-a"))
+    assert failed.rejected_manifest_sha256 == _HASH_B
+    assert marker is not None
+    assert marker.required_since == clock.now()
+    assert adapter.pending_outbox(100).count(event) == 1
+
+    repeated = _job("job-repeated")
+    adapter.create_job(repeated, _event("repeated-created"))
+    repeated_claim = adapter.claim_job(_claim_job(repeated.job_id, "worker", clock))
+    repeated_command = command.model_copy(update={
+        "job_id": repeated.job_id,
+        "fencing_token": repeated_claim.fencing_token,
+        "expected_resync_marker": True,
+    })
+    adapter.fail_job(repeated_command, _event("resync-repeated"))
+    assert adapter.query_raw_resync_state(RawResyncStateQuery(identity, "agent-a")) == marker
+
+
+def _accept_full_and_delta(adapter: Any, clock: MutableClock, identity: RawIdentity) -> None:
+    marker = adapter.query_raw_resync_state(RawResyncStateQuery(identity, "agent-a"))
+    delta = _raw_record("delta-preserves", "agent-a", 2, clock.now())
+    _accept_record(adapter, delta, clock, "job-delta")
+    assert adapter.query_raw_resync_state(RawResyncStateQuery(identity, "agent-a")) == marker
+    assert adapter.query_agent_raw_manifest_chain(
+        AgentRawManifestChainQuery(identity, "agent-a")
+    ) == ()
+
+    clock.advance(timedelta(seconds=1))
+    full = _raw_record("full-clears", "agent-a", 1, clock.now())
+    _accept_record(adapter, full, clock, "job-full")
+    assert adapter.query_raw_manifest_by_id(
+        RawManifestByIdQuery(_TENANT, full.manifest_id)
+    ) == full
+    assert adapter.query_raw_manifest_by_id(
+        RawManifestByIdQuery("other", full.manifest_id)
+    ) is None
+    chain = adapter.query_agent_raw_manifest_chain(
+        AgentRawManifestChainQuery(identity, "agent-a", 31)
+    )
+    assert tuple(ref.manifest_id for ref in chain) == (full.manifest_id,)
+    assert adapter.query_raw_resync_state(RawResyncStateQuery(identity, "agent-a")) is None
+
+    clock.advance(timedelta(seconds=1))
+    linked = _raw_record("linked", "agent-a", 2, clock.now()).model_copy(update={
+        "base_snapshot_id": full.snapshot_id,
+        "previous_manifest_sha256": full.manifest_sha256,
+    })
+    _accept_record(adapter, linked, clock, "job-linked")
+    assert adapter.query_agent_raw_manifest_chain(
+        AgentRawManifestChainQuery(identity, "agent-a", 1)
+    ) == ()
+
+
+def _case_raw_registration_state(adapter: Any, clock: MutableClock) -> None:
+    identity = RawIdentity(_TENANT, "CNES", "ST", "2026-07")
+    assert adapter.query_agent_raw_manifest_chain(
+        AgentRawManifestChainQuery(identity, "agent-a", 0)
+    ) == ()
+    assert adapter.query_agent_raw_manifest_chain(
+        AgentRawManifestChainQuery(identity, "agent-a")
+    ) == ()
+    _reject_twice(adapter, clock, identity)
+    _accept_full_and_delta(adapter, clock, identity)
+
+
+def _delta_completion(adapter: Any, record: Any, clock: MutableClock, job_id: str) -> CompleteJob:
+    job = _job(job_id).model_copy(update={"requested_snapshot_mode": "DELTA"})
+    adapter.create_job(job, _event(f"{job_id}-created"))
+    claim = adapter.claim_job(_claim_job(job_id, "worker", clock))
+    return CompleteJob(
+        tenant_id=_TENANT,
+        job_id=job_id,
+        owner="worker",
+        fencing_token=claim.fencing_token,
+        manifest=record,
+        expected_head_manifest_id="manifest-agent-a-base-agent-a",
+    )
+
+
+def _case_delta_completion_cas(adapter: Any, clock: MutableClock) -> None:
+    adapter.put_agent(_agent("agent-a"))
+    base = _raw_record("base-agent-a", "agent-a", 1, clock.now())
+    _accept_record(adapter, base, clock, "job-z-base")
+    deltas = tuple(
+        _raw_record(f"delta-{suffix}", "agent-a", 2, clock.now()).model_copy(
+            update={"previous_manifest_sha256": base.manifest_sha256}
+        )
+        for suffix in ("a", "b")
+    )
+    commands = tuple(
+        _delta_completion(adapter, item, clock, f"job-{suffix}-delta")
+        for item, suffix in zip(deltas, ("a", "b"), strict=True)
+    )
+    adapter.complete_job(commands[0], _event("delta-a-accepted"))
+    identity = RawIdentity(_TENANT, "CNES", "ST", "2026-07")
+    assert adapter.query_latest_succeeded_job(
+        LatestSucceededJobQuery(identity, "agent-a")
+    ).result_manifest_id == deltas[0].manifest_id
+    with pytest.raises(Conflict):
+        adapter.complete_job(commands[1], _event("delta-b-accepted"))
+    assert adapter.query_raw_manifest_by_id(
+        RawManifestByIdQuery(_TENANT, deltas[1].manifest_id)
+    ) is None
+
+
+def _case_delta_completion_rejects_marker(adapter: Any, clock: MutableClock) -> None:
+    adapter.put_agent(_agent("agent-a"))
+    base = _raw_record("base-agent-a", "agent-a", 1, clock.now())
+    _accept_record(adapter, base, clock, "job-base")
+    delta = _raw_record("delta-marker", "agent-a", 2, clock.now()).model_copy(
+        update={"previous_manifest_sha256": base.manifest_sha256}
+    )
+    completion = _delta_completion(adapter, delta, clock, "job-delta-marker")
+    marker_job = _job("job-marker")
+    adapter.create_job(marker_job, _event("marker-created"))
+    marker_claim = adapter.claim_job(_claim_job("job-marker", "marker-worker", clock))
+    failure = _fail_job(
+        "marker-worker", marker_claim.fencing_token, "RAW_RESYNC_BASE_UNKNOWN"
+    ).model_copy(update={
+        "job_id": "job-marker", "retryable": False,
+        "rejected_manifest_sha256": _HASH_B,
+    })
+    adapter.fail_job(failure, _event("marker-required"))
+    with pytest.raises(Conflict):
+        adapter.complete_job(completion, _event("delta-marker-accepted"))
 
 
 def _case_raw_chains(adapter: Any, clock: MutableClock) -> None:

--- a/packages/cnes_infra/tests/contracts/harness_raw_queries.py
+++ b/packages/cnes_infra/tests/contracts/harness_raw_queries.py
@@ -2,14 +2,32 @@ from typing import Any
 
 from cnes_domain.control_plane.enums import RunState
 from cnes_domain.control_plane.queries import (
+    AgentRawManifestChainQuery,
     LatestSucceededJobQuery,
+    RawManifestByIdQuery,
     RawManifestChainQuery,
+    RawResyncStateQuery,
     WaitingRunsForDependencyQuery,
 )
 from cnes_infra.control_plane.raw_query_compat import DeprecatedRawQueryMixin
 
 
 class HarnessRawQueries(DeprecatedRawQueryMixin):
+    def query_raw_manifest_by_id(self, query: RawManifestByIdQuery) -> Any | None:
+        return next(
+            (record for record in self.raw_records
+             if (record.tenant_id, record.manifest_id) == (query.tenant_id, query.manifest_id)),
+            None,
+        )
+
+    def query_agent_raw_manifest_chain(
+        self, query: AgentRawManifestChainQuery
+    ) -> tuple[Any, ...]:
+        return ()
+
+    def query_raw_resync_state(self, query: RawResyncStateQuery) -> Any | None:
+        return None
+
     def query_latest_succeeded_job(self, query: LatestSucceededJobQuery) -> Any | None:
         identity = query.identity
         matches = [

--- a/packages/cnes_infra/tests/control_plane/test_dynamodb_queries.py
+++ b/packages/cnes_infra/tests/control_plane/test_dynamodb_queries.py
@@ -200,7 +200,13 @@ def test_latest_succeeded_ignora_omissao_do_gsi_e_historico(ctx: _DynamoContext)
         _store_record(adapter, record, clock)
     requests = [next(iter(action.values())) for action in spy.transactions[-1]]
     items = [request["Item" if "Item" in request else "Key"] for request in requests]
-    assert len(requests) == len({(item["pk"]["S"], item["sk"]["S"]) for item in items}) == 8
+    assert len(requests) == len({(item["pk"]["S"], item["sk"]["S"]) for item in items}) == 10
+    raw_records = [
+        request for request in requests
+        if request.get("Item", {}).get("entity") == {"S": "RAWMANIFESTRECORD"}
+    ]
+    assert len(raw_records) == 2
+    assert any("Delete" in action for action in spy.transactions[-1])
     head = next(
         request for request in requests if request.get("Item", {}).get("entity") == {"S": "RAWHEAD"}
     )

--- a/packages/cnes_infra/tests/control_plane/test_raw_registration_adapters.py
+++ b/packages/cnes_infra/tests/control_plane/test_raw_registration_adapters.py
@@ -1,0 +1,397 @@
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from cnes_domain.control_plane.commands import CompleteJob, FailJob
+from cnes_domain.control_plane.entities import RawResyncState
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.control_plane.queries import (
+    AgentRawManifestChainQuery,
+    LatestSucceededJobQuery,
+    RawIdentity,
+    RawResyncStateQuery,
+)
+from cnes_infra.control_plane.dynamodb_adapter import DynamoDBControlPlane
+from cnes_infra.control_plane.dynamodb_codec import encode_model
+from cnes_infra.control_plane.dynamodb_keys import (
+    item_key,
+    key_component,
+    raw_manifest_lookup_key,
+    raw_partition,
+    raw_resync_key,
+)
+from cnes_infra.control_plane.sqlite_adapter import SQLiteControlPlane
+from packages.cnes_infra.tests.contracts.clock import (
+    _TENANT,
+    MutableClock,
+    _agent,
+    _claim_job,
+    _event,
+    _fail_job,
+    _job,
+    _raw_record,
+)
+from packages.cnes_infra.tests.contracts.control_plane_raw_contract import (
+    _accept_record,
+    _case_delta_completion_cas,
+    _case_delta_completion_rejects_marker,
+    _case_raw_registration_state,
+    _delta_completion,
+)
+from packages.cnes_infra.tests.control_plane.test_dynamodb_adapter import _create_table
+
+_TABLE_NAME = "cnesdata-control-plane"
+
+
+@pytest.fixture
+def clock() -> MutableClock:
+    return MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
+
+
+@pytest.fixture
+def sqlite_control_plane(tmp_path, clock: MutableClock) -> SQLiteControlPlane:
+    adapter = SQLiteControlPlane(tmp_path / "control-plane.sqlite3", clock.now)
+    adapter.initialize()
+    return adapter
+
+
+@pytest.fixture
+def dynamodb_adapter() -> Iterator[tuple[DynamoDBControlPlane, MutableClock]]:
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-east-1")
+        _create_table(client)
+        clock = MutableClock(datetime(2026, 7, 15, 12, tzinfo=UTC))
+        yield DynamoDBControlPlane(client, _TABLE_NAME, clock.now), clock
+
+
+class _TransactionSpy:
+    def __init__(self, client: Any) -> None:
+        self.client = client
+        self.transactions = []
+        self.before_transaction = self._create_marker
+
+    def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
+        actions = kwargs["TransactItems"]
+        self.transactions.append(actions)
+        if self.before_transaction is not None:
+            self.before_transaction(actions)
+        return self.client.transact_write_items(**kwargs)
+
+    def _create_marker(self, actions: list[dict[str, Any]]) -> None:
+        self.before_transaction = None
+        marker = next(
+            action["Update"] for action in actions
+            if "if_not_exists" in action.get("Update", {}).get("UpdateExpression", "")
+        )
+        self.client.update_item(**marker)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.client, name)
+
+
+class _FullMarkerRaceSpy:
+    def __init__(self, client: Any, marker_item: dict[str, Any]) -> None:
+        self.client = client
+        self.marker_item = marker_item
+        self.transactions = 0
+
+    def transact_write_items(self, **kwargs: Any) -> dict[str, Any]:
+        self.transactions += 1
+        if self.marker_item:
+            item = self.marker_item
+            self.marker_item = {}
+            self.client.put_item(TableName=_TABLE_NAME, Item=item)
+        return self.client.transact_write_items(**kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.client, name)
+
+
+def test_sqlite_persiste_registro_raw_atomico(sqlite_control_plane, clock) -> None:
+    _case_raw_registration_state(sqlite_control_plane, clock)
+
+
+def test_dynamodb_persiste_registro_raw_atomico(dynamodb_adapter) -> None:
+    adapter, clock = dynamodb_adapter
+    _case_raw_registration_state(adapter, clock)
+
+
+def test_sqlite_rejeita_fork_delta_concorrente(sqlite_control_plane, clock) -> None:
+    _case_delta_completion_cas(sqlite_control_plane, clock)
+
+
+def test_sqlite_aceite_antigo_nao_regride_cabeca(sqlite_control_plane, clock) -> None:
+    sqlite_control_plane.put_agent(_agent("agent-a"))
+    newest = _raw_record("newest", "agent-a", 1, clock.now())
+    older = _raw_record("older", "agent-a", 1, clock.now())
+    _accept_record(sqlite_control_plane, newest, clock, "job-z-newest")
+    with sqlite_control_plane.write_transaction() as connection:
+        connection.execute("DELETE FROM raw_agent_heads")
+    _accept_record(sqlite_control_plane, older, clock, "job-a-older")
+    oldest = _raw_record("oldest", "agent-a", 1, clock.now())
+    _accept_record(sqlite_control_plane, oldest, clock, "job-0-oldest")
+    query = AgentRawManifestChainQuery(
+        RawIdentity(_TENANT, "CNES", "ST", "2026-07"), "agent-a"
+    )
+    chain = sqlite_control_plane.query_agent_raw_manifest_chain(query)
+    assert tuple(item.manifest_id for item in chain) == (newest.manifest_id,)
+
+
+def test_sqlite_aceita_primeiro_delta_de_banco_anterior_ao_ponteiro(
+    sqlite_control_plane, clock
+) -> None:
+    sqlite_control_plane.put_agent(_agent("agent-a"))
+    base = _raw_record("base-agent-a", "agent-a", 1, clock.now())
+    _accept_record(sqlite_control_plane, base, clock, "job-z-base")
+    with sqlite_control_plane.write_transaction() as connection:
+        connection.execute("DELETE FROM raw_agent_heads")
+    delta = _raw_record("delta-upgrade", "agent-a", 2, clock.now()).model_copy(
+        update={"previous_manifest_sha256": base.manifest_sha256}
+    )
+    completion = _delta_completion(sqlite_control_plane, delta, clock, "job-a-delta")
+    sqlite_control_plane.complete_job(completion, _event("delta-upgrade-accepted"))
+    query = AgentRawManifestChainQuery(
+        RawIdentity(_TENANT, "CNES", "ST", "2026-07"), "agent-a"
+    )
+    chain = sqlite_control_plane.query_agent_raw_manifest_chain(query)
+    assert tuple(item.manifest_id for item in chain) == (base.manifest_id, delta.manifest_id)
+
+
+def test_dynamodb_rejeita_fork_delta_concorrente(dynamodb_adapter) -> None:
+    adapter, clock = dynamodb_adapter
+    _case_delta_completion_cas(adapter, clock)
+
+
+def test_sqlite_rejeita_delta_se_marcador_surgir(sqlite_control_plane, clock) -> None:
+    _case_delta_completion_rejects_marker(sqlite_control_plane, clock)
+
+
+def test_dynamodb_rejeita_delta_se_marcador_surgir(dynamodb_adapter) -> None:
+    adapter, clock = dynamodb_adapter
+    _case_delta_completion_rejects_marker(adapter, clock)
+
+
+def test_sqlite_rejeicao_obsoleta_nao_bloqueia_full(sqlite_control_plane, clock) -> None:
+    _case_rejection_loses_to_full(sqlite_control_plane, clock)
+
+
+def test_dynamodb_rejeicao_obsoleta_nao_bloqueia_full(dynamodb_adapter) -> None:
+    adapter, clock = dynamodb_adapter
+    _case_rejection_loses_to_full(adapter, clock)
+
+
+def _case_rejection_loses_to_full(adapter: Any, clock: MutableClock) -> None:
+    adapter.put_agent(_agent("agent-a"))
+    rejected = _job("job-rejected")
+    adapter.create_job(rejected, _event("rejected-created"))
+    claim = adapter.claim_job(_claim_job(rejected.job_id, "worker", clock))
+    failure = _fail_job("worker", claim.fencing_token, "RAW_RESYNC_BASE_UNKNOWN").model_copy(
+        update={
+            "job_id": rejected.job_id,
+            "retryable": False,
+            "rejected_manifest_sha256": "b" * 64,
+            "expected_resync_marker": False,
+        }
+    )
+    full = _raw_record("concurrent-full", "agent-a", 1, clock.now())
+    _accept_record(adapter, full, clock, "job-full")
+    with pytest.raises(Conflict):
+        adapter.fail_job(failure, _event("stale-resync"))
+    assert adapter.get_job(_TENANT, rejected.job_id).state is JobState.LEASED
+    identity = RawIdentity(_TENANT, "CNES", "ST", "2026-07")
+    assert adapter.query_raw_resync_state(RawResyncStateQuery(identity, "agent-a")) is None
+
+
+def _guarded_failure(
+    job_id: str, fence: int, marker: bool, head: str | None = None
+) -> FailJob:
+    return FailJob(
+        tenant_id=_TENANT,
+        job_id=job_id,
+        owner="worker",
+        fencing_token=fence,
+        error_code="RAW_RESYNC_BASE_UNKNOWN",
+        retryable=False,
+        rejected_manifest_sha256="b" * 64,
+        expected_head_manifest_id=head,
+        expected_resync_marker=marker,
+    )
+
+
+def test_sqlite_rejeicao_guardada_perde_para_full(sqlite_control_plane, clock) -> None:
+    _case_guarded_rejection_loses_to_full(sqlite_control_plane, clock)
+
+
+def test_dynamodb_rejeicao_guardada_perde_para_full(dynamodb_adapter) -> None:
+    adapter, clock = dynamodb_adapter
+    _case_guarded_rejection_loses_to_full(adapter, clock)
+
+
+def _case_guarded_rejection_loses_to_full(adapter: Any, clock: MutableClock) -> None:
+    adapter.put_agent(_agent("agent-a"))
+    base = _raw_record("guard-base", "agent-a", 1, clock.now())
+    _accept_record(adapter, base, clock, "job-base")
+    first = _job("job-first-rejection")
+    adapter.create_job(first, _event("first-rejection-created"))
+    claim = adapter.claim_job(_claim_job(first.job_id, "worker", clock))
+    adapter.fail_job(
+        _guarded_failure(first.job_id, claim.fencing_token, False, base.manifest_id),
+        _event("first-resync"),
+    )
+    second = _job("job-second-rejection")
+    adapter.create_job(second, _event("second-rejection-created"))
+    claim = adapter.claim_job(_claim_job(second.job_id, "worker", clock))
+    stale = _guarded_failure(second.job_id, claim.fencing_token, True)
+    full = _raw_record("guard-full", "agent-a", 1, clock.now())
+    _accept_record(adapter, full, clock, "job-z-full")
+    with pytest.raises(Conflict):
+        adapter.fail_job(stale, _event("stale-marker-resync"))
+    assert adapter.get_job(_TENANT, second.job_id).state is JobState.LEASED
+
+
+def test_sqlite_full_de_recuperacao_antigo_vira_cabeca(sqlite_control_plane, clock) -> None:
+    _case_recovery_full_becomes_head(sqlite_control_plane, clock)
+
+
+def test_dynamodb_full_de_recuperacao_antigo_vira_cabeca(dynamodb_adapter) -> None:
+    adapter, clock = dynamodb_adapter
+    _case_recovery_full_becomes_head(adapter, clock)
+
+
+def _case_recovery_full_becomes_head(adapter: Any, clock: MutableClock) -> None:
+    adapter.put_agent(_agent("agent-a"))
+    head = _raw_record("existing-head", "agent-a", 1, clock.now())
+    _accept_record(adapter, head, clock, "job-z-head")
+    rejected = _job("job-marker")
+    adapter.create_job(rejected, _event("marker-created"))
+    claim = adapter.claim_job(_claim_job(rejected.job_id, "worker", clock))
+    adapter.fail_job(
+        _guarded_failure(rejected.job_id, claim.fencing_token, False, head.manifest_id),
+        _event("marker-required"),
+    )
+    recovery = _raw_record("recovery", "agent-a", 1, clock.now())
+    _accept_record(adapter, recovery, clock, "job-a-recovery")
+    identity = RawIdentity(_TENANT, "CNES", "ST", "2026-07")
+    latest = adapter.query_latest_succeeded_job(LatestSucceededJobQuery(identity, "agent-a"))
+    assert latest.result_manifest_id == recovery.manifest_id
+    assert adapter.query_raw_resync_state(RawResyncStateQuery(identity, "agent-a")) is None
+
+
+def test_dynamodb_retry_de_full_reavalia_marcador_criado_em_corrida(
+    dynamodb_adapter,
+) -> None:
+    adapter, clock = dynamodb_adapter
+    adapter.put_agent(_agent("agent-a"))
+    head = _raw_record("race-head", "agent-a", 1, clock.now())
+    _accept_record(adapter, head, clock, "job-z-head")
+    recovery = _raw_record("race-recovery", "agent-a", 1, clock.now())
+    job = _job("job-a-recovery")
+    adapter.create_job(job, _event("recovery-created"))
+    claim = adapter.claim_job(_claim_job(job.job_id, "worker", clock))
+    command = CompleteJob(
+        tenant_id=_TENANT, job_id=job.job_id, owner="worker",
+        fencing_token=claim.fencing_token, manifest=recovery,
+    )
+    partition = raw_partition(_TENANT, "CNES", "ST", "2026-07")
+    key = raw_resync_key(partition, "agent-a")
+    state = RawResyncState(
+        tenant_id=_TENANT, agent_id="agent-a", source_type="CNES",
+        file_subtype="ST", competencia="2026-07", required_since=clock.now(),
+    )
+    adapter._client = spy = _FullMarkerRaceSpy(
+        adapter._client, encode_model(state, "RAWRESYNCSTATE", key)
+    )
+    adapter.complete_job(command, _event("recovery-accepted"))
+    identity = RawIdentity(_TENANT, "CNES", "ST", "2026-07")
+    latest = adapter.query_latest_succeeded_job(LatestSucceededJobQuery(identity, "agent-a"))
+    assert latest.result_manifest_id == recovery.manifest_id
+    assert spy.transactions == 2
+
+
+def test_dynamodb_rejeita_delta_se_head_sumir(dynamodb_adapter) -> None:
+    adapter, clock = dynamodb_adapter
+    adapter.put_agent(_agent("agent-a"))
+    delta = _raw_record("delta-sem-head", "agent-a", 2, clock.now())
+    completion = _delta_completion(adapter, delta, clock, "job-delta-sem-head")
+    with pytest.raises(Conflict):
+        adapter.complete_job(completion, _event("delta-sem-head-accepted"))
+    assert adapter.get_job(_TENANT, completion.job_id).state is JobState.LEASED
+
+
+def test_dynamodb_rejeita_resync_se_head_observado_sumir(dynamodb_adapter) -> None:
+    adapter, clock = dynamodb_adapter
+    adapter.put_agent(_agent("agent-a"))
+    base = _raw_record("guard-missing", "agent-a", 1, clock.now())
+    _accept_record(adapter, base, clock, "job-base")
+    rejected = _job("job-rejected-missing")
+    adapter.create_job(rejected, _event("rejected-missing-created"))
+    claim = adapter.claim_job(_claim_job(rejected.job_id, "worker", clock))
+    failure = _guarded_failure(
+        rejected.job_id, claim.fencing_token, False, base.manifest_id
+    )
+    partition = raw_partition(_TENANT, "CNES", "ST", "2026-07")
+    key = partition, f"LATEST_JOB#{key_component('agent-a')}"
+    adapter._client.delete_item(TableName=_TABLE_NAME, Key=item_key(*key))
+    with pytest.raises(Conflict):
+        adapter.fail_job(failure, _event("missing-head-resync"))
+    assert adapter.get_job(_TENANT, rejected.job_id).state is JobState.LEASED
+
+
+def test_sqlite_rejeita_delta_se_head_sumir(sqlite_control_plane, clock) -> None:
+    sqlite_control_plane.put_agent(_agent("agent-a"))
+    delta = _raw_record("delta-sem-head", "agent-a", 2, clock.now())
+    completion = _delta_completion(sqlite_control_plane, delta, clock, "job-delta-sem-head")
+    with pytest.raises(Conflict):
+        sqlite_control_plane.complete_job(completion, _event("delta-sem-head-accepted"))
+    assert sqlite_control_plane.get_job(_TENANT, completion.job_id).state is JobState.LEASED
+
+
+def test_rejeicao_dynamodb_preserva_marcador_criado_em_corrida(dynamodb_adapter) -> None:
+    adapter, clock = dynamodb_adapter
+    adapter.put_agent(_agent("agent-a"))
+    adapter.create_job(_job("job-a"), _event("job-created"))
+    claimed = adapter.claim_job(_claim_job("job-a", "worker-a", clock))
+    command = _fail_job("worker-a", claimed.fencing_token, "RAW_RESYNC_BASE_UNKNOWN").model_copy(
+        update={"retryable": False, "rejected_manifest_sha256": "b" * 64}
+    )
+    adapter._client = spy = _TransactionSpy(adapter._client)
+    failed = adapter.fail_job(command, _event("resync-required"))
+    identity = RawIdentity(_TENANT, "CNES", "ST", "2026-07")
+    assert failed.state is JobState.FAILED_FINAL
+    assert adapter.query_raw_resync_state(RawResyncStateQuery(identity, "agent-a")) is not None
+    assert len(spy.transactions) == 1
+
+
+def test_sqlite_omite_cadeia_se_lookup_da_cabeca_sumir(sqlite_control_plane, clock) -> None:
+    base = _raw_record("full-base", "agent-a", 1, clock.now())
+    record = _raw_record("full-corrupted", "agent-a", 1, clock.now())
+    sqlite_control_plane.put_agent(_agent("agent-a"))
+    _accept_record(sqlite_control_plane, base, clock, "job-a-base")
+    _accept_record(sqlite_control_plane, record, clock, "job-z-corrupted")
+    with sqlite_control_plane.write_transaction() as connection:
+        connection.execute(
+            "DELETE FROM raw_manifests WHERE tenant_id = ? AND manifest_id = ?",
+            (_TENANT, record.manifest_id),
+        )
+    query = AgentRawManifestChainQuery(
+        RawIdentity(_TENANT, "CNES", "ST", "2026-07"), "agent-a"
+    )
+    assert sqlite_control_plane.query_agent_raw_manifest_chain(query) == ()
+
+
+def test_dynamodb_omite_cadeia_se_lookup_da_cabeca_sumir(dynamodb_adapter) -> None:
+    adapter, clock = dynamodb_adapter
+    record = _raw_record("full-corrupted", "agent-a", 1, clock.now())
+    adapter.put_agent(_agent("agent-a"))
+    _accept_record(adapter, record, clock, "job-corrupted")
+    key = raw_manifest_lookup_key(_TENANT, record.manifest_id)
+    adapter._client.delete_item(TableName=_TABLE_NAME, Key=item_key(*key))
+    query = AgentRawManifestChainQuery(
+        RawIdentity(_TENANT, "CNES", "ST", "2026-07"), "agent-a"
+    )
+    assert adapter.query_agent_raw_manifest_chain(query) == ()


### PR DESCRIPTION
## Summary

- validate canonical raw manifests, immutable objects, leases, fences and terminal replays
- enforce ordered FULL/DELTA resync policy and immutable manifest lookup
- persist acceptance or resync rejection atomically in SQLite and DynamoDB

## Verification

- rtk uv run ruff check .
- focused domain, adapter and service suites: 1,169 passed
- fast global suite: 1,996 passed, 14 skipped
- service branch coverage: 93.98%

Closes #140