### PR TITLE
feat(infra): ingest DATASUS CNES PF files

### DIFF
--- a/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_raw.py
+++ b/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_raw.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from dataclasses import dataclass
 from hashlib import sha256
 from io import BytesIO
@@ -91,11 +92,11 @@ class DatasusCnesRawAdapter:
         finally:
             close = getattr(iterator, "close", None)
             if callable(close):
-                try:
+                if failed:
+                    with suppress(Exception):
+                        close()
+                else:
                     close()
-                except Exception:
-                    if not failed:
-                        raise
 
     @staticmethod
     def _project(

--- a/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_raw.py
+++ b/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_raw.py
@@ -83,12 +83,19 @@ class DatasusCnesRawAdapter:
 
     def _project_rows(self, request: DatasusCnesRequest) -> list[dict[str, object]]:
         iterator = iter(self._transport.fetch(request))
+        failed = True
         try:
-            return [self._project(row, request) for row in iterator]
+            projected = [self._project(row, request) for row in iterator]
+            failed = False
+            return projected
         finally:
             close = getattr(iterator, "close", None)
             if callable(close):
-                close()
+                try:
+                    close()
+                except Exception:
+                    if not failed:
+                        raise
 
     @staticmethod
     def _project(

--- a/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_raw.py
+++ b/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_raw.py
@@ -1,0 +1,231 @@
+"""Adapter raw para vínculos PF do CNES nacional."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from io import BytesIO
+from typing import TYPE_CHECKING, Never
+
+import polars as pl
+
+from cnes_contracts import RawManifest, SnapshotMode, SourceType
+from cnes_infra.ingestion.datasus_cnes_transport import (
+    DatasusCnesError,
+    DatasusCnesRequest,
+    DatasusCnesTransportPort,
+    _validate_request,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from datetime import datetime
+
+    from cnes_domain.ports.object_store import ObjectStorePort
+
+_SCHEMA = {
+    "CPF": pl.String,
+    "CNS": pl.String,
+    "NOME_PROFISSIONAL": pl.String,
+    "NOME_SOCIAL": pl.String,
+    "SEXO": pl.String,
+    "CBO": pl.String,
+    "CNES": pl.String,
+    "TIPO_VINCULO": pl.String,
+    "SUS": pl.String,
+    "CH_TOTAL": pl.Int64,
+    "CH_AMBULATORIAL": pl.Int64,
+    "CH_OUTRAS": pl.Int64,
+    "CH_HOSPITALAR": pl.Int64,
+    "FONTE": pl.String,
+}
+_COLUMNS = tuple(_SCHEMA)
+
+
+@dataclass(frozen=True, slots=True)
+class _RawObject:
+    key: str
+    payload: bytes
+    digest: str
+    row_count: int
+
+
+def _raise(code: str, retryable: bool = False) -> Never:
+    raise DatasusCnesError(code, retryable) from None
+
+
+class DatasusCnesRawAdapter:
+    def __init__(
+        self,
+        transport: DatasusCnesTransportPort,
+        store: ObjectStorePort,
+        clock: Callable[[], datetime],
+    ) -> None:
+        self._transport = transport
+        self._store = store
+        self._clock = clock
+
+    def extract(self, request: DatasusCnesRequest) -> RawManifest:
+        _validate_request(request)
+        projected = self._project_rows(request)
+        if not projected:
+            _raise("source_not_published", True)
+        frame = pl.DataFrame(projected, schema=_SCHEMA).sort(
+            _COLUMNS, nulls_last=True
+        )
+        payload = self._serialize(frame)
+        digest = sha256(payload).hexdigest()
+        key = self._object_key(request)
+        raw_object = _RawObject(key, payload, digest, frame.height)
+        manifest = self._manifest(request, raw_object)
+        self._store.put(key, BytesIO(payload), digest)
+        return manifest
+
+    def _project_rows(self, request: DatasusCnesRequest) -> list[dict[str, object]]:
+        iterator = iter(self._transport.fetch(request))
+        try:
+            return [self._project(row, request) for row in iterator]
+        finally:
+            close = getattr(iterator, "close", None)
+            if callable(close):
+                close()
+
+    @staticmethod
+    def _project(
+        row: Mapping[str, object], request: DatasusCnesRequest
+    ) -> dict[str, object]:
+        _validate_boundary(row, request)
+        outpatient = _hours(row, "HORA_AMB")
+        other = _hours(row, "HORAOUTR")
+        hospital = _hours(row, "HORAHOSP")
+        return {
+            "CPF": _document(row, "CPF_PROF", 11),
+            "CNS": _document(row, "CNS_PROF", 15),
+            "NOME_PROFISSIONAL": _text(row, "NOMEPROF"),
+            "NOME_SOCIAL": None,
+            "SEXO": None,
+            "CBO": _padded(row, "CBO", 6),
+            "CNES": _padded(row, "CNES", 7),
+            "TIPO_VINCULO": _padded(row, "VINCULAC", 6),
+            "SUS": _sus(row),
+            "CH_TOTAL": outpatient + other + hospital,
+            "CH_AMBULATORIAL": outpatient,
+            "CH_OUTRAS": other,
+            "CH_HOSPITALAR": hospital,
+            "FONTE": "NACIONAL",
+        }
+
+    @staticmethod
+    def _serialize(frame: pl.DataFrame) -> bytes:
+        output = BytesIO()
+        frame.write_parquet(
+            output,
+            compression="zstd",
+            compression_level=3,
+            statistics=True,
+            row_group_size=64_000,
+        )
+        return output.getvalue()
+
+    @staticmethod
+    def _object_key(request: DatasusCnesRequest) -> str:
+        return (
+            f"raw/{request.tenant_id}/CNES_NACIONAL/{request.competencia}/"
+            f"{request.snapshot_id}/data.parquet"
+        )
+
+    def _manifest(
+        self,
+        request: DatasusCnesRequest,
+        raw_object: _RawObject,
+    ) -> RawManifest:
+        return RawManifest(
+            manifest_version=1,
+            manifest_id=request.snapshot_id,
+            tenant_id=request.tenant_id,
+            source_type=SourceType.CNES_NACIONAL,
+            file_subtype=request.file_subtype,
+            competencia=request.competencia,
+            agent_id=request.agent_id,
+            agent_version=request.agent_version,
+            schema_version="cnes-profissional-v1",
+            snapshot_mode=SnapshotMode.FULL,
+            snapshot_id=request.snapshot_id,
+            base_snapshot_id=None,
+            sequence=1,
+            previous_manifest_sha256=None,
+            object_sha256=raw_object.digest,
+            row_count=raw_object.row_count,
+            size_bytes=len(raw_object.payload),
+            object_key=raw_object.key,
+            created_at=self._clock(),
+        )
+
+
+def _text(row: Mapping[str, object], field: str) -> str:
+    try:
+        value = row[field]
+    except (KeyError, TypeError):
+        _raise("field_invalid")
+    if not isinstance(value, str):
+        _raise("field_invalid")
+    return value.strip()
+
+
+def _validate_boundary(row: Mapping[str, object], request: DatasusCnesRequest) -> None:
+    try:
+        competencia = _text(row, "COMPETEN")
+        municipio = _text(row, "CODUFMUN")
+    except DatasusCnesError:
+        _raise("transport_contract_invalid")
+    if competencia != request.competencia.replace("-", ""):
+        _raise("transport_contract_invalid")
+    if municipio != request.tenant_id:
+        _raise("transport_contract_invalid")
+
+
+def _document(row: Mapping[str, object], field: str, width: int) -> str | None:
+    value = _text(row, field)
+    if value == "" or value == "9" * width:
+        return None
+    if len(value) != width or not _is_ascii_digits(value):
+        _raise("field_invalid")
+    return value
+
+
+def _padded(row: Mapping[str, object], field: str, width: int) -> str:
+    value = _text(row, field)
+    if not _is_ascii_digits(value) or len(value) > width:
+        _raise("field_invalid")
+    return value.zfill(width)
+
+
+def _sus(row: Mapping[str, object]) -> str:
+    value = _text(row, "PROF_SUS")
+    if value == "1":
+        return "S"
+    if value == "0":
+        return "N"
+    _raise("field_invalid")
+
+
+def _hours(row: Mapping[str, object], field: str) -> int:
+    try:
+        value = row[field]
+    except (KeyError, TypeError):
+        _raise("field_invalid")
+    if value is None or value == "":
+        return 0
+    if isinstance(value, bool):
+        _raise("field_invalid")
+    if isinstance(value, int) and value >= 0:
+        return value
+    if isinstance(value, float) and value >= 0 and value.is_integer():
+        return int(value)
+    if isinstance(value, str) and _is_ascii_digits(value.strip()):
+        return int(value.strip())
+    _raise("field_invalid")
+
+
+def _is_ascii_digits(value: str) -> bool:
+    return value.isascii() and value.isdigit()

--- a/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_transport.py
+++ b/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_transport.py
@@ -254,7 +254,10 @@ class DatasusCnesFtpTransport:
 
     @staticmethod
     def _metadata(ftp: FTP, remote_path: str) -> _Metadata:
-        size = ftp.size(remote_path)
+        try:
+            size = ftp.size(remote_path)
+        except ValueError:
+            _raise("metadata_invalid", True)
         modified = ftp.sendcmd(f"MDTM {remote_path}")
         if isinstance(size, bool) or not isinstance(size, int) or size < 0:
             _raise("metadata_invalid", True)
@@ -285,8 +288,10 @@ class DatasusCnesFtpTransport:
             ftp.quit()
         except Exception:
             pass
-        finally:
+        try:
             _close(ftp)
+        except Exception:
+            pass
 
     @staticmethod
     def _decompress(dbc_path: Path, dbf_path: Path) -> None:

--- a/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_transport.py
+++ b/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from dataclasses import dataclass
 from ftplib import FTP, error_perm
 from ftplib import Error as FtpError
@@ -218,8 +219,9 @@ class DatasusCnesFtpTransport:
     def _iterate(
         self, request: DatasusCnesRequest, remote_path: str
     ) -> Iterator[Mapping[str, object]]:
-        with TemporaryDirectory(prefix="datasus-cnes-") as temporary:
-            dbc_path = Path(temporary) / Path(remote_path).name
+        temporary = TemporaryDirectory(prefix="datasus-cnes-")
+        try:
+            dbc_path = Path(temporary.name) / Path(remote_path).name
             dbf_path = dbc_path.with_suffix(".dbf")
             self._download_protected(remote_path, dbc_path)
             self._decompress(dbc_path, dbf_path)
@@ -228,6 +230,9 @@ class DatasusCnesFtpTransport:
             self._validate_layout(table)
             self._validate_competencia(table, request.competencia.replace("-", ""))
             yield from self._municipal_rows(table, request.tenant_id)
+        finally:
+            with suppress(Exception):
+                temporary.cleanup()
 
     def _download_protected(self, remote_path: str, destination: Path) -> None:
         try:

--- a/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_transport.py
+++ b/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_transport.py
@@ -1,0 +1,421 @@
+"""Transporte FTP para arquivos PF do CNES nacional."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from ftplib import FTP, error_perm
+from ftplib import Error as FtpError
+from hashlib import sha256
+from pathlib import Path
+from re import fullmatch
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Never, Protocol
+
+from datasus_dbc import decompress
+from dbfread import DBF
+
+from cnes_domain.pipeline.circuit_breaker import CircuitBreaker, CircuitBreakerAberto
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Mapping
+
+_HOST = "ftp.datasus.gov.br"
+_ROOT = "/dissemin/publicos/CNES/200508_/Dados/PF"
+_SUBTYPE = "CNES_VINCULO"
+_AGENT = "system-datasus"
+_BLOCK_SIZE = 64 * 1024
+_TIMEOUT = 30
+_UF_BY_CODE = {
+    "11": "RO",
+    "12": "AC",
+    "13": "AM",
+    "14": "RR",
+    "15": "PA",
+    "16": "AP",
+    "17": "TO",
+    "21": "MA",
+    "22": "PI",
+    "23": "CE",
+    "24": "RN",
+    "25": "PB",
+    "26": "PE",
+    "27": "AL",
+    "28": "SE",
+    "29": "BA",
+    "31": "MG",
+    "32": "ES",
+    "33": "RJ",
+    "35": "SP",
+    "41": "PR",
+    "42": "SC",
+    "43": "RS",
+    "50": "MS",
+    "51": "MT",
+    "52": "GO",
+    "53": "DF",
+}
+_PF_LAYOUT = (
+    ("CNES", "C", 7, 0),
+    ("CODUFMUN", "C", 6, 0),
+    ("REGSAUDE", "C", 4, 0),
+    ("MICR_REG", "C", 6, 0),
+    ("DISTRSAN", "C", 4, 0),
+    ("DISTRADM", "C", 4, 0),
+    ("TPGESTAO", "C", 1, 0),
+    ("PF_PJ", "C", 1, 0),
+    ("CPF_CNPJ", "C", 14, 0),
+    ("NIV_DEP", "C", 1, 0),
+    ("CNPJ_MAN", "C", 14, 0),
+    ("ESFERA_A", "C", 2, 0),
+    ("ATIVIDAD", "C", 2, 0),
+    ("RETENCAO", "C", 2, 0),
+    ("NATUREZA", "C", 2, 0),
+    ("CLIENTEL", "C", 2, 0),
+    ("TP_UNID", "C", 2, 0),
+    ("TURNO_AT", "C", 2, 0),
+    ("NIV_HIER", "C", 2, 0),
+    ("TERCEIRO", "C", 1, 0),
+    ("CPF_PROF", "C", 11, 0),
+    ("CPFUNICO", "C", 1, 0),
+    ("CBO", "C", 6, 0),
+    ("CBOUNICO", "C", 6, 0),
+    ("NOMEPROF", "C", 60, 0),
+    ("CNS_PROF", "C", 15, 0),
+    ("CONSELHO", "C", 2, 0),
+    ("REGISTRO", "C", 13, 0),
+    ("VINCULAC", "C", 6, 0),
+    ("VINCUL_C", "C", 1, 0),
+    ("VINCUL_A", "C", 1, 0),
+    ("VINCUL_N", "C", 1, 0),
+    ("PROF_SUS", "C", 1, 0),
+    ("PROFNSUS", "C", 1, 0),
+    ("HORAOUTR", "N", 3, 0),
+    ("HORAHOSP", "N", 3, 0),
+    ("HORA_AMB", "N", 3, 0),
+    ("COMPETEN", "C", 6, 0),
+    ("UFMUNRES", "C", 6, 0),
+    ("NAT_JUR", "C", 4, 0),
+)
+_DBF_HEADER_SIZE = 33 + len(_PF_LAYOUT) * 32
+_DBF_RECORD_SIZE = 1 + sum(field[2] for field in _PF_LAYOUT)
+_DBF_VERSION = 3
+
+
+class DatasusCnesError(Exception):
+    def __init__(self, code: str, retryable: bool) -> None:
+        self.code = code
+        self.retryable = retryable
+        super().__init__(f"code={code} retryable={str(retryable).lower()}")
+
+
+@dataclass(frozen=True, slots=True)
+class DatasusCnesRequest:
+    tenant_id: str
+    competencia: str
+    file_subtype: str
+    snapshot_id: str
+    agent_id: str
+    agent_version: str
+
+
+class DatasusCnesTransportPort(Protocol):
+    def fetch(
+        self, request: DatasusCnesRequest
+    ) -> Iterator[Mapping[str, object]]: ...  # pragma: no cover
+
+
+class _Closable(Protocol):
+    def close(self) -> None: ...  # pragma: no cover
+
+
+@dataclass(frozen=True, slots=True)
+class _Metadata:
+    size: int
+    modified: str
+
+
+@dataclass(frozen=True, slots=True)
+class _Download:
+    size: int
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class _DbfPhysical:
+    file_size: int
+    version: int
+    records: int
+    header_size: int
+    record_size: int
+    descriptor_end: bytes
+    last_byte: bytes
+
+
+def _default_ftp_factory() -> FTP:
+    return FTP()  # noqa: S321
+
+
+def _raise(code: str, retryable: bool) -> Never:
+    raise DatasusCnesError(code, retryable) from None
+
+
+def _validate_request(request: DatasusCnesRequest) -> None:
+    values = (
+        request.tenant_id,
+        request.competencia,
+        request.file_subtype,
+        request.snapshot_id,
+        request.agent_id,
+        request.agent_version,
+    )
+    if not all(isinstance(value, str) for value in values):
+        _raise("request_invalid", False)
+    valid_tenant = bool(fullmatch(r"[0-9]{6}", request.tenant_id))
+    valid_competencia = bool(
+        fullmatch(r"[0-9]{4}-(0[1-9]|1[0-2])", request.competencia)
+    )
+    valid_snapshot = bool(
+        fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", request.snapshot_id)
+    )
+    valid_identity = valid_snapshot and bool(request.agent_version.strip())
+    if not valid_tenant or request.tenant_id[:2] not in _UF_BY_CODE:
+        _raise("request_invalid", False)
+    if not valid_competencia or not valid_identity:
+        _raise("request_invalid", False)
+    if request.file_subtype != _SUBTYPE or request.agent_id != _AGENT:
+        _raise("request_invalid", False)
+
+
+def _close(resource: _Closable) -> None:
+    resource.close()
+
+
+class DatasusCnesFtpTransport:
+    def __init__(
+        self,
+        ftp_factory: Callable[[], FTP] | None = None,
+        circuit_breaker: CircuitBreaker | None = None,
+    ) -> None:
+        self._ftp_factory = ftp_factory or _default_ftp_factory
+        self._breaker = circuit_breaker or CircuitBreaker(
+            failure_threshold=3, service_name="DATASUS_FTP"
+        )
+
+    def fetch(self, request: DatasusCnesRequest) -> Iterator[Mapping[str, object]]:
+        _validate_request(request)
+        uf = _UF_BY_CODE[request.tenant_id[:2]]
+        yymm = request.competencia[2:4] + request.competencia[5:7]
+        path = f"{_ROOT}/PF{uf}{yymm}.dbc"
+        return self._iterate(request, path)
+
+    def _iterate(
+        self, request: DatasusCnesRequest, remote_path: str
+    ) -> Iterator[Mapping[str, object]]:
+        with TemporaryDirectory(prefix="datasus-cnes-") as temporary:
+            dbc_path = Path(temporary) / Path(remote_path).name
+            dbf_path = dbc_path.with_suffix(".dbf")
+            self._download_protected(remote_path, dbc_path)
+            self._decompress(dbc_path, dbf_path)
+            _validate_dbf_file(dbf_path)
+            table = self._open_dbf(dbf_path)
+            self._validate_layout(table)
+            self._validate_competencia(table, request.competencia.replace("-", ""))
+            yield from self._municipal_rows(table, request.tenant_id)
+
+    def _download_protected(self, remote_path: str, destination: Path) -> None:
+        try:
+            self._breaker.call(self._download, remote_path, destination)
+        except CircuitBreakerAberto:
+            _raise("circuit_open", True)
+
+    def _download(self, remote_path: str, destination: Path) -> None:
+        ftp: FTP | None = None
+        try:
+            ftp = self._ftp_factory()
+            ftp.connect(_HOST, timeout=_TIMEOUT)
+            ftp.login()
+            ftp.voidcmd("TYPE I")
+            before = self._metadata(ftp, remote_path)
+            downloaded = self._retrieve(ftp, remote_path, destination)
+            after = self._metadata(ftp, remote_path)
+            if before != after:
+                _raise("source_changed", True)
+            if downloaded.size != before.size:
+                _raise("size_mismatch", True)
+        except DatasusCnesError:
+            raise
+        except error_perm as error:
+            code = "source_not_published" if str(error).startswith("550") else "source_unavailable"
+            _raise(code, True)
+        except (FtpError, OSError, EOFError):
+            _raise("source_unavailable", True)
+        finally:
+            self._close_ftp(ftp)
+
+    @staticmethod
+    def _metadata(ftp: FTP, remote_path: str) -> _Metadata:
+        size = ftp.size(remote_path)
+        modified = ftp.sendcmd(f"MDTM {remote_path}")
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            _raise("metadata_invalid", True)
+        if not isinstance(modified, str) or not fullmatch(r"213 [0-9]{14}", modified):
+            _raise("metadata_invalid", True)
+        return _Metadata(size, modified)
+
+    @staticmethod
+    def _retrieve(ftp: FTP, remote_path: str, destination: Path) -> _Download:
+        digest = sha256()
+        size = 0
+        with destination.open("wb") as stream:
+
+            def write(chunk: bytes) -> None:
+                nonlocal size
+                stream.write(chunk)
+                digest.update(chunk)
+                size += len(chunk)
+
+            ftp.retrbinary(f"RETR {remote_path}", write, blocksize=_BLOCK_SIZE)
+        return _Download(size, digest.hexdigest())
+
+    @staticmethod
+    def _close_ftp(ftp: FTP | None) -> None:
+        if ftp is None:
+            return
+        try:
+            ftp.quit()
+        except Exception:
+            pass
+        finally:
+            _close(ftp)
+
+    @staticmethod
+    def _decompress(dbc_path: Path, dbf_path: Path) -> None:
+        _validate_dbc_file(dbc_path)
+        try:
+            decompress(str(dbc_path), str(dbf_path))
+        except Exception:
+            _raise("dbc_invalid", False)
+
+    @staticmethod
+    def _open_dbf(dbf_path: Path) -> object:
+        try:
+            return DBF(str(dbf_path), load=False, encoding="latin-1")
+        except Exception:
+            _raise("dbf_invalid", False)
+
+    @staticmethod
+    def _validate_layout(table: object) -> None:
+        try:
+            layout = tuple(
+                (field.name, field.type, field.length, field.decimal_count)
+                for field in table.fields
+            )
+        except Exception:
+            _raise("dbf_invalid", False)
+        if layout != _PF_LAYOUT:
+            _raise("schema_invalid", False)
+
+    @staticmethod
+    def _validate_competencia(table: object, expected: str) -> None:
+        iterator = _table_iterator(table)
+        try:
+            for row in iterator:
+                if _row_text(row, "COMPETEN") != expected:
+                    _raise("competencia_invalid", False)
+        except DatasusCnesError:
+            raise
+        except Exception:
+            _raise("dbf_invalid", False)
+        finally:
+            _close(iterator)
+
+    @staticmethod
+    def _municipal_rows(table: object, tenant_id: str) -> Iterator[Mapping[str, object]]:
+        iterator = _table_iterator(table)
+        found = False
+        try:
+            for row in iterator:
+                if _row_text(row, "CODUFMUN") == tenant_id:
+                    found = True
+                    yield row
+        except DatasusCnesError:
+            raise
+        except Exception:
+            _raise("dbf_invalid", False)
+        finally:
+            _close(iterator)
+        if not found:
+            _raise("source_not_published", True)
+
+
+def _row_text(row: Mapping[str, object], field: str) -> str:
+    try:
+        value = row[field]
+    except (KeyError, TypeError):
+        _raise("field_invalid", False)
+    if not isinstance(value, str):
+        _raise("field_invalid", False)
+    return value.strip()
+
+
+def _table_iterator(table: object) -> Iterator[Mapping[str, object]]:
+    try:
+        return iter(table)
+    except Exception:
+        _raise("dbf_invalid", False)
+
+
+def _inspect_dbf(path: Path, code: str) -> _DbfPhysical:
+    try:
+        file_size = path.stat().st_size
+        with path.open("rb") as stream:
+            raw = stream.read(12)
+            if len(raw) != 12:
+                _raise(code, False)
+            header_size = int.from_bytes(raw[8:10], "little")
+            descriptor_end = b""
+            if 0 < header_size <= file_size:
+                stream.seek(header_size - 1)
+                descriptor_end = stream.read(1)
+            stream.seek(-1, 2)
+            last_byte = stream.read(1)
+    except DatasusCnesError:
+        raise
+    except OSError:
+        _raise(code, False)
+    return _DbfPhysical(
+        file_size,
+        raw[0],
+        int.from_bytes(raw[4:8], "little"),
+        header_size,
+        int.from_bytes(raw[10:12], "little"),
+        descriptor_end,
+        last_byte,
+    )
+
+
+def _valid_shape(physical: _DbfPhysical) -> bool:
+    return (
+        physical.version == _DBF_VERSION
+        and physical.header_size == _DBF_HEADER_SIZE
+        and physical.record_size == _DBF_RECORD_SIZE
+        and physical.descriptor_end == b"\x0d"
+    )
+
+
+def _validate_dbc_file(path: Path) -> None:
+    physical = _inspect_dbf(path, "dbc_invalid")
+    if not _valid_shape(physical):
+        _raise("dbc_invalid", False)
+
+
+def _validate_dbf_file(path: Path) -> None:
+    physical = _inspect_dbf(path, "dbf_invalid")
+    if not _valid_shape(physical):
+        _raise("dbf_invalid", False)
+    expected = physical.header_size + physical.records * physical.record_size
+    if physical.file_size == expected:
+        return
+    if physical.file_size == expected + 1 and physical.last_byte == b"\x1a":
+        return
+    _raise("dbf_invalid", False)

--- a/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_transport.py
+++ b/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_transport.py
@@ -12,7 +12,7 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Never, Protocol
 
 from datasus_dbc import decompress
-from dbfread import DBF
+from dbfread import DBF, FieldParser
 
 from cnes_domain.pipeline.circuit_breaker import CircuitBreaker, CircuitBreakerAberto
 
@@ -126,6 +126,13 @@ class DatasusCnesTransportPort(Protocol):
 
 class _Closable(Protocol):
     def close(self) -> None: ...  # pragma: no cover
+
+
+class _PfFieldParser(FieldParser):
+    def parseN(self, field: object, data: bytes) -> object:  # noqa: N802
+        if b"*" in data:
+            return data
+        return super().parseN(field, data)
 
 
 @dataclass(frozen=True, slots=True)
@@ -308,7 +315,12 @@ class DatasusCnesFtpTransport:
     @staticmethod
     def _open_dbf(dbf_path: Path) -> object:
         try:
-            return DBF(str(dbf_path), load=False, encoding="latin-1")
+            return DBF(
+                str(dbf_path),
+                load=False,
+                encoding="latin-1",
+                parserclass=_PfFieldParser,
+            )
         except Exception:
             _raise("dbf_invalid", False)
 

--- a/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_transport.py
+++ b/packages/cnes_infra/src/cnes_infra/ingestion/datasus_cnes_transport.py
@@ -224,11 +224,13 @@ class DatasusCnesFtpTransport:
 
     def _download_protected(self, remote_path: str, destination: Path) -> None:
         try:
-            self._breaker.call(self._download, remote_path, destination)
+            published = self._breaker.call(self._download, remote_path, destination)
         except CircuitBreakerAberto:
             _raise("circuit_open", True)
+        if not published:
+            _raise("source_not_published", True)
 
-    def _download(self, remote_path: str, destination: Path) -> None:
+    def _download(self, remote_path: str, destination: Path) -> bool:
         ftp: FTP | None = None
         try:
             ftp = self._ftp_factory()
@@ -245,12 +247,14 @@ class DatasusCnesFtpTransport:
         except DatasusCnesError:
             raise
         except error_perm as error:
-            code = "source_not_published" if str(error).startswith("550") else "source_unavailable"
-            _raise(code, True)
+            if str(error).startswith("550"):
+                return False
+            _raise("source_unavailable", True)
         except (FtpError, OSError, EOFError):
             _raise("source_unavailable", True)
         finally:
             self._close_ftp(ftp)
+        return True
 
     @staticmethod
     def _metadata(ftp: FTP, remote_path: str) -> _Metadata:

--- a/packages/cnes_infra/tests/ingestion/test_datasus_cnes_ftp_smoke.py
+++ b/packages/cnes_infra/tests/ingestion/test_datasus_cnes_ftp_smoke.py
@@ -1,0 +1,30 @@
+"""Smoke opt-in do FTP PF do DATASUS."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from cnes_infra.ingestion.datasus_cnes_transport import (
+    DatasusCnesFtpTransport,
+    DatasusCnesRequest,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("DATASUS_FTP_SMOKE") != "1", reason="DATASUS_FTP_SMOKE != 1"
+)
+
+
+def test_ftp_publica_pf_sem_expor_dados_pessoais():
+    request = DatasusCnesRequest(
+        tenant_id="354130",
+        competencia="2026-01",
+        file_subtype="CNES_VINCULO",
+        snapshot_id="smoke",
+        agent_id="system-datasus",
+        agent_version="1.0.0",
+    )
+
+    rows = DatasusCnesFtpTransport().fetch(request)
+    assert sum(1 for _ in rows) > 0

--- a/packages/cnes_infra/tests/ingestion/test_datasus_cnes_raw.py
+++ b/packages/cnes_infra/tests/ingestion/test_datasus_cnes_raw.py
@@ -112,6 +112,22 @@ def _error_code(rows: list[dict[str, object]]) -> tuple[str, bool]:
     return captured.value.code, captured.value.retryable
 
 
+def _replace_dbf_field(payload: bytearray, field_name: str, value: bytes) -> None:
+    record_offset = 1
+    descriptor_offset = 32
+    while payload[descriptor_offset] != 0x0D:
+        descriptor = payload[descriptor_offset : descriptor_offset + 32]
+        name = bytes(descriptor[:11]).split(b"\x00", 1)[0].decode("ascii")
+        length = descriptor[16]
+        if name == field_name:
+            header_size = int.from_bytes(payload[8:10], "little")
+            payload[header_size + record_offset : header_size + record_offset + length] = value
+            return
+        record_offset += length
+        descriptor_offset += 32
+    raise AssertionError(field_name)
+
+
 def test_projeta_schema_padding_documentos_nulos_e_horas():
     manifest, store = _extract(
         [_row(CPF_PROF="99999999999", CNS_PROF="999999999999999", HORAOUTR="")]
@@ -433,4 +449,30 @@ def test_preserva_cancelamento_do_descompressor(monkeypatch: pytest.MonkeyPatch)
     with pytest.raises(KeyboardInterrupt):
         DatasusCnesRawAdapter(transport, store, lambda: _CREATED_AT).extract(_request())
 
+    assert store.calls == []
+
+
+def test_rejeita_overflow_numerico_do_dbf_como_campo_invalido(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    store = _Store()
+    transport = DatasusCnesFtpTransport()
+    real_decompress = transport_module.decompress
+
+    def download(_remote: str, destination: Path) -> None:
+        destination.write_bytes(_DBC_FIXTURE.read_bytes())
+
+    def inject_overflow(source: str, destination: str) -> None:
+        real_decompress(source, destination)
+        payload = bytearray(Path(destination).read_bytes())
+        _replace_dbf_field(payload, "HORAOUTR", b"***")
+        Path(destination).write_bytes(payload)
+
+    monkeypatch.setattr(transport, "_download_protected", download)
+    monkeypatch.setattr(transport_module, "decompress", inject_overflow)
+
+    with pytest.raises(Exception) as captured:
+        DatasusCnesRawAdapter(transport, store, lambda: _CREATED_AT).extract(_request())
+
+    assert (captured.value.code, captured.value.retryable) == ("field_invalid", False)
     assert store.calls == []

--- a/packages/cnes_infra/tests/ingestion/test_datasus_cnes_raw.py
+++ b/packages/cnes_infra/tests/ingestion/test_datasus_cnes_raw.py
@@ -1,0 +1,436 @@
+"""Testes do adapter raw para CNES nacional."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta, timezone
+from hashlib import sha256
+from io import BytesIO
+from pathlib import Path
+from traceback import format_exception
+from typing import Any
+
+import polars as pl
+import pyarrow.parquet as pq
+import pytest
+
+from cnes_domain.ports.object_store import ObjectStat
+from cnes_infra.ingestion import datasus_cnes_transport as transport_module
+from cnes_infra.ingestion.datasus_cnes_raw import DatasusCnesRawAdapter
+from cnes_infra.ingestion.datasus_cnes_transport import (
+    DatasusCnesFtpTransport,
+    DatasusCnesRequest,
+)
+
+_ROOT = Path(__file__).resolve().parents[4]
+_GOLDEN = _ROOT / "docs" / "fixtures" / "data-plane" / "cnes-nacional-v1.parquet"
+_DBC_FIXTURE = Path(__file__).parent / "fixtures" / "PFSP2601.dbc"
+_CREATED_AT = datetime(2026, 2, 1, tzinfo=UTC)
+_COLUMNS = (
+    "CPF",
+    "CNS",
+    "NOME_PROFISSIONAL",
+    "NOME_SOCIAL",
+    "SEXO",
+    "CBO",
+    "CNES",
+    "TIPO_VINCULO",
+    "SUS",
+    "CH_TOTAL",
+    "CH_AMBULATORIAL",
+    "CH_OUTRAS",
+    "CH_HOSPITALAR",
+    "FONTE",
+)
+
+
+class _Transport:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self.rows = rows
+        self.requests: list[DatasusCnesRequest] = []
+
+    def fetch(self, request: DatasusCnesRequest):
+        self.requests.append(request)
+        yield from self.rows
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bytes, str]] = []
+
+    def put(self, key: str, body: Any, expected_sha256: str) -> ObjectStat:
+        payload = body.read()
+        self.calls.append((key, payload, expected_sha256))
+        return ObjectStat(key, len(payload), expected_sha256)
+
+
+def _request(**updates: str) -> DatasusCnesRequest:
+    values = {
+        "tenant_id": "354130",
+        "competencia": "2026-01",
+        "file_subtype": "CNES_VINCULO",
+        "snapshot_id": "snapshot-1",
+        "agent_id": "system-datasus",
+        "agent_version": "1.2.3",
+    }
+    return DatasusCnesRequest(**(values | updates))
+
+
+def _row(**updates: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "CPF_PROF": "90000000001",
+        "CNS_PROF": "700000000000001",
+        "NOMEPROF": " Profissional Teste ",
+        "CBO": "123",
+        "CNES": "456",
+        "VINCULAC": "12",
+        "PROF_SUS": "1",
+        "HORAOUTR": 8,
+        "HORAHOSP": "20",
+        "HORA_AMB": "12",
+        "COMPETEN": "202601",
+        "CODUFMUN": "354130",
+    }
+    return values | updates
+
+
+def _extract(rows: list[dict[str, object]], request: DatasusCnesRequest | None = None):
+    store = _Store()
+    manifest = DatasusCnesRawAdapter(_Transport(rows), store, lambda: _CREATED_AT).extract(
+        request or _request()
+    )
+    return manifest, store
+
+
+def _read(store: _Store) -> pl.DataFrame:
+    return pl.read_parquet(BytesIO(store.calls[0][1]))
+
+
+def _error_code(rows: list[dict[str, object]]) -> tuple[str, bool]:
+    with pytest.raises(Exception) as captured:
+        _extract(rows)
+    return captured.value.code, captured.value.retryable
+
+
+def test_projeta_schema_padding_documentos_nulos_e_horas():
+    manifest, store = _extract(
+        [_row(CPF_PROF="99999999999", CNS_PROF="999999999999999", HORAOUTR="")]
+    )
+    frame = _read(store)
+
+    assert frame.columns == list(_COLUMNS)
+    assert frame.schema == {
+        **dict.fromkeys(_COLUMNS[:9], pl.String),
+        **dict.fromkeys(_COLUMNS[9:13], pl.Int64),
+        "FONTE": pl.String,
+    }
+    assert frame.to_dicts() == [
+        {
+            "CPF": None,
+            "CNS": None,
+            "NOME_PROFISSIONAL": "Profissional Teste",
+            "NOME_SOCIAL": None,
+            "SEXO": None,
+            "CBO": "000123",
+            "CNES": "0000456",
+            "TIPO_VINCULO": "000012",
+            "SUS": "S",
+            "CH_TOTAL": 32,
+            "CH_AMBULATORIAL": 12,
+            "CH_OUTRAS": 0,
+            "CH_HOSPITALAR": 20,
+            "FONTE": "NACIONAL",
+        }
+    ]
+    assert manifest.row_count == 1
+
+
+def test_preserva_duplicatas_ordena_nulos_por_ultimo_e_mapeia_nao_sus():
+    first = _row(CPF_PROF="", CNS_PROF="", NOMEPROF="Zulu", PROF_SUS="0")
+    second = _row(CPF_PROF="10000000000", CNS_PROF="100000000000000", NOMEPROF="Alfa")
+    _, store = _extract([first, second, second.copy()])
+
+    rows = _read(store).to_dicts()
+
+    assert [row["CPF"] for row in rows] == ["10000000000", "10000000000", None]
+    assert rows[0] == rows[1]
+    assert rows[2]["SUS"] == "N"
+
+
+def test_bytes_hash_e_metadados_parquet_sao_deterministicos():
+    rows = [_row(CPF_PROF="20000000000"), _row(CPF_PROF="10000000000")]
+    first_manifest, first_store = _extract(rows)
+    second_manifest, second_store = _extract(list(reversed(rows)))
+    first_payload = first_store.calls[0][1]
+    metadata = pq.ParquetFile(BytesIO(first_payload)).metadata
+
+    assert first_payload == second_store.calls[0][1]
+    assert first_manifest.object_sha256 == second_manifest.object_sha256
+    assert first_manifest.object_sha256 == sha256(first_payload).hexdigest()
+    assert metadata.created_by == "Polars"
+    assert metadata.num_row_groups == 1
+    assert all(
+        metadata.row_group(0).column(index).compression == "ZSTD"
+        and metadata.row_group(0).column(index).statistics is not None
+        for index in range(metadata.num_columns)
+    )
+
+
+def test_schema_parquet_preserva_contrato_do_fixture_ratificado():
+    _, store = _extract([_row()])
+    generated = pq.ParquetFile(BytesIO(store.calls[0][1]))
+    golden = pq.ParquetFile(_GOLDEN)
+
+    assert generated.schema_arrow == golden.schema_arrow
+    assert generated.metadata.created_by == golden.metadata.created_by == "Polars"
+
+
+def test_row_groups_tem_no_maximo_64000_linhas():
+    _, store = _extract([_row()] * 64_001)
+    metadata = pq.ParquetFile(BytesIO(store.calls[0][1])).metadata
+
+    assert metadata.num_row_groups == 2
+    assert [metadata.row_group(index).num_rows for index in range(2)] == [64_000, 1]
+
+
+def test_faz_put_unico_e_retorna_manifesto_full():
+    request = _request()
+    transport = _Transport([_row()])
+    store = _Store()
+    manifest = DatasusCnesRawAdapter(transport, store, lambda: _CREATED_AT).extract(request)
+    key, payload, digest = store.calls[0]
+
+    assert transport.requests == [request]
+    assert len(store.calls) == 1
+    assert key == "raw/354130/CNES_NACIONAL/2026-01/snapshot-1/data.parquet"
+    assert digest == sha256(payload).hexdigest()
+    assert manifest.model_dump() == {
+        "manifest_version": 1,
+        "manifest_id": "snapshot-1",
+        "tenant_id": "354130",
+        "source_type": "CNES_NACIONAL",
+        "file_subtype": "CNES_VINCULO",
+        "competencia": "2026-01",
+        "agent_id": "system-datasus",
+        "agent_version": "1.2.3",
+        "schema_version": "cnes-profissional-v1",
+        "snapshot_mode": "FULL",
+        "snapshot_id": "snapshot-1",
+        "base_snapshot_id": None,
+        "sequence": 1,
+        "previous_manifest_sha256": None,
+        "object_sha256": digest,
+        "row_count": 1,
+        "size_bytes": len(payload),
+        "object_key": key,
+        "created_at": _CREATED_AT,
+    }
+
+
+@pytest.mark.parametrize(
+    ("updates", "code"),
+    [
+        ({"COMPETEN": "202512", "CODUFMUN": "330455"}, "transport_contract_invalid"),
+        ({"CODUFMUN": "330455"}, "transport_contract_invalid"),
+    ],
+)
+def test_revalida_competencia_e_municipio_do_transport_fake(
+    updates: dict[str, object], code: str
+):
+    assert _error_code([_row(**updates)]) == (code, False)
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"CPF_PROF": "123"},
+        {"CPF_PROF": "²" * 11},
+        {"CNS_PROF": "123"},
+        {"CBO": "ABC"},
+        {"CBO": "00000²"},
+        {"CBO": "1234567"},
+        {"CNES": "12345678"},
+        {"VINCULAC": "1234567"},
+        {"PROF_SUS": ""},
+        {"PROF_SUS": "2"},
+        {"HORAOUTR": "1.5"},
+        {"HORAHOSP": -1},
+        {"HORA_AMB": "ABC"},
+        {"HORA_AMB": "²"},
+    ],
+)
+def test_rejeita_campos_invalidos_com_falha_final(updates: dict[str, object]):
+    assert _error_code([_row(**updates)]) == ("field_invalid", False)
+
+
+def test_erro_e_logs_nao_expoem_dados_pessoais(caplog: pytest.LogCaptureFixture):
+    cpf = "12345678901"
+    cns = "123456789012345"
+    nome = "NOME MUITO SENSIVEL"
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(Exception) as captured:
+        _extract([_row(CPF_PROF=cpf, CNS_PROF=cns, NOMEPROF=nome, PROF_SUS="x")])
+
+    exposed = "".join(format_exception(captured.value)) + caplog.text
+    assert cpf not in exposed
+    assert cns not in exposed
+    assert nome not in exposed
+
+
+def test_rejeita_transport_sem_linhas_como_nao_publicado():
+    assert _error_code([]) == ("source_not_published", True)
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"NOMEPROF": None},
+        {"HORAOUTR": True},
+        {"HORAOUTR": 1.0},
+    ],
+)
+def test_valida_tipos_de_campos_do_dbf(updates: dict[str, object]):
+    if isinstance(updates.get("HORAOUTR"), float):
+        _, store = _extract([_row(**updates)])
+        assert _read(store)["CH_OUTRAS"].to_list() == [1]
+        return
+    assert _error_code([_row(**updates)]) == ("field_invalid", False)
+
+
+def test_rejeita_campos_ausentes():
+    missing_competencia = _row()
+    missing_competencia.pop("COMPETEN")
+    missing_hours = _row()
+    missing_hours.pop("HORAOUTR")
+
+    assert _error_code([missing_competencia]) == ("transport_contract_invalid", False)
+    assert _error_code([missing_hours]) == ("field_invalid", False)
+
+
+def test_rejeita_snapshot_inseguro_sem_put():
+    store = _Store()
+    adapter = DatasusCnesRawAdapter(_Transport([_row()]), store, lambda: _CREATED_AT)
+
+    with pytest.raises(Exception) as captured:
+        adapter.extract(_request(snapshot_id="bad/path"))
+
+    assert (captured.value.code, captured.value.retryable) == ("request_invalid", False)
+    assert store.calls == []
+
+
+def test_valida_manifesto_antes_do_put():
+    store = _Store()
+
+    def invalid_clock() -> datetime:
+        return datetime(2026, 2, 1, tzinfo=timezone(timedelta(hours=-3)))
+
+    adapter = DatasusCnesRawAdapter(_Transport([_row()]), store, invalid_clock)
+
+    with pytest.raises(Exception):
+        adapter.extract(_request())
+
+    assert store.calls == []
+
+
+def test_fecha_iterador_do_transport_quando_projecao_falha():
+    closed = False
+
+    def rows():
+        nonlocal closed
+        try:
+            yield _row(PROF_SUS="invalid")
+        finally:
+            closed = True
+
+    retained = rows()
+    transport = _Transport([])
+    transport.fetch = lambda request: retained
+
+    with pytest.raises(Exception):
+        DatasusCnesRawAdapter(transport, _Store(), lambda: _CREATED_AT).extract(_request())
+
+    assert closed is True
+
+
+def test_aceita_iterador_do_transport_sem_close():
+    transport = _Transport([])
+    transport.fetch = lambda request: iter([_row()])
+
+    manifest = DatasusCnesRawAdapter(transport, _Store(), lambda: _CREATED_AT).extract(_request())
+
+    assert manifest.row_count == 1
+
+
+@pytest.mark.parametrize("payload", [b"\x00" * 10, b"\x00" * 1313, None])
+def test_rejeita_dbc_ausente_ou_com_cabecalho_malformado_sem_put(
+    monkeypatch: pytest.MonkeyPatch, payload: bytes | None
+):
+    store = _Store()
+    transport = DatasusCnesFtpTransport()
+
+    def download(_remote: str, destination: Path) -> None:
+        if payload is not None:
+            destination.write_bytes(payload)
+
+    monkeypatch.setattr(transport, "_download_protected", download)
+    adapter = DatasusCnesRawAdapter(transport, store, lambda: _CREATED_AT)
+
+    with pytest.raises(BaseException) as captured:
+        adapter.extract(_request())
+
+    assert isinstance(captured.value, Exception)
+    assert (captured.value.code, captured.value.retryable) == ("dbc_invalid", False)
+    assert store.calls == []
+
+
+@pytest.mark.parametrize("mutation", ["truncated", "invalid_eof", "invalid_shape"])
+def test_rejeita_dbf_fisicamente_invalido_sem_put(
+    monkeypatch: pytest.MonkeyPatch, mutation: str
+):
+    store = _Store()
+    transport = DatasusCnesFtpTransport()
+    real_decompress = transport_module.decompress
+
+    def download(_remote: str, destination: Path) -> None:
+        destination.write_bytes(_DBC_FIXTURE.read_bytes())
+
+    def truncate(source: str, destination: str) -> None:
+        real_decompress(source, destination)
+        payload = bytearray(Path(destination).read_bytes())
+        if mutation == "truncated":
+            payload[4:8] = (2).to_bytes(4, "little")
+        elif mutation == "invalid_eof":
+            payload[-1] = 0
+        else:
+            payload[10:12] = (1).to_bytes(2, "little")
+        Path(destination).write_bytes(payload)
+
+    monkeypatch.setattr(transport, "_download_protected", download)
+    monkeypatch.setattr(transport_module, "decompress", truncate)
+    adapter = DatasusCnesRawAdapter(transport, store, lambda: _CREATED_AT)
+
+    with pytest.raises(Exception) as captured:
+        adapter.extract(_request())
+
+    assert (captured.value.code, captured.value.retryable) == ("dbf_invalid", False)
+    assert store.calls == []
+
+
+def test_preserva_cancelamento_do_descompressor(monkeypatch: pytest.MonkeyPatch):
+    store = _Store()
+    transport = DatasusCnesFtpTransport()
+
+    def download(_remote: str, destination: Path) -> None:
+        destination.write_bytes(_DBC_FIXTURE.read_bytes())
+
+    def cancel(_source: str, _destination: str) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(transport, "_download_protected", download)
+    monkeypatch.setattr(transport_module, "decompress", cancel)
+
+    with pytest.raises(KeyboardInterrupt):
+        DatasusCnesRawAdapter(transport, store, lambda: _CREATED_AT).extract(_request())
+
+    assert store.calls == []

