### PR TITLE
feat(edge): emit raw manifest v1 chains

### DIFF
--- a/apps/dump_agent_go/internal/delta/store.go
+++ b/apps/dump_agent_go/internal/delta/store.go
@@ -28,13 +28,11 @@ var ErrPendingExists = errors.New("pending_exists")
 var ErrPendingNotFound = errors.New("pending_missing")
 
 type Store struct{ db *bbolt.DB }
-
 type PendingRef struct {
 	SourceKey    SourceKey
 	JobID        string
 	FencingToken uint64
 }
-
 type chainState struct {
 	SnapshotID        string
 	Sequence          uint32
@@ -43,7 +41,6 @@ type chainState struct {
 	ConfirmedRef      PendingRef
 	ConfirmedManifest manifest.Raw
 }
-
 type PendingTx struct {
 	store  *Store
 	key    SourceKey
@@ -77,9 +74,7 @@ func Open(path string) (*Store, error) {
 	}
 	return &Store{db: db}, nil
 }
-
 func (s *Store) Close() error { return s.db.Close() }
-
 func (s *Store) GetCommitted(key SourceKey) (map[string][32]byte, error) {
 	out := map[string][32]byte{}
 	err := s.db.View(func(tx *bbolt.Tx) error {
@@ -96,7 +91,6 @@ func (s *Store) GetCommitted(key SourceKey) (map[string][32]byte, error) {
 	})
 	return out, err
 }
-
 func (s *Store) BeginPending(key SourceKey, jobID string) (*PendingTx, error) {
 	p := &PendingTx{store: s, key: key, path: key.BucketPath() + "/" + jobID, root: pendingBucket}
 	p.puts = map[string][32]byte{}
@@ -117,7 +111,6 @@ func (s *Store) BeginPending(key SourceKey, jobID string) (*PendingTx, error) {
 	}
 	return p, nil
 }
-
 func (s *Store) BeginPendingRef(ref PendingRef) (*PendingTx, error) {
 	if err := ref.validate(); err != nil {
 		return nil, err
@@ -135,7 +128,6 @@ func (s *Store) BeginPendingRef(ref PendingRef) (*PendingTx, error) {
 	}
 	return &PendingTx{store: s, key: ref.SourceKey, path: ref.path(), root: rawPendingBucket}, nil
 }
-
 func (s *Store) ResumePendingRef(ref PendingRef) (*PendingTx, error) {
 	if err := ref.validate(); err != nil {
 		return nil, err
@@ -151,11 +143,9 @@ func (s *Store) ResumePendingRef(ref PendingRef) (*PendingTx, error) {
 	}
 	return &PendingTx{store: s, key: ref.SourceKey, path: ref.path(), root: rawPendingBucket}, nil
 }
-
 func (r PendingRef) path() string {
 	return fmt.Sprintf("%s/%s/%d", r.SourceKey.BucketPath(), r.JobID, r.FencingToken)
 }
-
 func (r PendingRef) validate() error {
 	for _, segment := range []string{
 		r.SourceKey.Source, r.SourceKey.Intent, r.SourceKey.Competencia, r.JobID,
@@ -166,7 +156,6 @@ func (r PendingRef) validate() error {
 	}
 	return nil
 }
-
 func (p *PendingTx) Put(pk string, h [32]byte) error {
 	if p.closed {
 		return errors.New("pending_closed")
@@ -183,7 +172,6 @@ func (p *PendingTx) Put(pk string, h [32]byte) error {
 		return b.Put([]byte(pk), h[:])
 	})
 }
-
 func (p *PendingTx) Replace(hashes map[string][32]byte) error {
 	if p.closed || p.root != rawPendingBucket {
 		return errors.New("pending=not_raw_or_closed")
@@ -234,7 +222,6 @@ func (p *PendingTx) Commit() error {
 	}
 	return err
 }
-
 func (p *PendingTx) Abort() {
 	if p.closed {
 		return
@@ -244,7 +231,6 @@ func (p *PendingTx) Abort() {
 		return deleteNestedPrune(tx.Bucket([]byte(p.root)), p.path)
 	})
 }
-
 func (s *Store) ChainHead(key SourceKey) (string, uint32, string, time.Time, bool, error) {
 	var head chainState
 	var ok bool
@@ -255,7 +241,6 @@ func (s *Store) ChainHead(key SourceKey) (string, uint32, string, time.Time, boo
 	})
 	return head.SnapshotID, head.Sequence, head.ManifestSHA256, head.CreatedAt, ok, err
 }
-
 func readHead(tx *bbolt.Tx, key SourceKey) (chainState, bool, error) {
 	var head chainState
 	data := tx.Bucket([]byte(headBucket)).Get([]byte(key.BucketPath()))
@@ -402,31 +387,47 @@ func (s *Store) RequireFull(ref PendingRef, reason string) error {
 }
 
 func (s *Store) GarbageCollectStalePending(maxAge time.Duration) (int, error) {
-	var stale []string
+	cutoff := time.Now().UTC().Add(-maxAge)
+	return s.deletePendingWhere(pendingBucket, func(_ string, b *bbolt.Bucket) bool {
+		created, err := time.Parse(time.RFC3339Nano, string(b.Get([]byte(createdAtKey))))
+		return err != nil || created.Before(cutoff)
+	})
+}
+
+func (s *Store) ReconcileRawPending(retained []PendingRef) (int, error) {
+	keep := make(map[string]bool, len(retained))
+	for _, ref := range retained {
+		if err := ref.validate(); err != nil {
+			return 0, err
+		}
+		keep[ref.path()] = true
+	}
+	return s.deletePendingWhere(rawPendingBucket,
+		func(path string, _ *bbolt.Bucket) bool { return !keep[path] })
+}
+
+func (s *Store) deletePendingWhere(rootName string,
+	remove func(string, *bbolt.Bucket) bool,
+) (int, error) {
+	var paths []string
 	err := s.db.Update(func(tx *bbolt.Tx) error {
-		root := tx.Bucket([]byte(pendingBucket))
-		cutoff := time.Now().UTC().Add(-maxAge)
-		err := walkLeafBuckets(root, "", func(path string, b *bbolt.Bucket) error {
-			created, err := time.Parse(time.RFC3339Nano, string(b.Get([]byte(createdAtKey))))
-			if err != nil || created.Before(cutoff) {
-				stale = append(stale, path)
+		root := tx.Bucket([]byte(rootName))
+		if err := walkLeafBuckets(root, "", func(path string, b *bbolt.Bucket) error {
+			if remove(path, b) {
+				paths = append(paths, path)
 			}
 			return nil
-		})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
-		for _, path := range stale {
+		for _, path := range paths {
 			if err := deleteNestedPrune(root, path); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
-	if err != nil {
-		return 0, err
-	}
-	return len(stale), nil
+	return len(paths), err
 }
 
 func navigate(start *bbolt.Bucket, path string) *bbolt.Bucket {

--- a/apps/dump_agent_go/internal/delta/store.go
+++ b/apps/dump_agent_go/internal/delta/store.go
@@ -1,6 +1,9 @@
 package delta
 
 import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -8,57 +11,75 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cnesdata/dumpagent/internal/manifest"
 	"go.etcd.io/bbolt"
 )
 
 const (
-	committedBucket = "committed"
-	pendingBucket   = "pending"
-	createdAtKey    = "_created_at"
+	committedBucket  = "committed"
+	pendingBucket    = "pending"
+	rawPendingBucket = "raw_pending"
+	headBucket       = "chain_heads"
+	forceFullBucket  = "force_full"
+	createdAtKey     = "_created_at"
 )
 
-// ErrPendingExists indicates an existing pending sub-bucket for the same key.
 var ErrPendingExists = errors.New("pending_exists")
+var ErrPendingNotFound = errors.New("pending_missing")
 
-var errEarlyStop = errors.New("stop")
+type Store struct{ db *bbolt.DB }
 
-// Store wraps *bbolt.DB with two top-level buckets: committed and pending.
-type Store struct {
-	db *bbolt.DB
+type PendingRef struct {
+	SourceKey    SourceKey
+	JobID        string
+	FencingToken uint64
 }
 
-// Open creates parent dirs and opens the bbolt file. Initializes the two
-// top-level buckets. File lock timeout 5s prevents indefinite hang.
+type chainState struct {
+	SnapshotID        string
+	Sequence          uint32
+	ManifestSHA256    string
+	CreatedAt         time.Time
+	ConfirmedRef      PendingRef
+	ConfirmedManifest manifest.Raw
+}
+
+type PendingTx struct {
+	store  *Store
+	key    SourceKey
+	path   string
+	root   string
+	closed bool
+	puts   map[string][32]byte
+}
+
 func Open(path string) (*Store, error) {
-	if err := ensureDir(filepath.Dir(path)); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("ensure_dir: %w", err)
 	}
 	db, err := bbolt.Open(path, 0o644, &bbolt.Options{Timeout: 5 * time.Second})
 	if err != nil {
 		return nil, fmt.Errorf("bbolt_open: %w", err)
 	}
-	if err := initRoots(db); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("init_roots: %w", err)
-	}
-	return &Store{db: db}, nil
-}
-
-func initRoots(db *bbolt.DB) error {
-	return db.Update(func(tx *bbolt.Tx) error {
-		for _, name := range []string{committedBucket, pendingBucket} {
+	err = db.Update(func(tx *bbolt.Tx) error {
+		for _, name := range []string{
+			committedBucket, pendingBucket, rawPendingBucket, headBucket, forceFullBucket,
+		} {
 			if _, err := tx.CreateBucketIfNotExists([]byte(name)); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("init_roots: %w", err)
+	}
+	return &Store{db: db}, nil
 }
 
-// Close releases the bbolt file lock.
 func (s *Store) Close() error { return s.db.Close() }
 
-// GetCommitted returns the pk→hash map for key. Empty map if absent.
 func (s *Store) GetCommitted(key SourceKey) (map[string][32]byte, error) {
 	out := map[string][32]byte{}
 	err := s.db.View(func(tx *bbolt.Tx) error {
@@ -67,282 +88,401 @@ func (s *Store) GetCommitted(key SourceKey) (map[string][32]byte, error) {
 			return nil
 		}
 		return b.ForEach(func(k, v []byte) error {
-			var h [32]byte
-			copy(h[:], v)
-			out[string(k)] = h
+			var hash [32]byte
+			copy(hash[:], v)
+			out[string(k)] = hash
 			return nil
 		})
 	})
 	return out, err
 }
 
-// PendingTx stages pk→hash entries; flushed atomically on Commit.
-type PendingTx struct {
-	store  *Store
-	key    SourceKey
-	jobID  string
-	closed bool
-	puts   map[string][32]byte
+func (s *Store) BeginPending(key SourceKey, jobID string) (*PendingTx, error) {
+	p := &PendingTx{store: s, key: key, path: key.BucketPath() + "/" + jobID, root: pendingBucket}
+	p.puts = map[string][32]byte{}
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		root := tx.Bucket([]byte(pendingBucket))
+		parent := navigate(root, key.BucketPath())
+		if parent != nil && !isEmptyBucket(parent) {
+			return ErrPendingExists
+		}
+		b, err := createNested(root, p.path)
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(createdAtKey), []byte(time.Now().UTC().Format(time.RFC3339Nano)))
+	})
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
-// BeginPending opens a staging tx for key. Refuses if any pending sub-bucket
-// already exists for key (any jobID under pending/<key>).
-func (s *Store) BeginPending(key SourceKey, jobID string) (*PendingTx, error) {
-	exists := false
+func (s *Store) BeginPendingRef(ref PendingRef) (*PendingTx, error) {
+	if err := ref.validate(); err != nil {
+		return nil, err
+	}
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		root := tx.Bucket([]byte(rawPendingBucket))
+		if navigate(root, ref.path()) != nil {
+			return ErrPendingExists
+		}
+		_, err := createNested(root, ref.path())
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &PendingTx{store: s, key: ref.SourceKey, path: ref.path(), root: rawPendingBucket}, nil
+}
+
+func (s *Store) ResumePendingRef(ref PendingRef) (*PendingTx, error) {
+	if err := ref.validate(); err != nil {
+		return nil, err
+	}
 	err := s.db.View(func(tx *bbolt.Tx) error {
-		exists = pendingExistsForKey(tx, key)
+		if navigate(tx.Bucket([]byte(rawPendingBucket)), ref.path()) == nil {
+			return ErrPendingNotFound
+		}
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	if exists {
-		return nil, ErrPendingExists
-	}
-	if err := s.writeCreatedAt(key, jobID); err != nil {
-		return nil, fmt.Errorf("init_pending: %w", err)
-	}
-	return &PendingTx{
-		store: s, key: key, jobID: jobID,
-		puts: map[string][32]byte{},
-	}, nil
+	return &PendingTx{store: s, key: ref.SourceKey, path: ref.path(), root: rawPendingBucket}, nil
 }
 
-func (s *Store) writeCreatedAt(key SourceKey, jobID string) error {
-	return s.db.Update(func(tx *bbolt.Tx) error {
-		root := tx.Bucket([]byte(pendingBucket))
-		b, err := createNested(root, key.BucketPath()+"/"+jobID)
-		if err != nil {
-			return err
+func (r PendingRef) path() string {
+	return fmt.Sprintf("%s/%s/%d", r.SourceKey.BucketPath(), r.JobID, r.FencingToken)
+}
+
+func (r PendingRef) validate() error {
+	for _, segment := range []string{
+		r.SourceKey.Source, r.SourceKey.Intent, r.SourceKey.Competencia, r.JobID,
+	} {
+		if segment == "" || strings.Contains(segment, "/") {
+			return errors.New("pending_ref=invalid")
 		}
-		return b.Put([]byte(createdAtKey),
-			[]byte(time.Now().UTC().Format(time.RFC3339Nano)))
-	})
+	}
+	return nil
 }
 
-// Put stages an entry. Flushed during Commit.
 func (p *PendingTx) Put(pk string, h [32]byte) error {
 	if p.closed {
 		return errors.New("pending_closed")
 	}
-	p.puts[pk] = h
-	return nil
-}
-
-// Commit atomically: writes staged entries → wipes committed for key →
-// recopies from pending → drops pending sub-bucket.
-func (p *PendingTx) Commit() error {
-	if p.closed {
-		return errors.New("pending_closed")
+	if p.root == pendingBucket {
+		p.puts[pk] = h
+		return nil
 	}
-	p.closed = true
 	return p.store.db.Update(func(tx *bbolt.Tx) error {
-		return p.commitTx(tx)
+		b := navigate(tx.Bucket([]byte(p.root)), p.path)
+		if b == nil {
+			return errors.New("pending_missing")
+		}
+		return b.Put([]byte(pk), h[:])
 	})
 }
 
-func (p *PendingTx) commitTx(tx *bbolt.Tx) error {
-	pendRoot := tx.Bucket([]byte(pendingBucket))
-	pendBucket, err := createNested(pendRoot, p.key.BucketPath()+"/"+p.jobID)
-	if err != nil {
-		return err
+func (p *PendingTx) Replace(hashes map[string][32]byte) error {
+	if p.closed || p.root != rawPendingBucket {
+		return errors.New("pending=not_raw_or_closed")
 	}
-	for k, v := range p.puts {
-		hash := v
-		if err := pendBucket.Put([]byte(k), hash[:]); err != nil {
+	return p.store.db.Update(func(tx *bbolt.Tx) error {
+		root := tx.Bucket([]byte(p.root))
+		if navigate(root, p.path) == nil {
+			return errors.New("pending_missing")
+		}
+		if err := deleteNested(root, p.path); err != nil {
 			return err
 		}
-	}
-	commRoot := tx.Bucket([]byte(committedBucket))
-	if err := deleteNested(commRoot, p.key.BucketPath()); err != nil {
-		return err
-	}
-	commBucket, err := createNested(commRoot, p.key.BucketPath())
-	if err != nil {
-		return err
-	}
-	if err := copyEntries(pendBucket, commBucket); err != nil {
-		return err
-	}
-	return deleteNestedPrune(pendRoot, p.key.BucketPath()+"/"+p.jobID)
-}
-
-func copyEntries(src, dst *bbolt.Bucket) error {
-	return src.ForEach(func(k, v []byte) error {
-		if string(k) == createdAtKey {
-			return nil
+		b, err := createNested(root, p.path)
+		if err != nil {
+			return err
 		}
-		return dst.Put(k, v)
+		for pk, hash := range hashes {
+			if err := b.Put([]byte(pk), hash[:]); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 }
 
-// Abort drops the pending sub-bucket without touching committed.
+func (p *PendingTx) Commit() error {
+	if p.closed || p.root == rawPendingBucket {
+		return errors.New("pending=closed_or_requires_ack")
+	}
+	err := p.store.db.Update(func(tx *bbolt.Tx) error {
+		root := tx.Bucket([]byte(p.root))
+		b := navigate(root, p.path)
+		if b == nil {
+			return errors.New("pending_missing")
+		}
+		for pk, hash := range p.puts {
+			if err := b.Put([]byte(pk), hash[:]); err != nil {
+				return err
+			}
+		}
+		if err := promote(tx, p.key, b); err != nil {
+			return err
+		}
+		return deleteNestedPrune(root, p.path)
+	})
+	if err == nil {
+		p.closed = true
+	}
+	return err
+}
+
 func (p *PendingTx) Abort() {
 	if p.closed {
 		return
 	}
 	p.closed = true
 	_ = p.store.db.Update(func(tx *bbolt.Tx) error {
-		root := tx.Bucket([]byte(pendingBucket))
-		return deleteNestedPrune(root, p.key.BucketPath()+"/"+p.jobID)
+		return deleteNestedPrune(tx.Bucket([]byte(p.root)), p.path)
 	})
 }
 
-// GarbageCollectStalePending removes pending sub-buckets older than maxAge,
-// or those missing/with malformed _created_at marker. Returns count removed.
-func (s *Store) GarbageCollectStalePending(maxAge time.Duration) (int, error) {
-	stale, err := s.findStalePending(maxAge)
+func (s *Store) ChainHead(key SourceKey) (string, uint32, string, time.Time, bool, error) {
+	var head chainState
+	var ok bool
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		var err error
+		head, ok, err = readHead(tx, key)
+		return err
+	})
+	return head.SnapshotID, head.Sequence, head.ManifestSHA256, head.CreatedAt, ok, err
+}
+
+func readHead(tx *bbolt.Tx, key SourceKey) (chainState, bool, error) {
+	var head chainState
+	data := tx.Bucket([]byte(headBucket)).Get([]byte(key.BucketPath()))
+	if data == nil {
+		return head, false, nil
+	}
+	err := json.Unmarshal(data, &head)
+	return head, err == nil, err
+}
+
+func (s *Store) ConfirmPending(ref PendingRef, raw manifest.Raw, serverHash string) error {
+	if err := ref.validate(); err != nil {
+		return err
+	}
+	if err := validateConfirmation(ref, raw, serverHash); err != nil {
+		return err
+	}
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		head, _, err := readHead(tx, ref.SourceKey)
+		if err != nil {
+			return err
+		}
+		root := tx.Bucket([]byte(rawPendingBucket))
+		pending := navigate(root, ref.path())
+		if pending == nil {
+			if head.matches(ref, raw, serverHash) {
+				return nil
+			}
+			return errors.New("pending_missing")
+		}
+		next, err := nextHead(head, ref, raw, serverHash)
+		if err != nil {
+			return err
+		}
+		if err := promote(tx, ref.SourceKey, pending); err != nil {
+			return err
+		}
+		if err := saveHead(tx, ref.SourceKey, next); err != nil {
+			return err
+		}
+		return deleteNestedPrune(root, ref.path())
+	})
+}
+
+func (h chainState) matches(ref PendingRef, raw manifest.Raw, hash string) bool {
+	want, err := json.Marshal(raw)
+	got, storedErr := json.Marshal(h.ConfirmedManifest)
+	return err == nil && storedErr == nil && h.ConfirmedRef == ref &&
+		h.ManifestSHA256 == hash && bytes.Equal(want, got)
+}
+
+func validateConfirmation(ref PendingRef, raw manifest.Raw, hash string) error {
+	decoded, err := hex.DecodeString(hash)
+	if err != nil || len(decoded) != 32 || strings.ToLower(hash) != hash {
+		return errors.New("manifest_sha256=invalid")
+	}
+	if raw.ManifestID != ref.JobID || raw.SnapshotID != ref.JobID || raw.CreatedAt.IsZero() {
+		return errors.New("confirmation_identity=invalid")
+	}
+	return nil
+}
+
+func nextHead(head chainState, ref PendingRef, raw manifest.Raw, hash string) (chainState, error) {
+	switch raw.SnapshotMode {
+	case manifest.SnapshotModeFull:
+		if raw.Sequence != 1 || raw.BaseSnapshotID != nil || raw.PreviousManifestSHA256 != nil {
+			return head, errors.New("full_chain=invalid")
+		}
+		head.SnapshotID, head.CreatedAt = raw.SnapshotID, raw.CreatedAt
+	case manifest.SnapshotModeDelta:
+		if !validDeltaHead(head, raw) {
+			return head, errors.New("delta_chain=invalid")
+		}
+	default:
+		return head, errors.New("snapshot_mode=invalid")
+	}
+	head.Sequence, head.ManifestSHA256, head.ConfirmedRef = raw.Sequence, hash, ref
+	head.ConfirmedManifest = raw
+	return head, nil
+}
+
+func validDeltaHead(head chainState, raw manifest.Raw) bool {
+	return head.Sequence > 0 && head.Sequence < ^uint32(0) && raw.Sequence == head.Sequence+1 &&
+		raw.BaseSnapshotID != nil && *raw.BaseSnapshotID == head.SnapshotID &&
+		raw.PreviousManifestSHA256 != nil && *raw.PreviousManifestSHA256 == head.ManifestSHA256
+}
+
+func saveHead(tx *bbolt.Tx, key SourceKey, head chainState) error {
+	data, err := json.Marshal(head)
 	if err != nil {
-		return 0, err
+		return err
 	}
-	if len(stale) == 0 {
-		return 0, nil
+	if err := tx.Bucket([]byte(headBucket)).Put([]byte(key.BucketPath()), data); err != nil {
+		return err
 	}
-	err = s.db.Update(func(tx *bbolt.Tx) error {
+	if head.Sequence == 1 {
+		return tx.Bucket([]byte(forceFullBucket)).Delete([]byte(key.BucketPath()))
+	}
+	return nil
+}
+
+func promote(tx *bbolt.Tx, key SourceKey, rows *bbolt.Bucket) error {
+	root := tx.Bucket([]byte(committedBucket))
+	if err := deleteNested(root, key.BucketPath()); err != nil {
+		return err
+	}
+	committed, err := createNested(root, key.BucketPath())
+	if err != nil {
+		return err
+	}
+	return rows.ForEach(func(pk, hash []byte) error {
+		if string(pk) == createdAtKey && len(hash) != 32 {
+			return nil
+		}
+		return committed.Put(pk, hash)
+	})
+}
+
+func (s *Store) ForceFull(key SourceKey) (string, bool, error) {
+	var reason string
+	var required bool
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		data := tx.Bucket([]byte(forceFullBucket)).Get([]byte(key.BucketPath()))
+		reason, required = string(data), data != nil
+		return nil
+	})
+	return reason, required, err
+}
+
+func (s *Store) RequireFull(ref PendingRef, reason string) error {
+	if err := ref.validate(); err != nil {
+		return err
+	}
+	if reason == "" {
+		return errors.New("force_full_reason=empty")
+	}
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		if err := tx.Bucket([]byte(forceFullBucket)).Put([]byte(ref.SourceKey.BucketPath()),
+			[]byte(reason)); err != nil {
+			return err
+		}
+		return deleteNestedPrune(tx.Bucket([]byte(rawPendingBucket)), ref.path())
+	})
+}
+
+func (s *Store) GarbageCollectStalePending(maxAge time.Duration) (int, error) {
+	var stale []string
+	err := s.db.Update(func(tx *bbolt.Tx) error {
 		root := tx.Bucket([]byte(pendingBucket))
-		for _, p := range stale {
-			if err := deleteNestedPrune(root, p); err != nil {
+		cutoff := time.Now().UTC().Add(-maxAge)
+		err := walkLeafBuckets(root, "", func(path string, b *bbolt.Bucket) error {
+			created, err := time.Parse(time.RFC3339Nano, string(b.Get([]byte(createdAtKey))))
+			if err != nil || created.Before(cutoff) {
+				stale = append(stale, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		for _, path := range stale {
+			if err := deleteNestedPrune(root, path); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
-	return len(stale), err
-}
-
-func (s *Store) findStalePending(maxAge time.Duration) ([]string, error) {
-	cutoff := time.Now().UTC().Add(-maxAge)
-	stale := []string{}
-	err := s.db.View(func(tx *bbolt.Tx) error {
-		root := tx.Bucket([]byte(pendingBucket))
-		return walkLeafBuckets(root, "", func(path string, b *bbolt.Bucket) error {
-			ts := b.Get([]byte(createdAtKey))
-			if ts == nil {
-				stale = append(stale, path)
-				return nil
-			}
-			t, err := time.Parse(time.RFC3339Nano, string(ts))
-			if err != nil || t.Before(cutoff) {
-				stale = append(stale, path)
-			}
-			return nil
-		})
-	})
-	return stale, err
+	if err != nil {
+		return 0, err
+	}
+	return len(stale), nil
 }
 
 func navigate(start *bbolt.Bucket, path string) *bbolt.Bucket {
-	if start == nil {
-		return nil
-	}
 	cur := start
-	for _, seg := range splitPath(path) {
-		next := cur.Bucket([]byte(seg))
-		if next == nil {
+	for _, segment := range strings.Split(path, "/") {
+		if cur == nil {
 			return nil
 		}
-		cur = next
+		cur = cur.Bucket([]byte(segment))
 	}
 	return cur
 }
 
 func createNested(start *bbolt.Bucket, path string) (*bbolt.Bucket, error) {
 	cur := start
-	for _, seg := range splitPath(path) {
-		next, err := cur.CreateBucketIfNotExists([]byte(seg))
+	for _, segment := range strings.Split(path, "/") {
+		var err error
+		cur, err = cur.CreateBucketIfNotExists([]byte(segment))
 		if err != nil {
 			return nil, err
 		}
-		cur = next
 	}
 	return cur, nil
 }
 
 func deleteNested(start *bbolt.Bucket, path string) error {
-	parts := splitPath(path)
-	if len(parts) == 0 {
-		return nil
+	parent, leaf := start, path
+	if index := strings.LastIndex(path, "/"); index >= 0 {
+		parent, leaf = navigate(start, path[:index]), path[index+1:]
 	}
-	parent := start
-	for i := 0; i < len(parts)-1; i++ {
-		next := parent.Bucket([]byte(parts[i]))
-		if next == nil {
-			return nil
-		}
-		parent = next
-	}
-	leaf := parts[len(parts)-1]
-	if parent.Bucket([]byte(leaf)) == nil {
+	if parent == nil || parent.Bucket([]byte(leaf)) == nil {
 		return nil
 	}
 	return parent.DeleteBucket([]byte(leaf))
 }
 
-func splitPath(p string) []string {
-	if p == "" {
-		return nil
-	}
-	return strings.Split(p, "/")
-}
-
-// deleteNestedPrune deletes the leaf at path then removes ancestor buckets
-// that became empty (no keys, no sub-buckets). Root is never deleted.
 func deleteNestedPrune(start *bbolt.Bucket, path string) error {
-	parts := splitPath(path)
-	if len(parts) == 0 {
-		return nil
-	}
 	if err := deleteNested(start, path); err != nil {
 		return err
 	}
-	for i := len(parts) - 1; i >= 1; i-- {
-		ancestorPath := strings.Join(parts[:i], "/")
-		ancestor := navigate(start, ancestorPath)
-		if ancestor == nil {
+	for index := strings.LastIndex(path, "/"); index >= 0; index = strings.LastIndex(path, "/") {
+		path = path[:index]
+		ancestor := navigate(start, path)
+		if ancestor == nil || !isEmptyBucket(ancestor) {
 			return nil
 		}
-		if !isEmptyBucket(ancestor) {
-			return nil
-		}
-		if err := deleteNested(start, ancestorPath); err != nil {
+		if err := deleteNested(start, path); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func isEmptyBucket(b *bbolt.Bucket) bool {
-	empty := true
-	_ = b.ForEach(func(_, _ []byte) error {
-		empty = false
-		return errEarlyStop
-	})
-	return empty
-}
+func isEmptyBucket(b *bbolt.Bucket) bool { k, _ := b.Cursor().First(); return k == nil }
 
-func pendingExistsForKey(tx *bbolt.Tx, key SourceKey) bool {
-	root := tx.Bucket([]byte(pendingBucket))
-	if root == nil {
-		return false
-	}
-	parent := navigate(root, key.BucketPath())
-	if parent == nil {
-		return false
-	}
-	exists := false
-	_ = parent.ForEachBucket(func(_ []byte) error {
-		exists = true
-		return errEarlyStop
-	})
-	return exists
-}
-
-func walkLeafBuckets(
-	b *bbolt.Bucket, prefix string, fn func(path string, b *bbolt.Bucket) error,
-) error {
-	if b == nil {
-		return nil
-	}
+func walkLeafBuckets(b *bbolt.Bucket, prefix string, fn func(string, *bbolt.Bucket) error) error {
 	return b.ForEachBucket(func(k []byte) error {
 		child := b.Bucket(k)
 		path := string(k)
@@ -350,20 +490,10 @@ func walkLeafBuckets(
 			path = prefix + "/" + path
 		}
 		hasChild := false
-		_ = child.ForEachBucket(func(_ []byte) error {
-			hasChild = true
-			return errEarlyStop
-		})
+		_ = child.ForEachBucket(func([]byte) error { hasChild = true; return nil })
 		if !hasChild {
 			return fn(path, child)
 		}
 		return walkLeafBuckets(child, path, fn)
 	})
-}
-
-func ensureDir(dir string) error {
-	if dir == "" {
-		return nil
-	}
-	return os.MkdirAll(dir, 0o755)
 }

--- a/apps/dump_agent_go/internal/delta/store_test.go
+++ b/apps/dump_agent_go/internal/delta/store_test.go
@@ -438,3 +438,24 @@ func TestStore_GarbageCollectStalePending(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, count2, "second call has nothing left to GC")
 }
+
+func TestReconcileRawPendingRemoveSomenteRefsSemEnvelope(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "delta.db"))
+	require.NoError(t, err)
+	defer store.Close()
+	orphan := referenciaPendente("orphan", 1)
+	retained := referenciaPendente("retained", 2)
+	for _, ref := range []PendingRef{orphan, retained} {
+		pending, err := store.BeginPendingRef(ref)
+		require.NoError(t, err)
+		require.NoError(t, pending.Replace(map[string][32]byte{"row": {1}}))
+	}
+
+	removed, err := store.ReconcileRawPending([]PendingRef{retained})
+	require.NoError(t, err)
+	require.Equal(t, 1, removed)
+	_, err = store.ResumePendingRef(orphan)
+	require.ErrorIs(t, err, ErrPendingNotFound)
+	_, err = store.ResumePendingRef(retained)
+	require.NoError(t, err)
+}

--- a/apps/dump_agent_go/internal/delta/store_test.go
+++ b/apps/dump_agent_go/internal/delta/store_test.go
@@ -3,9 +3,11 @@ package delta
 import (
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/cnesdata/dumpagent/internal/manifest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,6 +16,337 @@ func TestStore_OpenClose(t *testing.T) {
 	s, err := Open(path)
 	require.NoError(t, err)
 	require.NoError(t, s.Close())
+}
+
+func TestFingerprintsPendentesSobrevivemReinicioAntesDaFila(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "delta.db")
+	s, err := Open(path)
+	require.NoError(t, err)
+	ref := referenciaPendente("job-full", 1)
+	pending, err := s.BeginPendingRef(ref)
+	require.NoError(t, err)
+	require.NoError(t, pending.Replace(map[string][32]byte{"pk": {7}}))
+	require.NoError(t, s.Close())
+	s, err = Open(path)
+	require.NoError(t, err)
+	defer s.Close()
+	count, err := s.GarbageCollectStalePending(0)
+	require.NoError(t, err)
+	require.Zero(t, count)
+	committed, err := s.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Empty(t, committed)
+	require.NoError(t, s.ConfirmPending(ref, manifestoFull(ref.JobID), strings.Repeat("a", 64)))
+	committed, err = s.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"pk": {7}}, committed)
+}
+
+func TestRetomaPendenteAposReinicioPreservandoDadosAteSubstituicao(t *testing.T) {
+	for _, replace := range []bool{false, true} {
+		name := "preserva"
+		if replace {
+			name = "substitui"
+		}
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "delta.db")
+			s, err := Open(path)
+			require.NoError(t, err)
+			ref := referenciaPendente("full", 9)
+			pending, err := s.BeginPendingRef(ref)
+			require.NoError(t, err)
+			require.NoError(t, pending.Replace(map[string][32]byte{"original": {1}}))
+			require.NoError(t, s.Close())
+			s, err = Open(path)
+			require.NoError(t, err)
+			defer s.Close()
+			resumed, err := s.ResumePendingRef(ref)
+			require.NoError(t, err)
+			require.NotNil(t, resumed)
+			want := map[string][32]byte{"original": {1}}
+			if replace {
+				require.NoError(t, resumed.Replace(map[string][32]byte{"substituido": {2}}))
+				want = map[string][32]byte{"substituido": {2}}
+			}
+			require.NoError(t, s.ConfirmPending(ref, manifestoFull(ref.JobID), strings.Repeat("a", 64)))
+			committed, err := s.GetCommitted(ref.SourceKey)
+			require.NoError(t, err)
+			require.Equal(t, want, committed)
+		})
+	}
+}
+
+func TestRetomadaAusenteNaoCriaPendenteNemAlteraOutraReferencia(t *testing.T) {
+	s := abreStore(t)
+	ref := referenciaPendente("full", 1)
+	pending, err := s.BeginPendingRef(ref)
+	require.NoError(t, err)
+	require.NoError(t, pending.Replace(map[string][32]byte{"original": {1}}))
+	otherSource, otherJob, otherFence := ref, ref, ref
+	otherSource.SourceKey.Source = "sihd"
+	otherJob.JobID = "outro"
+	otherFence.FencingToken++
+	for _, absent := range []PendingRef{otherSource, otherJob, otherFence} {
+		resumed, err := s.ResumePendingRef(absent)
+		require.ErrorIs(t, err, ErrPendingNotFound)
+		require.Nil(t, resumed)
+		created, err := s.BeginPendingRef(absent)
+		require.NoError(t, err)
+		created.Abort()
+	}
+	require.NoError(t, s.ConfirmPending(ref, manifestoFull(ref.JobID), strings.Repeat("a", 64)))
+	committed, err := s.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"original": {1}}, committed)
+}
+
+func TestRetomadaValidaReferenciaAntesDeConsultarPendente(t *testing.T) {
+	s := abreStore(t)
+	ref := referenciaPendente("job/invalido", 1)
+	resumed, err := s.ResumePendingRef(ref)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrPendingNotFound)
+	require.Nil(t, resumed)
+	_, _, _, _, ok, err := s.ChainHead(ref.SourceKey)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestSubstituicaoPendenteAtomicaPreservaConjuntoAnteriorSeFalhar(t *testing.T) {
+	s := abreStore(t)
+	ref := referenciaPendente("full", 1)
+	pending, err := s.BeginPendingRef(ref)
+	require.NoError(t, err)
+	require.NoError(t, pending.Replace(map[string][32]byte{"removido": {1}}))
+	require.NoError(t, pending.Replace(map[string][32]byte{"preservado": {2}}))
+	require.Error(t, pending.Replace(map[string][32]byte{"": {3}}))
+	require.NoError(t, s.ConfirmPending(ref, manifestoFull(ref.JobID), strings.Repeat("a", 64)))
+	committed, err := s.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"preservado": {2}}, committed)
+}
+
+func TestDeltaAvancaHashDoServidorEPreservaBaseFull(t *testing.T) {
+	s := abreStore(t)
+	full := referenciaPendente("full", 1)
+	confirmaFull(t, s, full)
+	ref := referenciaPendente("delta", 2)
+	pending, err := s.BeginPendingRef(ref)
+	require.NoError(t, err)
+	require.NoError(t, pending.Replace(map[string][32]byte{"nova": {2}}))
+	raw := manifestoFull(ref.JobID)
+	raw.SnapshotMode, raw.Sequence = manifest.SnapshotModeDelta, 2
+	base, previous := "full", strings.Repeat("a", 64)
+	raw.BaseSnapshotID, raw.PreviousManifestSHA256 = &base, &previous
+	raw.CreatedAt = raw.CreatedAt.Add(time.Hour)
+	require.NoError(t, s.ConfirmPending(ref, raw, strings.Repeat("b", 64)))
+	require.NoError(t, s.ConfirmPending(ref, raw, strings.Repeat("b", 64)))
+	snapshot, sequence, hash, created, ok, err := s.ChainHead(ref.SourceKey)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "full", snapshot)
+	require.Equal(t, uint32(2), sequence)
+	require.Equal(t, strings.Repeat("b", 64), hash)
+	require.Equal(t, manifestoFull("full").CreatedAt, created)
+	committed, err := s.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"nova": {2}}, committed)
+}
+
+func TestResposta409DescartaSomenteFonteEFenceRejeitados(t *testing.T) {
+	s := abreStore(t)
+	ref := referenciaPendente("rejeitado", 1)
+	confirmaFull(t, s, referenciaPendente("base", 1))
+	otherFence := referenciaPendente("rejeitado", 2)
+	otherSource := referenciaPendente("outra", 1)
+	otherSource.SourceKey.Source = "sihd"
+	for _, current := range []PendingRef{ref, otherFence, otherSource} {
+		pending, err := s.BeginPendingRef(current)
+		require.NoError(t, err)
+		require.NoError(t, pending.Replace(map[string][32]byte{"pk": {9}}))
+	}
+	require.NoError(t, s.RequireFull(ref, "base_missing"))
+	require.NoError(t, s.RequireFull(ref, "base_missing"))
+	reason, required, err := s.ForceFull(ref.SourceKey)
+	require.NoError(t, err)
+	require.True(t, required)
+	require.Equal(t, "base_missing", reason)
+	_, required, err = s.ForceFull(otherSource.SourceKey)
+	require.NoError(t, err)
+	require.False(t, required)
+	committed, err := s.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"base": {1}}, committed)
+	snapshot, _, _, _, ok, err := s.ChainHead(ref.SourceKey)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "base", snapshot)
+	require.Error(t, s.ConfirmPending(ref, manifestoFull(ref.JobID), strings.Repeat("a", 64)))
+	for _, current := range []PendingRef{otherFence, otherSource} {
+		err := s.ConfirmPending(current, manifestoFull(current.JobID), strings.Repeat("b", 64))
+		require.NoError(t, err)
+	}
+	_, required, err = s.ForceFull(ref.SourceKey)
+	require.NoError(t, err)
+	require.False(t, required)
+}
+
+func TestForcaFullSobreviveReinicio(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "delta.db")
+	s, err := Open(path)
+	require.NoError(t, err)
+	ref := referenciaPendente("full", 1)
+	require.NoError(t, s.RequireFull(ref, "sequence_gap"))
+	require.NoError(t, s.Close())
+	s, err = Open(path)
+	require.NoError(t, err)
+	defer s.Close()
+	reason, required, err := s.ForceFull(ref.SourceKey)
+	require.NoError(t, err)
+	require.True(t, required)
+	require.Equal(t, "sequence_gap", reason)
+}
+
+func TestConfirmacaoInvalidaMantemCabecaEPendente(t *testing.T) {
+	s := abreStore(t)
+	ref := referenciaPendente("delta", 2)
+	confirmaFull(t, s, referenciaPendente("base", 1))
+	pending, err := s.BeginPendingRef(ref)
+	require.NoError(t, err)
+	require.NoError(t, pending.Replace(map[string][32]byte{"nova": {2}}))
+	raw := manifestoFull(ref.JobID)
+	require.Error(t, s.ConfirmPending(ref, raw, "invalid"))
+	wrong := ref
+	wrong.FencingToken++
+	require.Error(t, s.ConfirmPending(wrong, raw, strings.Repeat("b", 64)))
+	committed, err := s.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"base": {1}}, committed)
+	require.NoError(t, s.ConfirmPending(ref, raw, strings.Repeat("b", 64)))
+}
+
+func TestReplayRecusaManifestoAlteradoComMesmaReferencia(t *testing.T) {
+	s := abreStore(t)
+	ref := referenciaPendente("full", 1)
+	confirmaFull(t, s, ref)
+	raw := manifestoFull(ref.JobID)
+	raw.CreatedAt = raw.CreatedAt.Add(time.Hour)
+	require.Error(t, s.ConfirmPending(ref, raw, strings.Repeat("a", 64)))
+	raw = manifestoFull(ref.JobID)
+	raw.SnapshotMode = manifest.SnapshotModeDelta
+	require.Error(t, s.ConfirmPending(ref, raw, strings.Repeat("a", 64)))
+}
+
+func TestReinicioAposConfirmacaoPermiteReplaySemRecriarPendente(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "delta.db")
+	s, err := Open(path)
+	require.NoError(t, err)
+	ref := referenciaPendente("full", 1)
+	confirmaFull(t, s, ref)
+	require.NoError(t, s.Close())
+	s, err = Open(path)
+	require.NoError(t, err)
+	defer s.Close()
+	require.NoError(t, s.ConfirmPending(ref, manifestoFull(ref.JobID), strings.Repeat("a", 64)))
+	snapshot, sequence, hash, _, ok, err := s.ChainHead(ref.SourceKey)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "full", snapshot)
+	require.Equal(t, uint32(1), sequence)
+	require.Equal(t, strings.Repeat("a", 64), hash)
+}
+
+func TestFullVazioSubstituiFingerprintsSomenteNaConfirmacao(t *testing.T) {
+	s := abreStore(t)
+	confirmaFull(t, s, referenciaPendente("base", 1))
+	ref := referenciaPendente("vazio", 2)
+	pending, err := s.BeginPendingRef(ref)
+	require.NoError(t, err)
+	require.NoError(t, pending.Replace(nil))
+	require.Error(t, pending.Commit())
+	committed, err := s.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Len(t, committed, 1)
+	require.NoError(t, s.ConfirmPending(ref, manifestoFull(ref.JobID), strings.Repeat("b", 64)))
+	committed, err = s.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Empty(t, committed)
+}
+
+func TestFalhaAoPersistirCabecaRevertePromocaoEPermiteRetry(t *testing.T) {
+	s := abreStore(t)
+	confirmaFull(t, s, referenciaPendente("base", 1))
+	ref := referenciaPendente("full", 2)
+	pending, err := s.BeginPendingRef(ref)
+	require.NoError(t, err)
+	require.NoError(t, pending.Replace(map[string][32]byte{"nova": {2}}))
+	raw := manifestoFull(ref.JobID)
+	raw.CreatedAt = time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.Error(t, s.ConfirmPending(ref, raw, strings.Repeat("b", 64)))
+	committed, err := s.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"base": {1}}, committed)
+	snapshot, sequence, hash, _, ok, err := s.ChainHead(ref.SourceKey)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "base", snapshot)
+	require.Equal(t, uint32(1), sequence)
+	require.Equal(t, strings.Repeat("a", 64), hash)
+	require.NoError(t, s.ConfirmPending(ref, manifestoFull(ref.JobID), strings.Repeat("b", 64)))
+}
+
+func TestDeltaInvalidoPreservaEstadoEFullObrigatorio(t *testing.T) {
+	s := abreStore(t)
+	confirmaFull(t, s, referenciaPendente("base", 1))
+	ref := referenciaPendente("delta", 2)
+	pending, err := s.BeginPendingRef(ref)
+	require.NoError(t, err)
+	require.NoError(t, pending.Replace(map[string][32]byte{"nova": {2}}))
+	require.NoError(t, s.RequireFull(referenciaPendente("rejeitado", 1), "base_missing"))
+	raw := manifestoFull(ref.JobID)
+	raw.SnapshotMode, raw.Sequence = manifest.SnapshotModeDelta, 3
+	base, previous := "base", strings.Repeat("a", 64)
+	raw.BaseSnapshotID, raw.PreviousManifestSHA256 = &base, &previous
+	require.Error(t, s.ConfirmPending(ref, raw, strings.Repeat("b", 64)))
+	raw.Sequence = 2
+	previous = strings.Repeat("c", 64)
+	require.Error(t, s.ConfirmPending(ref, raw, strings.Repeat("b", 64)))
+	previous = strings.Repeat("a", 64)
+	require.NoError(t, s.ConfirmPending(ref, raw, strings.Repeat("b", 64)))
+	reason, required, err := s.ForceFull(ref.SourceKey)
+	require.NoError(t, err)
+	require.True(t, required)
+	require.Equal(t, "base_missing", reason)
+}
+
+func abreStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "delta.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	return s
+}
+
+func referenciaPendente(job string, fence uint64) PendingRef {
+	return PendingRef{
+		SourceKey: SourceKey{Source: "cnes", Intent: "estabelecimentos", Competencia: "202605"},
+		JobID:     job, FencingToken: fence,
+	}
+}
+
+func manifestoFull(job string) manifest.Raw {
+	return manifest.Raw{
+		ManifestID: job, SnapshotID: job, SnapshotMode: manifest.SnapshotModeFull,
+		Sequence: 1, CreatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func confirmaFull(t *testing.T, s *Store, ref PendingRef) {
+	t.Helper()
+	pending, err := s.BeginPendingRef(ref)
+	require.NoError(t, err)
+	require.NoError(t, pending.Replace(map[string][32]byte{"base": {1}}))
+	require.NoError(t, s.ConfirmPending(ref, manifestoFull(ref.JobID), strings.Repeat("a", 64)))
 }
 
 func TestStore_GetCommitted_Empty(t *testing.T) {

--- a/apps/dump_agent_go/internal/manifest/raw.go
+++ b/apps/dump_agent_go/internal/manifest/raw.go
@@ -1,0 +1,312 @@
+package manifest
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type SourceType string
+
+const (
+	SourceTypeCNESLocal    SourceType = "CNES_LOCAL"
+	SourceTypeCNESNacional SourceType = "CNES_NACIONAL"
+	SourceTypeSIHD         SourceType = "SIHD"
+	SourceTypeBPAMag       SourceType = "BPA_MAG"
+	SourceTypeSIALocal     SourceType = "SIA_LOCAL"
+)
+
+type SnapshotMode string
+
+const (
+	SnapshotModeFull  SnapshotMode = "FULL"
+	SnapshotModeDelta SnapshotMode = "DELTA"
+)
+
+type Raw struct {
+	ManifestVersion        int          `json:"manifest_version"`
+	ManifestID             string       `json:"manifest_id"`
+	TenantID               string       `json:"tenant_id"`
+	SourceType             SourceType   `json:"source_type"`
+	FileSubtype            string       `json:"file_subtype"`
+	Competencia            string       `json:"competencia"`
+	AgentID                string       `json:"agent_id"`
+	AgentVersion           string       `json:"agent_version"`
+	SchemaVersion          string       `json:"schema_version"`
+	SnapshotMode           SnapshotMode `json:"snapshot_mode"`
+	SnapshotID             string       `json:"snapshot_id"`
+	BaseSnapshotID         *string      `json:"base_snapshot_id"`
+	Sequence               uint32       `json:"sequence"`
+	PreviousManifestSHA256 *string      `json:"previous_manifest_sha256"`
+	ObjectSHA256           string       `json:"object_sha256"`
+	RowCount               int64        `json:"row_count"`
+	SizeBytes              int64        `json:"size_bytes"`
+	ObjectKey              string       `json:"object_key"`
+	CreatedAt              time.Time    `json:"created_at"`
+}
+
+type PreviousHead struct {
+	SnapshotID     string
+	Sequence       uint32
+	ManifestSHA256 string
+}
+
+type BuildRequest struct {
+	JobID         string
+	TenantID      string
+	SourceType    SourceType
+	FileSubtype   string
+	Competencia   string
+	AgentID       string
+	AgentVersion  string
+	SchemaVersion string
+	SnapshotMode  SnapshotMode
+	ObjectSHA256  string
+	RowCount      int64
+	SizeBytes     int64
+	CreatedAt     time.Time
+	Previous      *PreviousHead
+}
+
+var (
+	competenciaPattern = regexp.MustCompile(`^[0-9]{4}-(0[1-9]|1[0-2])$`)
+	hashPattern        = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	safeSegmentPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+)
+
+func Build(request BuildRequest) (Raw, error) {
+	baseSnapshotID, sequence, previousHash, err := buildChain(request)
+	if err != nil {
+		return Raw{}, err
+	}
+	raw := Raw{
+		ManifestVersion: 1, ManifestID: request.JobID, TenantID: request.TenantID,
+		SourceType: request.SourceType, FileSubtype: request.FileSubtype,
+		Competencia: request.Competencia, AgentID: request.AgentID,
+		AgentVersion: request.AgentVersion, SchemaVersion: request.SchemaVersion,
+		SnapshotMode: request.SnapshotMode, SnapshotID: request.JobID,
+		BaseSnapshotID: baseSnapshotID, Sequence: sequence,
+		PreviousManifestSHA256: previousHash, ObjectSHA256: request.ObjectSHA256,
+		RowCount: request.RowCount, SizeBytes: request.SizeBytes,
+		CreatedAt: request.CreatedAt,
+	}
+	raw.ObjectKey = rawObjectKey(raw)
+	if err := validateRaw(raw); err != nil {
+		return Raw{}, err
+	}
+	return raw, nil
+}
+
+func CanonicalJSON(raw Raw) ([]byte, error) {
+	if err := validateRaw(raw); err != nil {
+		return nil, err
+	}
+	var output bytes.Buffer
+	encoder := json.NewEncoder(&output)
+	encoder.SetEscapeHTML(false)
+	type fields Raw
+	value := struct {
+		*fields
+		CreatedAt string `json:"created_at"`
+	}{(*fields)(&raw), pythonTimestamp(raw.CreatedAt)}
+	if err := encoder.Encode(value); err != nil {
+		return nil, fmt.Errorf("json=%w", err)
+	}
+	return pythonSeparators(bytes.TrimSuffix(output.Bytes(), []byte{'\n'})), nil
+}
+
+func pythonTimestamp(value time.Time) string {
+	if value.Nanosecond() == 0 {
+		return value.Format(time.RFC3339)
+	}
+	return value.Format("2006-01-02T15:04:05.000000Z")
+}
+
+func pythonSeparators(input []byte) []byte {
+	var output bytes.Buffer
+	for i := 0; i < len(input); i++ {
+		if input[i] != '\\' || i+1 >= len(input) {
+			output.WriteByte(input[i])
+			continue
+		}
+		if i+6 <= len(input) && string(input[i:i+5]) == `\u202` &&
+			(input[i+5] == '8' || input[i+5] == '9') {
+			output.WriteRune('\u2028' + rune(input[i+5]-'8'))
+			i += 5
+			continue
+		}
+		output.Write(input[i : i+2])
+		i++
+	}
+	return output.Bytes()
+}
+
+func SHA256(raw Raw) (string, error) {
+	payload, err := CanonicalJSON(raw)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func buildChain(request BuildRequest) (*string, uint32, *string, error) {
+	switch request.SnapshotMode {
+	case SnapshotModeFull:
+		return nil, 1, nil, nil
+	case SnapshotModeDelta:
+		if err := validatePrevious(request.Previous); err != nil {
+			return nil, 0, nil, err
+		}
+		base := request.Previous.SnapshotID
+		previousHash := request.Previous.ManifestSHA256
+		return &base, request.Previous.Sequence + 1, &previousHash, nil
+	default:
+		return nil, 0, nil, invalid("snapshot_mode")
+	}
+}
+
+func validatePrevious(previous *PreviousHead) error {
+	if previous == nil {
+		return invalid("previous")
+	}
+	if !safeSegmentPattern.MatchString(previous.SnapshotID) {
+		return invalid("previous_snapshot_id")
+	}
+	if previous.Sequence == 0 || previous.Sequence == ^uint32(0) {
+		return invalid("previous_sequence")
+	}
+	if !hashPattern.MatchString(previous.ManifestSHA256) {
+		return invalid("previous_manifest_sha256")
+	}
+	return nil
+}
+
+func validateRaw(raw Raw) error {
+	if raw.ManifestVersion != 1 {
+		return invalid("manifest_version")
+	}
+	if err := validateRequired(raw); err != nil {
+		return err
+	}
+	if !validSourceType(raw.SourceType) {
+		return invalid("source_type")
+	}
+	if !competenciaPattern.MatchString(raw.Competencia) {
+		return invalid("competencia")
+	}
+	if !hashPattern.MatchString(raw.ObjectSHA256) {
+		return invalid("object_sha256")
+	}
+	if raw.RowCount < 0 || raw.SizeBytes <= 0 {
+		return invalid("cardinality")
+	}
+	if err := validateTimestamp(raw.CreatedAt); err != nil {
+		return err
+	}
+	if err := validateChain(raw); err != nil {
+		return err
+	}
+	return validateObjectKey(raw)
+}
+
+func validateTimestamp(value time.Time) error {
+	if _, offset := value.Zone(); offset != 0 {
+		return invalid("created_at")
+	}
+	if value.Nanosecond()%1000 != 0 {
+		return invalid("created_at_precision")
+	}
+	return nil
+}
+
+func validateRequired(raw Raw) error {
+	values := []struct {
+		name  string
+		value string
+	}{
+		{"manifest_id", raw.ManifestID}, {"tenant_id", raw.TenantID},
+		{"file_subtype", raw.FileSubtype}, {"agent_id", raw.AgentID},
+		{"agent_version", raw.AgentVersion}, {"schema_version", raw.SchemaVersion},
+		{"snapshot_id", raw.SnapshotID}, {"object_key", raw.ObjectKey},
+	}
+	for _, field := range values {
+		if field.value == "" {
+			return invalid(field.name)
+		}
+	}
+	return nil
+}
+
+func validateChain(raw Raw) error {
+	switch raw.SnapshotMode {
+	case SnapshotModeFull:
+		if raw.Sequence != 1 || raw.BaseSnapshotID != nil || raw.PreviousManifestSHA256 != nil {
+			return invalid("full_chain")
+		}
+	case SnapshotModeDelta:
+		return validateDeltaChain(raw)
+	default:
+		return invalid("snapshot_mode")
+	}
+	return nil
+}
+
+func validateDeltaChain(raw Raw) error {
+	if raw.Sequence < 2 || raw.BaseSnapshotID == nil || *raw.BaseSnapshotID == "" {
+		return invalid("delta_chain")
+	}
+	if raw.PreviousManifestSHA256 == nil ||
+		!hashPattern.MatchString(*raw.PreviousManifestSHA256) {
+		return invalid("previous_manifest_sha256")
+	}
+	return nil
+}
+
+func validateObjectKey(raw Raw) error {
+	parts := strings.Split(raw.ObjectKey, "/")
+	if len(parts) != 6 {
+		return invalid("object_key_layout")
+	}
+	for _, part := range parts {
+		if !safeSegmentPattern.MatchString(part) {
+			return invalid("object_key_segment")
+		}
+	}
+	wantPrefix := []string{
+		"raw", raw.TenantID, string(raw.SourceType), raw.Competencia, raw.SnapshotID,
+	}
+	if strings.Join(parts[:5], "/") != strings.Join(wantPrefix, "/") {
+		return invalid("object_key_identity")
+	}
+	if parts[5] != "data.parquet" {
+		return invalid("object_key_filename")
+	}
+	return nil
+}
+
+func validSourceType(sourceType SourceType) bool {
+	switch sourceType {
+	case SourceTypeCNESLocal, SourceTypeCNESNacional, SourceTypeSIHD,
+		SourceTypeBPAMag, SourceTypeSIALocal:
+		return true
+	default:
+		return false
+	}
+}
+
+func rawObjectKey(raw Raw) string {
+	return fmt.Sprintf(
+		"raw/%s/%s/%s/%s/data.parquet",
+		raw.TenantID, raw.SourceType, raw.Competencia, raw.SnapshotID,
+	)
+}
+
+func invalid(field string) error {
+	return fmt.Errorf("field=%s", field)
+}

--- a/apps/dump_agent_go/internal/manifest/raw_test.go
+++ b/apps/dump_agent_go/internal/manifest/raw_test.go
@@ -1,0 +1,186 @@
+package manifest
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const goldenSHA256 = "9c6005f90bbc5af3bcb3c5469474e44ea895e4e2e8ef27e014e0933e45af0e99"
+
+func TestManifestoRawCorrespondeAoGoldenPython(t *testing.T) {
+	want, err := os.ReadFile("../../../../docs/fixtures/data-plane/raw-manifest-v1.json")
+	require.NoError(t, err)
+	require.Len(t, want, 630)
+
+	got, err := Build(goldenRequest())
+	require.NoError(t, err)
+	require.Equal(t, "fixture-cnes-nacional-v1", got.ManifestID)
+	require.Equal(t, got.ManifestID, got.SnapshotID)
+	require.Nil(t, got.BaseSnapshotID)
+	require.Nil(t, got.PreviousManifestSHA256)
+	require.Equal(t, uint32(1), got.Sequence)
+
+	payload, err := CanonicalJSON(got)
+	require.NoError(t, err)
+	require.Equal(t, want, payload)
+
+	digest, err := SHA256(got)
+	require.NoError(t, err)
+	require.Equal(t, goldenSHA256, digest)
+}
+
+func TestConstrucaoDeltaCarregaBaseSequenciaEHashDoServidor(t *testing.T) {
+	serverHash := strings.Repeat("b", 64)
+	request := goldenRequest()
+	request.JobID = "job-delta-2"
+	request.SnapshotMode = SnapshotModeDelta
+	request.Previous = &PreviousHead{
+		SnapshotID:     "job-full-1",
+		Sequence:       7,
+		ManifestSHA256: serverHash,
+	}
+
+	got, err := Build(request)
+
+	require.NoError(t, err)
+	require.Equal(t, "job-delta-2", got.ManifestID)
+	require.Equal(t, "job-delta-2", got.SnapshotID)
+	require.Equal(t, "job-full-1", *got.BaseSnapshotID)
+	require.Equal(t, uint32(8), got.Sequence)
+	require.Equal(t, serverHash, *got.PreviousManifestSHA256)
+	require.Equal(t,
+		"raw/354130/CNES_NACIONAL/2026-01/job-delta-2/data.parquet",
+		got.ObjectKey,
+	)
+}
+
+func TestConstrucaoRejeitaContratoRawInvalido(t *testing.T) {
+	tests := map[string]func(*BuildRequest){
+		"identificador vazio": func(r *BuildRequest) { r.JobID = "" },
+		"fonte desconhecida":  func(r *BuildRequest) { r.SourceType = "OUTRA" },
+		"subtipo vazio":       func(r *BuildRequest) { r.FileSubtype = "" },
+		"competencia invalida": func(r *BuildRequest) {
+			r.Competencia = "2026-13"
+		},
+		"agente vazio":      func(r *BuildRequest) { r.AgentID = "" },
+		"versao vazia":      func(r *BuildRequest) { r.AgentVersion = "" },
+		"schema vazio":      func(r *BuildRequest) { r.SchemaVersion = "" },
+		"modo desconhecido": func(r *BuildRequest) { r.SnapshotMode = "OUTRO" },
+		"hash invalido":     func(r *BuildRequest) { r.ObjectSHA256 = strings.Repeat("A", 64) },
+		"linhas negativas":  func(r *BuildRequest) { r.RowCount = -1 },
+		"tamanho vazio":     func(r *BuildRequest) { r.SizeBytes = 0 },
+		"timestamp fora de UTC": func(r *BuildRequest) {
+			r.CreatedAt = time.Date(2026, 2, 1, 0, 0, 0, 0, time.FixedZone("BRT", -3*60*60))
+		},
+	}
+
+	for name, change := range tests {
+		t.Run(name, func(t *testing.T) {
+			request := goldenRequest()
+			change(&request)
+
+			_, err := Build(request)
+
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDeltaExigeCabecaAnteriorValida(t *testing.T) {
+	tests := map[string]*PreviousHead{
+		"ausente":        nil,
+		"snapshot vazio": {Sequence: 1, ManifestSHA256: strings.Repeat("a", 64)},
+		"sequencia zero": {SnapshotID: "job-full-1", ManifestSHA256: strings.Repeat("a", 64)},
+		"hash invalido":  {SnapshotID: "job-full-1", Sequence: 1, ManifestSHA256: "abc"},
+		"sequencia maxima": {
+			SnapshotID: "job-full-1", Sequence: ^uint32(0), ManifestSHA256: strings.Repeat("a", 64),
+		},
+	}
+
+	for name, previous := range tests {
+		t.Run(name, func(t *testing.T) {
+			request := goldenRequest()
+			request.SnapshotMode = SnapshotModeDelta
+			request.Previous = previous
+
+			_, err := Build(request)
+
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestManifestoRawRejeitaNomeDeObjetoDiferenteDeDataParquet(t *testing.T) {
+	raw, err := Build(goldenRequest())
+	require.NoError(t, err)
+	raw.ObjectKey = strings.Replace(raw.ObjectKey, "data.parquet", "outro.parquet", 1)
+	operations := map[string]func(Raw) error{
+		"json canonico": func(raw Raw) error {
+			_, err := CanonicalJSON(raw)
+			return err
+		},
+		"sha256": func(raw Raw) error {
+			_, err := SHA256(raw)
+			return err
+		},
+	}
+
+	for name, operation := range operations {
+		t.Run(name, func(t *testing.T) {
+			require.EqualError(t, operation(raw), "field=object_key_filename")
+		})
+	}
+}
+
+func goldenRequest() BuildRequest {
+	return BuildRequest{
+		JobID:         "fixture-cnes-nacional-v1",
+		TenantID:      "354130",
+		SourceType:    SourceTypeCNESNacional,
+		FileSubtype:   "CNES_VINCULO",
+		Competencia:   "2026-01",
+		AgentID:       "system-datasus",
+		AgentVersion:  "1.0.0",
+		SchemaVersion: "cnes-profissional-v1",
+		SnapshotMode:  SnapshotModeFull,
+		ObjectSHA256:  "30a60a84af9b06c568fe6170ce72365ee33cb1a706f130cc5bc7e197aef348ec",
+		RowCount:      5,
+		SizeBytes:     5123,
+		CreatedAt:     time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestJSONCanonicoPreservaMicrossegundosESeparadoresUnicodeDoPython(t *testing.T) {
+	request := goldenRequest()
+	request.CreatedAt = request.CreatedAt.Add(100000 * time.Microsecond)
+	request.AgentVersion = "line\u2028paragraph\u2029 literal\\u2028"
+	raw, err := Build(request)
+	require.NoError(t, err)
+	want, err := os.ReadFile("../../../../docs/fixtures/data-plane/raw-manifest-v1.json")
+	require.NoError(t, err)
+	expected := strings.Replace(string(want), `"agent_version":"1.0.0"`,
+		"\"agent_version\":\"line\u2028paragraph\u2029 literal\\\\u2028\"", 1)
+	expected = strings.Replace(expected, "00:00:00Z", "00:00:00.100000Z", 1)
+	payload, err := CanonicalJSON(raw)
+	require.NoError(t, err)
+	require.Equal(t, expected, string(payload))
+	hash, err := SHA256(raw)
+	require.NoError(t, err)
+	require.Equal(t, "8db9c1d06145a284d24c9cea25463666b5de83b47ed349a4b68f48f1509c9100", hash)
+}
+
+func TestManifestoRejeitaPrecisaoInferiorAMicrossegundo(t *testing.T) {
+	request := goldenRequest()
+	request.CreatedAt = request.CreatedAt.Add(time.Nanosecond)
+	_, err := Build(request)
+	require.Error(t, err)
+	raw, err := Build(goldenRequest())
+	require.NoError(t, err)
+	raw.CreatedAt = raw.CreatedAt.Add(time.Nanosecond)
+	_, err = CanonicalJSON(raw)
+	require.Error(t, err)
+}

--- a/apps/dump_agent_go/internal/manifest/raw_test.go
+++ b/apps/dump_agent_go/internal/manifest/raw_test.go
@@ -136,6 +136,7 @@ func TestManifestoRawRejeitaNomeDeObjetoDiferenteDeDataParquet(t *testing.T) {
 	}
 }
 
+//nolint:misspell // cnes-profissional-v1 is frozen by the cross-language golden.
 func goldenRequest() BuildRequest {
 	return BuildRequest{
 		JobID:         "fixture-cnes-nacional-v1",

--- a/apps/dump_agent_go/internal/queue/envelope.go
+++ b/apps/dump_agent_go/internal/queue/envelope.go
@@ -1,14 +1,19 @@
 // Package queue — bbolt-backed persistent outbox + classification.
 package queue
 
-import "time"
+import (
+	"time"
+
+	"github.com/cnesdata/dumpagent/internal/delta"
+)
 
 // EnvelopeType discriminates persisted outbound API calls.
 type EnvelopeType string
 
 const (
-	TypeComplete EnvelopeType = "complete"
-	TypeFail     EnvelopeType = "fail"
+	TypeComplete    EnvelopeType = "complete"
+	TypeFail        EnvelopeType = "fail"
+	TypeRawManifest EnvelopeType = "raw_manifest"
 )
 
 // Envelope is a single outbound API call persisted in the outbox.
@@ -16,13 +21,20 @@ const (
 // SHA256 + MinioKey are set for TypeComplete (FU1 RegisterJob dispatch)
 // so drain replay after agent restart can rebuild the full Job payload.
 type Envelope struct {
-	Type       EnvelopeType `json:"type"`
-	JobUUID    string       `json:"job_uuid"`
-	SizeBytes  int64        `json:"size_bytes,omitempty"`
-	SHA256     string       `json:"sha256,omitempty"`
-	MinioKey   string       `json:"minio_key,omitempty"`
-	Cause      string       `json:"cause,omitempty"`
-	EnqueuedAt time.Time    `json:"enqueued_at"`
-	Attempts   int          `json:"attempts"`
-	LastError  string       `json:"last_error,omitempty"`
+	Type           EnvelopeType    `json:"type"`
+	JobUUID        string          `json:"job_uuid"`
+	SizeBytes      int64           `json:"size_bytes,omitempty"`
+	SHA256         string          `json:"sha256,omitempty"`
+	MinioKey       string          `json:"minio_key,omitempty"`
+	Cause          string          `json:"cause,omitempty"`
+	EnqueuedAt     time.Time       `json:"enqueued_at"`
+	Attempts       int             `json:"attempts"`
+	LastError      string          `json:"last_error,omitempty"`
+	JobID          string          `json:"job_id,omitempty"`
+	FencingToken   uint64          `json:"fencing_token,omitempty"`
+	SourceKey      delta.SourceKey `json:"source_key,omitzero"`
+	ManifestJSON   []byte          `json:"manifest_json,omitempty"`
+	ManifestSHA256 string          `json:"manifest_sha256,omitempty"`
+	SpoolName      string          `json:"spool_name,omitempty"`
+	UploadURL      string          `json:"upload_url,omitempty"`
 }

--- a/apps/dump_agent_go/internal/queue/envelope_test.go
+++ b/apps/dump_agent_go/internal/queue/envelope_test.go
@@ -2,9 +2,36 @@ package queue
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 )
+
+func TestEnvelopeRawPreservaIdentidadeEBytes(t *testing.T) {
+	in := rawEnvelope(t, "job-1", 7)
+	payload, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{
+		"job_id", "fencing_token", "source_key", "manifest_json", "manifest_sha256",
+	} {
+		if _, ok := fields[field]; !ok {
+			t.Errorf("missing_field=%s", field)
+		}
+	}
+	var out Envelope
+	if err := json.Unmarshal(payload, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatal("identity_changed=true")
+	}
+}
 
 func TestEnvelope_RoundTripComplete(t *testing.T) {
 	now := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)

--- a/apps/dump_agent_go/internal/queue/outbox.go
+++ b/apps/dump_agent_go/internal/queue/outbox.go
@@ -1,25 +1,26 @@
 package queue
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"time"
 
 	"go.etcd.io/bbolt"
 )
 
 const bucketName = "outbox"
+const rawIndexBucket = "raw_job_fence"
+const rawTerminalBucket = "raw_terminal"
 
 // Outbox wraps *bbolt.DB with FIFO semantics over a single bucket.
-// Keys are 12 bytes: BigEndian(unix_ns)[8] || atomic_seq[4]. Values are
+// Keys are 12 bytes: BigEndian(unix_ns)[8] || durable_seq[4]. Values are
 // JSON-encoded Envelopes. Each Append commits its own transaction (fsync).
 type Outbox struct {
 	db      *bbolt.DB
-	seq     atomic.Uint32
 	nowFunc func() time.Time
 }
 
@@ -40,8 +41,12 @@ func Open(path string) (*Outbox, error) {
 		return nil, fmt.Errorf("outbox: open: %w", err)
 	}
 	if err := db.Update(func(tx *bbolt.Tx) error {
-		_, e := tx.CreateBucketIfNotExists([]byte(bucketName))
-		return e
+		for _, name := range []string{bucketName, rawIndexBucket, rawTerminalBucket} {
+			if _, err := tx.CreateBucketIfNotExists([]byte(name)); err != nil {
+				return err
+			}
+		}
+		return nil
 	}); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("outbox: bucket: %w", err)
@@ -58,10 +63,64 @@ func (o *Outbox) Append(env Envelope) error {
 	if err != nil {
 		return fmt.Errorf("outbox: marshal: %w", err)
 	}
-	key := o.makeKey(env.EnqueuedAt)
 	return o.db.Update(func(tx *bbolt.Tx) error {
-		return tx.Bucket([]byte(bucketName)).Put(key, payload)
+		if env.Type == TypeRawManifest {
+			return o.appendRaw(tx, env, payload)
+		}
+		_, err := persistEnvelope(tx.Bucket([]byte(bucketName)), env, payload)
+		return err
 	})
+}
+
+func (o *Outbox) appendRaw(tx *bbolt.Tx, env Envelope, payload []byte) error {
+	if err := validateRawIdentity(env); err != nil {
+		return err
+	}
+	index := tx.Bucket([]byte(rawIndexBucket))
+	b := tx.Bucket([]byte(bucketName))
+	identity := rawIdentity(env)
+	if key := index.Get(identity); key != nil {
+		var existing Envelope
+		if err := json.Unmarshal(b.Get(key), &existing); err != nil {
+			return fmt.Errorf("raw_envelope_index_invalid=%w", err)
+		}
+		if existing.SourceKey != env.SourceKey || existing.ManifestSHA256 != env.ManifestSHA256 ||
+			existing.SpoolName != env.SpoolName || existing.UploadURL != env.UploadURL ||
+			!bytes.Equal(existing.ManifestJSON, env.ManifestJSON) {
+			return fmt.Errorf("raw_envelope_conflict=true job_id=%s fence=%d", env.JobID, env.FencingToken)
+		}
+		return nil
+	}
+	key, err := persistEnvelope(b, env, payload)
+	if err != nil {
+		return err
+	}
+	return index.Put(identity, key)
+}
+
+func validateRawIdentity(env Envelope) error {
+	if env.JobID == "" || env.FencingToken == 0 || env.SourceKey.Source == "" ||
+		env.SourceKey.Intent == "" || env.SourceKey.Competencia == "" ||
+		len(env.ManifestJSON) == 0 || env.ManifestSHA256 == "" {
+		return fmt.Errorf("raw_envelope_identity_incomplete=true")
+	}
+	return nil
+}
+
+func persistEnvelope(b *bbolt.Bucket, env Envelope, payload []byte) ([]byte, error) {
+	for {
+		key, err := makeKey(b, env.EnqueuedAt)
+		if err != nil {
+			return nil, err
+		}
+		if b.Get(key) == nil {
+			return key, b.Put(key, payload)
+		}
+	}
+}
+
+func rawIdentity(env Envelope) []byte {
+	return binary.BigEndian.AppendUint64(append([]byte(env.JobID), 0), env.FencingToken)
 }
 
 // Peek returns up to n oldest items in FIFO order.
@@ -85,14 +144,49 @@ func (o *Outbox) Peek(n int) ([]Item, error) {
 // Delete removes the given keys atomically.
 func (o *Outbox) Delete(keys ...[]byte) error {
 	return o.db.Update(func(tx *bbolt.Tx) error {
-		b := tx.Bucket([]byte(bucketName))
 		for _, k := range keys {
-			if err := b.Delete(k); err != nil {
+			if err := deleteEnvelope(tx, k); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+}
+
+// RawTerminal consulta o recibo que autoriza a limpeza do spool.
+func (o *Outbox) RawTerminal(key []byte) (bool, error) {
+	var terminal bool
+	err := o.db.View(func(tx *bbolt.Tx) error {
+		terminal = tx.Bucket([]byte(rawTerminalBucket)).Get(key) != nil
+		return nil
+	})
+	return terminal, err
+}
+
+// MarkRawTerminal persiste o recibo somente para um envelope raw existente.
+func (o *Outbox) MarkRawTerminal(key []byte) error {
+	return o.db.Update(func(tx *bbolt.Tx) error {
+		var env Envelope
+		if json.Unmarshal(tx.Bucket([]byte(bucketName)).Get(key), &env) != nil ||
+			env.Type != TypeRawManifest {
+			return fmt.Errorf("raw_terminal=envelope_missing")
+		}
+		return tx.Bucket([]byte(rawTerminalBucket)).Put(key, []byte{1})
+	})
+}
+
+func deleteEnvelope(tx *bbolt.Tx, key []byte) error {
+	b := tx.Bucket([]byte(bucketName))
+	var env Envelope
+	if json.Unmarshal(b.Get(key), &env) == nil && env.Type == TypeRawManifest {
+		if err := tx.Bucket([]byte(rawIndexBucket)).Delete(rawIdentity(env)); err != nil {
+			return err
+		}
+	}
+	if err := tx.Bucket([]byte(rawTerminalBucket)).Delete(key); err != nil {
+		return err
+	}
+	return b.Delete(key)
 }
 
 // Evict drops envelopes older than maxAge first; if remaining count > maxCount,
@@ -127,7 +221,7 @@ func evictByTTL(b *bbolt.Bucket, cutoff time.Time) (int, error) {
 			keys = append(keys, append([]byte(nil), k...))
 			return nil
 		}
-		if env.EnqueuedAt.Before(cutoff) {
+		if env.Type != TypeRawManifest && env.EnqueuedAt.Before(cutoff) {
 			keys = append(keys, append([]byte(nil), k...))
 		}
 		return nil
@@ -139,17 +233,22 @@ func evictByTTL(b *bbolt.Bucket, cutoff time.Time) (int, error) {
 
 // evictByCap deletes the oldest entries beyond maxCount. No-op if under cap.
 func evictByCap(b *bbolt.Bucket, maxCount int) (int, error) {
-	remaining := b.Stats().KeyN
-	if remaining <= maxCount {
-		return 0, nil
-	}
-	toDrop := remaining - maxCount
 	c := b.Cursor()
-	keys := make([][]byte, 0, toDrop)
-	for k, _ := c.First(); k != nil && len(keys) < toDrop; k, _ = c.Next() {
+	var keys [][]byte
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		var env Envelope
+		if json.Unmarshal(v, &env) == nil && env.Type == TypeRawManifest {
+			continue
+		}
 		keys = append(keys, append([]byte(nil), k...))
 	}
-	return deleteAll(b, keys)
+	if maxCount < 0 {
+		maxCount = 0
+	}
+	if len(keys) <= maxCount {
+		return 0, nil
+	}
+	return deleteAll(b, keys[:len(keys)-maxCount])
 }
 
 func deleteAll(b *bbolt.Bucket, keys [][]byte) (int, error) {
@@ -171,10 +270,14 @@ func (o *Outbox) Close() error {
 	return err
 }
 
-func (o *Outbox) makeKey(t time.Time) []byte {
+func makeKey(b *bbolt.Bucket, t time.Time) ([]byte, error) {
+	seq, err := b.NextSequence()
+	if err != nil {
+		return nil, err
+	}
 	key := make([]byte, 12)
 	// UnixNano is non-negative for any time >= 1970-01-01; safe to cast.
 	binary.BigEndian.PutUint64(key[0:8], uint64(t.UnixNano())) //nolint:gosec // G115
-	binary.BigEndian.PutUint32(key[8:12], o.seq.Add(1))
-	return key
+	binary.BigEndian.PutUint32(key[8:12], uint32(seq&0xffffffff))
+	return key, nil
 }

--- a/apps/dump_agent_go/internal/queue/outbox.go
+++ b/apps/dump_agent_go/internal/queue/outbox.go
@@ -120,7 +120,31 @@ func persistEnvelope(b *bbolt.Bucket, env Envelope, payload []byte) ([]byte, err
 }
 
 func rawIdentity(env Envelope) []byte {
-	return binary.BigEndian.AppendUint64(append([]byte(env.JobID), 0), env.FencingToken)
+	return rawIdentityFor(env.JobID, env.FencingToken)
+}
+
+func rawIdentityFor(jobID string, fencingToken uint64) []byte {
+	return binary.BigEndian.AppendUint64(append([]byte(jobID), 0), fencingToken)
+}
+
+// RawItem consulta um envelope raw pelo índice durável de job e fence.
+func (o *Outbox) RawItem(jobID string, fencingToken uint64) (Item, bool, error) {
+	var item Item
+	var found bool
+	err := o.db.View(func(tx *bbolt.Tx) error {
+		key := tx.Bucket([]byte(rawIndexBucket)).Get(rawIdentityFor(jobID, fencingToken))
+		if key == nil {
+			return nil
+		}
+		payload := tx.Bucket([]byte(bucketName)).Get(key)
+		if err := json.Unmarshal(payload, &item.Envelope); err != nil {
+			return fmt.Errorf("raw_envelope_index_invalid=%w", err)
+		}
+		item.Key = append([]byte(nil), key...)
+		found = true
+		return nil
+	})
+	return item, found, err
 }
 
 // Peek returns up to n oldest items in FIFO order.

--- a/apps/dump_agent_go/internal/queue/outbox.go
+++ b/apps/dump_agent_go/internal/queue/outbox.go
@@ -275,9 +275,12 @@ func makeKey(b *bbolt.Bucket, t time.Time) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if seq > uint64(^uint32(0)) {
+		return nil, fmt.Errorf("outbox_sequence=overflow")
+	}
 	key := make([]byte, 12)
 	// UnixNano is non-negative for any time >= 1970-01-01; safe to cast.
 	binary.BigEndian.PutUint64(key[0:8], uint64(t.UnixNano())) //nolint:gosec // G115
-	binary.BigEndian.PutUint32(key[8:12], uint32(seq&0xffffffff))
+	binary.BigEndian.PutUint32(key[8:12], uint32(seq))         //nolint:gosec // Bounds checked above.
 	return key, nil
 }

--- a/apps/dump_agent_go/internal/queue/outbox_test.go
+++ b/apps/dump_agent_go/internal/queue/outbox_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"go.etcd.io/bbolt"
 )
 
 func rawEnvelope(t *testing.T, job string, fence uint64) Envelope {
@@ -352,6 +354,19 @@ func TestOutbox_CloseIdempotent(t *testing.T) {
 	}
 	if err := ob.Close(); err != nil {
 		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func TestOutbox_RejeitaOverflowDaSequencia(t *testing.T) {
+	ob, _ := newTestOutbox(t)
+	err := ob.db.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket([]byte(bucketName)).SetSequence(uint64(^uint32(0)))
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ob.Append(Envelope{JobUUID: "overflow"}); err == nil {
+		t.Fatal("expected sequence overflow")
 	}
 }
 

--- a/apps/dump_agent_go/internal/queue/outbox_test.go
+++ b/apps/dump_agent_go/internal/queue/outbox_test.go
@@ -101,6 +101,18 @@ func TestNovoFenceCriaEnvelopeImutavel(t *testing.T) {
 	}
 }
 
+func TestRawItemConsultaIndicePorJobEFence(t *testing.T) {
+	ob, _ := newTestOutbox(t)
+	require.NoError(t, ob.Append(rawEnvelope(t, "job", 7)))
+	item, ok, err := ob.RawItem("job", 7)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(7), item.Envelope.FencingToken)
+	_, ok, err = ob.RawItem("job", 8)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
 func TestRejeitaReplayRawComIdentidadeDivergente(t *testing.T) {
 	for _, field := range []string{"source_key", "manifest_json", "manifest_sha256"} {
 		t.Run(field, func(t *testing.T) {

--- a/apps/dump_agent_go/internal/queue/outbox_test.go
+++ b/apps/dump_agent_go/internal/queue/outbox_test.go
@@ -1,11 +1,199 @@
 package queue
 
 import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/require"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
 )
+
+func rawEnvelope(t *testing.T, job string, fence uint64) Envelope {
+	t.Helper()
+	payload := fmt.Sprintf(`{"type":"raw_manifest","job_id":%q,"fencing_token":%d,
+		"source_key":{"Source":"CNES","Intent":"VINCULO","Competencia":"2026-01"},
+		"manifest_json":"e30=","manifest_sha256":"abc"}`, job, fence)
+	var env Envelope
+	if err := json.Unmarshal([]byte(payload), &env); err != nil {
+		t.Fatal(err)
+	}
+	return env
+}
+
+func TestReciboTerminalSobreviveReinicioEDeletaJuntoDoEnvelope(t *testing.T) {
+	out, path := newTestOutbox(t)
+	require.NoError(t, out.Append(rawEnvelope(t, "job", 1)))
+	items, err := out.Peek(10)
+	require.NoError(t, err)
+	require.NoError(t, out.MarkRawTerminal(items[0].Key))
+	require.NoError(t, out.Close())
+	out, err = Open(path)
+	require.NoError(t, err)
+	defer out.Close()
+	terminal, err := out.RawTerminal(items[0].Key)
+	require.NoError(t, err)
+	require.True(t, terminal)
+	require.NoError(t, out.Delete(items[0].Key))
+	terminal, err = out.RawTerminal(items[0].Key)
+	require.NoError(t, err)
+	require.False(t, terminal)
+	require.Error(t, out.MarkRawTerminal(items[0].Key))
+}
+
+func TestEnvelopeRawNaoExpiraPorTTLOuLimite(t *testing.T) {
+	ob, _ := newTestOutbox(t)
+	now := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	ob.nowFunc = func() time.Time { return now }
+	old := rawEnvelope(t, "old", 1)
+	old.EnqueuedAt = now.Add(-100 * 24 * time.Hour)
+	for _, env := range []Envelope{
+		old, rawEnvelope(t, "new", 2),
+		{Type: TypeComplete, JobUUID: "expired", EnqueuedAt: old.EnqueuedAt},
+		{Type: TypeComplete, JobUUID: "cap"}, {Type: TypeComplete, JobUUID: "kept"},
+	} {
+		if err := ob.Append(env); err != nil {
+			t.Fatal(err)
+		}
+	}
+	deleted, err := ob.Evict(90*24*time.Hour, 1)
+	if err != nil || deleted != 2 {
+		t.Fatalf("deleted=%d error=%v want=2", deleted, err)
+	}
+	items, err := ob.Peek(10)
+	if err != nil || len(items) != 3 {
+		t.Fatalf("remaining=%d error=%v want=3", len(items), err)
+	}
+	if items[2].Envelope.JobUUID != "kept" {
+		t.Fatal("legacy_fifo_changed=true")
+	}
+}
+
+func TestNovoFenceCriaEnvelopeImutavel(t *testing.T) {
+	ob, path := newTestOutbox(t)
+	env := rawEnvelope(t, "job", 1)
+	if err := ob.Append(env); err != nil {
+		t.Fatal(err)
+	}
+	before, _ := ob.Peek(10)
+	if err := ob.Close(); err != nil {
+		t.Fatal(err)
+	}
+	ob, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ob.Close()
+	env.Attempts = 3
+	if err := ob.Append(env); err != nil {
+		t.Fatal(err)
+	}
+	if err := ob.Append(rawEnvelope(t, "job", 2)); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := ob.Peek(10)
+	if len(after) != 2 || !reflect.DeepEqual(before[0], after[0]) {
+		t.Fatalf("immutable_replay_failed=true count=%d", len(after))
+	}
+}
+
+func TestRejeitaReplayRawComIdentidadeDivergente(t *testing.T) {
+	for _, field := range []string{"source_key", "manifest_json", "manifest_sha256"} {
+		t.Run(field, func(t *testing.T) {
+			ob, _ := newTestOutbox(t)
+			env := rawEnvelope(t, "job", 1)
+			if err := ob.Append(env); err != nil {
+				t.Fatal(err)
+			}
+			payload, _ := json.Marshal(env)
+			fields := map[string]json.RawMessage{}
+			_ = json.Unmarshal(payload, &fields)
+			fields[field] = json.RawMessage(`"different"`)
+			if field == "source_key" {
+				fields[field] = json.RawMessage(`{"Source":"SIHD"}`)
+			}
+			if field == "manifest_json" {
+				fields[field] = json.RawMessage(`"eyJ4IjoxfQ=="`)
+			}
+			payload, _ = json.Marshal(fields)
+			_ = json.Unmarshal(payload, &env)
+			if err := ob.Append(env); err == nil {
+				t.Fatal("conflicting_replay_accepted=true")
+			}
+		})
+	}
+}
+
+func TestApagarEnvelopeRawLiberaIndice(t *testing.T) {
+	ob, _ := newTestOutbox(t)
+	env := rawEnvelope(t, "job", 1)
+	if err := ob.Append(env); err != nil {
+		t.Fatal(err)
+	}
+	items, _ := ob.Peek(10)
+	if err := ob.Delete(items[0].Key); err != nil {
+		t.Fatal(err)
+	}
+	if err := ob.Append(env); err != nil {
+		t.Fatal(err)
+	}
+	items, _ = ob.Peek(10)
+	if len(items) != 1 {
+		t.Fatalf("remaining=%d want=1", len(items))
+	}
+}
+
+func TestAppendLegadoNaoSobrescreveRawAposReinicio(t *testing.T) {
+	ob, path := newTestOutbox(t)
+	now := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	env := rawEnvelope(t, "job", 1)
+	env.EnqueuedAt = now
+	if err := ob.Append(env); err != nil {
+		t.Fatal(err)
+	}
+	if err := ob.Close(); err != nil {
+		t.Fatal(err)
+	}
+	ob, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ob.Close()
+	for i := 0; i < 3; i++ {
+		if err := ob.Append(Envelope{Type: TypeComplete, JobUUID: id(i), EnqueuedAt: now}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	items, err := ob.Peek(10)
+	if err != nil || len(items) != 4 {
+		t.Fatalf("remaining=%d error=%v want=4", len(items), err)
+	}
+	if !reflect.DeepEqual(env, items[0].Envelope) {
+		t.Fatal("raw_overwritten=true")
+	}
+}
+
+func TestRejeitaEnvelopeRawSemIdentidadeCompleta(t *testing.T) {
+	for _, field := range []string{
+		"job_id", "fencing_token", "source_key", "manifest_json", "manifest_sha256",
+	} {
+		ob, _ := newTestOutbox(t)
+		payload, _ := json.Marshal(rawEnvelope(t, "job", 1))
+		fields := map[string]json.RawMessage{}
+		_ = json.Unmarshal(payload, &fields)
+		delete(fields, field)
+		payload, _ = json.Marshal(fields)
+		var env Envelope
+		if err := json.Unmarshal(payload, &env); err != nil {
+			t.Fatal(err)
+		}
+		if err := ob.Append(env); err == nil {
+			t.Errorf("missing_identity_accepted=%s", field)
+		}
+	}
+}
 
 func newTestOutbox(t *testing.T) (*Outbox, string) {
 	t.Helper()
@@ -167,5 +355,7 @@ func TestOutbox_CloseIdempotent(t *testing.T) {
 	}
 }
 
-func id(i int) string             { return string(rune('a' + i)) }
-func idDeep(worker, j int) string { return string([]rune{rune('a' + worker), rune('0' + (j % 10))}) }
+func id(i int) string { return string(rune('a' + i)) }
+func idDeep(worker, j int) string {
+	return string([]rune{rune('a' + worker), rune('0' + (j % 10))})
+}

--- a/apps/dump_agent_go/internal/upload/put.go
+++ b/apps/dump_agent_go/internal/upload/put.go
@@ -3,15 +3,192 @@ package upload
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
 
+	"github.com/cnesdata/dumpagent/internal/integrity"
+	"github.com/cnesdata/dumpagent/internal/manifest"
 	"github.com/cnesdata/dumpagent/internal/obs"
 )
+
+// RawSpool referencia um Parquet sincronizado em disco.
+type RawSpool struct {
+	Name      string
+	SizeBytes int64
+	SHA256    string
+}
+
+// RawSpoolUpload vincula arquivo, destino e manifesto imutável.
+type RawSpoolUpload struct {
+	Directory    string
+	Name         string
+	URL          string
+	FencingToken uint64
+	Manifest     manifest.Raw
+}
+
+// PrepareRawSpool grava por streaming e publica o arquivo completo sincronizado.
+func PrepareRawSpool(ctx context.Context, directory string,
+	write func(io.Writer) error,
+) (result RawSpool, err error) {
+	if directory == "" {
+		return result, errors.New("raw_spool=unconfigured")
+	}
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return result, err
+	}
+	file, err := os.CreateTemp(directory, "raw-*.parquet")
+	if err != nil {
+		return result, err
+	}
+	defer func() {
+		_ = file.Close()
+		if err != nil {
+			_ = os.Remove(file.Name())
+		}
+	}()
+	result.SizeBytes, result.SHA256, err = writeRawSpool(ctx, file, write)
+	if err != nil {
+		return result, err
+	}
+	if err := file.Sync(); err != nil {
+		return result, err
+	}
+	if err := file.Close(); err != nil {
+		return result, err
+	}
+	if err := syncSpoolDirectory(directory); err != nil {
+		return result, err
+	}
+	result.Name = filepath.Base(file.Name())
+	return result, nil
+}
+
+func writeRawSpool(ctx context.Context, file *os.File,
+	write func(io.Writer) error,
+) (int64, string, error) {
+	reader, pipe := io.Pipe()
+	stop := context.AfterFunc(ctx, func() { _ = reader.CloseWithError(ctx.Err()) })
+	defer stop()
+	producer := obs.SafeGo(func() error {
+		defer pipe.Close()
+		err := write(pipe)
+		_ = pipe.CloseWithError(err)
+		return err
+	}, "raw_spool")
+	teed, digest := integrity.SHA256TeeReader(reader)
+	size, err := io.Copy(file, teed)
+	_ = reader.CloseWithError(err)
+	return size, digest.SumHex(), errors.Join(err, <-producer, ctx.Err())
+}
+
+// UploadRawSpool valida tamanho/hash antes do PUT e verifica o corpo consumido.
+func UploadRawSpool(ctx context.Context, uploader RawUploader,
+	request RawSpoolUpload,
+) (int64, error) {
+	if uploader == nil {
+		return 0, errors.New("raw_uploader=unconfigured")
+	}
+	path, err := rawSpoolPath(request.Directory, request.Name)
+	if err != nil {
+		return 0, err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	if err := verifyRawSpool(file, request.Manifest); err != nil {
+		return 0, err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	teed, hash := integrity.SHA256TeeReader(file)
+	size, err := uploader.PutRaw(ctx, RawPutRequest{URL: request.URL, Body: teed,
+		FencingToken: request.FencingToken, ObjectKey: request.Manifest.ObjectKey})
+	if err != nil {
+		return 0, err
+	}
+	if size != request.Manifest.SizeBytes || hash.SumHex() != request.Manifest.ObjectSHA256 {
+		return 0, errors.New("raw_spool=upload_integrity_mismatch")
+	}
+	return size, nil
+}
+
+func verifyRawSpool(file *os.File, raw manifest.Raw) error {
+	teed, hash := integrity.SHA256TeeReader(file)
+	size, err := io.Copy(io.Discard, teed)
+	if err != nil {
+		return err
+	}
+	if size != raw.SizeBytes || hash.SumHex() != raw.ObjectSHA256 {
+		return errors.New("raw_spool=integrity_mismatch")
+	}
+	return nil
+}
+
+// RemoveRawSpool remove somente o arquivo indicado.
+func RemoveRawSpool(directory, name string) error {
+	path, err := rawSpoolPath(directory, name)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return syncSpoolDirectory(directory)
+}
+
+func rawSpoolPath(directory, name string) (string, error) {
+	if directory == "" || filepath.Base(name) != name || !strings.HasSuffix(name, ".parquet") {
+		return "", errors.New("raw_spool=invalid_path")
+	}
+	return filepath.Join(directory, name), nil
+}
+
+func syncSpoolDirectory(directory string) error {
+	return syncSpoolDirectoryForOS(directory, runtime.GOOS, syncDirectory)
+}
+
+func syncSpoolDirectoryForOS(directory, goos string, sync func(string) error) error {
+	if goos == "windows" {
+		return nil
+	}
+	return sync(directory)
+}
+
+func syncDirectory(directory string) error {
+	file, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return file.Sync()
+}
 
 // Uploader contrato para upload streaming.
 type Uploader interface {
 	Put(ctx context.Context, url string, body io.Reader, contentType string) (int64, error)
+}
+
+// RawPutRequest define o destino e a identidade do upload raw.
+type RawPutRequest struct {
+	URL          string
+	Body         io.Reader
+	FencingToken uint64
+	ObjectKey    string
+}
+
+// RawUploader envia Parquet raw com identidade de fencing.
+type RawUploader interface {
+	PutRaw(context.Context, RawPutRequest) (int64, error)
 }
 
 // HTTP implementação padrão sobre http.Client.
@@ -29,7 +206,9 @@ func NewHTTP(client *http.Client) *HTTP {
 
 // Put streaming PUT. body é consumido por io.Pipe reader ou qualquer
 // io.Reader; ContentLength = -1 habilita transfer-encoding chunked.
-func (h *HTTP) Put(ctx context.Context, url string, body io.Reader, contentType string) (int64, error) {
+func (h *HTTP) Put(
+	ctx context.Context, url string, body io.Reader, contentType string,
+) (int64, error) {
 	cr := &countingReader{r: body}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, cr)
 	if err != nil {
@@ -37,7 +216,24 @@ func (h *HTTP) Put(ctx context.Context, url string, body io.Reader, contentType 
 	}
 	req.ContentLength = -1
 	req.Header.Set("Content-Type", contentType)
+	return h.send(req, cr)
+}
 
+// PutRaw envia o corpo por streaming com os cabeçalhos do contrato raw.
+func (h *HTTP) PutRaw(ctx context.Context, input RawPutRequest) (int64, error) {
+	cr := &countingReader{r: input.Body}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, input.URL, cr)
+	if err != nil {
+		return 0, err
+	}
+	req.ContentLength = -1
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("X-Fencing-Token", strconv.FormatUint(input.FencingToken, 10))
+	req.Header.Set("X-Object-Key", input.ObjectKey)
+	return h.send(req, cr)
+}
+
+func (h *HTTP) send(req *http.Request, cr *countingReader) (int64, error) {
 	resp, err := h.client.Do(req)
 	if err != nil {
 		return cr.n, err

--- a/apps/dump_agent_go/internal/upload/put.go
+++ b/apps/dump_agent_go/internal/upload/put.go
@@ -88,8 +88,8 @@ func writeRawSpool(ctx context.Context, file *os.File,
 	return size, digest.SumHex(), errors.Join(err, <-producer, ctx.Err())
 }
 
-// UploadRawSpool valida tamanho/hash antes do PUT e verifica o corpo consumido.
-func UploadRawSpool(ctx context.Context, uploader RawUploader,
+// PutRawSpool valida tamanho/hash antes do PUT e verifica o corpo consumido.
+func PutRawSpool(ctx context.Context, uploader RawUploader,
 	request RawSpoolUpload,
 ) (int64, error) {
 	if uploader == nil {

--- a/apps/dump_agent_go/internal/upload/put_test.go
+++ b/apps/dump_agent_go/internal/upload/put_test.go
@@ -1,16 +1,232 @@
-package upload_test
+package upload
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
-	"github.com/cnesdata/dumpagent/internal/upload"
+	"github.com/cnesdata/dumpagent/internal/manifest"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPutRawEnviaCabecalhosAntesDeConsumirCorpo(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	started := make(chan struct{})
+	requests := make(chan *http.Request, 1)
+	contents := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r
+		close(started)
+		body, _ := io.ReadAll(r.Body)
+		contents <- string(body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	var uploader RawUploader = NewHTTP(srv.Client())
+	body := &bodyAfterHeaders{ctx: ctx, started: started, r: strings.NewReader("PAR1payloadPAR1")}
+	n, err := uploader.PutRaw(ctx, RawPutRequest{
+		URL: srv.URL, Body: body, FencingToken: 18446744073709551615,
+		ObjectKey: "raw/354130/CNES/2026-01/snapshot/data.parquet",
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(15), n)
+	req := <-requests
+	require.Equal(t, http.MethodPut, req.Method)
+	require.Equal(t, int64(-1), req.ContentLength)
+	require.Equal(t, "application/octet-stream", req.Header.Get("Content-Type"))
+	require.Equal(t, "18446744073709551615", req.Header.Get("X-Fencing-Token"))
+	require.Equal(t, "raw/354130/CNES/2026-01/snapshot/data.parquet", req.Header.Get("X-Object-Key"))
+	require.Equal(t, "PAR1payloadPAR1", <-contents)
+}
+
+func TestSpoolDuravelPreservaBytesEValidaAntesDePut(t *testing.T) {
+	directory := t.TempDir()
+	spool, err := PrepareRawSpool(context.Background(), directory, func(dst io.Writer) error {
+		_, err := io.WriteString(dst, "PAR1payloadPAR1")
+		return err
+	})
+	require.NoError(t, err)
+	stored, err := os.ReadFile(filepath.Join(directory, spool.Name))
+	require.NoError(t, err)
+	require.Equal(t, "PAR1payloadPAR1", string(stored))
+	calls := 0
+	uploader := spoolUploader(func(_ context.Context, request RawPutRequest) (int64, error) {
+		calls++
+		return io.Copy(io.Discard, request.Body)
+	})
+	request := RawSpoolUpload{Directory: directory, Name: spool.Name, URL: "upload",
+		FencingToken: 1, Manifest: manifest.Raw{SizeBytes: spool.SizeBytes, ObjectSHA256: spool.SHA256}}
+	_, err = UploadRawSpool(context.Background(), uploader, request)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	request.Manifest.SizeBytes++
+	_, err = UploadRawSpool(context.Background(), uploader, request)
+	require.Error(t, err)
+	request.Manifest.SizeBytes--
+	require.NoError(t, os.WriteFile(filepath.Join(directory, spool.Name),
+		[]byte("PAR1changedPAR1"), 0o600))
+	_, err = UploadRawSpool(context.Background(), uploader, request)
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+	require.NoError(t, RemoveRawSpool(directory, spool.Name))
+	require.NoError(t, RemoveRawSpool(directory, spool.Name))
+	_, err = UploadRawSpool(context.Background(), uploader, request)
+	require.Error(t, err)
+}
+
+func TestSpoolEntregaReferenciaSomenteAposEscritaCompleta(t *testing.T) {
+	directory := t.TempDir()
+	started, release := make(chan struct{}), make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	type result struct {
+		spool RawSpool
+		err   error
+	}
+	prepared := make(chan result, 1)
+	go func() {
+		spool, err := PrepareRawSpool(context.Background(), directory, func(dst io.Writer) error {
+			close(started)
+			<-release
+			_, err := io.WriteString(dst, "complete")
+			return err
+		})
+		prepared <- result{spool, err}
+	}()
+	<-started
+	select {
+	case <-prepared:
+		t.Fatal("referencia_publicada_antes_de_completar=true")
+	default:
+	}
+	release <- struct{}{}
+	got := <-prepared
+	require.NoError(t, got.err)
+	files, err := os.ReadDir(directory)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, got.spool.Name, files[0].Name())
+	require.Equal(t, ".parquet", filepath.Ext(got.spool.Name))
+	stored, err := os.ReadFile(filepath.Join(directory, got.spool.Name))
+	require.NoError(t, err)
+	require.Equal(t, "complete", string(stored))
+}
+
+func TestSpoolNaoSobrescreveDestinoDisputadoDurantePublicacao(t *testing.T) {
+	directory := t.TempDir()
+	var destination string
+	var claimed bool
+	spool, prepareErr := PrepareRawSpool(context.Background(), directory, func(dst io.Writer) error {
+		files, err := os.ReadDir(directory)
+		if err != nil {
+			return err
+		}
+		name := strings.TrimSuffix(files[0].Name(), filepath.Ext(files[0].Name())) + ".parquet"
+		destination = filepath.Join(directory, name)
+		other, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			claimed = true
+			_, err = io.WriteString(other, "existing")
+			err = errors.Join(err, other.Close())
+		}
+		if err != nil && !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		_, err = io.WriteString(dst, "new")
+		return err
+	})
+	stored, err := os.ReadFile(destination)
+	require.NoError(t, err)
+	if claimed {
+		require.Equal(t, "existing", string(stored), "destino_preexistente_sobrescrito=true")
+		require.True(t, prepareErr != nil || destination != filepath.Join(directory, spool.Name))
+	} else {
+		require.NoError(t, prepareErr)
+		require.Equal(t, "new", string(stored))
+	}
+}
+
+func TestSincronizacaoDeDiretorioNaoUsaOperacaoInvalidaNoWindows(t *testing.T) {
+	for _, goos := range []string{"windows", "linux", "darwin"} {
+		t.Run(goos, func(t *testing.T) {
+			failure := errors.New("directory_sync=failed")
+			err := syncSpoolDirectoryForOS("spool", goos, func(path string) error {
+				require.Equal(t, "spool", path)
+				return failure
+			})
+			if goos == "windows" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, failure)
+			}
+		})
+	}
+}
+
+type spoolUploader func(context.Context, RawPutRequest) (int64, error)
+
+func (f spoolUploader) PutRaw(ctx context.Context, request RawPutRequest) (int64, error) {
+	return f(ctx, request)
+}
+
+func TestSpoolFalhoOuCanceladoNaoDeixaArquivoParcial(t *testing.T) {
+	directory := t.TempDir()
+	spool, err := PrepareRawSpool(context.Background(), directory, func(io.Writer) error {
+		return errors.New("write=failed")
+	})
+	require.Error(t, err)
+	require.Empty(t, spool.Name)
+	files, err := os.ReadDir(directory)
+	require.NoError(t, err)
+	require.Empty(t, files)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	spool, err = PrepareRawSpool(ctx, directory, func(dst io.Writer) error {
+		_, err := io.WriteString(dst, "cancelled")
+		return err
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, spool.Name)
+	files, err = os.ReadDir(directory)
+	require.NoError(t, err)
+	require.Empty(t, files)
+	require.Error(t, RemoveRawSpool(directory, "../outside.parquet"))
+}
+
+type bodyAfterHeaders struct {
+	ctx     context.Context
+	started <-chan struct{}
+	r       io.Reader
+}
+
+func (b *bodyAfterHeaders) Read(p []byte) (int, error) {
+	select {
+	case <-b.started:
+		return b.r.Read(p)
+	case <-b.ctx.Done():
+		return 0, b.ctx.Err()
+	}
+}
+
+func TestPutRawPropagaFalhaHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("unavailable"))
+	}))
+	defer srv.Close()
+	_, err := NewHTTP(srv.Client()).PutRaw(context.Background(), RawPutRequest{
+		URL: srv.URL, Body: strings.NewReader("x"), FencingToken: 9, ObjectKey: "raw/data.parquet",
+	})
+	require.ErrorContains(t, err, "503")
+	require.ErrorContains(t, err, "unavailable")
+}
 
 func TestPut_Streams(t *testing.T) {
 	var body []byte
@@ -25,8 +241,9 @@ func TestPut_Streams(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	u := upload.NewHTTP(http.DefaultClient)
-	n, err := u.Put(context.Background(), srv.URL, strings.NewReader("hello world"), "application/octet-stream")
+	u := NewHTTP(http.DefaultClient)
+	n, err := u.Put(context.Background(), srv.URL,
+		strings.NewReader("hello world"), "application/octet-stream")
 	require.NoError(t, err)
 	require.Equal(t, int64(11), n)
 	require.Equal(t, http.MethodPut, method)
@@ -41,7 +258,7 @@ func TestPut_Returns_HTTPError_On_Non_2xx(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	u := upload.NewHTTP(http.DefaultClient)
+	u := NewHTTP(http.DefaultClient)
 	_, err := u.Put(context.Background(), srv.URL, strings.NewReader("x"), "application/octet-stream")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "403")

--- a/apps/dump_agent_go/internal/upload/put_test.go
+++ b/apps/dump_agent_go/internal/upload/put_test.go
@@ -64,21 +64,21 @@ func TestSpoolDuravelPreservaBytesEValidaAntesDePut(t *testing.T) {
 	})
 	request := RawSpoolUpload{Directory: directory, Name: spool.Name, URL: "upload",
 		FencingToken: 1, Manifest: manifest.Raw{SizeBytes: spool.SizeBytes, ObjectSHA256: spool.SHA256}}
-	_, err = UploadRawSpool(context.Background(), uploader, request)
+	_, err = PutRawSpool(context.Background(), uploader, request)
 	require.NoError(t, err)
 	require.Equal(t, 1, calls)
 	request.Manifest.SizeBytes++
-	_, err = UploadRawSpool(context.Background(), uploader, request)
+	_, err = PutRawSpool(context.Background(), uploader, request)
 	require.Error(t, err)
 	request.Manifest.SizeBytes--
 	require.NoError(t, os.WriteFile(filepath.Join(directory, spool.Name),
 		[]byte("PAR1changedPAR1"), 0o600))
-	_, err = UploadRawSpool(context.Background(), uploader, request)
+	_, err = PutRawSpool(context.Background(), uploader, request)
 	require.Error(t, err)
 	require.Equal(t, 1, calls)
 	require.NoError(t, RemoveRawSpool(directory, spool.Name))
 	require.NoError(t, RemoveRawSpool(directory, spool.Name))
-	_, err = UploadRawSpool(context.Background(), uploader, request)
+	_, err = PutRawSpool(context.Background(), uploader, request)
 	require.Error(t, err)
 }
 

--- a/apps/dump_agent_go/internal/worker/consumer.go
+++ b/apps/dump_agent_go/internal/worker/consumer.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"math/rand"
 	"time"
@@ -26,6 +27,10 @@ type JobAPIClient interface {
 type JobExecutorIface interface {
 	Run(ctx context.Context, job *Job) (int64, error)
 	EmitCommitted(job Job, size int64)
+}
+
+type rawTerminalWaiter interface {
+	WaitRawTerminal(context.Context, *Job) error
 }
 
 // JobSpecSource produz o próximo JobSpec a ser registrado, ou nil/err.
@@ -109,6 +114,9 @@ func (c *Consumer) processJob(ctx context.Context, job Job) {
 	}, "heartbeat")
 
 	size, execErr := c.executor.Run(jobCtx, &job)
+	if waiter, ok := c.executor.(rawTerminalWaiter); ok && job.RawRequest != nil {
+		execErr = errors.Join(execErr, waiter.WaitRawTerminal(jobCtx, &job))
+	}
 	jobCancel()
 	<-hbCh
 

--- a/apps/dump_agent_go/internal/worker/consumer.go
+++ b/apps/dump_agent_go/internal/worker/consumer.go
@@ -50,7 +50,9 @@ type Consumer struct {
 }
 
 // NewConsumer construtor.
-func NewConsumer(api JobAPIClient, source JobSpecSource, executor JobExecutorIface, cfg ConsumerConfig) *Consumer {
+func NewConsumer(api JobAPIClient, source JobSpecSource,
+	executor JobExecutorIface, cfg ConsumerConfig,
+) *Consumer {
 	return &Consumer{api: api, source: source, executor: executor, config: cfg}
 }
 
@@ -110,6 +112,12 @@ func (c *Consumer) processJob(ctx context.Context, job Job) {
 	jobCancel()
 	<-hbCh
 
+	if job.RawRequest != nil {
+		if execErr != nil {
+			slog.Warn("raw_execution_failed", "job_id", job.ID)
+		}
+		return
+	}
 	if execErr != nil {
 		if err := c.api.FailJob(ctx, job, execErr); err != nil {
 			slog.Error("fail_job_api_error", "job_id", job.ID, "err", err.Error())

--- a/apps/dump_agent_go/internal/worker/consumer_test.go
+++ b/apps/dump_agent_go/internal/worker/consumer_test.go
@@ -59,6 +59,23 @@ type execStub struct {
 	committedCalls int32
 }
 
+type rawWaitExecStub struct {
+	*execStub
+	waitFn func(context.Context, *worker.Job) error
+}
+
+type appendFailOutbox struct {
+	*queue.Outbox
+}
+
+func (o appendFailOutbox) Append(queue.Envelope) error {
+	return errors.New("outbox=unavailable")
+}
+
+func (e *rawWaitExecStub) WaitRawTerminal(ctx context.Context, job *worker.Job) error {
+	return e.waitFn(ctx, job)
+}
+
 func (e *execStub) Run(ctx context.Context, job *worker.Job) (int64, error) {
 	return e.runFn(ctx, job)
 }
@@ -207,6 +224,75 @@ func TestConsumerRawAguardaDrainerSemRegistrarOuFalharJobLegado(t *testing.T) {
 		require.NoError(t, consumer.Loop(ctx))
 		require.Zero(t, api.registerCalls)
 		require.Zero(t, executor.committedCalls)
+	}
+}
+
+func TestConsumerRawMantemHeartbeatAteEnvelopeTerminal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var heartbeats atomic.Int32
+	api := &apiStub{mintFn: func(context.Context, worker.JobSpec) (*worker.Job, error) {
+		return &worker.Job{ID: "raw-job", RawRequest: &manifest.BuildRequest{}}, nil
+	}, hbFn: func(context.Context, string) error {
+		heartbeats.Add(1)
+		return nil
+	}}
+	waiting, terminal := make(chan struct{}), make(chan struct{})
+	executor := &rawWaitExecStub{execStub: &execStub{
+		runFn: func(context.Context, *worker.Job) (int64, error) { return 10, nil },
+	}, waitFn: func(ctx context.Context, _ *worker.Job) error {
+		close(waiting)
+		select {
+		case <-terminal:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}}
+	source := &sourceStub{nextFn: func(context.Context) (*worker.JobSpec, error) {
+		return &worker.JobSpec{}, nil
+	}}
+	consumer := worker.NewConsumer(api, source, executor, worker.ConsumerConfig{
+		PollInterval: time.Millisecond, HeartbeatInterval: time.Millisecond})
+	done := make(chan error, 1)
+	go func() { done <- consumer.Loop(ctx) }()
+	<-waiting
+	require.Eventually(t, func() bool { return heartbeats.Load() > 0 }, time.Second, time.Millisecond)
+	close(terminal)
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func TestExecutorRawRemoveSpoolQuandoEnvelopeNaoPersiste(t *testing.T) {
+	executor, job := newRawExecutor(t), rawJob()
+	executor.RawOutbox = appendFailOutbox{Outbox: executor.RawOutbox.(*queue.Outbox)}
+
+	_, err := executor.RunRaw(context.Background(), &job)
+	require.ErrorContains(t, err, "outbox=unavailable")
+	entries, readErr := os.ReadDir(executor.RawSpoolDirectory)
+	require.NoError(t, readErr)
+	require.Empty(t, entries)
+}
+
+func TestExecutorRawAguardaEnvelopeTerminal(t *testing.T) {
+	executor, job := newRawExecutor(t), rawJob()
+	_, err := executor.RunRaw(context.Background(), &job)
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	go func() { done <- executor.WaitRawTerminal(context.Background(), &job) }()
+	select {
+	case err := <-done:
+		t.Fatalf("espera terminou antes do recibo: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	items, err := executor.RawOutbox.Peek(10)
+	require.NoError(t, err)
+	require.NoError(t, executor.RawOutbox.MarkRawTerminal(items[0].Key))
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("espera nao terminou apos recibo")
 	}
 }
 

--- a/apps/dump_agent_go/internal/worker/consumer_test.go
+++ b/apps/dump_agent_go/internal/worker/consumer_test.go
@@ -265,13 +265,21 @@ func TestConsumerRawMantemHeartbeatAteEnvelopeTerminal(t *testing.T) {
 
 func TestExecutorRawRemoveSpoolQuandoEnvelopeNaoPersiste(t *testing.T) {
 	executor, job := newRawExecutor(t), rawJob()
-	executor.RawOutbox = appendFailOutbox{Outbox: executor.RawOutbox.(*queue.Outbox)}
+	out := executor.RawOutbox.(*queue.Outbox)
+	oldRef := rawPendingRef(job)
+	executor.RawOutbox = appendFailOutbox{Outbox: out}
 
 	_, err := executor.RunRaw(context.Background(), &job)
 	require.ErrorContains(t, err, "outbox=unavailable")
 	entries, readErr := os.ReadDir(executor.RawSpoolDirectory)
 	require.NoError(t, readErr)
 	require.Empty(t, entries)
+	executor.RawOutbox = out
+	job.FencingToken++
+	_, err = executor.RunRaw(context.Background(), &job)
+	require.NoError(t, err)
+	_, err = executor.DeltaStore.ResumePendingRef(oldRef)
+	require.ErrorIs(t, err, delta.ErrPendingNotFound)
 }
 
 func TestExecutorRawAguardaEnvelopeTerminal(t *testing.T) {

--- a/apps/dump_agent_go/internal/worker/consumer_test.go
+++ b/apps/dump_agent_go/internal/worker/consumer_test.go
@@ -393,7 +393,7 @@ func TestDeltaPreservaVinculosCompletosEMultiplicidade(t *testing.T) {
 		{"reordena_mesma_identidade", []delta.Row{a, workforceLink("010101", "S", 30)},
 			[]delta.Row{workforceLink("010101", "S", 30), a}, nil},
 		{"remove_duplicata", []delta.Row{a, a}, []delta.Row{a}, []string{"D"}},
-		{"adiciona_duplicatas", []delta.Row{a}, []delta.Row{a, a, a}, []string{"I", "I"}},
+		{"adiciona_repetidos", []delta.Row{a}, []delta.Row{a, a, a}, []string{"I", "I"}},
 		{"muda_uma_duplicata", []delta.Row{a, a},
 			[]delta.Row{a, workforceLink("010101", "S", 30)}, []string{"U"}},
 	}

--- a/apps/dump_agent_go/internal/worker/consumer_test.go
+++ b/apps/dump_agent_go/internal/worker/consumer_test.go
@@ -1,13 +1,21 @@
 package worker_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cnesdata/dumpagent/internal/delta"
 	"github.com/cnesdata/dumpagent/internal/extractor"
+	"github.com/cnesdata/dumpagent/internal/manifest"
+	"github.com/cnesdata/dumpagent/internal/queue"
+	"github.com/cnesdata/dumpagent/internal/upload"
 	"github.com/cnesdata/dumpagent/internal/worker"
 	"github.com/stretchr/testify/require"
 )
@@ -47,7 +55,7 @@ func (a *apiStub) SendHeartbeat(ctx context.Context, jobID string) error {
 }
 
 type execStub struct {
-	runFn         func(ctx context.Context, job *worker.Job) (int64, error)
+	runFn          func(ctx context.Context, job *worker.Job) (int64, error)
 	committedCalls int32
 }
 
@@ -83,7 +91,8 @@ func TestConsumerLoop_ExitsOnContextDone(t *testing.T) {
 }
 
 func TestConsumerLoop_RegistersAfterSuccessfulRun(t *testing.T) {
-	job := &worker.Job{ID: "11111111-1111-1111-1111-111111111111", TenantID: "354130", Params: extractor.ExtractionParams{Intent: extractor.IntentCnesEstabelecimentos}}
+	job := &worker.Job{ID: "11111111-1111-1111-1111-111111111111", TenantID: "354130",
+		Params: extractor.ExtractionParams{Intent: extractor.IntentCnesEstabelecimentos}}
 	var mintCalls int32
 	api := &apiStub{
 		mintFn: func(_ context.Context, _ worker.JobSpec) (*worker.Job, error) {
@@ -93,7 +102,8 @@ func TestConsumerLoop_RegistersAfterSuccessfulRun(t *testing.T) {
 			return nil, nil
 		},
 	}
-	spec := &worker.JobSpec{JobID: "22222222-2222-2222-2222-222222222222", Intent: extractor.IntentCnesEstabelecimentos}
+	spec := &worker.JobSpec{JobID: "22222222-2222-2222-2222-222222222222",
+		Intent: extractor.IntentCnesEstabelecimentos}
 	src := &sourceStub{nextFn: func(_ context.Context) (*worker.JobSpec, error) {
 		return spec, nil
 	}}
@@ -111,7 +121,8 @@ func TestConsumerLoop_RegistersAfterSuccessfulRun(t *testing.T) {
 }
 
 func TestConsumerLoop_FailsJobOnError(t *testing.T) {
-	job := &worker.Job{ID: "11111111-1111-1111-1111-111111111111", Params: extractor.ExtractionParams{Intent: extractor.IntentCnesEstabelecimentos}}
+	job := &worker.Job{ID: "11111111-1111-1111-1111-111111111111",
+		Params: extractor.ExtractionParams{Intent: extractor.IntentCnesEstabelecimentos}}
 	var failCalls int32
 	api := &apiStub{
 		mintFn: func(_ context.Context, _ worker.JobSpec) (*worker.Job, error) {
@@ -122,7 +133,8 @@ func TestConsumerLoop_FailsJobOnError(t *testing.T) {
 			return nil
 		},
 	}
-	spec := &worker.JobSpec{JobID: "22222222-2222-2222-2222-222222222222", Intent: extractor.IntentCnesEstabelecimentos}
+	spec := &worker.JobSpec{JobID: "22222222-2222-2222-2222-222222222222",
+		Intent: extractor.IntentCnesEstabelecimentos}
 	src := &sourceStub{nextFn: func(_ context.Context) (*worker.JobSpec, error) {
 		return spec, nil
 	}}
@@ -172,4 +184,221 @@ func TestLoop_SequenceMintRunRegister(t *testing.T) {
 	if mint < 1 || register < 1 {
 		t.Errorf("mint=%d register=%d, want both >= 1", mint, register)
 	}
+}
+
+func TestConsumerRawAguardaDrainerSemRegistrarOuFalharJobLegado(t *testing.T) {
+	for _, executionErr := range []error{nil, errors.New("upload=failed")} {
+		ctx, cancel := context.WithCancel(context.Background())
+		api := &apiStub{mintFn: func(context.Context, worker.JobSpec) (*worker.Job, error) {
+			return &worker.Job{ID: "raw-job", RawRequest: &manifest.BuildRequest{}}, nil
+		}, failFn: func(context.Context, worker.Job, error) error {
+			t.Error("falha raw enviada ao fluxo legado")
+			return nil
+		}}
+		executor := &execStub{runFn: func(context.Context, *worker.Job) (int64, error) {
+			cancel()
+			return 10, executionErr
+		}}
+		source := &sourceStub{nextFn: func(context.Context) (*worker.JobSpec, error) {
+			return &worker.JobSpec{}, nil
+		}}
+		consumer := worker.NewConsumer(api, source, executor,
+			worker.ConsumerConfig{HeartbeatInterval: time.Hour})
+		require.NoError(t, consumer.Loop(ctx))
+		require.Zero(t, api.registerCalls)
+		require.Zero(t, executor.committedCalls)
+	}
+}
+
+func TestMetadataRawContraditoriaFalhaAntesDaExtracao(t *testing.T) {
+	cases := []struct {
+		name   string
+		change func(*worker.Job)
+	}{
+		{"fonte", func(job *worker.Job) { job.RawRequest.SourceType = manifest.SourceTypeSIHD }},
+		{"subtipo", func(job *worker.Job) { job.RawRequest.FileSubtype = "AIH" }},
+		{"competencia", func(job *worker.Job) { job.RawRequest.Competencia = "2026-02" }},
+		{"formato", func(job *worker.Job) { job.Params.Competencia = "2026--01" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			executor, job := newRawExecutor(t), rawJob()
+			tc.change(&job)
+			extractions := 0
+			executor.RawExtract = func(context.Context, worker.Job) ([]delta.Row, error) {
+				extractions++
+				return nil, nil
+			}
+			_, err := executor.RunRaw(context.Background(), &job)
+			require.Error(t, err)
+			require.Zero(t, extractions)
+			items, err := executor.RawOutbox.Peek(10)
+			require.NoError(t, err)
+			require.Empty(t, items)
+		})
+	}
+}
+
+func workforceLink(indicator, sus string, hours int64) delta.Row {
+	return delta.Row{"CPF": "synthetic", "CNES": "unit", "CBO": "role",
+		"TIPO_VINCULO": indicator, "SUS": sus, "CH_TOTAL": hours}
+}
+
+func extractRawDelta(t *testing.T, before, after []delta.Row) []delta.Row {
+	t.Helper()
+	return readRawOperations(t, extractRawDeltaBytes(t, before, after))
+}
+
+func extractRawDeltaBytes(t *testing.T, before, after []delta.Row) []byte {
+	t.Helper()
+	executor, job := newRawExecutor(t), rawJob()
+	executor.RawExtract = func(context.Context, worker.Job) ([]delta.Row, error) { return before, nil }
+	_, err := executor.RunRaw(context.Background(), &job)
+	require.NoError(t, err)
+	confirmRawExecutor(t, executor, job)
+	job.ID, job.FencingToken = "delta-job", 8
+	job.RawRequest.SnapshotMode = manifest.SnapshotModeDelta
+	executor.RawExtract = func(context.Context, worker.Job) ([]delta.Row, error) { return after, nil }
+	var payload []byte
+	executor.RawUploader = rawUploadFunc(func(_ context.Context,
+		request upload.RawPutRequest,
+	) (int64, error) {
+		payload, err = io.ReadAll(request.Body)
+		return int64(len(payload)), err
+	})
+	_, err = executor.RunRaw(context.Background(), &job)
+	require.NoError(t, err)
+	return payload
+}
+
+func TestDeltaComAtualizacaoEInsercaoIndependeDaOrdemDaExtracao(t *testing.T) {
+	before := []delta.Row{workforceLink("010101", "S", 20)}
+	a, b := workforceLink("010101", "S", 30), workforceLink("010101", "S", 40)
+	first := extractRawDeltaBytes(t, before, []delta.Row{a, b})
+	second := extractRawDeltaBytes(t, before, []delta.Row{b, a})
+	require.True(t, bytes.Equal(first, second), "delta_bytes_dependem_da_ordem=true")
+	rows := readRawOperations(t, first)
+	require.Len(t, rows, 2)
+	operations := map[any]int{}
+	var hours []any
+	for _, row := range rows {
+		operations[row["_op"]]++
+		hours = append(hours, row["CH_TOTAL"])
+	}
+	require.Equal(t, map[any]int{"I": 1, "U": 1}, operations)
+	require.ElementsMatch(t, []any{"30", "40"}, hours)
+}
+
+func TestDeltaPreservaVinculosCompletosEMultiplicidade(t *testing.T) {
+	a, b := workforceLink("010101", "S", 20), workforceLink("020202", "N", 40)
+	cases := []struct {
+		name          string
+		before, after []delta.Row
+		operations    []string
+	}{
+		{"remove_um_vinculo", []delta.Row{a, b}, []delta.Row{a}, []string{"D"}},
+		{"muda_um_vinculo", []delta.Row{a, b},
+			[]delta.Row{a, workforceLink("020202", "N", 30)}, []string{"U"}},
+		{"reordena_vinculos", []delta.Row{a, b}, []delta.Row{b, a}, nil},
+		{"remove_vinculo_diferente_so_sus", []delta.Row{a, workforceLink("010101", "N", 20)},
+			[]delta.Row{a}, []string{"D"}},
+		{"remove_vinculo_diferente_so_indicador", []delta.Row{a, workforceLink("020202", "S", 20)},
+			[]delta.Row{a}, []string{"D"}},
+		{"reordena_mesma_identidade", []delta.Row{a, workforceLink("010101", "S", 30)},
+			[]delta.Row{workforceLink("010101", "S", 30), a}, nil},
+		{"remove_duplicata", []delta.Row{a, a}, []delta.Row{a}, []string{"D"}},
+		{"adiciona_duplicatas", []delta.Row{a}, []delta.Row{a, a, a}, []string{"I", "I"}},
+		{"muda_uma_duplicata", []delta.Row{a, a},
+			[]delta.Row{a, workforceLink("010101", "S", 30)}, []string{"U"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := extractRawDelta(t, tc.before, tc.after)
+			require.Len(t, rows, len(tc.operations))
+			for index, op := range tc.operations {
+				require.Equal(t, op, rows[index]["_op"])
+				require.NotNil(t, rows[index]["TIPO_VINCULO"])
+				require.NotNil(t, rows[index]["SUS"])
+			}
+		})
+	}
+}
+
+type rawManifestClientFunc func(context.Context, queue.Envelope) (worker.RawManifestResponse, error)
+
+func (f rawManifestClientFunc) SendRawManifest(ctx context.Context,
+	env queue.Envelope,
+) (worker.RawManifestResponse, error) {
+	return f(ctx, env)
+}
+
+func restartRawExecutor(t *testing.T, executor *worker.JobExecutor) {
+	t.Helper()
+	directory := filepath.Dir(executor.RawSpoolDirectory)
+	require.NoError(t, executor.DeltaStore.Close())
+	require.NoError(t, executor.RawOutbox.(*queue.Outbox).Close())
+	store, err := delta.Open(filepath.Join(directory, "delta.db"))
+	require.NoError(t, err)
+	out, err := queue.Open(filepath.Join(directory, "outbox.db"))
+	require.NoError(t, err)
+	executor.DeltaStore, executor.RawOutbox = store, out
+	t.Cleanup(func() { _ = store.Close(); _ = out.Close() })
+}
+
+func TestSpoolRetomaBytesOriginaisAposCrashNoPut(t *testing.T) {
+	for _, phase := range []string{"antes_put", "durante_put", "apos_put"} {
+		t.Run(phase, func(t *testing.T) {
+			executor, job := newRawExecutor(t), rawJob()
+			executor.RawUploader = rawUploadFunc(func(_ context.Context,
+				request upload.RawPutRequest,
+			) (int64, error) {
+				if phase == "apos_put" {
+					return io.Copy(io.Discard, request.Body)
+				}
+				if phase == "durante_put" {
+					_, _ = io.CopyN(io.Discard, request.Body, 4)
+				}
+				return 0, errors.New("crash=put")
+			})
+			_, executionErr := executor.RunRaw(context.Background(), &job)
+			require.Equal(t, phase != "apos_put", executionErr != nil)
+			items, err := executor.RawOutbox.Peek(10)
+			require.NoError(t, err)
+			require.Len(t, items, 1)
+			require.NotEmpty(t, items[0].Envelope.SpoolName)
+			path := filepath.Join(executor.RawSpoolDirectory, items[0].Envelope.SpoolName)
+			original, err := os.ReadFile(path)
+			require.NoError(t, err)
+			restartRawExecutor(t, executor)
+			verifySpoolReplay(t, executor, original)
+			_, err = os.Stat(path)
+			require.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func verifySpoolReplay(t *testing.T, executor *worker.JobExecutor, original []byte) {
+	t.Helper()
+	uploaded := false
+	client := rawManifestClientFunc(func(_ context.Context,
+		env queue.Envelope,
+	) (worker.RawManifestResponse, error) {
+		require.True(t, uploaded)
+		return worker.RawManifestResponse{StatusCode: 200, ManifestSHA256: env.ManifestSHA256}, nil
+	})
+	drainer := worker.NewRawDrainer(client, executor.DeltaStore, nil)
+	drainer.SpoolDirectory = executor.RawSpoolDirectory
+	drainer.Uploader = rawUploadFunc(func(_ context.Context,
+		request upload.RawPutRequest,
+	) (int64, error) {
+		body, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+		require.Equal(t, original, body)
+		uploaded = true
+		return int64(len(body)), nil
+	})
+	require.NoError(t, drainer.Drain(context.Background(), executor.RawOutbox))
+	items, err := executor.RawOutbox.Peek(10)
+	require.NoError(t, err)
+	require.Empty(t, items)
 }

--- a/apps/dump_agent_go/internal/worker/drain.go
+++ b/apps/dump_agent_go/internal/worker/drain.go
@@ -1,17 +1,168 @@
 package worker
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/cnesdata/dumpagent/internal/breaker"
+	"github.com/cnesdata/dumpagent/internal/delta"
+	"github.com/cnesdata/dumpagent/internal/manifest"
 	"github.com/cnesdata/dumpagent/internal/obs"
 	"github.com/cnesdata/dumpagent/internal/queue"
+	"github.com/cnesdata/dumpagent/internal/upload"
 )
+
+// RawManifestResponse contém o acknowledgement tipado do servidor.
+type RawManifestResponse struct {
+	StatusCode     int
+	ManifestSHA256 string
+	ForceFull      bool
+	Reason         string
+}
+
+// RawManifestClient envia a identidade imutável do manifesto persistido.
+type RawManifestClient interface {
+	SendRawManifest(context.Context, queue.Envelope) (RawManifestResponse, error)
+}
+
+// RawDrainer confirma estado durável antes de remover manifests da fila.
+type RawDrainer struct {
+	client         RawManifestClient
+	store          *delta.Store
+	legacy         JobAPIClient
+	SpoolDirectory string
+	Uploader       upload.RawUploader
+}
+
+// NewRawDrainer constrói o drainer independente da composição do serviço.
+func NewRawDrainer(client RawManifestClient, store *delta.Store, legacy JobAPIClient) *RawDrainer {
+	return &RawDrainer{client: client, store: store, legacy: legacy}
+}
+
+// Drain envia um lote de envelopes e conserva qualquer falha para replay.
+func (d *RawDrainer) Drain(ctx context.Context, out EnvelopeOutbox) error {
+	items, err := out.Peek(drainBatchSize)
+	if err != nil {
+		return err
+	}
+	legacy := &Drainer{out: out, breaker: breaker.New(5, time.Minute, "raw_legacy"), inner: d.legacy}
+	for _, item := range items {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if item.Envelope.Type != queue.TypeRawManifest {
+			if d.legacy == nil || !legacy.dispatchOne(ctx, item) {
+				return errors.New("legacy_dispatch=pending")
+			}
+			continue
+		}
+		if err := d.deliverRaw(ctx, out, item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *RawDrainer) deliverRaw(ctx context.Context, out EnvelopeOutbox, item queue.Item) error {
+	raw, err := decodeRawEnvelope(item.Envelope)
+	if err != nil {
+		return err
+	}
+	terminal, err := out.RawTerminal(item.Key)
+	if err != nil {
+		return err
+	}
+	if !terminal {
+		if err := d.uploadAndConfirm(ctx, item.Envelope, raw); err != nil {
+			return err
+		}
+		if err := out.MarkRawTerminal(item.Key); err != nil {
+			return err
+		}
+	}
+	if err := upload.RemoveRawSpool(d.SpoolDirectory, item.Envelope.SpoolName); err != nil {
+		return err
+	}
+	return out.Delete(item.Key)
+}
+
+func (d *RawDrainer) uploadAndConfirm(ctx context.Context,
+	env queue.Envelope, raw manifest.Raw,
+) error {
+	_, err := upload.UploadRawSpool(ctx, d.Uploader, upload.RawSpoolUpload{
+		Directory: d.SpoolDirectory, Name: env.SpoolName, URL: env.UploadURL,
+		FencingToken: env.FencingToken, Manifest: raw})
+	if err != nil {
+		return err
+	}
+	return d.confirm(ctx, env)
+}
+
+func (d *RawDrainer) confirm(ctx context.Context, env queue.Envelope) error {
+	raw, err := decodeRawEnvelope(env)
+	if err != nil {
+		return err
+	}
+	if d.client == nil || d.store == nil {
+		return errors.New("raw_drainer=unconfigured")
+	}
+	callCtx, cancel := context.WithTimeout(ctx, dispatchTimeout)
+	defer cancel()
+	response, err := d.client.SendRawManifest(callCtx, env)
+	if err != nil {
+		return err
+	}
+	ref := pendingRef(env)
+	if successfulRawResponse(response) {
+		return d.store.ConfirmPending(ref, raw, response.ManifestSHA256)
+	}
+	if resyncRawResponse(response, env) {
+		return d.store.RequireFull(ref, response.Reason)
+	}
+	return fmt.Errorf("raw_ack=invalid_or_retryable status=%d", response.StatusCode)
+}
+
+func successfulRawResponse(response RawManifestResponse) bool {
+	return response.StatusCode >= 200 && response.StatusCode < 300 &&
+		!response.ForceFull && response.Reason == ""
+}
+
+func resyncRawResponse(response RawManifestResponse, env queue.Envelope) bool {
+	return response.StatusCode == http.StatusConflict && response.ForceFull &&
+		strings.TrimSpace(response.Reason) != "" && response.ManifestSHA256 == env.ManifestSHA256
+}
+
+func decodeRawEnvelope(env queue.Envelope) (manifest.Raw, error) {
+	var raw manifest.Raw
+	if err := json.Unmarshal(env.ManifestJSON, &raw); err != nil {
+		return raw, errors.New("raw_manifest=json_invalid")
+	}
+	canonical, err := manifest.CanonicalJSON(raw)
+	if err != nil {
+		return raw, err
+	}
+	hash, err := manifest.SHA256(raw)
+	if err != nil {
+		return raw, err
+	}
+	if raw.ManifestID != env.JobID || raw.SnapshotID != env.JobID ||
+		env.FencingToken == 0 || hash != env.ManifestSHA256 ||
+		!bytes.Equal(canonical, env.ManifestJSON) {
+		return raw, errors.New("raw_manifest=identity_invalid")
+	}
+	return raw, validateRawScope(env.SourceKey, raw)
+}
+
+func pendingRef(env queue.Envelope) delta.PendingRef {
+	return delta.PendingRef{SourceKey: env.SourceKey, JobID: env.JobID, FencingToken: env.FencingToken}
+}
 
 const (
 	drainTickInterval   = 30 * time.Second
@@ -25,7 +176,7 @@ const (
 // Drainer ships persisted envelopes to the central_api in FIFO order,
 // gated by a circuit breaker. End-of-tick eviction enforces TTL + cap.
 type Drainer struct {
-	out      *queue.Outbox
+	out      EnvelopeOutbox
 	breaker  *breaker.CircuitBreaker
 	inner    JobAPIClient
 	interval time.Duration
@@ -97,6 +248,9 @@ func (d *Drainer) tick(ctx context.Context) {
 
 // dispatchOne returns true when the loop may continue.
 func (d *Drainer) dispatchOne(ctx context.Context, item queue.Item) bool {
+	if item.Envelope.Type == queue.TypeRawManifest {
+		return false
+	}
 	callCtx, cancel := context.WithTimeout(ctx, dispatchTimeout)
 	defer cancel()
 
@@ -118,7 +272,12 @@ func (d *Drainer) dispatchOne(ctx context.Context, item queue.Item) bool {
 	if errors.Is(callErr, breaker.ErrOpen) {
 		return false
 	}
+	return d.applyResponse(ctx, item, resp, dispErr)
+}
 
+func (d *Drainer) applyResponse(ctx context.Context, item queue.Item,
+	resp *http.Response, dispErr error,
+) bool {
 	cls, sleep := queue.Classify(resp, dispErr)
 	switch cls {
 	case queue.ClassSuccess:

--- a/apps/dump_agent_go/internal/worker/drain.go
+++ b/apps/dump_agent_go/internal/worker/drain.go
@@ -41,7 +41,7 @@ type RawDrainer struct {
 	Uploader       upload.RawUploader
 }
 
-// NewRawDrainer constrói o drainer independente da composição do serviço.
+// NewRawDrainer constrói o drainer sem depender da composição do serviço.
 func NewRawDrainer(client RawManifestClient, store *delta.Store, legacy JobAPIClient) *RawDrainer {
 	return &RawDrainer{client: client, store: store, legacy: legacy}
 }
@@ -96,7 +96,7 @@ func (d *RawDrainer) deliverRaw(ctx context.Context, out EnvelopeOutbox, item qu
 func (d *RawDrainer) uploadAndConfirm(ctx context.Context,
 	env queue.Envelope, raw manifest.Raw,
 ) error {
-	_, err := upload.UploadRawSpool(ctx, d.Uploader, upload.RawSpoolUpload{
+	_, err := upload.PutRawSpool(ctx, d.Uploader, upload.RawSpoolUpload{
 		Directory: d.SpoolDirectory, Name: env.SpoolName, URL: env.UploadURL,
 		FencingToken: env.FencingToken, Manifest: raw})
 	if err != nil {

--- a/apps/dump_agent_go/internal/worker/drain_test.go
+++ b/apps/dump_agent_go/internal/worker/drain_test.go
@@ -2,14 +2,19 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cnesdata/dumpagent/internal/breaker"
+	"github.com/cnesdata/dumpagent/internal/delta"
+	"github.com/cnesdata/dumpagent/internal/manifest"
 	"github.com/cnesdata/dumpagent/internal/obs"
 	"github.com/cnesdata/dumpagent/internal/queue"
+	"github.com/stretchr/testify/require"
 )
 
 type stubJobAPI struct {
@@ -194,4 +199,274 @@ func TestDrainer_TickIntervalJittered_Mid(t *testing.T) {
 	if got != want {
 		t.Errorf("rand=0.5 got %v want %v", got, want)
 	}
+}
+
+type rawClientFunc func(context.Context, queue.Envelope) (RawManifestResponse, error)
+
+func (f rawClientFunc) SendRawManifest(
+	ctx context.Context, envelope queue.Envelope,
+) (RawManifestResponse, error) {
+	return f(ctx, envelope)
+}
+
+type rawDrainFixture struct {
+	store          *delta.Store
+	out            *queue.Outbox
+	env            queue.Envelope
+	raw            manifest.Raw
+	ref            delta.PendingRef
+	storePath      string
+	outPath        string
+	spoolDirectory string
+}
+
+func newRawDrainFixture(t *testing.T) rawDrainFixture {
+	t.Helper()
+	storePath := filepath.Join(t.TempDir(), "state.db")
+	store, err := delta.Open(storePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	ref := delta.PendingRef{JobID: "new-job", FencingToken: 2, SourceKey: delta.SourceKey{
+		Source: "cnes", Intent: "profissionais", Competencia: "202601",
+	}}
+	spoolDirectory, spool := newFixtureSpool(t)
+	raw, err := manifest.Build(manifest.BuildRequest{
+		JobID: ref.JobID, TenantID: "tenant", SourceType: manifest.SourceTypeCNESLocal,
+		FileSubtype: "CNES_VINCULO", Competencia: "2026-01", AgentID: "agent",
+		AgentVersion: "1", SchemaVersion: "1", SnapshotMode: manifest.SnapshotModeFull,
+		ObjectSHA256: spool.SHA256, RowCount: 1, SizeBytes: spool.SizeBytes,
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	outPath := filepath.Join(t.TempDir(), "outbox.db")
+	out, err := queue.Open(outPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = out.Close() })
+	f := rawDrainFixture{store: store, out: out, raw: raw, ref: ref,
+		storePath: storePath, outPath: outPath, spoolDirectory: spoolDirectory}
+	prior, priorRef := raw, ref
+	prior.ManifestID, prior.SnapshotID, priorRef.JobID = "prior", "prior", "prior"
+	stageRawHashes(t, store, priorRef, map[string][32]byte{"old": {1}})
+	require.NoError(t, store.ConfirmPending(priorRef, prior, strings.Repeat("a", 64)))
+	stageRawHashes(t, store, ref, map[string][32]byte{"new": {2}})
+	f.env = rawEnvelope(t, ref, raw)
+	f.env.SpoolName, f.env.UploadURL = spool.Name, "upload"
+	require.NoError(t, f.out.Append(f.env))
+	return f
+}
+
+func stageRawHashes(t *testing.T, store *delta.Store, ref delta.PendingRef,
+	hashes map[string][32]byte,
+) {
+	t.Helper()
+	pending, err := store.BeginPendingRef(ref)
+	require.NoError(t, err)
+	require.NoError(t, pending.Replace(hashes))
+}
+
+func rawEnvelope(t *testing.T, ref delta.PendingRef, raw manifest.Raw) queue.Envelope {
+	t.Helper()
+	payload, err := manifest.CanonicalJSON(raw)
+	require.NoError(t, err)
+	hash, err := manifest.SHA256(raw)
+	require.NoError(t, err)
+	return queue.Envelope{Type: queue.TypeRawManifest, JobID: ref.JobID,
+		FencingToken: ref.FencingToken, SourceKey: ref.SourceKey,
+		ManifestJSON: payload, ManifestSHA256: hash}
+}
+
+func TestSucessoConfirmaHashDoServidorAntesDeApagarEnvelope(t *testing.T) {
+	f := newRawDrainFixture(t)
+	client := rawClientFunc(func(_ context.Context, env queue.Envelope) (RawManifestResponse, error) {
+		require.Equal(t, f.env.ManifestJSON, env.ManifestJSON)
+		_, _, head, _, _, err := f.store.ChainHead(f.ref.SourceKey)
+		require.NoError(t, err)
+		require.Equal(t, strings.Repeat("a", 64), head)
+		return RawManifestResponse{StatusCode: 201, ManifestSHA256: strings.Repeat("b", 64)}, nil
+	})
+	require.NoError(t, f.drainer(client).Drain(context.Background(), f.out))
+	_, seq, hash, _, ok, err := f.store.ChainHead(f.ref.SourceKey)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint32(1), seq)
+	require.Equal(t, strings.Repeat("b", 64), hash)
+	committed, err := f.store.GetCommitted(f.ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"new": {2}}, committed)
+	items, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.Empty(t, items)
+}
+
+func TestRedeE5xxPreservamPendenteCabecaEEnvelope(t *testing.T) {
+	cases := []struct {
+		name     string
+		response RawManifestResponse
+		err      error
+	}{
+		{"rede", RawManifestResponse{}, errors.New("network=down")},
+		{"5xx", RawManifestResponse{StatusCode: 503}, nil},
+		{"limite", RawManifestResponse{StatusCode: 429}, nil},
+		{"4xx", RawManifestResponse{StatusCode: 400}, nil},
+		{"409_comum", RawManifestResponse{StatusCode: 409}, nil},
+		{"sucesso_sem_hash", RawManifestResponse{StatusCode: 200}, nil},
+		{"hash_invalido", RawManifestResponse{StatusCode: 200, ManifestSHA256: "bad"}, nil},
+		{"409_inconsistente", RawManifestResponse{StatusCode: 409,
+			ManifestSHA256: strings.Repeat("b", 64), ForceFull: true, Reason: "base_missing"}, nil},
+		{"sucesso_resync", RawManifestResponse{StatusCode: 200,
+			ManifestSHA256: strings.Repeat("b", 64), ForceFull: true}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newRawDrainFixture(t)
+			before, err := f.out.Peek(10)
+			require.NoError(t, err)
+			client := rawClientFunc(func(context.Context, queue.Envelope) (RawManifestResponse, error) {
+				return tc.response, tc.err
+			})
+			require.Error(t, f.drainer(client).Drain(context.Background(), f.out))
+			after, err := f.out.Peek(10)
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+			_, _, hash, _, _, err := f.store.ChainHead(f.ref.SourceKey)
+			require.NoError(t, err)
+			require.Equal(t, strings.Repeat("a", 64), hash)
+			require.NoError(t, f.store.ConfirmPending(f.ref, f.raw, strings.Repeat("b", 64)))
+		})
+	}
+}
+
+func TestResposta409TipadaMarcaSoFonteParaFullEDescartaPendente(t *testing.T) {
+	f := newRawDrainFixture(t)
+	other := f.ref
+	other.SourceKey.Competencia = "202602"
+	stageRawHashes(t, f.store, other, map[string][32]byte{"other": {3}})
+	client := rawClientFunc(func(context.Context, queue.Envelope) (RawManifestResponse, error) {
+		return RawManifestResponse{StatusCode: 409, ManifestSHA256: f.env.ManifestSHA256,
+			ForceFull: true, Reason: "base_missing"}, nil
+	})
+	require.NoError(t, f.drainer(client).Drain(context.Background(), f.out))
+	reason, force, err := f.store.ForceFull(f.ref.SourceKey)
+	require.NoError(t, err)
+	require.True(t, force)
+	require.Equal(t, "base_missing", reason)
+	_, force, err = f.store.ForceFull(other.SourceKey)
+	require.NoError(t, err)
+	require.False(t, force)
+	require.NoError(t, f.store.ConfirmPending(other, f.raw, strings.Repeat("c", 64)))
+	committed, err := f.store.GetCommitted(f.ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"old": {1}}, committed)
+	require.Error(t, f.store.ConfirmPending(f.ref, f.raw, strings.Repeat("b", 64)))
+	items, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.Empty(t, items)
+}
+
+func TestReplayAposCommitLocalAntesDaExclusaoConverge(t *testing.T) {
+	f := newRawDrainFixture(t)
+	hash := strings.Repeat("b", 64)
+	require.NoError(t, f.store.ConfirmPending(f.ref, f.raw, hash))
+	client := rawClientFunc(func(context.Context, queue.Envelope) (RawManifestResponse, error) {
+		return RawManifestResponse{StatusCode: 200, ManifestSHA256: hash}, nil
+	})
+	require.NoError(t, f.drainer(client).Drain(context.Background(), f.out))
+	items, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.Empty(t, items)
+}
+
+func TestManifestoCorrompidoPermaneceNaFilaSemEnvio(t *testing.T) {
+	f := newRawDrainFixture(t)
+	items, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.NoError(t, f.out.Delete(items[0].Key))
+	f.raw.ManifestID = "different-job"
+	f.env.ManifestJSON, err = json.Marshal(f.raw)
+	require.NoError(t, err)
+	require.NoError(t, f.out.Append(f.env))
+	client := rawClientFunc(func(context.Context, queue.Envelope) (RawManifestResponse, error) {
+		t.Fatal("manifesto corrompido enviado")
+		return RawManifestResponse{}, nil
+	})
+	require.Error(t, f.drainer(client).Drain(context.Background(), f.out))
+	items, err = f.out.Peek(10)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+}
+
+func TestDrainerLegadoPreservaEnvelopeRawImutavel(t *testing.T) {
+	f := newRawDrainFixture(t)
+	before, err := f.out.Peek(10)
+	require.NoError(t, err)
+	d := NewDrainer(f.out, breaker.New(5, time.Minute, "legacy"), &stubJobAPI{})
+	d.tick(context.Background())
+	after, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+}
+
+func Test409ComHashCertoSemIndicacaoOuMotivoPreservaPendente(t *testing.T) {
+	for _, response := range []RawManifestResponse{
+		{StatusCode: 409, Reason: "base_missing"},
+		{StatusCode: 409, ForceFull: true},
+		{StatusCode: 409, ForceFull: true, Reason: "  "},
+	} {
+		f := newRawDrainFixture(t)
+		response.ManifestSHA256 = f.env.ManifestSHA256
+		client := rawClientFunc(func(context.Context, queue.Envelope) (RawManifestResponse, error) {
+			return response, nil
+		})
+		require.Error(t, f.drainer(client).Drain(context.Background(), f.out))
+		_, force, err := f.store.ForceFull(f.ref.SourceKey)
+		require.NoError(t, err)
+		require.False(t, force)
+		require.NoError(t, f.store.ConfirmPending(f.ref, f.raw, strings.Repeat("b", 64)))
+		items, err := f.out.Peek(10)
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+	}
+}
+
+func Test409NaoMarcaOutraCompetenciaQuandoChaveContradizManifesto(t *testing.T) {
+	f := newRawDrainFixture(t)
+	items, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.NoError(t, f.out.Delete(items[0].Key))
+	f.env.SourceKey.Competencia = "202602"
+	require.NoError(t, f.out.Append(f.env))
+	before, err := f.out.Peek(10)
+	require.NoError(t, err)
+	calls := 0
+	client := rawClientFunc(func(context.Context, queue.Envelope) (RawManifestResponse, error) {
+		calls++
+		return RawManifestResponse{StatusCode: 409, ManifestSHA256: f.env.ManifestSHA256,
+			ForceFull: true, Reason: "base_missing"}, nil
+	})
+	require.Error(t, f.drainer(client).Drain(context.Background(), f.out))
+	require.Zero(t, calls)
+	after, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	_, forced, err := f.store.ForceFull(f.env.SourceKey)
+	require.NoError(t, err)
+	require.False(t, forced)
+	require.NoError(t, f.store.ConfirmPending(f.ref, f.raw, strings.Repeat("c", 64)))
+}
+
+func TestDecodificacaoVinculaFonteIntentECompetenciaNormalizada(t *testing.T) {
+	f := newRawDrainFixture(t)
+	for _, key := range []delta.SourceKey{
+		{Source: "sihd", Intent: "profissionais", Competencia: "202601"},
+		{Source: "cnes", Intent: "aih", Competencia: "202601"},
+		{Source: "cnes", Intent: "profissionais", Competencia: "2026--01"},
+	} {
+		env := f.env
+		env.SourceKey = key
+		_, err := decodeRawEnvelope(env)
+		require.Error(t, err)
+	}
+	f.env.SourceKey.Competencia = "2026-01"
+	_, err := decodeRawEnvelope(f.env)
+	require.NoError(t, err)
 }

--- a/apps/dump_agent_go/internal/worker/executor.go
+++ b/apps/dump_agent_go/internal/worker/executor.go
@@ -66,11 +66,13 @@ type JobExecutor struct {
 
 // RunRaw prepara o manifesto durável e envia o Parquet sem confirmar estado.
 func (e *JobExecutor) RunRaw(ctx context.Context, job *Job) (int64, error) {
-	if err := e.reconcileRawSpools(); err != nil {
-		return 0, err
-	}
 	if size, replay, err := e.replayRaw(job); replay || err != nil {
 		return size, err
+	}
+	ref := delta.PendingRef{SourceKey: deltaKeyFromParams(job.Params),
+		JobID: job.ID, FencingToken: job.FencingToken}
+	if err := e.reconcileRawState(ref); err != nil {
+		return 0, err
 	}
 	cycle, err := e.prepareRaw(ctx, job)
 	if err != nil {

--- a/apps/dump_agent_go/internal/worker/executor.go
+++ b/apps/dump_agent_go/internal/worker/executor.go
@@ -66,6 +66,9 @@ type JobExecutor struct {
 
 // RunRaw prepara o manifesto durável e envia o Parquet sem confirmar estado.
 func (e *JobExecutor) RunRaw(ctx context.Context, job *Job) (int64, error) {
+	if err := e.reconcileRawSpools(); err != nil {
+		return 0, err
+	}
 	if size, replay, err := e.replayRaw(job); replay || err != nil {
 		return size, err
 	}

--- a/apps/dump_agent_go/internal/worker/executor.go
+++ b/apps/dump_agent_go/internal/worker/executor.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -17,6 +16,8 @@ import (
 	"github.com/cnesdata/dumpagent/internal/delta"
 	"github.com/cnesdata/dumpagent/internal/extractor"
 	"github.com/cnesdata/dumpagent/internal/integrity"
+	"github.com/cnesdata/dumpagent/internal/manifest"
+	"github.com/cnesdata/dumpagent/internal/obs"
 	"github.com/cnesdata/dumpagent/internal/upload"
 	"github.com/cnesdata/dumpagent/internal/writer"
 	"golang.org/x/sync/errgroup"
@@ -28,22 +29,24 @@ var ErrUnknownIntent = errors.New("unknown_intent")
 // JobSpec descreve o que o agent quer registrar em /jobs/register.
 // IDs são locais ao agent; extraction_id é retornado pelo central.
 type JobSpec struct {
-	JobID         string
-	FonteSistema  string
-	TipoExtracao  string
-	Competencia   int
-	Intent        string
+	JobID        string
+	FonteSistema string
+	TipoExtracao string
+	Competencia  int
+	Intent       string
 }
 
 // Job payload executado pelo executor.
 type Job struct {
-	ID        string
-	TenantID  string
-	UploadURL string
-	MinioKey  string
-	Params    extractor.ExtractionParams
-	Sha256    string
-	RowCount  int
+	ID           string
+	TenantID     string
+	UploadURL    string
+	MinioKey     string
+	Params       extractor.ExtractionParams
+	Sha256       string
+	RowCount     int
+	FencingToken uint64
+	RawRequest   *manifest.BuildRequest
 }
 
 // JobExecutor executa 1 job end-to-end: DB conn → pipeline → upload.
@@ -51,10 +54,72 @@ type Job struct {
 // snapshot legado. AuditLogger != nil emite eventos lifecycle
 // (Extracted/Uploaded/Committed/Aborted); nil → no-op.
 type JobExecutor struct {
-	DB          *sql.DB
-	Uploader    upload.Uploader
-	DeltaStore  *delta.Store
-	AuditLogger *audit.Logger
+	DB                *sql.DB
+	Uploader          upload.Uploader
+	DeltaStore        *delta.Store
+	AuditLogger       *audit.Logger
+	RawExtract        func(context.Context, Job) ([]delta.Row, error)
+	RawUploader       upload.RawUploader
+	RawOutbox         EnvelopeOutbox
+	RawSpoolDirectory string
+}
+
+// RunRaw prepara o manifesto durável e envia o Parquet sem confirmar estado.
+func (e *JobExecutor) RunRaw(ctx context.Context, job *Job) (int64, error) {
+	if size, replay, err := e.replayRaw(job); replay || err != nil {
+		return size, err
+	}
+	cycle, err := e.prepareRaw(ctx, job)
+	if err != nil {
+		return 0, err
+	}
+	spool, err := upload.PrepareRawSpool(ctx, e.RawSpoolDirectory, cycle.write)
+	if err != nil {
+		return 0, err
+	}
+	cycle.spoolName, cycle.uploadURL = spool.Name, job.UploadURL
+	cycle.request.SizeBytes, cycle.request.ObjectSHA256 = spool.SizeBytes, spool.SHA256
+	raw, err := manifest.Build(cycle.request)
+	if err != nil {
+		return 0, err
+	}
+	if err := e.enqueueRaw(cycle, raw); err != nil {
+		return 0, err
+	}
+	size, err := upload.UploadRawSpool(ctx, e.RawUploader, upload.RawSpoolUpload{
+		Directory: e.RawSpoolDirectory, Name: spool.Name, URL: job.UploadURL,
+		FencingToken: job.FencingToken, Manifest: raw})
+	if err != nil {
+		return 0, err
+	}
+	job.Sha256, job.MinioKey, job.RowCount = spool.SHA256, raw.ObjectKey, int(raw.RowCount)
+	return size, nil
+}
+
+func streamParquet(ctx context.Context, write func(io.Writer) error,
+	consume func(io.Reader) (int64, error),
+) (int64, string, error) {
+	reader, pipe := io.Pipe()
+	stop := context.AfterFunc(ctx, func() {
+		_ = reader.CloseWithError(ctx.Err())
+		_ = pipe.CloseWithError(ctx.Err())
+	})
+	defer stop()
+	producer := obs.SafeGo(func() error {
+		defer pipe.Close()
+		err := write(pipe)
+		_ = pipe.CloseWithError(err)
+		return err
+	}, "parquet_stream")
+	teed, hasher := integrity.SHA256TeeReader(reader)
+	var size int64
+	err := obs.SafeRun(func() error {
+		var err error
+		size, err = consume(teed)
+		return err
+	}, "parquet_consume")
+	_ = reader.CloseWithError(err)
+	return size, hasher.SumHex(), errors.Join(err, <-producer, ctx.Err())
 }
 
 // Run executa job. Retorna tamanho total uploadado em bytes. Se DeltaStore
@@ -62,6 +127,9 @@ type JobExecutor struct {
 // caso contrário usa o pipeline snapshot streaming. job.Sha256 é
 // preenchido no caminho delta (após o tee de integrity sobre o upload).
 func (e *JobExecutor) Run(ctx context.Context, job *Job) (sizeBytes int64, err error) {
+	if job.RawRequest != nil {
+		return e.RunRaw(ctx, job)
+	}
 	if e.DeltaStore != nil {
 		return e.runDeltaWithCommit(ctx, job)
 	}
@@ -166,7 +234,7 @@ func (e *JobExecutor) RunDelta(
 	extractionID := uuid.NewString()
 	e.appendAudit(audit.Event{
 		Source: key.Source, Intent: key.Intent,
-		Competencia: key.Competencia,
+		Competencia:  key.Competencia,
 		ExtractionID: extractionID, JobID: job.ID,
 		Lifecycle: audit.LifecycleExtracted,
 	})
@@ -201,24 +269,20 @@ func (e *JobExecutor) writeAndUploadDelta(
 	ctx context.Context, job *Job, ds delta.Set, uc uploadCtx,
 ) (int64, error) {
 	cols := delta.ProfileFor(uc.Key.Source, uc.Key.Intent).FingerprintColumns
-	var buf bytes.Buffer
-	if err := writer.WriteDeltaParquet(&buf, ds, cols); err != nil {
-		uc.Pending.Abort()
-		e.emitAborted(uc, job.ID)
-		return 0, fmt.Errorf("write_delta_parquet: %w", err)
-	}
-	teed, hasher := integrity.SHA256TeeReader(&buf)
-	size, err := e.Uploader.Put(ctx, job.UploadURL, teed,
-		"application/octet-stream")
+	size, digest, err := streamParquet(ctx, func(dst io.Writer) error {
+		return writer.WriteDeltaParquet(dst, ds, cols)
+	}, func(body io.Reader) (int64, error) {
+		return e.Uploader.Put(ctx, job.UploadURL, body, "application/octet-stream")
+	})
 	if err != nil {
 		uc.Pending.Abort()
 		e.emitAborted(uc, job.ID)
 		return 0, fmt.Errorf("upload: %w", err)
 	}
-	job.Sha256 = hasher.SumHex()
+	job.Sha256 = digest
 	e.appendAudit(audit.Event{
 		Source: uc.Key.Source, Intent: uc.Key.Intent,
-		Competencia: uc.Key.Competencia,
+		Competencia:  uc.Key.Competencia,
 		ExtractionID: uc.ExtractionID, JobID: job.ID,
 		SHA256: job.Sha256, SizeBytes: size,
 		Lifecycle: audit.LifecycleUploaded,
@@ -229,7 +293,7 @@ func (e *JobExecutor) writeAndUploadDelta(
 func (e *JobExecutor) emitAborted(uc uploadCtx, jobID string) {
 	e.appendAudit(audit.Event{
 		Source: uc.Key.Source, Intent: uc.Key.Intent,
-		Competencia: uc.Key.Competencia,
+		Competencia:  uc.Key.Competencia,
 		ExtractionID: uc.ExtractionID, JobID: jobID,
 		Lifecycle: audit.LifecycleAborted,
 	})

--- a/apps/dump_agent_go/internal/worker/executor.go
+++ b/apps/dump_agent_go/internal/worker/executor.go
@@ -89,7 +89,7 @@ func (e *JobExecutor) RunRaw(ctx context.Context, job *Job) (int64, error) {
 	if err := e.enqueueRaw(cycle, raw); err != nil {
 		return 0, removeUnpersistedRawSpool(e.RawSpoolDirectory, spool.Name, err)
 	}
-	size, err := upload.UploadRawSpool(ctx, e.RawUploader, upload.RawSpoolUpload{
+	size, err := upload.PutRawSpool(ctx, e.RawUploader, upload.RawSpoolUpload{
 		Directory: e.RawSpoolDirectory, Name: spool.Name, URL: job.UploadURL,
 		FencingToken: job.FencingToken, Manifest: raw})
 	if err != nil {

--- a/apps/dump_agent_go/internal/worker/executor.go
+++ b/apps/dump_agent_go/internal/worker/executor.go
@@ -67,7 +67,13 @@ type JobExecutor struct {
 }
 
 // RunRaw prepara o manifesto durável e envia o Parquet sem confirmar estado.
-func (e *JobExecutor) RunRaw(ctx context.Context, job *Job) (int64, error) {
+func (e *JobExecutor) RunRaw(ctx context.Context, job *Job) (sizeBytes int64, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			sizeBytes = 0
+			err = fmt.Errorf("panic in RunRaw: %v\n%s", recovered, debug.Stack())
+		}
+	}()
 	if size, replay, err := e.replayRaw(job); replay || err != nil {
 		return size, err
 	}

--- a/apps/dump_agent_go/internal/worker/executor.go
+++ b/apps/dump_agent_go/internal/worker/executor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"runtime/debug"
 	"strings"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/cnesdata/dumpagent/internal/integrity"
 	"github.com/cnesdata/dumpagent/internal/manifest"
 	"github.com/cnesdata/dumpagent/internal/obs"
+	"github.com/cnesdata/dumpagent/internal/queue"
 	"github.com/cnesdata/dumpagent/internal/upload"
 	"github.com/cnesdata/dumpagent/internal/writer"
 	"golang.org/x/sync/errgroup"
@@ -103,6 +105,56 @@ func (e *JobExecutor) RunRaw(ctx context.Context, job *Job) (int64, error) {
 
 func removeUnpersistedRawSpool(directory, name string, cause error) error {
 	return errors.Join(cause, upload.RemoveRawSpool(directory, name))
+}
+
+func (e *JobExecutor) reconcileRawState(current delta.PendingRef) error {
+	if e.RawOutbox == nil || e.DeltaStore == nil || e.RawSpoolDirectory == "" {
+		return errors.New("raw_executor=unconfigured")
+	}
+	items, err := allEnvelopeItems(e.RawOutbox)
+	if err != nil {
+		return err
+	}
+	refs, retained := retainedRawState(current, items)
+	if _, err := e.DeltaStore.ReconcileRawPending(refs); err != nil {
+		return err
+	}
+	return reconcileRawSpoolFiles(e.RawSpoolDirectory, retained)
+}
+
+func retainedRawState(current delta.PendingRef,
+	items []queue.Item,
+) ([]delta.PendingRef, map[string]bool) {
+	refs := []delta.PendingRef{current}
+	spools := make(map[string]bool, len(items))
+	for _, item := range items {
+		if item.Envelope.Type == queue.TypeRawManifest {
+			spools[item.Envelope.SpoolName] = true
+			refs = append(refs, pendingRef(item.Envelope))
+		}
+	}
+	return refs, spools
+}
+
+func reconcileRawSpoolFiles(directory string, retained map[string]bool) error {
+	entries, err := os.ReadDir(directory)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasPrefix(name, "raw-") ||
+			!strings.HasSuffix(name, ".parquet") || retained[name] {
+			continue
+		}
+		if err := upload.RemoveRawSpool(directory, name); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func streamParquet(ctx context.Context, write func(io.Writer) error,

--- a/apps/dump_agent_go/internal/worker/executor.go
+++ b/apps/dump_agent_go/internal/worker/executor.go
@@ -81,10 +81,10 @@ func (e *JobExecutor) RunRaw(ctx context.Context, job *Job) (int64, error) {
 	cycle.request.SizeBytes, cycle.request.ObjectSHA256 = spool.SizeBytes, spool.SHA256
 	raw, err := manifest.Build(cycle.request)
 	if err != nil {
-		return 0, err
+		return 0, removeUnpersistedRawSpool(e.RawSpoolDirectory, spool.Name, err)
 	}
 	if err := e.enqueueRaw(cycle, raw); err != nil {
-		return 0, err
+		return 0, removeUnpersistedRawSpool(e.RawSpoolDirectory, spool.Name, err)
 	}
 	size, err := upload.UploadRawSpool(ctx, e.RawUploader, upload.RawSpoolUpload{
 		Directory: e.RawSpoolDirectory, Name: spool.Name, URL: job.UploadURL,
@@ -94,6 +94,10 @@ func (e *JobExecutor) RunRaw(ctx context.Context, job *Job) (int64, error) {
 	}
 	job.Sha256, job.MinioKey, job.RowCount = spool.SHA256, raw.ObjectKey, int(raw.RowCount)
 	return size, nil
+}
+
+func removeUnpersistedRawSpool(directory, name string, cause error) error {
+	return errors.Join(cause, upload.RemoveRawSpool(directory, name))
 }
 
 func streamParquet(ctx context.Context, write func(io.Writer) error,

--- a/apps/dump_agent_go/internal/worker/executor_rundelta_test.go
+++ b/apps/dump_agent_go/internal/worker/executor_rundelta_test.go
@@ -53,6 +53,7 @@ func rawJob() worker.Job {
 		}}
 }
 
+//nolint:misspell // NOME_PROFISSIONAL is a frozen CNES field name.
 func newRawExecutor(t *testing.T) *worker.JobExecutor {
 	t.Helper()
 	directory := t.TempDir()
@@ -386,7 +387,7 @@ func (s *stubFailUploader) Put(
 	return 0, s.err
 }
 
-func confirmRawExecutor(t *testing.T, executor *worker.JobExecutor, job worker.Job) manifest.Raw {
+func confirmRawExecutor(t *testing.T, executor *worker.JobExecutor, job worker.Job) {
 	t.Helper()
 	items, err := executor.RawOutbox.Peek(10)
 	require.NoError(t, err)
@@ -396,7 +397,6 @@ func confirmRawExecutor(t *testing.T, executor *worker.JobExecutor, job worker.J
 	require.NoError(t, executor.DeltaStore.ConfirmPending(
 		rawPendingRef(job), raw, strings.Repeat("b", 64)))
 	require.NoError(t, executor.RawOutbox.Delete(items[0].Key))
-	return raw
 }
 
 func TestDeltaRawUsaCabecaConfirmadaEPreservaChavesNulasNaExclusao(t *testing.T) {

--- a/apps/dump_agent_go/internal/worker/executor_rundelta_test.go
+++ b/apps/dump_agent_go/internal/worker/executor_rundelta_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -113,6 +114,18 @@ func TestExecutorRawPersistePendenteEEnvelopeAntesDoUpload(t *testing.T) {
 	committed, err := exe.DeltaStore.GetCommitted(rawPendingRef(job).SourceKey)
 	require.NoError(t, err)
 	require.Empty(t, committed)
+}
+
+func TestExecutorRawRemoveSpoolSemEnvelopeAntesDoNovoRun(t *testing.T) {
+	executor, job := newRawExecutor(t), rawJob()
+	require.NoError(t, os.MkdirAll(executor.RawSpoolDirectory, 0o700))
+	orphan := filepath.Join(executor.RawSpoolDirectory, "raw-orphan.parquet")
+	require.NoError(t, os.WriteFile(orphan, []byte("orphan"), 0o600))
+
+	_, err := executor.RunRaw(context.Background(), &job)
+	require.NoError(t, err)
+	_, err = os.Stat(orphan)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestFalhaDeUploadRawPreservaEstadoDuravel(t *testing.T) {

--- a/apps/dump_agent_go/internal/worker/executor_rundelta_test.go
+++ b/apps/dump_agent_go/internal/worker/executor_rundelta_test.go
@@ -1,19 +1,28 @@
 package worker_test
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/cnesdata/dumpagent/internal/delta"
 	"github.com/cnesdata/dumpagent/internal/extractor"
+	"github.com/cnesdata/dumpagent/internal/manifest"
+	"github.com/cnesdata/dumpagent/internal/queue"
 	"github.com/cnesdata/dumpagent/internal/upload"
 	"github.com/cnesdata/dumpagent/internal/worker"
+	pq "github.com/parquet-go/parquet-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,6 +32,176 @@ func newDeltaStore(t *testing.T) *delta.Store {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 	return store
+}
+
+type rawUploadFunc func(context.Context, upload.RawPutRequest) (int64, error)
+
+func (f rawUploadFunc) PutRaw(ctx context.Context, req upload.RawPutRequest) (int64, error) {
+	return f(ctx, req)
+}
+
+func rawJob() worker.Job {
+	return worker.Job{ID: "full-job", TenantID: "tenant", FencingToken: 7,
+		UploadURL: "https://object.invalid", Params: extractor.ExtractionParams{
+			Intent: extractor.IntentCnesProfissionais, Competencia: "202601",
+		}, RawRequest: &manifest.BuildRequest{
+			SourceType: manifest.SourceTypeCNESLocal, FileSubtype: "CNES_VINCULO",
+			Competencia: "2026-01", AgentID: "agent", AgentVersion: "1", SchemaVersion: "1",
+			SnapshotMode: manifest.SnapshotModeFull,
+			CreatedAt:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		}}
+}
+
+func newRawExecutor(t *testing.T) *worker.JobExecutor {
+	t.Helper()
+	directory := t.TempDir()
+	out, err := queue.Open(filepath.Join(directory, "outbox.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = out.Close() })
+	store, err := delta.Open(filepath.Join(directory, "delta.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return &worker.JobExecutor{DeltaStore: store, RawOutbox: out,
+		RawSpoolDirectory: filepath.Join(directory, "spool"),
+		RawExtract: func(context.Context, worker.Job) ([]delta.Row, error) {
+			return []delta.Row{{"CPF": "synthetic", "CNES": "unit", "CBO": "role",
+				"CNS": "card", "NOME_PROFISSIONAL": "Teste", "NOME_SOCIAL": nil,
+				"SEXO": "F", "TIPO_VINCULO": "1", "SUS": "S", "CH_TOTAL": int64(40),
+				"CH_AMBULATORIAL": int64(20), "CH_OUTRAS": int64(0),
+				"CH_HOSPITALAR": int64(20), "FONTE": "CNES_LOCAL"}}, nil
+		}, RawUploader: rawUploadFunc(func(_ context.Context, r upload.RawPutRequest) (int64, error) {
+			return io.Copy(io.Discard, r.Body)
+		})}
+}
+
+func rawPendingRef(job worker.Job) delta.PendingRef {
+	return delta.PendingRef{JobID: job.ID, FencingToken: job.FencingToken,
+		SourceKey: delta.SourceKey{Source: "cnes", Intent: "profissionais", Competencia: "202601"}}
+}
+
+func TestExecutorRawPersistePendenteEEnvelopeAntesDoUpload(t *testing.T) {
+	exe, job := newRawExecutor(t), rawJob()
+	var payload []byte
+	exe.RawUploader = rawUploadFunc(func(_ context.Context,
+		request upload.RawPutRequest,
+	) (int64, error) {
+		items, err := exe.RawOutbox.Peek(10)
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		_, err = exe.DeltaStore.BeginPendingRef(rawPendingRef(job))
+		require.ErrorIs(t, err, delta.ErrPendingExists)
+		require.Equal(t, uint64(7), request.FencingToken)
+		require.Equal(t, "raw/tenant/CNES_LOCAL/2026-01/full-job/data.parquet", request.ObjectKey)
+		payload, err = io.ReadAll(request.Body)
+		return int64(len(payload)), err
+	})
+	size, err := exe.Run(context.Background(), &job)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(payload)), size)
+	digest := sha256.Sum256(payload)
+	require.Equal(t, hex.EncodeToString(digest[:]), job.Sha256)
+	file, err := pq.OpenFile(bytes.NewReader(payload), size)
+	require.NoError(t, err)
+	require.Len(t, file.Schema().Columns(), 14)
+	require.Equal(t, int64(1), file.NumRows())
+	items, err := exe.RawOutbox.Peek(10)
+	require.NoError(t, err)
+	var raw manifest.Raw
+	require.NoError(t, json.Unmarshal(items[0].Envelope.ManifestJSON, &raw))
+	require.Equal(t, job.Sha256, raw.ObjectSHA256)
+	require.Equal(t, size, raw.SizeBytes)
+	committed, err := exe.DeltaStore.GetCommitted(rawPendingRef(job).SourceKey)
+	require.NoError(t, err)
+	require.Empty(t, committed)
+}
+
+func TestFalhaDeUploadRawPreservaEstadoDuravel(t *testing.T) {
+	for _, name := range []string{"rede", "tamanho", "corpo_incompleto"} {
+		t.Run(name, func(t *testing.T) {
+			exe, job := newRawExecutor(t), rawJob()
+			exe.RawUploader = rawUploadFunc(func(_ context.Context, r upload.RawPutRequest) (int64, error) {
+				if name == "rede" {
+					return 0, errors.New("network=down")
+				}
+				if name == "corpo_incompleto" {
+					return 0, nil
+				}
+				n, err := io.Copy(io.Discard, r.Body)
+				return n + 1, err
+			})
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_, err := exe.RunRaw(ctx, &job)
+			require.Error(t, err)
+			items, err := exe.RawOutbox.Peek(10)
+			require.NoError(t, err)
+			require.Len(t, items, 1)
+			_, err = exe.DeltaStore.BeginPendingRef(rawPendingRef(job))
+			require.ErrorIs(t, err, delta.ErrPendingExists)
+			_, _, _, _, ok, err := exe.DeltaStore.ChainHead(rawPendingRef(job).SourceKey)
+			require.NoError(t, err)
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestFullForcadoEsperaJobFullSolicitado(t *testing.T) {
+	exe, job := newRawExecutor(t), rawJob()
+	extract, calls := exe.RawExtract, 0
+	exe.RawExtract = func(ctx context.Context, job worker.Job) ([]delta.Row, error) {
+		calls++
+		return extract(ctx, job)
+	}
+	ref := rawPendingRef(job)
+	require.NoError(t, exe.DeltaStore.RequireFull(ref, "base_missing"))
+	job.RawRequest.SnapshotMode = manifest.SnapshotModeDelta
+	_, err := exe.RunRaw(context.Background(), &job)
+	require.ErrorContains(t, err, "force_full")
+	require.Zero(t, calls)
+	items, err := exe.RawOutbox.Peek(10)
+	require.NoError(t, err)
+	require.Empty(t, items)
+	job.RawRequest.SnapshotMode = manifest.SnapshotModeFull
+	_, err = exe.RunRaw(context.Background(), &job)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	_, force, err := exe.DeltaStore.ForceFull(ref.SourceKey)
+	require.NoError(t, err)
+	require.True(t, force)
+	items, err = exe.RawOutbox.Peek(10)
+	require.NoError(t, err)
+	var raw manifest.Raw
+	require.NoError(t, json.Unmarshal(items[0].Envelope.ManifestJSON, &raw))
+	require.NoError(t, exe.DeltaStore.ConfirmPending(ref, raw, strings.Repeat("a", 64)))
+	_, force, err = exe.DeltaStore.ForceFull(ref.SourceKey)
+	require.NoError(t, err)
+	require.False(t, force)
+}
+
+func TestExecutorRawRejeitaConfiguracaoETiposAntesDePersistir(t *testing.T) {
+	for _, name := range []string{"extrator_ausente", "tipo_invalido", "delta_sem_base"} {
+		t.Run(name, func(t *testing.T) {
+			exe, job := newRawExecutor(t), rawJob()
+			switch name {
+			case "extrator_ausente":
+				exe.RawExtract = nil
+			case "tipo_invalido":
+				exe.RawExtract = func(context.Context, worker.Job) ([]delta.Row, error) {
+					return []delta.Row{{"CPF": "synthetic", "CH_TOTAL": "40"}}, nil
+				}
+			case "delta_sem_base":
+				job.RawRequest.SnapshotMode = manifest.SnapshotModeDelta
+			}
+			_, err := exe.RunRaw(context.Background(), &job)
+			require.Error(t, err)
+			items, err := exe.RawOutbox.Peek(10)
+			require.NoError(t, err)
+			require.Empty(t, items)
+			pending, err := exe.DeltaStore.BeginPendingRef(rawPendingRef(job))
+			require.NoError(t, err)
+			pending.Abort()
+		})
+	}
 }
 
 func mockEstabelecimentosRow(mock sqlmock.Sqlmock) {
@@ -192,4 +371,112 @@ func (s *stubFailUploader) Put(
 ) (int64, error) {
 	_, _ = io.Copy(io.Discard, body)
 	return 0, s.err
+}
+
+func confirmRawExecutor(t *testing.T, executor *worker.JobExecutor, job worker.Job) manifest.Raw {
+	t.Helper()
+	items, err := executor.RawOutbox.Peek(10)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	var raw manifest.Raw
+	require.NoError(t, json.Unmarshal(items[0].Envelope.ManifestJSON, &raw))
+	require.NoError(t, executor.DeltaStore.ConfirmPending(
+		rawPendingRef(job), raw, strings.Repeat("b", 64)))
+	require.NoError(t, executor.RawOutbox.Delete(items[0].Key))
+	return raw
+}
+
+func TestDeltaRawUsaCabecaConfirmadaEPreservaChavesNulasNaExclusao(t *testing.T) {
+	executor, job := newRawExecutor(t), rawJob()
+	rows := []delta.Row{{"CPF": nil, "CNES": "unit", "CBO": "role"},
+		{"CPF": "update", "CNES": "unit", "CBO": "role", "CH_TOTAL": int64(20)},
+		{"CPF": "same", "CNES": "unit", "CBO": "role"}}
+	executor.RawExtract = func(context.Context, worker.Job) ([]delta.Row, error) { return rows, nil }
+	_, err := executor.RunRaw(context.Background(), &job)
+	require.NoError(t, err)
+	confirmRawExecutor(t, executor, job)
+	job.ID, job.FencingToken = "delta-job", 8
+	job.RawRequest.SnapshotMode = manifest.SnapshotModeDelta
+	rows = []delta.Row{{"CPF": "insert", "CNES": "unit", "CBO": "role"},
+		{"CPF": "update", "CNES": "unit", "CBO": "role", "CH_TOTAL": int64(40)}, rows[2]}
+	var payload []byte
+	executor.RawUploader = rawUploadFunc(func(_ context.Context,
+		r upload.RawPutRequest,
+	) (int64, error) {
+		payload, err = io.ReadAll(r.Body)
+		return int64(len(payload)), err
+	})
+	_, err = executor.RunRaw(context.Background(), &job)
+	require.NoError(t, err)
+	items, err := executor.RawOutbox.Peek(10)
+	require.NoError(t, err)
+	var raw manifest.Raw
+	require.NoError(t, json.Unmarshal(items[0].Envelope.ManifestJSON, &raw))
+	require.Equal(t, uint32(2), raw.Sequence)
+	require.Equal(t, "full-job", *raw.BaseSnapshotID)
+	require.Equal(t, strings.Repeat("b", 64), *raw.PreviousManifestSHA256)
+	require.Equal(t, int64(3), raw.RowCount)
+	decoded := readRawOperations(t, payload)
+	require.Equal(t, "insert", decoded[0]["CPF"])
+	require.Equal(t, "I", decoded[0]["_op"])
+	require.Equal(t, "40", decoded[1]["CH_TOTAL"])
+	require.Equal(t, "U", decoded[1]["_op"])
+	require.Nil(t, decoded[2]["CPF"])
+	require.Equal(t, "D", decoded[2]["_op"])
+}
+
+func readRawOperations(t *testing.T, payload []byte) []delta.Row {
+	t.Helper()
+	reader := pq.NewReader(bytes.NewReader(payload))
+	defer reader.Close()
+	columns := reader.Schema().Columns()
+	rows := make([]pq.Row, 10)
+	n, err := reader.ReadRows(rows)
+	if err != io.EOF {
+		require.NoError(t, err)
+	}
+	result := make([]delta.Row, n)
+	for i, row := range rows[:n] {
+		result[i] = delta.Row{}
+		row.Range(func(column int, values []pq.Value) bool {
+			if !values[0].IsNull() {
+				result[i][columns[column][0]] = values[0].String()
+			}
+			return true
+		})
+	}
+	return result
+}
+
+func TestRetryAposFalhaDeUploadIgnoraMudancasNaFonte(t *testing.T) {
+	executor, job := newRawExecutor(t), rawJob()
+	executor.RawUploader = rawUploadFunc(func(context.Context, upload.RawPutRequest) (int64, error) {
+		return 0, errors.New("network=down")
+	})
+	_, err := executor.RunRaw(context.Background(), &job)
+	require.Error(t, err)
+	before, err := executor.RawOutbox.Peek(10)
+	require.NoError(t, err)
+	extractions, uploads := 0, 0
+	executor.RawExtract = func(context.Context, worker.Job) ([]delta.Row, error) {
+		extractions++
+		return []delta.Row{{"CPF": "changed", "CNES": "unit", "CBO": "role"}}, nil
+	}
+	executor.RawUploader = rawUploadFunc(func(_ context.Context,
+		r upload.RawPutRequest,
+	) (int64, error) {
+		uploads++
+		return io.Copy(io.Discard, r.Body)
+	})
+	_, err = executor.RunRaw(context.Background(), &job)
+	require.NoError(t, err)
+	require.Zero(t, extractions)
+	require.Zero(t, uploads)
+	after, err := executor.RawOutbox.Peek(10)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	_, _, _, _, exists, err := executor.DeltaStore.ChainHead(rawPendingRef(job).SourceKey)
+	require.NoError(t, err)
+	require.False(t, exists)
+	confirmRawExecutor(t, executor, job)
 }

--- a/apps/dump_agent_go/internal/worker/outbox_adapter.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"os"
 	"slices"
 	"strings"
 	"time"
@@ -14,7 +13,6 @@ import (
 	"github.com/cnesdata/dumpagent/internal/delta"
 	"github.com/cnesdata/dumpagent/internal/manifest"
 	"github.com/cnesdata/dumpagent/internal/queue"
-	"github.com/cnesdata/dumpagent/internal/upload"
 	"github.com/cnesdata/dumpagent/internal/writer"
 )
 
@@ -40,45 +38,6 @@ type rawCycle struct {
 }
 
 const rawTerminalPollInterval = 10 * time.Millisecond
-
-func (e *JobExecutor) reconcileRawState(current delta.PendingRef) error {
-	if e.RawOutbox == nil || e.DeltaStore == nil || e.RawSpoolDirectory == "" {
-		return errors.New("raw_executor=unconfigured")
-	}
-	items, err := allEnvelopeItems(e.RawOutbox)
-	if err != nil {
-		return err
-	}
-	refs := []delta.PendingRef{current}
-	retained := make(map[string]bool, len(items))
-	for _, item := range items {
-		if item.Envelope.Type == queue.TypeRawManifest {
-			retained[item.Envelope.SpoolName] = true
-			refs = append(refs, pendingRef(item.Envelope))
-		}
-	}
-	if _, err := e.DeltaStore.ReconcileRawPending(refs); err != nil {
-		return err
-	}
-	entries, err := os.ReadDir(e.RawSpoolDirectory)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || !strings.HasPrefix(name, "raw-") ||
-			!strings.HasSuffix(name, ".parquet") || retained[name] {
-			continue
-		}
-		if err := upload.RemoveRawSpool(e.RawSpoolDirectory, name); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 func allEnvelopeItems(out EnvelopeOutbox) ([]queue.Item, error) {
 	for limit := drainBatchSize; ; limit *= 2 {

--- a/apps/dump_agent_go/internal/worker/outbox_adapter.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/cnesdata/dumpagent/internal/delta"
 	"github.com/cnesdata/dumpagent/internal/manifest"
 	"github.com/cnesdata/dumpagent/internal/queue"
+	"github.com/cnesdata/dumpagent/internal/upload"
 	"github.com/cnesdata/dumpagent/internal/writer"
 )
 
@@ -38,6 +40,49 @@ type rawCycle struct {
 }
 
 const rawTerminalPollInterval = 10 * time.Millisecond
+
+func (e *JobExecutor) reconcileRawSpools() error {
+	if e.RawOutbox == nil || e.RawSpoolDirectory == "" {
+		return errors.New("raw_executor=unconfigured")
+	}
+	entries, err := os.ReadDir(e.RawSpoolDirectory)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	items, err := allEnvelopeItems(e.RawOutbox)
+	if err != nil {
+		return err
+	}
+	retained := make(map[string]bool, len(items))
+	for _, item := range items {
+		if item.Envelope.Type == queue.TypeRawManifest {
+			retained[item.Envelope.SpoolName] = true
+		}
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasPrefix(name, "raw-") ||
+			!strings.HasSuffix(name, ".parquet") || retained[name] {
+			continue
+		}
+		if err := upload.RemoveRawSpool(e.RawSpoolDirectory, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func allEnvelopeItems(out EnvelopeOutbox) ([]queue.Item, error) {
+	for limit := drainBatchSize; ; limit *= 2 {
+		items, err := out.Peek(limit)
+		if err != nil || len(items) < limit {
+			return items, err
+		}
+	}
+}
 
 // WaitRawTerminal mantém a lease até o ack remoto estar durável ou o envelope sumir.
 func (e *JobExecutor) WaitRawTerminal(ctx context.Context, job *Job) error {

--- a/apps/dump_agent_go/internal/worker/outbox_adapter.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter.go
@@ -37,6 +37,36 @@ type rawCycle struct {
 	uploadURL string
 }
 
+const rawTerminalPollInterval = 10 * time.Millisecond
+
+// WaitRawTerminal mantém a lease até o ack remoto estar durável ou o envelope sumir.
+func (e *JobExecutor) WaitRawTerminal(ctx context.Context, job *Job) error {
+	if job == nil || e.RawOutbox == nil {
+		return errors.New("raw_executor=unconfigured")
+	}
+	ref := delta.PendingRef{JobID: job.ID, FencingToken: job.FencingToken}
+	ticker := time.NewTicker(rawTerminalPollInterval)
+	defer ticker.Stop()
+	for {
+		item, exists, err := findRawItem(e.RawOutbox, ref)
+		if err != nil || !exists {
+			return err
+		}
+		terminal, err := e.RawOutbox.RawTerminal(item.Key)
+		if err != nil {
+			return err
+		}
+		if terminal {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
 func (e *JobExecutor) prepareRaw(ctx context.Context, job *Job) (rawCycle, error) {
 	cycle, err := e.rawRequest(job)
 	if err != nil {
@@ -334,19 +364,24 @@ func (e *JobExecutor) enqueueRaw(cycle rawCycle, raw manifest.Raw) error {
 }
 
 func findRawEnvelope(out EnvelopeOutbox, ref delta.PendingRef) (queue.Envelope, bool, error) {
+	item, exists, err := findRawItem(out, ref)
+	return item.Envelope, exists, err
+}
+
+func findRawItem(out EnvelopeOutbox, ref delta.PendingRef) (queue.Item, bool, error) {
 	for limit := drainBatchSize; ; limit *= 2 {
 		items, err := out.Peek(limit)
 		if err != nil {
-			return queue.Envelope{}, false, err
+			return queue.Item{}, false, err
 		}
 		for _, item := range items {
 			if item.Envelope.Type == queue.TypeRawManifest &&
 				item.Envelope.JobID == ref.JobID && item.Envelope.FencingToken == ref.FencingToken {
-				return item.Envelope, true, nil
+				return item, true, nil
 			}
 		}
 		if len(items) < limit {
-			return queue.Envelope{}, false, nil
+			return queue.Item{}, false, nil
 		}
 	}
 }

--- a/apps/dump_agent_go/internal/worker/outbox_adapter.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter.go
@@ -379,6 +379,11 @@ func findRawEnvelope(out EnvelopeOutbox, ref delta.PendingRef) (queue.Envelope, 
 }
 
 func findRawItem(out EnvelopeOutbox, ref delta.PendingRef) (queue.Item, bool, error) {
+	if indexed, ok := out.(interface {
+		RawItem(string, uint64) (queue.Item, bool, error)
+	}); ok {
+		return indexed.RawItem(ref.JobID, ref.FencingToken)
+	}
 	for limit := drainBatchSize; ; limit *= 2 {
 		items, err := out.Peek(limit)
 		if err != nil {

--- a/apps/dump_agent_go/internal/worker/outbox_adapter.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter.go
@@ -245,6 +245,7 @@ func (e *JobExecutor) rawReplayConfigured(job *Job) bool {
 	return job != nil && job.RawRequest != nil && e.RawOutbox != nil && job.FencingToken > 0
 }
 
+//nolint:misspell // NOME_PROFISSIONAL is a frozen CNES field name.
 func rawProfile() delta.Profile {
 	return delta.Profile{Source: "cnes", Intent: "profissionais",
 		PKExtractor: func(row delta.Row) string {

--- a/apps/dump_agent_go/internal/worker/outbox_adapter.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter.go
@@ -1,10 +1,355 @@
 package worker
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"time"
 
+	"github.com/cnesdata/dumpagent/internal/delta"
+	"github.com/cnesdata/dumpagent/internal/manifest"
 	"github.com/cnesdata/dumpagent/internal/queue"
+	"github.com/cnesdata/dumpagent/internal/writer"
 )
+
+// EnvelopeOutbox delimita a persistência de envelopes e suas falhas de disco.
+type EnvelopeOutbox interface {
+	Peek(int) ([]queue.Item, error)
+	Append(queue.Envelope) error
+	Delete(...[]byte) error
+	Evict(time.Duration, int) (int, error)
+	RawTerminal([]byte) (bool, error)
+	MarkRawTerminal([]byte) error
+}
+
+type rawCycle struct {
+	ref       delta.PendingRef
+	request   manifest.BuildRequest
+	rows      []delta.Row
+	set       delta.Set
+	hashes    map[string][32]byte
+	indexed   map[string]delta.Row
+	spoolName string
+	uploadURL string
+}
+
+func (e *JobExecutor) prepareRaw(ctx context.Context, job *Job) (rawCycle, error) {
+	cycle, err := e.rawRequest(job)
+	if err != nil {
+		return cycle, err
+	}
+	if err := ctx.Err(); err != nil {
+		return cycle, err
+	}
+	cycle.rows, err = e.RawExtract(ctx, *job)
+	if err != nil {
+		return cycle, err
+	}
+	committed, err := e.DeltaStore.GetCommitted(cycle.ref.SourceKey)
+	if err != nil {
+		return cycle, err
+	}
+	profile := rawProfile()
+	prior := committed
+	if cycle.request.SnapshotMode == manifest.SnapshotModeFull {
+		prior = nil
+	}
+	cycle.indexed, err = indexRawRows(cycle.rows, prior)
+	if err != nil {
+		return cycle, err
+	}
+	cycle.hashes = make(map[string][32]byte, len(cycle.rows))
+	for key, row := range cycle.indexed {
+		cycle.hashes[key] = delta.Hash(row, profile.FingerprintColumns)
+	}
+	cycle.request.RowCount = int64(len(cycle.rows))
+	if cycle.request.SnapshotMode == manifest.SnapshotModeDelta {
+		if err := cycle.computeChanges(committed); err != nil {
+			return cycle, err
+		}
+		cycle.request.RowCount = int64(cycle.set.TotalCount())
+	}
+	return cycle, nil
+}
+
+func (e *JobExecutor) rawRequest(job *Job) (rawCycle, error) {
+	cycle := rawCycle{}
+	if err := e.validateRawRequest(job); err != nil {
+		return cycle, err
+	}
+	cycle.ref = delta.PendingRef{SourceKey: deltaKeyFromParams(job.Params),
+		JobID: job.ID, FencingToken: job.FencingToken}
+	cycle.request = *job.RawRequest
+	cycle.request.JobID, cycle.request.TenantID = job.ID, job.TenantID
+	key := cycle.ref.SourceKey
+	_, forced, err := e.DeltaStore.ForceFull(key)
+	if err != nil {
+		return cycle, err
+	}
+	if forced && cycle.request.SnapshotMode == manifest.SnapshotModeDelta {
+		return cycle, errors.New("force_full=required")
+	}
+	snapshot, seq, hash, _, ok, err := e.DeltaStore.ChainHead(key)
+	if err != nil {
+		return cycle, err
+	}
+	cycle.request.Previous = nil
+	if ok {
+		cycle.request.Previous = &manifest.PreviousHead{
+			SnapshotID: snapshot, Sequence: seq, ManifestSHA256: hash}
+	}
+	cycle.request.SizeBytes, cycle.request.ObjectSHA256 = 1, strings.Repeat("0", 64)
+	_, err = manifest.Build(cycle.request)
+	return cycle, err
+}
+
+func (e *JobExecutor) validateRawRequest(job *Job) error {
+	if job == nil || job.RawRequest == nil || e.DeltaStore == nil || e.RawOutbox == nil ||
+		e.RawUploader == nil || e.RawExtract == nil || job.FencingToken == 0 {
+		return errors.New("raw_executor=unconfigured")
+	}
+	return validateRawIdentity(job)
+}
+
+func validateRawIdentity(job *Job) error {
+	if job.RawRequest.CreatedAt.IsZero() {
+		return errors.New("raw_request=identity_invalid")
+	}
+	return validateRawScope(deltaKeyFromParams(job.Params), manifest.Raw{
+		SourceType: job.RawRequest.SourceType, FileSubtype: job.RawRequest.FileSubtype,
+		Competencia: job.RawRequest.Competencia})
+}
+
+func validateRawScope(key delta.SourceKey, raw manifest.Raw) error {
+	if key.Source != "cnes" || raw.SourceType != manifest.SourceTypeCNESLocal ||
+		key.Intent != "profissionais" || raw.FileSubtype != "CNES_VINCULO" {
+		return errors.New("raw_source=identity_invalid")
+	}
+	layout := "200601"
+	if len(key.Competencia) == 7 {
+		layout = "2006-01"
+	}
+	month, err := time.Parse(layout, key.Competencia)
+	if err != nil || month.Format("2006-01") != raw.Competencia {
+		return errors.New("raw_competencia=identity_invalid")
+	}
+	return nil
+}
+
+func (e *JobExecutor) replayRaw(job *Job) (int64, bool, error) {
+	if !e.rawReplayConfigured(job) {
+		return 0, false, errors.New("raw_executor=unconfigured")
+	}
+	if err := validateRawIdentity(job); err != nil {
+		return 0, false, err
+	}
+	ref := delta.PendingRef{JobID: job.ID, FencingToken: job.FencingToken}
+	env, exists, err := findRawEnvelope(e.RawOutbox, ref)
+	if err != nil || !exists {
+		return 0, exists, err
+	}
+	raw, err := decodeRawEnvelope(env)
+	if err != nil {
+		return 0, true, err
+	}
+	if err := validateRawScope(deltaKeyFromParams(job.Params), raw); err != nil {
+		return 0, true, err
+	}
+	if raw.TenantID != job.TenantID {
+		return 0, true, errors.New("raw_tenant=identity_invalid")
+	}
+	job.Sha256, job.MinioKey, job.RowCount = raw.ObjectSHA256, raw.ObjectKey, int(raw.RowCount)
+	return raw.SizeBytes, true, nil
+}
+
+func (e *JobExecutor) rawReplayConfigured(job *Job) bool {
+	return job != nil && job.RawRequest != nil && e.RawOutbox != nil && job.FencingToken > 0
+}
+
+func rawProfile() delta.Profile {
+	return delta.Profile{Source: "cnes", Intent: "profissionais",
+		PKExtractor: func(row delta.Row) string {
+			key, _ := json.Marshal([5]any{row["CPF"], row["CNES"], row["CBO"],
+				row["TIPO_VINCULO"], row["SUS"]})
+			return string(key)
+		}, FingerprintColumns: []string{
+			"CPF", "CNS", "NOME_PROFISSIONAL", "NOME_SOCIAL", "SEXO", "CBO", "CNES",
+			"TIPO_VINCULO", "SUS", "CH_TOTAL", "CH_AMBULATORIAL", "CH_OUTRAS",
+			"CH_HOSPITALAR", "FONTE",
+		}}
+}
+
+func (cycle *rawCycle) computeChanges(committed map[string][32]byte) error {
+	for key, row := range cycle.indexed {
+		prior, exists := committed[key]
+		if !exists {
+			cycle.set.Inserts = append(cycle.set.Inserts, row)
+		} else if prior != cycle.hashes[key] {
+			cycle.set.Updates = append(cycle.set.Updates, row)
+		}
+	}
+	for key := range committed {
+		if _, exists := cycle.hashes[key]; exists {
+			continue
+		}
+		var identity rawRowKey
+		if err := json.Unmarshal([]byte(key), &identity); err != nil {
+			return errors.New("raw_committed_key=invalid")
+		}
+		var columns [5]any
+		if err := json.Unmarshal([]byte(identity.Identity), &columns); err != nil {
+			return errors.New("raw_committed_key=invalid")
+		}
+		cycle.set.Deletes = append(cycle.set.Deletes,
+			delta.Row{"CPF": columns[0], "CNES": columns[1], "CBO": columns[2],
+				"TIPO_VINCULO": columns[3], "SUS": columns[4]})
+	}
+	return nil
+}
+
+type rawRowKey struct {
+	Identity   string
+	Occurrence int
+}
+
+func indexRawRows(rows []delta.Row, committed map[string][32]byte) (map[string]delta.Row, error) {
+	profile := rawProfile()
+	prior := map[string][]string{}
+	for key := range committed {
+		var identity rawRowKey
+		if err := json.Unmarshal([]byte(key), &identity); err != nil {
+			return nil, errors.New("raw_committed_key=invalid")
+		}
+		prior[identity.Identity] = append(prior[identity.Identity], key)
+	}
+	groups := map[string][]delta.Row{}
+	for _, row := range rows {
+		key := profile.PKExtractor(row)
+		groups[key] = append(groups[key], row)
+	}
+	indexed := map[string]delta.Row{}
+	for identity, group := range groups {
+		matchRawGroup(group, prior[identity], committed, indexed)
+	}
+	return indexed, nil
+}
+
+func matchRawGroup(rows []delta.Row, prior []string,
+	committed map[string][32]byte, indexed map[string]delta.Row,
+) {
+	slices.Sort(prior)
+	byHash := map[[32]byte][]string{}
+	for _, key := range prior {
+		byHash[committed[key]] = append(byHash[committed[key]], key)
+	}
+	profile := rawProfile()
+	var unmatched []delta.Row
+	for _, row := range rows {
+		hash := delta.Hash(row, profile.FingerprintColumns)
+		keys := byHash[hash]
+		if len(keys) == 0 {
+			unmatched = append(unmatched, row)
+			continue
+		}
+		indexed[keys[0]], byHash[hash] = row, keys[1:]
+	}
+	var free []string
+	for _, key := range prior {
+		if _, matched := indexed[key]; !matched {
+			free = append(free, key)
+		}
+	}
+	assignRawOccurrences(unmatched, free, indexed)
+}
+
+func assignRawOccurrences(rows []delta.Row, free []string, indexed map[string]delta.Row) {
+	profile := rawProfile()
+	slices.SortFunc(rows, func(left, right delta.Row) int {
+		l := delta.Hash(left, profile.FingerprintColumns)
+		r := delta.Hash(right, profile.FingerprintColumns)
+		return bytes.Compare(l[:], r[:])
+	})
+	occurrence := 0
+	for i, row := range rows {
+		if i < len(free) {
+			indexed[free[i]] = row
+			continue
+		}
+		for {
+			key, _ := json.Marshal(rawRowKey{profile.PKExtractor(row), occurrence})
+			occurrence++
+			if _, exists := indexed[string(key)]; !exists {
+				indexed[string(key)] = row
+				break
+			}
+		}
+	}
+}
+
+func (cycle rawCycle) write(dst io.Writer) error {
+	if cycle.request.SnapshotMode == manifest.SnapshotModeFull {
+		return writer.WriteRawFullParquet(dst, cycle.rows)
+	}
+	return writer.WriteRawDeltaParquet(dst, cycle.set)
+}
+
+func (e *JobExecutor) enqueueRaw(cycle rawCycle, raw manifest.Raw) error {
+	payload, err := manifest.CanonicalJSON(raw)
+	if err != nil {
+		return err
+	}
+	hash, err := manifest.SHA256(raw)
+	if err != nil {
+		return err
+	}
+	env := queue.Envelope{Type: queue.TypeRawManifest, JobID: cycle.ref.JobID,
+		FencingToken: cycle.ref.FencingToken, SourceKey: cycle.ref.SourceKey,
+		ManifestJSON: payload, ManifestSHA256: hash,
+		SpoolName: cycle.spoolName, UploadURL: cycle.uploadURL}
+	if _, err := decodeRawEnvelope(env); err != nil {
+		return err
+	}
+	_, exists, err := findRawEnvelope(e.RawOutbox, cycle.ref)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return e.RawOutbox.Append(env)
+	}
+	pending, err := e.DeltaStore.BeginPendingRef(cycle.ref)
+	if errors.Is(err, delta.ErrPendingExists) {
+		pending, err = e.DeltaStore.ResumePendingRef(cycle.ref)
+	}
+	if err != nil {
+		return err
+	}
+	if err := pending.Replace(cycle.hashes); err != nil {
+		return err
+	}
+	return e.RawOutbox.Append(env)
+}
+
+func findRawEnvelope(out EnvelopeOutbox, ref delta.PendingRef) (queue.Envelope, bool, error) {
+	for limit := drainBatchSize; ; limit *= 2 {
+		items, err := out.Peek(limit)
+		if err != nil {
+			return queue.Envelope{}, false, err
+		}
+		for _, item := range items {
+			if item.Envelope.Type == queue.TypeRawManifest &&
+				item.Envelope.JobID == ref.JobID && item.Envelope.FencingToken == ref.FencingToken {
+				return item.Envelope, true, nil
+			}
+		}
+		if len(items) < limit {
+			return queue.Envelope{}, false, nil
+		}
+	}
+}
 
 // OutboxAdapter persists RegisterJob/FailJob (terminal outcomes) to a
 // bbolt outbox (fire-and-forget for the caller) and delegates

--- a/apps/dump_agent_go/internal/worker/outbox_adapter.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter.go
@@ -41,9 +41,24 @@ type rawCycle struct {
 
 const rawTerminalPollInterval = 10 * time.Millisecond
 
-func (e *JobExecutor) reconcileRawSpools() error {
-	if e.RawOutbox == nil || e.RawSpoolDirectory == "" {
+func (e *JobExecutor) reconcileRawState(current delta.PendingRef) error {
+	if e.RawOutbox == nil || e.DeltaStore == nil || e.RawSpoolDirectory == "" {
 		return errors.New("raw_executor=unconfigured")
+	}
+	items, err := allEnvelopeItems(e.RawOutbox)
+	if err != nil {
+		return err
+	}
+	refs := []delta.PendingRef{current}
+	retained := make(map[string]bool, len(items))
+	for _, item := range items {
+		if item.Envelope.Type == queue.TypeRawManifest {
+			retained[item.Envelope.SpoolName] = true
+			refs = append(refs, pendingRef(item.Envelope))
+		}
+	}
+	if _, err := e.DeltaStore.ReconcileRawPending(refs); err != nil {
+		return err
 	}
 	entries, err := os.ReadDir(e.RawSpoolDirectory)
 	if errors.Is(err, os.ErrNotExist) {
@@ -51,16 +66,6 @@ func (e *JobExecutor) reconcileRawSpools() error {
 	}
 	if err != nil {
 		return err
-	}
-	items, err := allEnvelopeItems(e.RawOutbox)
-	if err != nil {
-		return err
-	}
-	retained := make(map[string]bool, len(items))
-	for _, item := range items {
-		if item.Envelope.Type == queue.TypeRawManifest {
-			retained[item.Envelope.SpoolName] = true
-		}
 	}
 	for _, entry := range entries {
 		name := entry.Name()

--- a/apps/dump_agent_go/internal/worker/outbox_adapter_test.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/cnesdata/dumpagent/internal/delta"
+	"github.com/cnesdata/dumpagent/internal/extractor"
+	"github.com/cnesdata/dumpagent/internal/manifest"
 	"github.com/cnesdata/dumpagent/internal/queue"
 	"github.com/cnesdata/dumpagent/internal/upload"
 	"github.com/cnesdata/dumpagent/internal/writer"
@@ -193,6 +195,23 @@ func TestCrashAntesDoEnvelopeRetomaPendenteDuravel(t *testing.T) {
 	got, err := f.store.GetCommitted(ref.SourceKey)
 	require.NoError(t, err)
 	require.Equal(t, map[string][32]byte{"complete": {8}}, got)
+}
+
+func TestRunRawConvertePanicDaExtracaoEmErroDoJob(t *testing.T) {
+	f := newRawDrainFixture(t)
+	job := Job{ID: "panic-job", TenantID: f.raw.TenantID, FencingToken: 9,
+		UploadURL: "https://object.invalid", Params: extractor.ExtractionParams{
+			Intent: extractor.IntentCnesProfissionais, Competencia: "202601"},
+		RawRequest: &manifest.BuildRequest{SourceType: f.raw.SourceType,
+			FileSubtype: f.raw.FileSubtype, Competencia: f.raw.Competencia,
+			AgentID: f.raw.AgentID, AgentVersion: f.raw.AgentVersion,
+			SchemaVersion: f.raw.SchemaVersion, SnapshotMode: manifest.SnapshotModeFull,
+			CreatedAt: f.raw.CreatedAt}}
+	executor := &JobExecutor{DeltaStore: f.store, RawOutbox: f.out,
+		RawSpoolDirectory: f.spoolDirectory, RawUploader: fixtureRawUploader{},
+		RawExtract: func(context.Context, Job) ([]delta.Row, error) { panic("extract") }}
+	_, err := executor.RunRaw(context.Background(), &job)
+	require.ErrorContains(t, err, "panic in RunRaw")
 }
 
 func TestRetryComEnvelopeNaoSobrescreveFingerprintsPendentes(t *testing.T) {

--- a/apps/dump_agent_go/internal/worker/outbox_adapter_test.go
+++ b/apps/dump_agent_go/internal/worker/outbox_adapter_test.go
@@ -3,11 +3,18 @@ package worker
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/cnesdata/dumpagent/internal/delta"
 	"github.com/cnesdata/dumpagent/internal/queue"
+	"github.com/cnesdata/dumpagent/internal/upload"
+	"github.com/cnesdata/dumpagent/internal/writer"
+	"github.com/stretchr/testify/require"
 )
 
 type mockJobAPI struct {
@@ -17,6 +24,297 @@ type mockJobAPI struct {
 	heartbeatCalls int
 	mintErr        error
 	mintJob        *Job
+}
+
+func newFixtureSpool(t *testing.T) (string, upload.RawSpool) {
+	t.Helper()
+	directory := t.TempDir()
+	spool, err := upload.PrepareRawSpool(context.Background(), directory, func(dst io.Writer) error {
+		return writer.WriteRawFullParquet(dst, []delta.Row{{"CPF": "fixture"}})
+	})
+	require.NoError(t, err)
+	return directory, spool
+}
+
+type fixtureRawUploader struct{}
+
+func (fixtureRawUploader) PutRaw(_ context.Context, request upload.RawPutRequest) (int64, error) {
+	return io.Copy(io.Discard, request.Body)
+}
+
+func (f rawDrainFixture) drainer(client RawManifestClient) *RawDrainer {
+	drainer := NewRawDrainer(client, f.store, nil)
+	drainer.SpoolDirectory, drainer.Uploader = f.spoolDirectory, fixtureRawUploader{}
+	return drainer
+}
+
+func TestSpoolAusenteSemReciboNaoRegistraManifesto(t *testing.T) {
+	f := newRawDrainFixture(t)
+	require.NoError(t, upload.RemoveRawSpool(f.spoolDirectory, f.env.SpoolName))
+	client := rawClientFunc(func(context.Context, queue.Envelope) (RawManifestResponse, error) {
+		t.Error("manifesto_enviado_sem_spool=true")
+		return RawManifestResponse{}, nil
+	})
+	require.Error(t, f.drainer(client).Drain(context.Background(), f.out))
+	items, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.NoError(t, f.store.ConfirmPending(f.ref, f.raw, strings.Repeat("b", 64)))
+}
+
+type cleanupFailureOutbox struct {
+	*queue.Outbox
+	path string
+}
+
+func (o cleanupFailureOutbox) MarkRawTerminal(key []byte) error {
+	if err := o.Outbox.MarkRawTerminal(key); err != nil {
+		return err
+	}
+	if err := os.Rename(o.path, o.path+".retained"); err != nil {
+		return err
+	}
+	if err := os.Mkdir(o.path, 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(o.path, "busy"), []byte("busy"), 0o600)
+}
+
+func TestFalhaNaLimpezaRetomaSoLimpezaAposReinicio(t *testing.T) {
+	f := newRawDrainFixture(t)
+	path := filepath.Join(f.spoolDirectory, f.env.SpoolName)
+	calls := 0
+	client := rawClientFunc(func(context.Context, queue.Envelope) (RawManifestResponse, error) {
+		calls++
+		return RawManifestResponse{StatusCode: 200, ManifestSHA256: f.env.ManifestSHA256}, nil
+	})
+	out := cleanupFailureOutbox{Outbox: f.out, path: path}
+	require.Error(t, f.drainer(client).Drain(context.Background(), out))
+	items, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	terminal, err := f.out.RawTerminal(items[0].Key)
+	require.NoError(t, err)
+	require.True(t, terminal)
+	require.FileExists(t, path+".retained")
+	require.NoError(t, os.Remove(filepath.Join(path, "busy")))
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, os.Rename(path+".retained", path))
+	reopenRawFixture(t, &f)
+	drainer := f.drainer(client)
+	drainer.Uploader = nil
+	require.NoError(t, drainer.Drain(context.Background(), f.out))
+	require.Equal(t, 1, calls)
+	_, err = os.Stat(path)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	items, err = f.out.Peek(10)
+	require.NoError(t, err)
+	require.Empty(t, items)
+}
+
+type failingEnvelopeStore struct {
+	*queue.Outbox
+	onDelete func() error
+	onAppend func(queue.Envelope) error
+}
+
+func (f failingEnvelopeStore) Delete(keys ...[]byte) error {
+	if f.onDelete != nil {
+		if err := f.onDelete(); err != nil {
+			return err
+		}
+	}
+	return f.Outbox.Delete(keys...)
+}
+
+func (f failingEnvelopeStore) Append(env queue.Envelope) error {
+	if f.onAppend != nil {
+		if err := f.onAppend(env); err != nil {
+			return err
+		}
+	}
+	return f.Outbox.Append(env)
+}
+
+func TestCrashAposAckSoApagaEnvelopeAposPersistirEstado(t *testing.T) {
+	for _, status := range []int{201, 409} {
+		t.Run(httpStatusName(status), func(t *testing.T) {
+			f := newRawDrainFixture(t)
+			client := rawClientFunc(func(context.Context, queue.Envelope) (RawManifestResponse, error) {
+				response := RawManifestResponse{StatusCode: status, ManifestSHA256: f.env.ManifestSHA256}
+				if status == 409 {
+					response.ForceFull, response.Reason = true, "base_missing"
+				}
+				return response, nil
+			})
+			out := failingEnvelopeStore{Outbox: f.out, onDelete: func() error {
+				_, forced, err := f.store.ForceFull(f.ref.SourceKey)
+				require.NoError(t, err)
+				require.Equal(t, status == 409, forced)
+				_, _, hash, _, _, err := f.store.ChainHead(f.ref.SourceKey)
+				require.NoError(t, err)
+				if status == 201 {
+					require.Equal(t, f.env.ManifestSHA256, hash)
+				}
+				return errors.New("disk=unavailable")
+			}}
+			drainer := f.drainer(client)
+			require.Error(t, drainer.Drain(context.Background(), out))
+			items, err := f.out.Peek(10)
+			require.NoError(t, err)
+			require.Len(t, items, 1)
+			require.NoError(t, drainer.Drain(context.Background(), f.out))
+			items, err = f.out.Peek(10)
+			require.NoError(t, err)
+			require.Empty(t, items)
+		})
+	}
+}
+
+func httpStatusName(status int) string {
+	if status == 409 {
+		return "resync"
+	}
+	return "sucesso"
+}
+
+func TestCrashAntesDoEnvelopeRetomaPendenteDuravel(t *testing.T) {
+	f := newRawDrainFixture(t)
+	ref := f.ref
+	ref.JobID = "orphan"
+	stageRawHashes(t, f.store, ref, map[string][32]byte{"partial": {9}})
+	executor := &JobExecutor{DeltaStore: f.store, RawOutbox: f.out}
+	cycle := rawCycle{ref: ref, hashes: map[string][32]byte{"complete": {8}}}
+	raw := f.raw
+	raw.ManifestID, raw.SnapshotID = ref.JobID, ref.JobID
+	raw.ObjectKey = "raw/tenant/CNES_LOCAL/2026-01/orphan/data.parquet"
+	require.NoError(t, executor.enqueueRaw(cycle, raw))
+	require.NoError(t, f.store.ConfirmPending(ref, raw, strings.Repeat("d", 64)))
+	got, err := f.store.GetCommitted(ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"complete": {8}}, got)
+}
+
+func TestRetryComEnvelopeNaoSobrescreveFingerprintsPendentes(t *testing.T) {
+	f := newRawDrainFixture(t)
+	executor := &JobExecutor{DeltaStore: f.store, RawOutbox: f.out}
+	cycle := rawCycle{ref: f.ref, hashes: map[string][32]byte{"changed": {9}}}
+	cycle.spoolName, cycle.uploadURL = f.env.SpoolName, f.env.UploadURL
+	before, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.NoError(t, executor.enqueueRaw(cycle, f.raw))
+	changed := f.raw
+	changed.SizeBytes++
+	require.Error(t, executor.enqueueRaw(cycle, changed))
+	after, err := f.out.Peek(10)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	require.NoError(t, f.store.ConfirmPending(f.ref, f.raw, strings.Repeat("d", 64)))
+	got, err := f.store.GetCommitted(f.ref.SourceKey)
+	require.NoError(t, err)
+	require.Equal(t, map[string][32]byte{"new": {2}}, got)
+}
+
+func TestPendenteCompletoExisteAntesDePersistirEnvelope(t *testing.T) {
+	f := newRawDrainFixture(t)
+	ref := f.ref
+	ref.JobID = "next-job"
+	raw := f.raw
+	raw.ManifestID, raw.SnapshotID = ref.JobID, ref.JobID
+	raw.ObjectKey = "raw/tenant/CNES_LOCAL/2026-01/next-job/data.parquet"
+	out := failingEnvelopeStore{Outbox: f.out, onAppend: func(queue.Envelope) error {
+		require.NoError(t, f.store.ConfirmPending(ref, raw, strings.Repeat("d", 64)))
+		got, err := f.store.GetCommitted(ref.SourceKey)
+		require.NoError(t, err)
+		require.Equal(t, map[string][32]byte{"complete": {8}}, got)
+		return errors.New("disk=full")
+	}}
+	executor := &JobExecutor{DeltaStore: f.store, RawOutbox: out}
+	cycle := rawCycle{ref: ref, hashes: map[string][32]byte{"complete": {8}}}
+	require.Error(t, executor.enqueueRaw(cycle, raw))
+}
+
+func TestRawDrainerTambemEntregaEnvelopesLegados(t *testing.T) {
+	api := &stubJobAPI{}
+	out := newOutbox(t)
+	require.NoError(t, out.Append(queue.Envelope{Type: queue.TypeComplete,
+		JobUUID: "legacy", EnqueuedAt: time.Now(), SizeBytes: 123}))
+	require.NoError(t, NewRawDrainer(nil, nil, api).Drain(context.Background(), out))
+	require.Equal(t, "legacy", api.lastJob.ID)
+	require.Equal(t, int64(123), api.lastSize)
+}
+
+func reopenRawFixture(t *testing.T, f *rawDrainFixture) {
+	t.Helper()
+	_ = f.store.Close()
+	require.NoError(t, f.out.Close())
+	store, err := delta.Open(f.storePath)
+	require.NoError(t, err)
+	out, err := queue.Open(f.outPath)
+	require.NoError(t, err)
+	f.store, f.out = store, out
+	t.Cleanup(func() { _ = store.Close(); _ = out.Close() })
+}
+
+func TestReinicioConvergeEmCadaFronteiraDuravel(t *testing.T) {
+	for _, phase := range []string{"pendente", "envelope", "ack", "commit", "delete", "resync"} {
+		t.Run(phase, func(t *testing.T) {
+			f := newRawDrainFixture(t)
+			items, err := f.out.Peek(10)
+			require.NoError(t, err)
+			simulateRawCrash(t, &f, phase)
+			reopenRawFixture(t, &f)
+			if phase == "pendente" {
+				executor := JobExecutor{DeltaStore: f.store, RawOutbox: f.out}
+				require.NoError(t, executor.enqueueRaw(rawCycle{ref: f.ref,
+					hashes: map[string][32]byte{"new": {2}}, spoolName: f.env.SpoolName,
+					uploadURL: f.env.UploadURL}, f.raw))
+			}
+			client := rawClientFunc(func(_ context.Context,
+				env queue.Envelope,
+			) (RawManifestResponse, error) {
+				require.Equal(t, items[0].Envelope.ManifestJSON, env.ManifestJSON)
+				response := RawManifestResponse{StatusCode: 200, ManifestSHA256: f.env.ManifestSHA256}
+				if phase == "resync" {
+					response.StatusCode, response.ForceFull, response.Reason = 409, true, "base_missing"
+				}
+				return response, nil
+			})
+			require.NoError(t, f.drainer(client).Drain(context.Background(), f.out))
+			remaining, err := f.out.Peek(10)
+			require.NoError(t, err)
+			require.Empty(t, remaining)
+			committed, err := f.store.GetCommitted(f.ref.SourceKey)
+			require.NoError(t, err)
+			if phase == "resync" {
+				require.Equal(t, map[string][32]byte{"old": {1}}, committed)
+			} else {
+				require.Equal(t, map[string][32]byte{"new": {2}}, committed)
+			}
+		})
+	}
+}
+
+func simulateRawCrash(t *testing.T, f *rawDrainFixture, phase string) {
+	t.Helper()
+	items, err := f.out.Peek(10)
+	require.NoError(t, err)
+	if phase == "resync" {
+		require.NoError(t, f.store.RequireFull(f.ref, "base_missing"))
+	}
+	if phase == "commit" || phase == "delete" {
+		require.NoError(t, f.store.ConfirmPending(f.ref, f.raw, f.env.ManifestSHA256))
+	}
+	if phase == "delete" || phase == "pendente" {
+		require.NoError(t, f.out.Delete(items[0].Key))
+	}
+	if phase == "ack" {
+		client := rawClientFunc(func(context.Context, queue.Envelope) (RawManifestResponse, error) {
+			require.NoError(t, f.store.Close())
+			return RawManifestResponse{StatusCode: 200, ManifestSHA256: f.env.ManifestSHA256}, nil
+		})
+		require.Error(t, f.drainer(client).Drain(context.Background(), f.out))
+	}
 }
 
 func (m *mockJobAPI) MintUploadURL(_ context.Context, _ JobSpec) (*Job, error) {

--- a/apps/dump_agent_go/internal/writer/delta_parquet.go
+++ b/apps/dump_agent_go/internal/writer/delta_parquet.go
@@ -82,6 +82,7 @@ type rawColumn struct {
 	kind pq.Kind
 }
 
+//nolint:misspell // NOME_PROFISSIONAL is a frozen CNES field name.
 var rawColumns = []rawColumn{
 	{"CPF", pq.ByteArray}, {"CNS", pq.ByteArray}, {"NOME_PROFISSIONAL", pq.ByteArray},
 	{"NOME_SOCIAL", pq.ByteArray}, {"SEXO", pq.ByteArray}, {"CBO", pq.ByteArray},
@@ -120,7 +121,7 @@ func writeRawParquet(dst io.Writer, buckets []rawBucket, deltaMode bool) (err er
 		}
 	}
 	schema := buildRawSchema(deltaMode)
-	pw := pq.NewWriter(dst, schema, &pq.WriterConfig{CreatedBy: "Polars"},
+	pw := pq.NewGenericWriter[any](dst, schema, &pq.WriterConfig{CreatedBy: "Polars"},
 		pq.Compression(&zstd.Codec{Level: zstd.SpeedDefault}),
 		pq.MaxRowsPerRowGroup(64000), pq.DataPageStatistics(true))
 	defer func() { err = errors.Join(err, pw.Close()) }()
@@ -185,7 +186,7 @@ func rawValue(col rawColumn, value any) (pq.Value, error) {
 	return pq.Value{}, fmt.Errorf("raw_column_type_invalid=%s", col.name)
 }
 
-func writeRawBucket(pw *pq.Writer, schema *pq.Schema, bucket rawBucket) error {
+func writeRawBucket(pw *pq.GenericWriter[any], schema *pq.Schema, bucket rawBucket) error {
 	rows := slices.Clone(bucket.rows)
 	slices.SortStableFunc(rows, compareRawRows)
 	for _, row := range rows {

--- a/apps/dump_agent_go/internal/writer/delta_parquet.go
+++ b/apps/dump_agent_go/internal/writer/delta_parquet.go
@@ -1,11 +1,15 @@
 package writer
 
 import (
+	"cmp"
+	"errors"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/cnesdata/dumpagent/internal/delta"
 	pq "github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/compress/zstd"
 )
 
 const opColumnName = "_op"
@@ -22,7 +26,8 @@ type deltaSchema struct {
 // populated, others null + _op="D".
 func WriteDeltaParquet(w io.Writer, ds delta.Set, schemaColumns []string) error {
 	ds2 := buildDeltaSchema(schemaColumns)
-	pw := pq.NewWriter(w, ds2.schema) //nolint:staticcheck // SA1019 pq.Writer required for dynamic schema; GenericWriter[T] needs concrete struct
+	//nolint:staticcheck // SA1019: dynamic schema requires pq.Writer.
+	pw := pq.NewWriter(w, ds2.schema)
 	if err := ds2.writeOp(pw, ds.Inserts, "I"); err != nil {
 		return err
 	}
@@ -49,7 +54,8 @@ func buildDeltaSchema(cols []string) *deltaSchema {
 	return &deltaSchema{schema: schema, idx: idx, cols: cols}
 }
 
-func (d *deltaSchema) writeOp(pw *pq.Writer, rows []delta.Row, op string) error { //nolint:staticcheck // SA1019 see WriteDeltaParquet
+//nolint:staticcheck // SA1019: dynamic schema requires pq.Writer.
+func (d *deltaSchema) writeOp(pw *pq.Writer, rows []delta.Row, op string) error {
 	for _, r := range rows {
 		if _, err := pw.WriteRows([]pq.Row{d.buildRow(r, op)}); err != nil {
 			return err
@@ -69,4 +75,160 @@ func (d *deltaSchema) buildRow(r delta.Row, op string) pq.Row {
 	}
 	b.Add(d.idx[opColumnName], pq.ValueOf(op))
 	return b.Row()
+}
+
+type rawColumn struct {
+	name string
+	kind pq.Kind
+}
+
+var rawColumns = []rawColumn{
+	{"CPF", pq.ByteArray}, {"CNS", pq.ByteArray}, {"NOME_PROFISSIONAL", pq.ByteArray},
+	{"NOME_SOCIAL", pq.ByteArray}, {"SEXO", pq.ByteArray}, {"CBO", pq.ByteArray},
+	{"CNES", pq.ByteArray}, {"TIPO_VINCULO", pq.ByteArray}, {"SUS", pq.ByteArray},
+	{"CH_TOTAL", pq.Int64}, {"CH_AMBULATORIAL", pq.Int64}, {"CH_OUTRAS", pq.Int64},
+	{"CH_HOSPITALAR", pq.Int64}, {"FONTE", pq.ByteArray},
+}
+
+type rawBucket struct {
+	rows []delta.Row
+	op   string
+}
+
+type orderedRawGroup struct {
+	pq.Group
+	fields []pq.Field
+}
+
+func (g orderedRawGroup) Fields() []pq.Field { return g.fields }
+
+// WriteRawFullParquet emite todas as linhas no schema raw congelado, sem _op.
+func WriteRawFullParquet(dst io.Writer, rows []delta.Row) error {
+	return writeRawParquet(dst, []rawBucket{{rows: rows}}, false)
+}
+
+// WriteRawDeltaParquet emite os buckets ordenados I/U/D no schema raw congelado.
+func WriteRawDeltaParquet(dst io.Writer, set delta.Set) error {
+	buckets := []rawBucket{{set.Inserts, "I"}, {set.Updates, "U"}, {set.Deletes, "D"}}
+	return writeRawParquet(dst, buckets, true)
+}
+
+func writeRawParquet(dst io.Writer, buckets []rawBucket, deltaMode bool) (err error) {
+	for _, bucket := range buckets {
+		if err := validateRawBucket(bucket); err != nil {
+			return err
+		}
+	}
+	schema := buildRawSchema(deltaMode)
+	pw := pq.NewWriter(dst, schema, &pq.WriterConfig{CreatedBy: "Polars"},
+		pq.Compression(&zstd.Codec{Level: zstd.SpeedDefault}),
+		pq.MaxRowsPerRowGroup(64000), pq.DataPageStatistics(true))
+	defer func() { err = errors.Join(err, pw.Close()) }()
+	for _, bucket := range buckets {
+		if err := writeRawBucket(pw, schema, bucket); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildRawSchema(deltaMode bool) *pq.Schema {
+	group := orderedRawGroup{Group: pq.Group{}}
+	for _, col := range rawColumns {
+		node := pq.String()
+		if col.kind == pq.Int64 {
+			node = pq.Int(64)
+		}
+		group.Group[col.name] = pq.Optional(node)
+		field := pq.Group{col.name: group.Group[col.name]}.Fields()[0]
+		group.fields = append(group.fields, field)
+	}
+	if deltaMode {
+		group.Group[opColumnName] = pq.String()
+		group.fields = append(group.fields, pq.Group{opColumnName: pq.String()}.Fields()[0])
+	}
+	return pq.NewSchema("raw", group)
+}
+
+func validateRawBucket(bucket rawBucket) error {
+	for _, row := range bucket.rows {
+		if op, exists := row[opColumnName]; exists && (bucket.op == "" || op != bucket.op) {
+			return errors.New("raw_operation_invalid=true")
+		}
+		for _, col := range rawColumns {
+			if _, err := rawValue(col, row[col.name]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func rawValue(col rawColumn, value any) (pq.Value, error) {
+	if value == nil {
+		return pq.NullValue(), nil
+	}
+	if col.kind == pq.ByteArray {
+		if text, ok := value.(string); ok {
+			return pq.ValueOf(text), nil
+		}
+	} else {
+		switch number := value.(type) {
+		case int:
+			return pq.Int64Value(int64(number)), nil
+		case int32:
+			return pq.Int64Value(int64(number)), nil
+		case int64:
+			return pq.Int64Value(number), nil
+		}
+	}
+	return pq.Value{}, fmt.Errorf("raw_column_type_invalid=%s", col.name)
+}
+
+func writeRawBucket(pw *pq.Writer, schema *pq.Schema, bucket rawBucket) error {
+	rows := slices.Clone(bucket.rows)
+	slices.SortStableFunc(rows, compareRawRows)
+	for _, row := range rows {
+		builder := pq.NewRowBuilder(schema)
+		for i, col := range rawColumns {
+			value, _ := rawValue(col, row[col.name])
+			if !value.IsNull() {
+				builder.Add(i, value)
+			}
+		}
+		if bucket.op != "" {
+			builder.Add(len(rawColumns), pq.ValueOf(bucket.op))
+		}
+		if _, err := pw.WriteRows([]pq.Row{builder.Row()}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func compareRawRows(left, right delta.Row) int {
+	for _, col := range rawColumns {
+		l, _ := rawValue(col, left[col.name])
+		r, _ := rawValue(col, right[col.name])
+		if result := compareRawValues(l, r); result != 0 {
+			return result
+		}
+	}
+	return 0
+}
+
+func compareRawValues(left, right pq.Value) int {
+	if left.IsNull() && right.IsNull() {
+		return 0
+	}
+	if left.IsNull() {
+		return 1
+	}
+	if right.IsNull() {
+		return -1
+	}
+	if left.Kind() == pq.Int64 {
+		return cmp.Compare(left.Int64(), right.Int64())
+	}
+	return cmp.Compare(left.String(), right.String())
 }

--- a/apps/dump_agent_go/internal/writer/delta_parquet_test.go
+++ b/apps/dump_agent_go/internal/writer/delta_parquet_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:misspell // NOME_PROFISSIONAL is a frozen CNES field name.
 var frozenColumns = []string{
 	"CPF", "CNS", "NOME_PROFISSIONAL", "NOME_SOCIAL", "SEXO", "CBO", "CNES",
 	"TIPO_VINCULO", "SUS", "CH_TOTAL", "CH_AMBULATORIAL", "CH_OUTRAS", "CH_HOSPITALAR", "FONTE",
 }
 
+//nolint:misspell // NOME_PROFISSIONAL is a frozen CNES field name.
 func frozenRow() delta.Row {
 	return delta.Row{
 		"CPF": "00000000001", "CNS": "000000000000001", "NOME_PROFISSIONAL": "Fixture",
@@ -93,6 +95,7 @@ func TestFullUsaParquetCongeladoSemOp(t *testing.T) {
 	require.NotContains(t, readDeltaRows(t, buf.Bytes())[0], "_op")
 }
 
+//nolint:misspell // NOME_PROFISSIONAL is asserted as part of the frozen schema.
 func TestDeltaUsaParquetCongeladoComIUD(t *testing.T) {
 	ds := delta.Set{
 		Inserts: []delta.Row{frozenRow()}, Updates: []delta.Row{frozenRow()},

--- a/apps/dump_agent_go/internal/writer/delta_parquet_test.go
+++ b/apps/dump_agent_go/internal/writer/delta_parquet_test.go
@@ -2,14 +2,193 @@ package writer_test
 
 import (
 	"bytes"
+	"errors"
 	"io"
+	"slices"
 	"testing"
 
 	"github.com/cnesdata/dumpagent/internal/delta"
 	"github.com/cnesdata/dumpagent/internal/writer"
 	pq "github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/format"
 	"github.com/stretchr/testify/require"
 )
+
+var frozenColumns = []string{
+	"CPF", "CNS", "NOME_PROFISSIONAL", "NOME_SOCIAL", "SEXO", "CBO", "CNES",
+	"TIPO_VINCULO", "SUS", "CH_TOTAL", "CH_AMBULATORIAL", "CH_OUTRAS", "CH_HOSPITALAR", "FONTE",
+}
+
+func frozenRow() delta.Row {
+	return delta.Row{
+		"CPF": "00000000001", "CNS": "000000000000001", "NOME_PROFISSIONAL": "Fixture",
+		"NOME_SOCIAL": nil, "SEXO": nil, "CBO": "000001", "CNES": "0000001",
+		"TIPO_VINCULO": "000001", "SUS": "S", "CH_TOTAL": int64(40),
+		"CH_AMBULATORIAL": int64(20), "CH_OUTRAS": int64(5), "CH_HOSPITALAR": int64(15),
+		"FONTE": "NACIONAL",
+	}
+}
+
+func assertFrozenParquet(t *testing.T, data []byte, deltaMode bool) *pq.File {
+	t.Helper()
+	require.Equal(t, "PAR1", string(data[:4]))
+	require.Equal(t, "PAR1", string(data[len(data)-4:]))
+	file, err := pq.OpenFile(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	columns := slices.Clone(frozenColumns)
+	if deltaMode {
+		columns = append(columns, "_op")
+	}
+	fields := file.Schema().Fields()
+	require.Len(t, fields, len(columns))
+	for i, col := range columns {
+		require.Equal(t, col, fields[i].Name())
+		if i >= 9 && i <= 12 {
+			require.Equal(t, pq.Int64, fields[i].Type().Kind())
+		} else {
+			require.Equal(t, pq.ByteArray, fields[i].Type().Kind())
+			require.NotNil(t, fields[i].Type().LogicalType().UTF8)
+		}
+		require.Equal(t, col != "_op", fields[i].Optional())
+	}
+	require.Equal(t, "Polars", file.Metadata().CreatedBy)
+	for _, group := range file.Metadata().RowGroups {
+		require.LessOrEqual(t, group.NumRows, int64(64000))
+		for _, col := range group.Columns {
+			require.Equal(t, format.Zstd, col.MetaData.Codec)
+			stats := col.MetaData.Statistics
+			require.True(t, len(stats.MinValue) > 0 || stats.NullCount == group.NumRows)
+		}
+	}
+	if len(file.RowGroups()) > 0 {
+		assertRawPageStatistics(t, file.RowGroups()[0].ColumnChunks()[0])
+	}
+	return file
+}
+
+func assertRawPageStatistics(t *testing.T, chunk pq.ColumnChunk) {
+	t.Helper()
+	pages := chunk.Pages()
+	defer pages.Close()
+	page, err := pages.ReadPage()
+	require.NoError(t, err)
+	minValue, maxValue, ok := page.Bounds()
+	require.True(t, ok)
+	require.Equal(t, "00000000001", minValue.String())
+	require.Equal(t, "00000000001", maxValue.String())
+}
+
+func TestFullUsaParquetCongeladoSemOp(t *testing.T) {
+	rows := make([]delta.Row, 64001)
+	for i := range rows {
+		rows[i] = frozenRow()
+	}
+	var buf bytes.Buffer
+	require.NoError(t, writer.WriteRawFullParquet(&buf, rows))
+	file := assertFrozenParquet(t, buf.Bytes(), false)
+	require.Equal(t, int64(64001), file.NumRows())
+	require.Len(t, file.RowGroups(), 2)
+	require.Equal(t, int64(64000), file.RowGroups()[0].NumRows())
+	require.Equal(t, int64(1), file.RowGroups()[1].NumRows())
+	require.NotContains(t, readDeltaRows(t, buf.Bytes())[0], "_op")
+}
+
+func TestDeltaUsaParquetCongeladoComIUD(t *testing.T) {
+	ds := delta.Set{
+		Inserts: []delta.Row{frozenRow()}, Updates: []delta.Row{frozenRow()},
+		Deletes: []delta.Row{{"CPF": "00000000001", "CNES": "0000001"}},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, writer.WriteRawDeltaParquet(&buf, ds))
+	file := assertFrozenParquet(t, buf.Bytes(), true)
+	require.Equal(t, int64(3), file.NumRows())
+	rows := readDeltaRows(t, buf.Bytes())
+	for i, op := range []string{"I", "U", "D"} {
+		require.Equal(t, op, rows[i]["_op"])
+	}
+	require.Equal(t, "40", rows[0]["CH_TOTAL"])
+	require.Nil(t, rows[2]["CH_TOTAL"])
+	require.Nil(t, rows[2]["NOME_PROFISSIONAL"])
+}
+
+func TestRawOrdenaColunasComNumerosENulosSemAlterarEntrada(t *testing.T) {
+	input := []delta.Row{
+		{"CPF": nil}, {"CPF": "b"}, {"CPF": "a", "CH_TOTAL": int64(10)},
+		{"CPF": "a", "CH_TOTAL": int64(2)}, {"CPF": "a"},
+		{"CPF": "a", "CNS": "z"}, {"CPF": "a", "CNS": "a"},
+	}
+	var first, second bytes.Buffer
+	require.NoError(t, writer.WriteRawFullParquet(&first, input))
+	require.Nil(t, input[0]["CPF"])
+	reordered := slices.Clone(input)
+	slices.Reverse(reordered)
+	require.NoError(t, writer.WriteRawFullParquet(&second, reordered))
+	require.Equal(t, first.Bytes(), second.Bytes())
+	rows := readDeltaRows(t, first.Bytes())
+	require.Equal(t, "a", rows[0]["CNS"])
+	require.Equal(t, "z", rows[1]["CNS"])
+	require.Equal(t, "2", rows[2]["CH_TOTAL"])
+	require.Equal(t, "10", rows[3]["CH_TOTAL"])
+	require.Nil(t, rows[4]["CH_TOTAL"])
+	require.Equal(t, "b", rows[5]["CPF"])
+	require.Nil(t, rows[6]["CPF"])
+}
+
+func TestDeltaOrdenaCadaBucketEPreservaDuplicatas(t *testing.T) {
+	input := []delta.Row{{"CPF": nil}, {"CPF": "b"}, {"CPF": "a"}, {"CPF": "a"}}
+	reversed := slices.Clone(input)
+	slices.Reverse(reversed)
+	var first, second bytes.Buffer
+	require.NoError(t, writer.WriteRawDeltaParquet(&first, delta.Set{
+		Inserts: input, Updates: input, Deletes: input,
+	}))
+	require.NoError(t, writer.WriteRawDeltaParquet(&second, delta.Set{
+		Inserts: reversed, Updates: reversed, Deletes: reversed,
+	}))
+	require.Equal(t, first.Bytes(), second.Bytes())
+	rows := readDeltaRows(t, first.Bytes())
+	require.Len(t, rows, 12)
+	for i, op := range []string{"I", "U", "D"} {
+		for j, cpf := range []any{"a", "a", "b", nil} {
+			require.Equal(t, op, rows[4*i+j]["_op"])
+			require.Equal(t, cpf, rows[4*i+j]["CPF"])
+		}
+	}
+}
+
+func TestRawRejeitaTiposEOpsInvalidosAntesDeEmitirArquivo(t *testing.T) {
+	for _, row := range []delta.Row{
+		{"CPF": 1}, {"CH_TOTAL": "40"}, {"CH_TOTAL": 1.5},
+		{"_op": "X"}, {"_op": "D"}, {"_op": nil},
+	} {
+		var buf bytes.Buffer
+		err := writer.WriteRawDeltaParquet(&buf, delta.Set{Inserts: []delta.Row{row}})
+		require.Error(t, err)
+		require.Empty(t, buf.Bytes())
+	}
+	var buf bytes.Buffer
+	require.Error(t, writer.WriteRawFullParquet(&buf, []delta.Row{{"_op": "I"}}))
+	require.Empty(t, buf.Bytes())
+}
+
+func TestRawVazioProduzArquivoValidoEPropagaErroDoDestino(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writer.WriteRawFullParquet(&buf, nil))
+	file := assertFrozenParquet(t, buf.Bytes(), false)
+	require.Zero(t, file.NumRows())
+	buf.Reset()
+	require.NoError(t, writer.WriteRawDeltaParquet(&buf, delta.Set{}))
+	file = assertFrozenParquet(t, buf.Bytes(), true)
+	require.Zero(t, file.NumRows())
+	err := writer.WriteRawFullParquet(rawFailWriter{}, []delta.Row{frozenRow()})
+	require.ErrorContains(t, err, "destination_failed")
+}
+
+type rawFailWriter struct{}
+
+func (rawFailWriter) Write([]byte) (int, error) {
+	return 0, errors.New("destination_failed=true")
+}
 
 func readDeltaRows(t *testing.T, raw []byte) []map[string]any {
 	t.Helper()


### PR DESCRIPTION
## Resumo
- emite RawManifest v1 canônico e Parquet FULL/DELTA congelado
- persiste pending, chain head, force-full, envelope raw e spool durável
- aplica replay idempotente para 2xx/409 e preserva estado em falhas transitórias
- mantém APIs e fluxo legados; composição global permanece para CND-034

## Verificação
- `go test -race -count=1 -coverprofile=coverage.out ./...`: 706 testes
- cobertura filtr filtrada: 85.0% (gate 65%)
- `ruff check .`: passou
- pytest unitário sem marcadores de infraestrutura: 1946 passaram
- gofmt, go vet, Windows cross-compile e diff checks: passaram

Closes #142