--- a/packages/cnes_infra/tests/ingestion/test_datasus_cnes_raw.py
+++ b/packages/cnes_infra/tests/ingestion/test_datasus_cnes_raw.py
@@ -369,6 +369,25 @@ def test_fecha_iterador_do_transport_quando_projecao_falha():
     assert closed is True
 
 
+def test_preserva_erro_de_projecao_quando_fechamento_do_iterador_falha():
+    def rows(prof_sus: str):
+        try:
+            yield _row(PROF_SUS=prof_sus)
+        finally:
+            raise OSError("cleanup-sensitive")
+
+    transport = _Transport([])
+    transport.fetch = lambda request: rows("invalid")
+
+    with pytest.raises(Exception) as captured:
+        DatasusCnesRawAdapter(transport, _Store(), lambda: _CREATED_AT).extract(_request())
+
+    assert (captured.value.code, captured.value.retryable) == ("field_invalid", False)
+    transport.fetch = lambda request: rows("1")
+    with pytest.raises(OSError, match="cleanup-sensitive"):
+        DatasusCnesRawAdapter(transport, _Store(), lambda: _CREATED_AT).extract(_request())
+
+
 def test_aceita_iterador_do_transport_sem_close():
     transport = _Transport([])
     transport.fetch = lambda request: iter([_row()])

--- a/packages/cnes_infra/tests/ingestion/test_datasus_cnes_transport.py
+++ b/packages/cnes_infra/tests/ingestion/test_datasus_cnes_transport.py
@@ -1,0 +1,500 @@
+"""Testes do transporte FTP dos arquivos PF do DATASUS."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from ftplib import error_perm, error_proto, error_reply, error_temp
+from pathlib import Path
+from traceback import format_exception
+from typing import Any
+
+import pytest
+
+from cnes_domain.pipeline.circuit_breaker import CircuitBreaker
+from cnes_infra.ingestion import datasus_cnes_transport as transport_module
+from cnes_infra.ingestion.datasus_cnes_transport import (
+    DatasusCnesFtpTransport,
+    DatasusCnesRequest,
+)
+
+_PATH = "/dissemin/publicos/CNES/200508_/Dados/PF/PFSP2601.dbc"
+_DBC_HEADER = (
+    b"\x03\x00\x00\x00\x00\x00\x00\x00\x21\x05\xe6\x00" + b"\x00" * 1300 + b"\x0d"
+)
+_LAYOUT = (
+    ("CNES", "C", 7, 0),
+    ("CODUFMUN", "C", 6, 0),
+    ("REGSAUDE", "C", 4, 0),
+    ("MICR_REG", "C", 6, 0),
+    ("DISTRSAN", "C", 4, 0),
+    ("DISTRADM", "C", 4, 0),
+    ("TPGESTAO", "C", 1, 0),
+    ("PF_PJ", "C", 1, 0),
+    ("CPF_CNPJ", "C", 14, 0),
+    ("NIV_DEP", "C", 1, 0),
+    ("CNPJ_MAN", "C", 14, 0),
+    ("ESFERA_A", "C", 2, 0),
+    ("ATIVIDAD", "C", 2, 0),
+    ("RETENCAO", "C", 2, 0),
+    ("NATUREZA", "C", 2, 0),
+    ("CLIENTEL", "C", 2, 0),
+    ("TP_UNID", "C", 2, 0),
+    ("TURNO_AT", "C", 2, 0),
+    ("NIV_HIER", "C", 2, 0),
+    ("TERCEIRO", "C", 1, 0),
+    ("CPF_PROF", "C", 11, 0),
+    ("CPFUNICO", "C", 1, 0),
+    ("CBO", "C", 6, 0),
+    ("CBOUNICO", "C", 6, 0),
+    ("NOMEPROF", "C", 60, 0),
+    ("CNS_PROF", "C", 15, 0),
+    ("CONSELHO", "C", 2, 0),
+    ("REGISTRO", "C", 13, 0),
+    ("VINCULAC", "C", 6, 0),
+    ("VINCUL_C", "C", 1, 0),
+    ("VINCUL_A", "C", 1, 0),
+    ("VINCUL_N", "C", 1, 0),
+    ("PROF_SUS", "C", 1, 0),
+    ("PROFNSUS", "C", 1, 0),
+    ("HORAOUTR", "N", 3, 0),
+    ("HORAHOSP", "N", 3, 0),
+    ("HORA_AMB", "N", 3, 0),
+    ("COMPETEN", "C", 6, 0),
+    ("UFMUNRES", "C", 6, 0),
+    ("NAT_JUR", "C", 4, 0),
+)
+
+
+@dataclass(frozen=True)
+class _Field:
+    name: str
+    type: str
+    length: int
+    decimal_count: int
+
+
+class _Rows:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = iter(rows)
+        self.closed = False
+
+    def __iter__(self) -> _Rows:
+        return self
+
+    def __next__(self) -> dict[str, object]:
+        return next(self._rows)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _ExplodingRows(_Rows):
+    def __next__(self) -> dict[str, object]:
+        raise RuntimeError("broken-dbf")
+
+
+class _Table:
+    def __init__(self, rows: list[dict[str, object]], layout: tuple = _LAYOUT) -> None:
+        self.fields = tuple(_Field(*field) for field in layout)
+        self.loaded = False
+        self._rows = rows
+        self.iterators: list[_Rows] = []
+
+    def __iter__(self) -> _Rows:
+        rows = _Rows(self._rows)
+        self.iterators.append(rows)
+        return rows
+
+
+class _BrokenTable(_Table):
+    def __init__(self, break_on_iteration: int) -> None:
+        super().__init__([_record()])
+        self._break_on_iteration = break_on_iteration
+
+    def __iter__(self) -> _Rows:
+        if len(self.iterators) + 1 == self._break_on_iteration:
+            raise RuntimeError("broken-dbf")
+        return super().__iter__()
+
+
+class _BrokenRowsTable(_Table):
+    def __init__(self, break_on_iteration: int) -> None:
+        super().__init__([_record()])
+        self._break_on_iteration = break_on_iteration
+
+    def __iter__(self) -> _Rows:
+        if len(self.iterators) + 1 == self._break_on_iteration:
+            rows = _ExplodingRows([])
+            self.iterators.append(rows)
+            return rows
+        return super().__iter__()
+
+
+class _Ftp:
+    def __init__(self, payload: bytes = _DBC_HEADER) -> None:
+        self.payload = payload
+        self.calls: list[tuple[str, object]] = []
+        self.sizes: list[object] = [len(payload), len(payload)]
+        self.mdtms: list[object] = ["213 20260202010101", "213 20260202010101"]
+        self.retrieval_error: Exception | None = None
+        self.quit_called = False
+        self.close_called = False
+
+    def connect(self, host: str, timeout: int) -> None:
+        self.calls.append(("connect", (host, timeout)))
+
+    def login(self) -> None:
+        self.calls.append(("login", None))
+
+    def voidcmd(self, command: str) -> None:
+        self.calls.append(("voidcmd", command))
+
+    def size(self, path: str) -> object:
+        self.calls.append(("size", path))
+        return self.sizes.pop(0)
+
+    def sendcmd(self, command: str) -> object:
+        self.calls.append(("sendcmd", command))
+        return self.mdtms.pop(0)
+
+    def retrbinary(self, command: str, callback: Any, blocksize: int) -> None:
+        self.calls.append(("retrbinary", (command, blocksize)))
+        if self.retrieval_error:
+            raise self.retrieval_error
+        for start in range(0, len(self.payload), 2):
+            callback(self.payload[start : start + 2])
+
+    def quit(self) -> None:
+        self.quit_called = True
+
+    def close(self) -> None:
+        self.close_called = True
+
+
+def _request(**updates: str) -> DatasusCnesRequest:
+    values = {
+        "tenant_id": "354130",
+        "competencia": "2026-01",
+        "file_subtype": "CNES_VINCULO",
+        "snapshot_id": "snapshot-1",
+        "agent_id": "system-datasus",
+        "agent_version": "1.2.3",
+    }
+    return DatasusCnesRequest(**(values | updates))
+
+
+def _record(municipio: str = "354130", competencia: str = "202601") -> dict[str, object]:
+    return {"CODUFMUN": municipio, "COMPETEN": competencia, "CPF_PROF": "90000000001"}
+
+
+def _install_table(monkeypatch: pytest.MonkeyPatch, table: _Table) -> list[tuple[str, str]]:
+    conversions: list[tuple[str, str]] = []
+
+    def decompress(source: str, destination: str) -> None:
+        conversions.append((source, destination))
+        row_count = len(getattr(table, "_rows", ()))
+        header = bytearray(_DBC_HEADER)
+        header[4:8] = row_count.to_bytes(4, "little")
+        record = b" " + b"\x00" * 229
+        eof = b"\x1a" if row_count % 2 == 0 else b""
+        Path(destination).write_bytes(header + record * row_count + eof)
+
+    monkeypatch.setattr(transport_module, "decompress", decompress)
+    monkeypatch.setattr(transport_module, "DBF", lambda *args, **kwargs: table)
+    return conversions
+
+
+def _error_code(action: Any) -> tuple[str, bool]:
+    with pytest.raises(Exception) as captured:
+        action()
+    return captured.value.code, captured.value.retryable
+
+
+def _ftp_error(error_type: type[Exception], message: str) -> Exception:
+    return error_type(message)
+
+
+def test_resolve_uf_e_yymm_em_url_unica(monkeypatch: pytest.MonkeyPatch):
+    ftp = _Ftp()
+    table = _Table([_record(), _record("330455")])
+    conversions = _install_table(monkeypatch, table)
+    adapter = DatasusCnesFtpTransport(lambda: ftp, CircuitBreaker(base_delay=0))
+
+    assert list(adapter.fetch(_request())) == [_record()]
+    assert ftp.calls.index(("voidcmd", "TYPE I")) < ftp.calls.index(("size", _PATH))
+    assert ("retrbinary", (f"RETR {_PATH}", 64 * 1024)) in ftp.calls
+    assert {value for operation, value in ftp.calls if operation == "size"} == {_PATH}
+    assert conversions[0][0].endswith("PFSP2601.dbc")
+    assert ftp.quit_called is True
+
+
+@pytest.mark.parametrize(
+    ("updates", "code"),
+    [
+        ({"tenant_id": "35413"}, "request_invalid"),
+        ({"tenant_id": "999999"}, "request_invalid"),
+        ({"tenant_id": "35\u0661\u0662\u0663\u0664"}, "request_invalid"),
+        ({"competencia": "2026-13"}, "request_invalid"),
+        ({"competencia": "\uff12\uff10\uff12\uff16-01"}, "request_invalid"),
+        ({"file_subtype": "CNES_ESTABELECIMENTO"}, "request_invalid"),
+        ({"snapshot_id": ""}, "request_invalid"),
+        ({"snapshot_id": " "}, "request_invalid"),
+        ({"agent_id": "edge"}, "request_invalid"),
+        ({"agent_version": ""}, "request_invalid"),
+        ({"agent_version": " "}, "request_invalid"),
+        ({"tenant_id": None}, "request_invalid"),
+    ],
+)
+def test_rejeita_request_invalido_sem_abrir_ftp(updates: dict[str, str], code: str):
+    opened = False
+
+    def factory() -> _Ftp:
+        nonlocal opened
+        opened = True
+        return _Ftp()
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(factory).fetch(_request(**updates))))
+
+    assert error == (code, False)
+    assert opened is False
+
+
+def test_ftp_550_retorna_source_not_published_sem_fallback(monkeypatch: pytest.MonkeyPatch):
+    ftp = _Ftp()
+    ftp.retrieval_error = _ftp_error(error_perm, "550 file unavailable")
+    _install_table(monkeypatch, _Table([]))
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request())))
+
+    assert error == ("source_not_published", True)
+    retrievals = [call for call in ftp.calls if call[0] == "retrbinary"]
+    assert retrievals == [("retrbinary", (f"RETR {_PATH}", 64 * 1024))]
+    assert ftp.close_called is True
+
+
+def test_falha_temporaria_e_retryable_e_limpa_ftp(monkeypatch: pytest.MonkeyPatch):
+    ftp = _Ftp()
+    ftp.retrieval_error = _ftp_error(error_temp, "421 unavailable")
+    _install_table(monkeypatch, _Table([]))
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request())))
+
+    assert error == ("source_unavailable", True)
+    assert ftp.close_called is True
+
+
+@pytest.mark.parametrize("error_type", [EOFError, error_reply, error_proto])
+def test_falha_de_resposta_ftp_e_retryable(
+    monkeypatch: pytest.MonkeyPatch, error_type: type[Exception]
+):
+    ftp = _Ftp()
+    _install_table(monkeypatch, _Table([]))
+
+    def fail_connect(*args: object, **kwargs: object) -> None:
+        raise _ftp_error(error_type, "sensitive-12345678901")
+
+    ftp.connect = fail_connect
+
+    with pytest.raises(Exception) as captured:
+        list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request()))
+
+    assert (captured.value.code, captured.value.retryable) == ("source_unavailable", True)
+    assert "sensitive-12345678901" not in "".join(format_exception(captured.value))
+
+
+def test_circuito_aberto_falha_sem_abrir_ftp():
+    breaker = CircuitBreaker(failure_threshold=1, base_delay=0)
+    with pytest.raises(RuntimeError):
+        breaker.call(lambda: (_ for _ in ()).throw(RuntimeError("offline")))
+    opened = False
+
+    def factory() -> _Ftp:
+        nonlocal opened
+        opened = True
+        return _Ftp()
+
+    error = _error_code(
+        lambda: list(DatasusCnesFtpTransport(factory, breaker).fetch(_request()))
+    )
+
+    assert error == ("circuit_open", True)
+    assert opened is False
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        ([3, 4], ["213 20260202010101"] * 2, b"dbc", "source_changed"),
+        ([3, 3], ["213 20260202010101", "213 20260202010102"], b"dbc", "source_changed"),
+        ([None], ["213 20260202010101"], b"dbc", "metadata_invalid"),
+        ([3], ["invalid"], b"dbc", "metadata_invalid"),
+        ([4, 4], ["213 20260202010101"] * 2, b"dbc", "size_mismatch"),
+    ],
+)
+def test_rejeita_metadados_instaveis_ou_invalidos(
+    monkeypatch: pytest.MonkeyPatch,
+    case: tuple[list[object], list[object], bytes, str],
+):
+    sizes, mdtms, payload, code = case
+    ftp = _Ftp(payload)
+    ftp.sizes = sizes
+    ftp.mdtms = mdtms
+    _install_table(monkeypatch, _Table([]))
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request())))
+
+    assert error == (code, True)
+    assert ftp.close_called is True
+
+
+@pytest.mark.parametrize(("failure", "code"), [("dbc", "dbc_invalid"), ("dbf", "dbf_invalid")])
+def test_rejeita_dbc_ou_dbf_invalido(
+    monkeypatch: pytest.MonkeyPatch, failure: str, code: str
+):
+    ftp = _Ftp()
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise ValueError("sensitive-data-must-not-leak")
+
+    converter = fail if failure == "dbc" else lambda _s, d: Path(d).write_bytes(
+        _DBC_HEADER + b"\x1a"
+    )
+    reader = fail if failure == "dbf" else lambda *_args, **_kwargs: None
+    monkeypatch.setattr(transport_module, "decompress", converter)
+    monkeypatch.setattr(transport_module, "DBF", reader)
+
+    with pytest.raises(Exception) as captured:
+        list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request()))
+
+    assert (captured.value.code, captured.value.retryable) == (code, False)
+    assert "sensitive-data-must-not-leak" not in "".join(format_exception(captured.value))
+
+
+def test_rejeita_layout_dbf_divergente(monkeypatch: pytest.MonkeyPatch):
+    layout = _LAYOUT[:-1] + (("CAMPO_ERRADO", "C", 4, 0),)
+    _install_table(monkeypatch, _Table([_record()], layout))
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
+
+    assert error == ("schema_invalid", False)
+
+
+def test_valida_competencia_antes_da_ausencia_municipal(monkeypatch: pytest.MonkeyPatch):
+    _install_table(monkeypatch, _Table([_record("330455", "202512")]))
+    adapter = DatasusCnesFtpTransport(_Ftp)
+
+    error = _error_code(lambda: list(adapter.fetch(_request())))
+
+    assert error == ("competencia_invalid", False)
+
+
+def test_ausencia_municipal_e_source_not_published(monkeypatch: pytest.MonkeyPatch):
+    _install_table(monkeypatch, _Table([_record("330455")]))
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
+
+    assert error == ("source_not_published", True)
+
+
+def test_leitura_incremental_fecha_iteradores_e_temporarios_no_cancelamento(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    table = _Table([_record(), _record()])
+    conversions = _install_table(monkeypatch, table)
+    rows = DatasusCnesFtpTransport(_Ftp).fetch(_request())
+
+    assert next(rows) == _record()
+    assert len(table.iterators) == 2
+    assert table.iterators[0].closed is True
+    temporary_root = Path(conversions[0][0]).parent
+    rows.close()
+
+    assert all(iterator.closed for iterator in table.iterators)
+    assert temporary_root.exists() is False
+
+
+def test_factory_padrao_cria_ftp(monkeypatch: pytest.MonkeyPatch):
+    ftp = _Ftp()
+    table = _Table([_record()])
+    _install_table(monkeypatch, table)
+    monkeypatch.setattr(transport_module, "FTP", lambda: ftp)
+
+    assert list(DatasusCnesFtpTransport().fetch(_request())) == [_record()]
+
+
+def test_falha_ao_criar_ftp_e_retryable(monkeypatch: pytest.MonkeyPatch):
+    _install_table(monkeypatch, _Table([]))
+
+    def factory() -> _Ftp:
+        raise OSError("offline")
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(factory).fetch(_request())))
+
+    assert error == ("source_unavailable", True)
+
+
+def test_limpa_ftp_quando_quit_falha(monkeypatch: pytest.MonkeyPatch):
+    ftp = _Ftp()
+
+    def broken_quit() -> None:
+        ftp.quit_called = True
+        raise OSError("offline")
+
+    ftp.quit = broken_quit
+    _install_table(monkeypatch, _Table([_record()]))
+
+    assert list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request())) == [_record()]
+    assert ftp.quit_called is True
+    assert ftp.close_called is True
+
+
+def test_rejeita_layout_dbf_ilegivel(monkeypatch: pytest.MonkeyPatch):
+    class BrokenLayout:
+        @property
+        def fields(self):
+            raise RuntimeError("broken-dbf")
+
+    _install_table(monkeypatch, BrokenLayout())
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
+
+    assert error == ("dbf_invalid", False)
+
+
+@pytest.mark.parametrize("iteration", [1, 2])
+def test_rejeita_iteracao_dbf_ilegivel(monkeypatch: pytest.MonkeyPatch, iteration: int):
+    _install_table(monkeypatch, _BrokenTable(iteration))
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
+
+    assert error == ("dbf_invalid", False)
+
+
+@pytest.mark.parametrize("iteration", [1, 2])
+def test_rejeita_leitura_dbf_ilegivel(monkeypatch: pytest.MonkeyPatch, iteration: int):
+    _install_table(monkeypatch, _BrokenRowsTable(iteration))
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
+
+    assert error == ("dbf_invalid", False)
+
+
+def test_rejeita_campo_dbf_invalido_com_falha_final(monkeypatch: pytest.MonkeyPatch):
+    _install_table(monkeypatch, _Table([_record(competencia=202601)]))
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
+
+    assert error == ("field_invalid", False)
+
+
+@pytest.mark.parametrize("field", ["COMPETEN", "CODUFMUN"])
+def test_rejeita_campo_dbf_ausente_com_falha_final(
+    monkeypatch: pytest.MonkeyPatch, field: str
+):
+    row = _record()
+    row.pop(field)
+    _install_table(monkeypatch, _Table([row]))
+
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
+
+    assert error == ("field_invalid", False)

--- a/packages/cnes_infra/tests/ingestion/test_datasus_cnes_transport.py
+++ b/packages/cnes_infra/tests/ingestion/test_datasus_cnes_transport.py
@@ -225,7 +225,6 @@ def test_resolve_uf_e_yymm_em_url_unica(monkeypatch: pytest.MonkeyPatch):
     table = _Table([_record(), _record("330455")])
     conversions = _install_table(monkeypatch, table)
     adapter = DatasusCnesFtpTransport(lambda: ftp, CircuitBreaker(base_delay=0))
-
     assert list(adapter.fetch(_request())) == [_record()]
     assert ftp.calls.index(("voidcmd", "TYPE I")) < ftp.calls.index(("size", _PATH))
     assert ("retrbinary", (f"RETR {_PATH}", 64 * 1024)) in ftp.calls
@@ -253,14 +252,11 @@ def test_resolve_uf_e_yymm_em_url_unica(monkeypatch: pytest.MonkeyPatch):
 )
 def test_rejeita_request_invalido_sem_abrir_ftp(updates: dict[str, str], code: str):
     opened = False
-
     def factory() -> _Ftp:
         nonlocal opened
         opened = True
         return _Ftp()
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(factory).fetch(_request(**updates))))
-
     assert error == (code, False)
     assert opened is False
 
@@ -275,7 +271,6 @@ def test_ftp_550_retorna_source_not_published_sem_abrir_circuito(
             ftp.retrieval_error = _ftp_error(error_perm, "550 file unavailable")
         opened.append(ftp)
         return ftp
-
     _install_table(monkeypatch, _Table([_record()]))
     adapter = DatasusCnesFtpTransport(factory, CircuitBreaker(base_delay=0))
     assert [_error_code(lambda: list(adapter.fetch(_request()))) for _ in range(3)] == [
@@ -300,15 +295,11 @@ def test_falha_de_resposta_ftp_e_retryable(
 ):
     ftp = _Ftp()
     _install_table(monkeypatch, _Table([]))
-
     def fail_connect(*args: object, **kwargs: object) -> None:
         raise _ftp_error(error_type, "sensitive-12345678901")
-
     ftp.connect = fail_connect
-
     with pytest.raises(Exception) as captured:
         list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request()))
-
     assert (captured.value.code, captured.value.retryable) == ("source_unavailable", True)
     assert "sensitive-12345678901" not in "".join(format_exception(captured.value))
 
@@ -322,7 +313,6 @@ def test_circuito_aberto_falha_sem_abrir_ftp():
         nonlocal opened
         opened = True
         return _Ftp()
-
     error = _error_code(
         lambda: list(DatasusCnesFtpTransport(factory, breaker).fetch(_request()))
     )
@@ -362,17 +352,14 @@ def test_rejeita_dbc_ou_dbf_invalido(
     ftp = _Ftp()
     def fail(*args: object, **kwargs: object) -> None:
         raise ValueError("sensitive-data-must-not-leak")
-
     converter = fail if failure == "dbc" else lambda _s, d: Path(d).write_bytes(
         _DBC_HEADER + b"\x1a"
     )
     reader = fail if failure == "dbf" else lambda *_args, **_kwargs: None
     monkeypatch.setattr(transport_module, "decompress", converter)
     monkeypatch.setattr(transport_module, "DBF", reader)
-
     with pytest.raises(Exception) as captured:
         list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request()))
-
     assert (captured.value.code, captured.value.retryable) == (code, False)
     assert "sensitive-data-must-not-leak" not in "".join(format_exception(captured.value))
 
@@ -380,9 +367,7 @@ def test_rejeita_dbc_ou_dbf_invalido(
 def test_rejeita_layout_dbf_divergente(monkeypatch: pytest.MonkeyPatch):
     layout = _LAYOUT[:-1] + (("CAMPO_ERRADO", "C", 4, 0),)
     _install_table(monkeypatch, _Table([_record()], layout))
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
-
     assert error == ("schema_invalid", False)
 
 
@@ -405,13 +390,11 @@ def test_leitura_incremental_fecha_iteradores_e_temporarios_no_cancelamento(
     table = _Table([_record(), _record()])
     conversions = _install_table(monkeypatch, table)
     rows = DatasusCnesFtpTransport(_Ftp).fetch(_request())
-
     assert next(rows) == _record()
     assert len(table.iterators) == 2
     assert table.iterators[0].closed is True
     temporary_root = Path(conversions[0][0]).parent
     rows.close()
-
     assert all(iterator.closed for iterator in table.iterators)
     assert temporary_root.exists() is False
 
@@ -421,34 +404,46 @@ def test_factory_padrao_cria_ftp(monkeypatch: pytest.MonkeyPatch):
     table = _Table([_record()])
     _install_table(monkeypatch, table)
     monkeypatch.setattr(transport_module, "FTP", lambda: ftp)
-
     assert list(DatasusCnesFtpTransport().fetch(_request())) == [_record()]
 
 
 def test_falha_ao_criar_ftp_e_retryable(monkeypatch: pytest.MonkeyPatch):
     _install_table(monkeypatch, _Table([]))
-
     def factory() -> _Ftp:
         raise OSError("offline")
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(factory).fetch(_request())))
-
     assert error == ("source_unavailable", True)
 
 
 def test_limpa_ftp_quando_quit_falha(monkeypatch: pytest.MonkeyPatch):
     ftp = _Ftp()
-
     def broken_quit() -> None:
         ftp.quit_called = True
         raise OSError("offline")
-
     ftp.quit = broken_quit
     ftp.close_error = OSError("close unavailable")
     _install_table(monkeypatch, _Table([_record()]))
     assert list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request())) == [_record()]
     assert ftp.quit_called is True
     assert ftp.close_called is True
+
+
+def test_preserva_erro_do_transporte_quando_limpeza_temporaria_falha(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    class BrokenTemporary:
+        name = str(tmp_path)
+        def __enter__(self) -> str:
+            return self.name
+        def __exit__(self, *args: object) -> None:
+            self.cleanup()
+        def cleanup(self) -> None:
+            raise OSError("cleanup-sensitive")
+    ftp = _Ftp()
+    ftp.retrieval_error = _ftp_error(error_temp, "421 unavailable")
+    monkeypatch.setattr(transport_module, "TemporaryDirectory", lambda prefix: BrokenTemporary())
+    error = _error_code(lambda: list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request())))
+    assert error == ("source_unavailable", True)
 
 
 def test_rejeita_layout_dbf_ilegivel(monkeypatch: pytest.MonkeyPatch):
@@ -464,26 +459,20 @@ def test_rejeita_layout_dbf_ilegivel(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.parametrize("iteration", [1, 2])
 def test_rejeita_iteracao_dbf_ilegivel(monkeypatch: pytest.MonkeyPatch, iteration: int):
     _install_table(monkeypatch, _BrokenTable(iteration))
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
-
     assert error == ("dbf_invalid", False)
 
 
 @pytest.mark.parametrize("iteration", [1, 2])
 def test_rejeita_leitura_dbf_ilegivel(monkeypatch: pytest.MonkeyPatch, iteration: int):
     _install_table(monkeypatch, _BrokenRowsTable(iteration))
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
-
     assert error == ("dbf_invalid", False)
 
 
 def test_rejeita_campo_dbf_invalido_com_falha_final(monkeypatch: pytest.MonkeyPatch):
     _install_table(monkeypatch, _Table([_record(competencia=202601)]))
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
-
     assert error == ("field_invalid", False)
 
 
@@ -494,7 +483,5 @@ def test_rejeita_campo_dbf_ausente_com_falha_final(
     row = _record()
     row.pop(field)
     _install_table(monkeypatch, _Table([row]))
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
-
     assert error == ("field_invalid", False)

--- a/packages/cnes_infra/tests/ingestion/test_datasus_cnes_transport.py
+++ b/packages/cnes_infra/tests/ingestion/test_datasus_cnes_transport.py
@@ -265,17 +265,24 @@ def test_rejeita_request_invalido_sem_abrir_ftp(updates: dict[str, str], code: s
     assert opened is False
 
 
-def test_ftp_550_retorna_source_not_published_sem_fallback(monkeypatch: pytest.MonkeyPatch):
-    ftp = _Ftp()
-    ftp.retrieval_error = _ftp_error(error_perm, "550 file unavailable")
-    _install_table(monkeypatch, _Table([]))
+def test_ftp_550_retorna_source_not_published_sem_abrir_circuito(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    opened: list[_Ftp] = []
+    def factory() -> _Ftp:
+        ftp = _Ftp()
+        if len(opened) < 3:
+            ftp.retrieval_error = _ftp_error(error_perm, "550 file unavailable")
+        opened.append(ftp)
+        return ftp
 
-    error = _error_code(lambda: list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request())))
-
-    assert error == ("source_not_published", True)
-    retrievals = [call for call in ftp.calls if call[0] == "retrbinary"]
-    assert retrievals == [("retrbinary", (f"RETR {_PATH}", 64 * 1024))]
-    assert ftp.close_called is True
+    _install_table(monkeypatch, _Table([_record()]))
+    adapter = DatasusCnesFtpTransport(factory, CircuitBreaker(base_delay=0))
+    assert [_error_code(lambda: list(adapter.fetch(_request()))) for _ in range(3)] == [
+        ("source_not_published", True)
+    ] * 3
+    assert list(adapter.fetch(_request())) == [_record()]
+    assert len(opened) == 4
 
 
 def test_falha_temporaria_e_retryable_e_limpa_ftp(monkeypatch: pytest.MonkeyPatch):
@@ -287,7 +294,7 @@ def test_falha_temporaria_e_retryable_e_limpa_ftp(monkeypatch: pytest.MonkeyPatc
     assert error == ("source_unavailable", True)
 
 
-@pytest.mark.parametrize("error_type", [EOFError, error_reply, error_proto])
+@pytest.mark.parametrize("error_type", [EOFError, error_perm, error_reply, error_proto])
 def test_falha_de_resposta_ftp_e_retryable(
     monkeypatch: pytest.MonkeyPatch, error_type: type[Exception]
 ):
@@ -311,7 +318,6 @@ def test_circuito_aberto_falha_sem_abrir_ftp():
     with pytest.raises(RuntimeError):
         breaker.call(lambda: (_ for _ in ()).throw(RuntimeError("offline")))
     opened = False
-
     def factory() -> _Ftp:
         nonlocal opened
         opened = True
@@ -320,7 +326,6 @@ def test_circuito_aberto_falha_sem_abrir_ftp():
     error = _error_code(
         lambda: list(DatasusCnesFtpTransport(factory, breaker).fetch(_request()))
     )
-
     assert error == ("circuit_open", True)
     assert opened is False
 
@@ -355,7 +360,6 @@ def test_rejeita_dbc_ou_dbf_invalido(
     monkeypatch: pytest.MonkeyPatch, failure: str, code: str
 ):
     ftp = _Ftp()
-
     def fail(*args: object, **kwargs: object) -> None:
         raise ValueError("sensitive-data-must-not-leak")
 
@@ -385,17 +389,13 @@ def test_rejeita_layout_dbf_divergente(monkeypatch: pytest.MonkeyPatch):
 def test_valida_competencia_antes_da_ausencia_municipal(monkeypatch: pytest.MonkeyPatch):
     _install_table(monkeypatch, _Table([_record("330455", "202512")]))
     adapter = DatasusCnesFtpTransport(_Ftp)
-
     error = _error_code(lambda: list(adapter.fetch(_request())))
-
     assert error == ("competencia_invalid", False)
 
 
 def test_ausencia_municipal_e_source_not_published(monkeypatch: pytest.MonkeyPatch):
     _install_table(monkeypatch, _Table([_record("330455")]))
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
-
     assert error == ("source_not_published", True)
 
 

--- a/packages/cnes_infra/tests/ingestion/test_datasus_cnes_transport.py
+++ b/packages/cnes_infra/tests/ingestion/test_datasus_cnes_transport.py
@@ -137,6 +137,7 @@ class _Ftp:
         self.sizes: list[object] = [len(payload), len(payload)]
         self.mdtms: list[object] = ["213 20260202010101", "213 20260202010101"]
         self.retrieval_error: Exception | None = None
+        self.close_error: Exception | None = None
         self.quit_called = False
         self.close_called = False
 
@@ -151,7 +152,10 @@ class _Ftp:
 
     def size(self, path: str) -> object:
         self.calls.append(("size", path))
-        return self.sizes.pop(0)
+        value = self.sizes.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
 
     def sendcmd(self, command: str) -> object:
         self.calls.append(("sendcmd", command))
@@ -169,6 +173,8 @@ class _Ftp:
 
     def close(self) -> None:
         self.close_called = True
+        if self.close_error:
+            raise self.close_error
 
 
 def _request(**updates: str) -> DatasusCnesRequest:
@@ -275,12 +281,10 @@ def test_ftp_550_retorna_source_not_published_sem_fallback(monkeypatch: pytest.M
 def test_falha_temporaria_e_retryable_e_limpa_ftp(monkeypatch: pytest.MonkeyPatch):
     ftp = _Ftp()
     ftp.retrieval_error = _ftp_error(error_temp, "421 unavailable")
+    ftp.close_error = OSError("close unavailable")
     _install_table(monkeypatch, _Table([]))
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request())))
-
     assert error == ("source_unavailable", True)
-    assert ftp.close_called is True
 
 
 @pytest.mark.parametrize("error_type", [EOFError, error_reply, error_proto])
@@ -327,6 +331,7 @@ def test_circuito_aberto_falha_sem_abrir_ftp():
         ([3, 4], ["213 20260202010101"] * 2, b"dbc", "source_changed"),
         ([3, 3], ["213 20260202010101", "213 20260202010102"], b"dbc", "source_changed"),
         ([None], ["213 20260202010101"], b"dbc", "metadata_invalid"),
+        ([ValueError("malformed size")], [], b"dbc", "metadata_invalid"),
         ([3], ["invalid"], b"dbc", "metadata_invalid"),
         ([4, 4], ["213 20260202010101"] * 2, b"dbc", "size_mismatch"),
     ],
@@ -340,9 +345,7 @@ def test_rejeita_metadados_instaveis_ou_invalidos(
     ftp.sizes = sizes
     ftp.mdtms = mdtms
     _install_table(monkeypatch, _Table([]))
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request())))
-
     assert error == (code, True)
     assert ftp.close_called is True
 
@@ -441,8 +444,8 @@ def test_limpa_ftp_quando_quit_falha(monkeypatch: pytest.MonkeyPatch):
         raise OSError("offline")
 
     ftp.quit = broken_quit
+    ftp.close_error = OSError("close unavailable")
     _install_table(monkeypatch, _Table([_record()]))
-
     assert list(DatasusCnesFtpTransport(lambda: ftp).fetch(_request())) == [_record()]
     assert ftp.quit_called is True
     assert ftp.close_called is True
@@ -453,11 +456,8 @@ def test_rejeita_layout_dbf_ilegivel(monkeypatch: pytest.MonkeyPatch):
         @property
         def fields(self):
             raise RuntimeError("broken-dbf")
-
     _install_table(monkeypatch, BrokenLayout())
-
     error = _error_code(lambda: list(DatasusCnesFtpTransport(_Ftp).fetch(_request())))
-
     assert error == ("dbf_invalid", False)
 
 


### PR DESCRIPTION
## Summary

- ingest the exact monthly DATASUS CNES PF file through anonymous FTP
- validate transfer metadata, DBC/DBF integrity, full PF schema and requested competency
- project deterministic 14-column Parquet snapshots and return FULL raw manifests
- cover cleanup, typed failures, privacy, deterministic bytes and opt-in FTP smoke behavior

## Verification

- uv lock --check
- ruff check .
- focused DATASUS PF suite: 80 passed, 1 skipped
- focused branch coverage: 100%
- ingestion suite: 150 passed, 1 skipped

Closes #143