### PR TITLE
feat(api): expose target raw ingestion protocol

### DIFF
--- a/apps/central_api/src/central_api/routes/raw_jobs.py
+++ b/apps/central_api/src/central_api/routes/raw_jobs.py
@@ -1,0 +1,243 @@
+"""Rotas autenticadas de jobs e upload raw do Edge Agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hmac import compare_digest
+from typing import TYPE_CHECKING, Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
+
+from central_api.schemas.raw_api import (
+    EdgeIdentity,
+    EdgeJobResponse,
+    HeartbeatRequest,
+    HeartbeatResponse,
+    RawUploadResponse,
+)
+from central_api.services.raw_ingestion import RawIngestionService  # noqa: TC001
+from central_api.services.raw_upload import (
+    RawUploadConflict,
+    RawUploadError,
+    RawUploadIdentityRejected,
+    RawUploadKeyRejected,
+    RawUploadNotFound,
+    RawUploadRequest,
+    RawUploadService,
+    RawUploadTooLarge,
+)
+from cnes_domain.control_plane.commands import ClaimJob, RenewJobLease
+from cnes_domain.control_plane.enums import AgentState
+from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
+from cnes_domain.ports.control_plane import ControlPlanePort  # noqa: TC001
+
+if TYPE_CHECKING:
+    from cnes_domain.control_plane.entities import Job
+
+EDGE_JOB_LEASE_SECONDS = 300
+router = APIRouter(prefix="/api/v1/edge", tags=["edge-raw"])
+_ERROR_ALIASES = {
+    "fence_mismatch": "job_fence_rejected",
+    "owner_mismatch": "job_owner_lost",
+    "lease_expired": "job_lease_expired",
+    "manifest_identity_mismatch": "manifest_identity_conflict",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _RawUploadBody:
+    request: Request
+    fencing_token: int
+    object_key: str
+
+
+def _raw_upload_body(
+    request: Request,
+    x_fencing_token: Annotated[str, Header(alias="X-Fencing-Token")],
+    x_object_key: Annotated[str, Header(alias="X-Object-Key")],
+    content_type: Annotated[str, Header(alias="Content-Type")],
+) -> _RawUploadBody:
+    if content_type != "application/octet-stream":
+        raise HTTPException(status_code=415, detail="media_type_unsupported")
+    try:
+        token = int(x_fencing_token)
+    except ValueError as error:
+        raise HTTPException(status_code=422, detail="fencing_token_required") from error
+    if token < 0:
+        raise HTTPException(status_code=422, detail="fencing_token_required")
+    return _RawUploadBody(request, token, x_object_key)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def get_edge_identity() -> EdgeIdentity:
+    """Falha fechado até o terminador mTLS fornecer a identidade."""
+
+    raise HTTPException(status_code=401, detail="mtls_required")
+
+
+def get_control_plane() -> ControlPlanePort:
+    """Falha fechado até a composição fornecer o control plane."""
+
+    raise HTTPException(status_code=503, detail="control_plane_not_configured")
+
+
+def get_raw_upload_service() -> RawUploadService:
+    """Falha fechado até a composição fornecer o upload raw."""
+
+    raise HTTPException(status_code=503, detail="raw_upload_not_configured")
+
+
+def get_raw_ingestion_service() -> RawIngestionService:
+    """Falha fechado até a composição fornecer a ingestão raw."""
+
+    raise HTTPException(status_code=503, detail="raw_ingestion_not_configured")
+
+
+def require_edge_agent(
+    identity: Annotated[EdgeIdentity, Depends(get_edge_identity)],
+    control_plane: Annotated[ControlPlanePort, Depends(get_control_plane)],
+) -> EdgeIdentity:
+    """Valida o agente persistido contra a identidade mTLS."""
+
+    agent = control_plane.get_agent(identity.tenant_id, identity.agent_id)
+    if agent is None:
+        raise HTTPException(status_code=403, detail="agent_missing")
+    if agent.state is AgentState.REVOKED:
+        raise HTTPException(status_code=403, detail="agent_revoked")
+    if (agent.tenant_id, agent.agent_id) != (identity.tenant_id, identity.agent_id):
+        raise HTTPException(status_code=403, detail="agent_identity_mismatch")
+    if not compare_digest(agent.certificate_fingerprint, identity.certificate_fingerprint):
+        raise HTTPException(status_code=403, detail="certificate_fingerprint_mismatch")
+    return identity
+
+
+@router.get("/jobs/next", response_model=EdgeJobResponse, responses={204: {}})
+def next_job(
+    identity: Annotated[EdgeIdentity, Depends(require_edge_agent)],
+    control_plane: Annotated[ControlPlanePort, Depends(get_control_plane)],
+) -> EdgeJobResponse | Response:
+    """Adquire por CAS o primeiro entre até dez jobs elegíveis."""
+
+    candidates = control_plane.list_claimable_jobs(identity.tenant_id, identity.agent_id, 10)
+    now = _utc_now()
+    for candidate in candidates:
+        if (candidate.tenant_id, candidate.agent_id) != (
+            identity.tenant_id,
+            identity.agent_id,
+        ):
+            continue
+        claimed = control_plane.claim_job(
+            ClaimJob(
+                tenant_id=identity.tenant_id,
+                job_id=candidate.job_id,
+                owner=identity.agent_id,
+                now=now,
+                lease_seconds=EDGE_JOB_LEASE_SECONDS,
+            )
+        )
+        if claimed is not None:
+            return _job_response(claimed, identity)
+    return Response(status_code=204)
+
+
+@router.post("/jobs/{job_id}/heartbeat", response_model=HeartbeatResponse)
+def heartbeat(
+    job_id: str,
+    body: HeartbeatRequest,
+    identity: Annotated[EdgeIdentity, Depends(require_edge_agent)],
+    control_plane: Annotated[ControlPlanePort, Depends(get_control_plane)],
+) -> HeartbeatResponse:
+    """Renova por 300 segundos o owner e fence apresentados."""
+
+    job = control_plane.get_job(identity.tenant_id, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="job_missing")
+    if (job.tenant_id, job.agent_id) != (identity.tenant_id, identity.agent_id):
+        raise HTTPException(status_code=403, detail="job_identity_mismatch")
+    command = RenewJobLease(
+        tenant_id=identity.tenant_id,
+        job_id=job_id,
+        owner=identity.agent_id,
+        fencing_token=body.fencing_token,
+        now=_utc_now(),
+        lease_seconds=EDGE_JOB_LEASE_SECONDS,
+    )
+    try:
+        renewed = control_plane.renew_job_lease(command)
+    except NotFound as error:
+        raise HTTPException(status_code=404, detail=_error_code(error)) from error
+    except (FenceRejected, LeaseLost, Conflict) as error:
+        raise HTTPException(status_code=409, detail=_error_code(error)) from error
+    if renewed.lease_until is None:
+        raise HTTPException(status_code=409, detail="job_not_leased")
+    return HeartbeatResponse(
+        job_id=renewed.job_id,
+        fencing_token=renewed.fencing_token,
+        lease_until=renewed.lease_until,
+    )
+
+
+@router.put("/jobs/{job_id}/raw-object", response_model=RawUploadResponse)
+async def upload_raw_object(
+    job_id: str,
+    identity: Annotated[EdgeIdentity, Depends(require_edge_agent)],
+    body: Annotated[_RawUploadBody, Depends(_raw_upload_body)],
+    service: Annotated[RawUploadService, Depends(get_raw_upload_service)],
+) -> RawUploadResponse:
+    """Transmite um objeto raw sem carregar o payload inteiro em memória."""
+
+    upload = RawUploadRequest(
+        tenant_id=identity.tenant_id,
+        agent_id=identity.agent_id,
+        job_id=job_id,
+        fencing_token=body.fencing_token,
+        object_key=body.object_key,
+    )
+    try:
+        stat = await service.upload(upload, body.request.stream())
+    except RawUploadError as error:
+        raise HTTPException(status_code=_upload_status(error), detail=error.code) from error
+    return RawUploadResponse(
+        object_key=stat.key,
+        object_sha256=stat.sha256,
+        size_bytes=stat.size_bytes,
+    )
+
+
+def _job_response(job: Job, identity: EdgeIdentity) -> EdgeJobResponse:
+    if (job.tenant_id, job.agent_id) != (identity.tenant_id, identity.agent_id):
+        raise HTTPException(status_code=409, detail="job_identity_mismatch")
+    if job.lease_until is None:
+        raise HTTPException(status_code=409, detail="job_not_leased")
+    return EdgeJobResponse(
+        job_id=job.job_id,
+        source_type=job.source_type,
+        file_subtype=job.file_subtype,
+        competencia=job.competencia,
+        requested_snapshot_mode=job.requested_snapshot_mode,
+        fencing_token=job.fencing_token,
+        lease_until=job.lease_until,
+        raw_upload_path=f"/api/v1/edge/jobs/{job.job_id}/raw-object",
+    )
+
+
+def _upload_status(error: RawUploadError) -> int:
+    if isinstance(error, RawUploadTooLarge):
+        return 413
+    if isinstance(error, RawUploadConflict):
+        return 409
+    if isinstance(error, RawUploadNotFound):
+        return 404
+    if isinstance(error, (RawUploadIdentityRejected, RawUploadKeyRejected)):
+        return 409
+    return 409
+
+
+def _error_code(error: Exception) -> str:
+    code = getattr(error, "code", None)
+    normalized = getattr(code, "value", code) or str(error)
+    return _ERROR_ALIASES.get(normalized, normalized)

--- a/apps/central_api/src/central_api/routes/raw_jobs.py
+++ b/apps/central_api/src/central_api/routes/raw_jobs.py
@@ -19,6 +19,7 @@ from central_api.schemas.raw_api import (
 from central_api.services.raw_ingestion import RawIngestionService  # noqa: TC001
 from central_api.services.raw_upload import (
     RawUploadConflict,
+    RawUploadEmpty,
     RawUploadError,
     RawUploadIdentityRejected,
     RawUploadKeyRejected,
@@ -228,6 +229,8 @@ def _job_response(job: Job, identity: EdgeIdentity) -> EdgeJobResponse:
 def _upload_status(error: RawUploadError) -> int:
     if isinstance(error, RawUploadTooLarge):
         return 413
+    if isinstance(error, RawUploadEmpty):
+        return 422
     if isinstance(error, RawUploadConflict):
         return 409
     if isinstance(error, RawUploadNotFound):

--- a/apps/central_api/src/central_api/routes/raw_manifests.py
+++ b/apps/central_api/src/central_api/routes/raw_manifests.py
@@ -1,0 +1,83 @@
+"""Rota autenticada de registro de manifestos raw."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+
+from central_api.routes.raw_jobs import (
+    _error_code,
+    _utc_now,
+    get_raw_ingestion_service,
+    require_edge_agent,
+)
+from central_api.schemas.raw_api import (
+    EdgeIdentity,
+    RawManifestResponse,
+    RawManifestSubmission,
+)
+from central_api.services.raw_ingestion import RawIngestionService, RegisterRawManifest
+from cnes_domain.control_plane.errors import Conflict, FenceRejected, LeaseLost, NotFound
+
+router = APIRouter(prefix="/api/v1/edge", tags=["edge-raw"])
+
+
+@router.post(
+    "/raw-manifests",
+    response_model=RawManifestResponse,
+    responses={
+        409: {
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "oneOf": [
+                            {"$ref": "#/components/schemas/RawManifestResponse"},
+                            {
+                                "type": "object",
+                                "properties": {"detail": {"type": "string"}},
+                                "required": ["detail"],
+                                "additionalProperties": False,
+                            },
+                        ]
+                    }
+                }
+            }
+        }
+    },
+)
+def register_raw_manifest(
+    body: RawManifestSubmission,
+    identity: Annotated[EdgeIdentity, Depends(require_edge_agent)],
+    service: Annotated[RawIngestionService, Depends(get_raw_ingestion_service)],
+) -> RawManifestResponse | JSONResponse:
+    """Registra o manifesto usando somente a identidade autenticada."""
+
+    canonical = body.manifest.model_dump_json(exclude_none=False, by_alias=False).encode()
+    command = RegisterRawManifest(
+        tenant_id=identity.tenant_id,
+        agent_id=identity.agent_id,
+        job_id=body.job_id,
+        owner=identity.agent_id,
+        fencing_token=body.fencing_token,
+        manifest=body.manifest,
+        manifest_bytes=canonical,
+        now=_utc_now(),
+    )
+    try:
+        acceptance = service.register(command)
+    except NotFound as error:
+        raise HTTPException(status_code=404, detail=_error_code(error)) from error
+    except (FenceRejected, LeaseLost, Conflict) as error:
+        raise HTTPException(status_code=409, detail=_error_code(error)) from error
+    response = RawManifestResponse(
+        accepted=acceptance.accepted,
+        manifest_id=acceptance.manifest_id,
+        manifest_sha256=acceptance.manifest_sha256,
+        full_resync_required=acceptance.full_resync_required,
+        reason=acceptance.reason.value if acceptance.reason is not None else None,
+    )
+    if response.full_resync_required:
+        return JSONResponse(status_code=409, content=response.model_dump(mode="json"))
+    return response

--- a/apps/central_api/src/central_api/schemas/raw_api.py
+++ b/apps/central_api/src/central_api/schemas/raw_api.py
@@ -1,0 +1,83 @@
+"""Schemas HTTP do protocolo raw do Edge Agent."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
+
+from cnes_contracts import RawManifest
+
+
+class _FrozenSchema(BaseModel):
+    model_config = ConfigDict(frozen=True, strict=True, extra="forbid")
+
+
+class EdgeIdentity(_FrozenSchema):
+    """Identidade autenticada do certificado mTLS."""
+
+    tenant_id: str = Field(min_length=1)
+    agent_id: str = Field(min_length=1)
+    certificate_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class EdgeJobResponse(_FrozenSchema):
+    """Job adquirido pelo Edge Agent."""
+
+    job_id: str
+    source_type: str
+    file_subtype: str
+    competencia: str
+    requested_snapshot_mode: str
+    fencing_token: int
+    lease_until: AwareDatetime
+    raw_upload_path: str
+
+
+class HeartbeatRequest(_FrozenSchema):
+    """Fence apresentado para renovação do lease."""
+
+    fencing_token: int = Field(ge=0)
+
+
+class HeartbeatResponse(_FrozenSchema):
+    """Lease renovado do job."""
+
+    job_id: str
+    fencing_token: int
+    lease_until: AwareDatetime
+
+
+class RawUploadResponse(_FrozenSchema):
+    """Recibo do objeto raw persistido."""
+
+    object_key: str
+    object_sha256: str
+    size_bytes: int
+
+
+class RawManifestSubmission(_FrozenSchema):
+    """Envelope autenticado de submissão do manifesto raw."""
+
+    job_id: str = Field(min_length=1)
+    fencing_token: int = Field(ge=0)
+    manifest: RawManifest
+
+    @field_validator("manifest", mode="before")
+    @classmethod
+    def normalize_manifest(cls, value: Any) -> RawManifest:
+        if isinstance(value, RawManifest):
+            return value
+        payload = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+        return RawManifest.model_validate_json(payload)
+
+
+class RawManifestResponse(_FrozenSchema):
+    """Resultado canônico do registro do manifesto raw."""
+
+    accepted: bool
+    manifest_id: str
+    manifest_sha256: str
+    full_resync_required: bool
+    reason: str | None

--- a/apps/central_api/src/central_api/services/raw_upload.py
+++ b/apps/central_api/src/central_api/services/raw_upload.py
@@ -1,0 +1,160 @@
+"""Upload streaming e imutável de objetos raw."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from hashlib import sha256
+from tempfile import SpooledTemporaryFile
+from typing import TYPE_CHECKING
+
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.errors import Conflict
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterable, Callable
+    from datetime import datetime
+
+    from cnes_domain.control_plane.entities import Job
+    from cnes_domain.ports.control_plane import ControlPlanePort
+    from cnes_domain.ports.object_store import ObjectStat, ObjectStorePort
+
+RAW_UPLOAD_MAX_BYTES = 1024**3
+RAW_UPLOAD_SPOOL_BYTES = 8 * 1024**2
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class RawUploadError(RuntimeError):
+    """Falha estável do upload raw."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class RawUploadNotFound(RawUploadError):
+    """Job de upload inexistente."""
+
+
+class RawUploadIdentityRejected(RawUploadError):
+    """Identidade do job incompatível."""
+
+
+class RawUploadLeaseRejected(RawUploadError):
+    """Lease do job incompatível."""
+
+
+class RawUploadFenceRejected(RawUploadError):
+    """Fence do job incompatível."""
+
+
+class RawUploadKeyRejected(RawUploadError):
+    """Chave do objeto incompatível."""
+
+
+class RawUploadTooLarge(RawUploadError):
+    """Payload maior que o limite raw."""
+
+
+class RawUploadConflict(RawUploadError):
+    """Replay divergente de objeto imutável."""
+
+
+@dataclass(frozen=True, slots=True)
+class RawUploadRequest:
+    """Comando imutável do upload raw autenticado."""
+
+    tenant_id: str
+    agent_id: str
+    job_id: str
+    fencing_token: int
+    object_key: str
+
+
+class RawUploadService:
+    """Valida, spoola e publica um objeto raw imutável."""
+
+    def __init__(
+        self,
+        control_plane: ControlPlanePort,
+        object_store: ObjectStorePort,
+        clock: Callable[[], datetime],
+    ) -> None:
+        self._control_plane = control_plane
+        self._object_store = object_store
+        self._clock = clock
+
+    async def upload(
+        self, request: RawUploadRequest, stream: AsyncIterable[bytes]
+    ) -> ObjectStat:
+        """Publica o stream após validar identidade, lease, fence e chave."""
+
+        self._validate(request)
+        with SpooledTemporaryFile(max_size=RAW_UPLOAD_SPOOL_BYTES, mode="w+b") as spool:
+            digest, size = await self._spool(stream, spool)
+            existing = self._object_store.stat(request.object_key)
+            if existing is not None:
+                self._validate(request)
+                return self._validate_replay(existing, digest, size)
+            spool.seek(0)
+            self._validate(request)
+            try:
+                return self._object_store.put(request.object_key, spool, digest)
+            except Conflict:
+                return self._resolve_publish_race(request, digest, size)
+
+    def _validate(self, request: RawUploadRequest) -> Job:
+        job = self._control_plane.get_job(request.tenant_id, request.job_id)
+        if job is None:
+            raise RawUploadNotFound("job_missing")
+        if (job.tenant_id, job.agent_id) != (request.tenant_id, request.agent_id):
+            raise RawUploadIdentityRejected("job_identity_mismatch")
+        if job.state is not JobState.LEASED:
+            raise RawUploadLeaseRejected("job_not_leased")
+        if job.lease_owner != request.agent_id:
+            raise RawUploadLeaseRejected("job_owner_lost")
+        if job.lease_until is None or job.lease_until <= self._clock():
+            raise RawUploadLeaseRejected("job_lease_expired")
+        if job.fencing_token != request.fencing_token:
+            raise RawUploadFenceRejected("job_fence_rejected")
+        if not _valid_object_key(request.object_key, job):
+            raise RawUploadKeyRejected("object_key_invalid")
+        return job
+
+    @staticmethod
+    async def _spool(stream: AsyncIterable[bytes], spool) -> tuple[str, int]:
+        digest = sha256()
+        size = 0
+        async for chunk in stream:
+            size += len(chunk)
+            if size > RAW_UPLOAD_MAX_BYTES:
+                raise RawUploadTooLarge("payload_too_large")
+            digest.update(chunk)
+            spool.write(chunk)
+        return digest.hexdigest(), size
+
+    @staticmethod
+    def _validate_replay(existing: ObjectStat, digest: str, size: int) -> ObjectStat:
+        if (existing.size_bytes, existing.sha256) != (size, digest):
+            raise RawUploadConflict("object_conflict")
+        return existing
+
+    def _resolve_publish_race(
+        self, request: RawUploadRequest, digest: str, size: int
+    ) -> ObjectStat:
+        existing = self._object_store.stat(request.object_key)
+        if existing is None:
+            raise RawUploadConflict("object_conflict")
+        return self._validate_replay(existing, digest, size)
+
+
+def _valid_object_key(key: str, job: Job) -> bool:
+    parts = key.split("/")
+    expected = ("raw", job.tenant_id, job.source_type, job.competencia)
+    return (
+        len(parts) == 6
+        and tuple(parts[:4]) == expected
+        and bool(_SAFE_SEGMENT.fullmatch(parts[4]))
+        and parts[4] not in {".", ".."}
+        and parts[5] == "data.parquet"
+    )

--- a/apps/central_api/src/central_api/services/raw_upload.py
+++ b/apps/central_api/src/central_api/services/raw_upload.py
@@ -146,7 +146,7 @@ class RawUploadService:
             if size > RAW_UPLOAD_MAX_BYTES:
                 raise RawUploadTooLarge("payload_too_large")
             digest.update(chunk)
-            spool.write(chunk)
+            await to_thread(spool.write, chunk)
         return digest.hexdigest(), size
 
     @staticmethod

--- a/apps/central_api/src/central_api/services/raw_upload.py
+++ b/apps/central_api/src/central_api/services/raw_upload.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from asyncio import to_thread
 from dataclasses import dataclass
 from hashlib import sha256
 from tempfile import SpooledTemporaryFile
@@ -56,6 +57,10 @@ class RawUploadTooLarge(RawUploadError):
     """Payload maior que o limite raw."""
 
 
+class RawUploadEmpty(RawUploadError):
+    """Payload raw vazio."""
+
+
 class RawUploadConflict(RawUploadError):
     """Replay divergente de objeto imutável."""
 
@@ -89,37 +94,48 @@ class RawUploadService:
     ) -> ObjectStat:
         """Publica o stream após validar identidade, lease, fence e chave."""
 
-        self._validate(request)
+        job = self._validate_request(request)
+        existing = await to_thread(self._object_store.stat, request.object_key)
+        self._validate_state(job, existing is not None)
         with SpooledTemporaryFile(max_size=RAW_UPLOAD_SPOOL_BYTES, mode="w+b") as spool:
             digest, size = await self._spool(stream, spool)
-            existing = self._object_store.stat(request.object_key)
+            if size == 0:
+                raise RawUploadEmpty("payload_empty")
+            existing = existing or await to_thread(self._object_store.stat, request.object_key)
             if existing is not None:
-                self._validate(request)
+                self._validate_state(self._validate_request(request), True)
                 return self._validate_replay(existing, digest, size)
             spool.seek(0)
-            self._validate(request)
+            self._validate_state(self._validate_request(request), False)
             try:
-                return self._object_store.put(request.object_key, spool, digest)
+                return await to_thread(self._object_store.put, request.object_key, spool, digest)
             except Conflict:
-                return self._resolve_publish_race(request, digest, size)
+                return await self._resolve_publish_race(request, digest, size)
 
-    def _validate(self, request: RawUploadRequest) -> Job:
+    def _validate_request(self, request: RawUploadRequest) -> Job:
         job = self._control_plane.get_job(request.tenant_id, request.job_id)
         if job is None:
             raise RawUploadNotFound("job_missing")
         if (job.tenant_id, job.agent_id) != (request.tenant_id, request.agent_id):
             raise RawUploadIdentityRejected("job_identity_mismatch")
-        if job.state is not JobState.LEASED:
-            raise RawUploadLeaseRejected("job_not_leased")
-        if job.lease_owner != request.agent_id:
-            raise RawUploadLeaseRejected("job_owner_lost")
-        if job.lease_until is None or job.lease_until <= self._clock():
-            raise RawUploadLeaseRejected("job_lease_expired")
         if job.fencing_token != request.fencing_token:
             raise RawUploadFenceRejected("job_fence_rejected")
         if not _valid_object_key(request.object_key, job):
             raise RawUploadKeyRejected("object_key_invalid")
         return job
+
+    def _validate_state(self, job: Job, terminal_replay: bool) -> None:
+        is_resync = job.state is JobState.FAILED_FINAL and bool(
+            job.error_code and job.error_code.startswith("RAW_RESYNC_")
+        )
+        if terminal_replay and (job.state is JobState.SUCCEEDED or is_resync):
+            return
+        if job.state is not JobState.LEASED:
+            raise RawUploadLeaseRejected("job_not_leased")
+        if job.lease_owner != job.agent_id:
+            raise RawUploadLeaseRejected("job_owner_lost")
+        if job.lease_until is None or job.lease_until <= self._clock():
+            raise RawUploadLeaseRejected("job_lease_expired")
 
     @staticmethod
     async def _spool(stream: AsyncIterable[bytes], spool) -> tuple[str, int]:
@@ -139,10 +155,10 @@ class RawUploadService:
             raise RawUploadConflict("object_conflict")
         return existing
 
-    def _resolve_publish_race(
+    async def _resolve_publish_race(
         self, request: RawUploadRequest, digest: str, size: int
     ) -> ObjectStat:
-        existing = self._object_store.stat(request.object_key)
+        existing = await to_thread(self._object_store.stat, request.object_key)
         if existing is None:
             raise RawUploadConflict("object_conflict")
         return self._validate_replay(existing, digest, size)

--- a/apps/central_api/src/central_api/services/raw_upload.py
+++ b/apps/central_api/src/central_api/services/raw_upload.py
@@ -94,7 +94,7 @@ class RawUploadService:
     ) -> ObjectStat:
         """Publica o stream após validar identidade, lease, fence e chave."""
 
-        job = self._validate_request(request)
+        job = await to_thread(self._validate_request, request)
         existing = await to_thread(self._object_store.stat, request.object_key)
         self._validate_state(job, existing is not None)
         with SpooledTemporaryFile(max_size=RAW_UPLOAD_SPOOL_BYTES, mode="w+b") as spool:
@@ -103,10 +103,12 @@ class RawUploadService:
                 raise RawUploadEmpty("payload_empty")
             existing = existing or await to_thread(self._object_store.stat, request.object_key)
             if existing is not None:
-                self._validate_state(self._validate_request(request), True)
+                current = await to_thread(self._validate_request, request)
+                self._validate_state(current, True)
                 return self._validate_replay(existing, digest, size)
             spool.seek(0)
-            self._validate_state(self._validate_request(request), False)
+            current = await to_thread(self._validate_request, request)
+            self._validate_state(current, False)
             try:
                 return await to_thread(self._object_store.put, request.object_key, spool, digest)
             except Conflict:

--- a/apps/central_api/tests/routes/test_raw_jobs.py
+++ b/apps/central_api/tests/routes/test_raw_jobs.py
@@ -417,8 +417,13 @@ def test_upload_mapeia_falhas_do_servico(jobs, key: str, status: int, detail: st
     assert response.json() == {"detail": detail}
 
 
-def test_upload_mapeia_tamanho_excedido(monkeypatch) -> None:
-    monkeypatch.setattr("central_api.services.raw_upload.RAW_UPLOAD_MAX_BYTES", 2)
+@pytest.mark.parametrize(
+    "case",
+    [(2, b"abc", 413, "payload_too_large"), (1024**3, b"", 422, "payload_empty")],
+)
+def test_upload_mapeia_tamanho_invalido(monkeypatch, case) -> None:
+    limit, body, status, detail = case
+    monkeypatch.setattr("central_api.services.raw_upload.RAW_UPLOAD_MAX_BYTES", limit)
     leased = job(
         state=JobState.LEASED,
         fencing_token=7,
@@ -430,7 +435,7 @@ def test_upload_mapeia_tamanho_excedido(monkeypatch) -> None:
 
     response = client(control, upload=upload).put(
         "/api/v1/edge/jobs/job-1/raw-object",
-        content=b"abc",
+        content=body,
         headers={
             "X-Fencing-Token": "7",
             "X-Object-Key": KEY,
@@ -438,8 +443,8 @@ def test_upload_mapeia_tamanho_excedido(monkeypatch) -> None:
         },
     )
 
-    assert response.status_code == 413
-    assert response.json() == {"detail": "payload_too_large"}
+    assert response.status_code == status
+    assert response.json() == {"detail": detail}
 
 
 @pytest.mark.parametrize("headers", [{}, {"X-Fencing-Token": "x"}, {"X-Fencing-Token": "7"}])

--- a/apps/central_api/tests/routes/test_raw_jobs.py
+++ b/apps/central_api/tests/routes/test_raw_jobs.py
@@ -1,0 +1,494 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+from threading import Barrier, Lock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from central_api.app import create_app
+from central_api.routes import raw_jobs
+from central_api.routes.raw_jobs import (
+    get_control_plane,
+    get_edge_identity,
+    get_raw_upload_service,
+    router,
+)
+from central_api.schemas.raw_api import EdgeIdentity
+from central_api.services.raw_upload import RawUploadService
+from cnes_domain.control_plane.entities import Agent, Job
+from cnes_domain.control_plane.enums import AgentState, JobState
+from cnes_domain.control_plane.errors import FenceRejected, LeaseLost, NotFound
+from cnes_domain.ports.object_store import ObjectStat
+
+NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
+FINGERPRINT = sha256(b"certificate").hexdigest()
+KEY = "raw/354130/CNES_LOCAL/2026-07/snapshot-1/data.parquet"
+
+
+def agent(**updates: object) -> Agent:
+    values = {
+        "tenant_id": "354130",
+        "agent_id": "agent-1",
+        "state": AgentState.ACTIVE,
+        "version": "1.0",
+        "certificate_fingerprint": FINGERPRINT,
+        "last_seen_at": NOW,
+        "created_at": NOW,
+    }
+    return Agent(**(values | updates))
+
+
+def job(**updates: object) -> Job:
+    values = {
+        "tenant_id": "354130",
+        "job_id": "job-1",
+        "agent_id": "agent-1",
+        "source_type": "CNES_LOCAL",
+        "file_subtype": "CNES_VINCULO",
+        "competencia": "2026-07",
+        "requested_snapshot_mode": "FULL",
+        "state": JobState.PENDING,
+        "attempt": 0,
+        "fencing_token": 0,
+        "lease_owner": None,
+        "lease_until": None,
+        "result_manifest_id": None,
+        "result_manifest_key": None,
+        "error_code": None,
+        "created_at": NOW,
+    }
+    return Job(**(values | updates))
+
+
+class ControlPlane:
+    def __init__(self, current_agent: Agent | None = None, jobs: tuple[Job, ...] = ()) -> None:
+        self.agent = current_agent
+        self.jobs = jobs
+        self.claimed: set[str] = set()
+        self.lock = Lock()
+        self.claim_barrier: Barrier | None = None
+        self.calls: list[str] = []
+        self.renew_error: Exception | None = None
+        self.renew_result: Job | None = None
+
+    def get_agent(self, tenant_id: str, agent_id: str) -> Agent | None:
+        self.calls.append("get_agent")
+        return self.agent
+
+    def list_claimable_jobs(self, tenant_id: str, agent_id: str, limit: int):
+        self.calls.append(f"list:{tenant_id}:{agent_id}:{limit}")
+        return self.jobs[:limit]
+
+    def claim_job(self, command):
+        if self.claim_barrier is not None:
+            self.claim_barrier.wait()
+        with self.lock:
+            if command.job_id in self.claimed:
+                return None
+            self.claimed.add(command.job_id)
+        candidate = next(item for item in self.jobs if item.job_id == command.job_id)
+        return candidate.model_copy(update={
+            "state": JobState.LEASED,
+            "attempt": candidate.attempt + 1,
+            "fencing_token": candidate.fencing_token + 1,
+            "lease_owner": command.owner,
+            "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+        })
+
+    def get_job(self, tenant_id: str, job_id: str) -> Job | None:
+        self.calls.append(f"job:{tenant_id}:{job_id}")
+        return next((item for item in self.jobs if item.job_id == job_id), None)
+
+    def renew_job_lease(self, command):
+        if self.renew_error:
+            raise self.renew_error
+        if self.renew_result is not None:
+            return self.renew_result
+        current = self.get_job(command.tenant_id, command.job_id)
+        assert current is not None
+        return current.model_copy(update={
+            "lease_until": command.now + timedelta(seconds=command.lease_seconds),
+        })
+
+
+class ObjectStore:
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.calls: list[str] = []
+
+    def stat(self, key: str) -> ObjectStat | None:
+        self.calls.append(f"stat:{key}")
+        value = self.objects.get(key)
+        if value is None:
+            return None
+        return ObjectStat(key, len(value), sha256(value).hexdigest())
+
+    def put(self, key: str, body, expected_sha256: str) -> ObjectStat:
+        self.calls.append(f"put:{key}")
+        value = body.read()
+        current = self.objects.setdefault(key, value)
+        if current != value:
+            raise RuntimeError("object=immutable")
+        return ObjectStat(key, len(value), expected_sha256)
+
+
+def client(control: ControlPlane, *, upload: RawUploadService | None = None) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    identity = EdgeIdentity(
+        tenant_id="354130", agent_id="agent-1", certificate_fingerprint=FINGERPRINT
+    )
+    app.dependency_overrides[get_edge_identity] = lambda: identity
+    app.dependency_overrides[get_control_plane] = lambda: control
+    upload_service = upload or RawUploadService(control, ObjectStore(), lambda: NOW)
+    app.dependency_overrides[get_raw_upload_service] = lambda: upload_service
+    return TestClient(app)
+
+
+def test_mtls_ausente_rejeita_antes_de_consultar_job() -> None:
+    control = ControlPlane(agent(), (job(),))
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_control_plane] = lambda: control
+
+    response = TestClient(app).get(
+        "/api/v1/edge/jobs/next",
+        headers={"X-SSL-Client-DN": "agent-1", "X-SSL-Client-Fingerprint": FINGERPRINT},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "mtls_required"}
+    assert control.calls == []
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [get_control_plane, get_raw_upload_service, raw_jobs.get_raw_ingestion_service],
+)
+def test_provider_nao_configurado_falha_fechado(provider) -> None:
+    with pytest.raises(HTTPException) as captured:
+        provider()
+
+    assert captured.value.status_code == 503
+
+
+@pytest.mark.parametrize(
+    ("current", "status", "detail"),
+    [
+        (None, 403, "agent_missing"),
+        (agent(state=AgentState.REVOKED), 403, "agent_revoked"),
+        (agent(tenant_id="other"), 403, "agent_identity_mismatch"),
+        (agent(certificate_fingerprint="b" * 64), 403, "certificate_fingerprint_mismatch"),
+    ],
+)
+def test_identidade_invalida_rejeita_claim(current, status: int, detail: str) -> None:
+    control = ControlPlane(current, (job(),))
+
+    response = client(control).get("/api/v1/edge/jobs/next")
+
+    assert response.status_code == status
+    assert response.json() == {"detail": detail}
+    assert not any(call.startswith("list:") for call in control.calls)
+
+
+def test_claim_isola_tenant_e_agente_e_retorna_job_fortemente_reclamado(monkeypatch) -> None:
+    monkeypatch.setattr(raw_jobs, "_utc_now", lambda: NOW)
+    control = ControlPlane(agent(), (job(),))
+
+    response = client(control).get("/api/v1/edge/jobs/next")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "job_id": "job-1",
+        "source_type": "CNES_LOCAL",
+        "file_subtype": "CNES_VINCULO",
+        "competencia": "2026-07",
+        "requested_snapshot_mode": "FULL",
+        "fencing_token": 1,
+        "lease_until": "2026-07-15T12:05:00Z",
+        "raw_upload_path": "/api/v1/edge/jobs/job-1/raw-object",
+    }
+    assert "list:354130:agent-1:10" in control.calls
+
+
+def test_claim_tenta_ate_primeiro_cas_confirmado(monkeypatch) -> None:
+    monkeypatch.setattr(raw_jobs, "_utc_now", lambda: NOW)
+    first = job(job_id="job-1")
+    second = job(job_id="job-2")
+    control = ControlPlane(agent(), (first, second))
+    control.claimed.add("job-1")
+
+    response = client(control).get("/api/v1/edge/jobs/next")
+
+    assert response.status_code == 200
+    assert response.json()["job_id"] == "job-2"
+
+
+def test_claim_ignora_candidato_de_outra_identidade(monkeypatch) -> None:
+    monkeypatch.setattr(raw_jobs, "_utc_now", lambda: NOW)
+    control = ControlPlane(agent(), (job(agent_id="other"),))
+
+    response = client(control).get("/api/v1/edge/jobs/next")
+
+    assert response.status_code == 204
+    assert control.claimed == set()
+
+
+def test_claim_sem_vencedor_retorna_204(monkeypatch) -> None:
+    monkeypatch.setattr(raw_jobs, "_utc_now", lambda: NOW)
+    control = ControlPlane(agent(), (job(),))
+    control.claimed.add("job-1")
+
+    response = client(control).get("/api/v1/edge/jobs/next")
+
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+def test_claim_concorrente_tem_um_unico_vencedor(monkeypatch) -> None:
+    monkeypatch.setattr(raw_jobs, "_utc_now", lambda: NOW)
+    control = ControlPlane(agent(), (job(),))
+    control.claim_barrier = Barrier(2)
+    api = client(control)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        responses = list(pool.map(lambda _: api.get("/api/v1/edge/jobs/next"), range(2)))
+
+    assert sorted(response.status_code for response in responses) == [200, 204]
+
+
+def test_heartbeat_distingue_job_ausente(monkeypatch) -> None:
+    monkeypatch.setattr(raw_jobs, "_utc_now", lambda: NOW)
+    response = client(ControlPlane(agent())).post(
+        "/api/v1/edge/jobs/missing/heartbeat", json={"fencing_token": 7}
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "job_missing"}
+
+
+def test_heartbeat_rejeita_job_de_outro_agente(monkeypatch) -> None:
+    monkeypatch.setattr(raw_jobs, "_utc_now", lambda: NOW)
+    response = client(ControlPlane(agent(), (job(agent_id="other"),))).post(
+        "/api/v1/edge/jobs/job-1/heartbeat", json={"fencing_token": 7}
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "job_identity_mismatch"}
+
+
+@pytest.mark.parametrize(
+    ("error", "detail"),
+    [
+        (FenceRejected("fence_mismatch"), "job_fence_rejected"),
+        (LeaseLost("lease_expired"), "job_lease_expired"),
+        (LeaseLost("owner_mismatch"), "job_owner_lost"),
+        (NotFound("job_missing"), "job_missing"),
+    ],
+)
+def test_heartbeat_rejeita_fence_ou_lease_obsoleto(monkeypatch, error, detail: str) -> None:
+    monkeypatch.setattr(raw_jobs, "_utc_now", lambda: NOW)
+    leased = job(
+        state=JobState.LEASED,
+        fencing_token=7,
+        lease_owner="agent-1",
+        lease_until=NOW + timedelta(minutes=1),
+    )
+    control = ControlPlane(agent(), (leased,))
+    control.renew_error = error
+
+    response = client(control).post(
+        "/api/v1/edge/jobs/job-1/heartbeat", json={"fencing_token": 7}
+    )
+
+    expected_status = 404 if isinstance(error, NotFound) else 409
+    assert response.status_code == expected_status
+    assert response.json() == {"detail": detail}
+
+
+def test_heartbeat_renova_owner_fence_por_300_segundos(monkeypatch) -> None:
+    monkeypatch.setattr(raw_jobs, "_utc_now", lambda: NOW)
+    leased = job(
+        state=JobState.LEASED,
+        fencing_token=7,
+        lease_owner="agent-1",
+        lease_until=NOW + timedelta(minutes=1),
+    )
+
+    response = client(ControlPlane(agent(), (leased,))).post(
+        "/api/v1/edge/jobs/job-1/heartbeat", json={"fencing_token": 7}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "job_id": "job-1",
+        "fencing_token": 7,
+        "lease_until": "2026-07-15T12:05:00Z",
+    }
+
+
+def test_heartbeat_rejeita_retorno_sem_lease(monkeypatch) -> None:
+    monkeypatch.setattr(raw_jobs, "_utc_now", lambda: NOW)
+    leased = job(
+        state=JobState.LEASED,
+        fencing_token=7,
+        lease_owner="agent-1",
+        lease_until=NOW + timedelta(minutes=1),
+    )
+    control = ControlPlane(agent(), (leased,))
+    control.renew_result = job()
+
+    response = client(control).post(
+        "/api/v1/edge/jobs/job-1/heartbeat", json={"fencing_token": 7}
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "job_not_leased"}
+
+
+def test_upload_rejeita_media_type_incorreto() -> None:
+    control = ControlPlane(agent(), (job(),))
+    response = client(control).put(
+        "/api/v1/edge/jobs/job-1/raw-object",
+        content=b"payload",
+        headers={"X-Fencing-Token": "7", "X-Object-Key": KEY, "Content-Type": "text/plain"},
+    )
+
+    assert response.status_code == 415
+    assert response.json() == {"detail": "media_type_unsupported"}
+
+
+def test_fingerprint_divergente_rejeita_antes_do_objeto() -> None:
+    control = ControlPlane(agent(certificate_fingerprint="b" * 64), (job(),))
+    store = ObjectStore()
+    upload = RawUploadService(control, store, lambda: NOW)
+
+    response = client(control, upload=upload).put(
+        "/api/v1/edge/jobs/job-1/raw-object",
+        content=b"payload",
+        headers={
+            "X-Fencing-Token": "7",
+            "X-Object-Key": KEY,
+            "Content-Type": "application/octet-stream",
+        },
+    )
+
+    assert response.status_code == 403
+    assert store.calls == []
+
+
+@pytest.mark.parametrize(
+    ("jobs", "key", "status", "detail"),
+    [
+        ((), KEY, 404, "job_missing"),
+        ((job(agent_id="other"),), KEY, 409, "job_identity_mismatch"),
+        (
+            (
+                job(
+                    state=JobState.LEASED,
+                    fencing_token=7,
+                    lease_owner="agent-1",
+                    lease_until=NOW + timedelta(minutes=1),
+                ),
+            ),
+            "raw/other/CNES_LOCAL/2026-07/s/data.parquet",
+            409,
+            "object_key_invalid",
+        ),
+    ],
+)
+def test_upload_mapeia_falhas_do_servico(jobs, key: str, status: int, detail: str) -> None:
+    control = ControlPlane(agent(), jobs)
+    upload = RawUploadService(control, ObjectStore(), lambda: NOW)
+
+    response = client(control, upload=upload).put(
+        "/api/v1/edge/jobs/job-1/raw-object",
+        content=b"payload",
+        headers={
+            "X-Fencing-Token": "7",
+            "X-Object-Key": key,
+            "Content-Type": "application/octet-stream",
+        },
+    )
+
+    assert response.status_code == status
+    assert response.json() == {"detail": detail}
+
+
+def test_upload_mapeia_tamanho_excedido(monkeypatch) -> None:
+    monkeypatch.setattr("central_api.services.raw_upload.RAW_UPLOAD_MAX_BYTES", 2)
+    leased = job(
+        state=JobState.LEASED,
+        fencing_token=7,
+        lease_owner="agent-1",
+        lease_until=NOW + timedelta(minutes=1),
+    )
+    control = ControlPlane(agent(), (leased,))
+    upload = RawUploadService(control, ObjectStore(), lambda: NOW)
+
+    response = client(control, upload=upload).put(
+        "/api/v1/edge/jobs/job-1/raw-object",
+        content=b"abc",
+        headers={
+            "X-Fencing-Token": "7",
+            "X-Object-Key": KEY,
+            "Content-Type": "application/octet-stream",
+        },
+    )
+
+    assert response.status_code == 413
+    assert response.json() == {"detail": "payload_too_large"}
+
+
+@pytest.mark.parametrize("headers", [{}, {"X-Fencing-Token": "x"}, {"X-Fencing-Token": "7"}])
+def test_upload_exige_headers_congelados(headers: dict[str, str]) -> None:
+    control = ControlPlane(agent(), (job(),))
+    response = client(control).put(
+        "/api/v1/edge/jobs/job-1/raw-object",
+        content=b"payload",
+        headers=headers | {"Content-Type": "application/octet-stream"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    ("existing", "body", "status"),
+    [(b"payload", b"payload", 200), (b"old", b"new", 409)],
+)
+def test_replay_pela_rota_preserva_imutabilidade(existing: bytes, body: bytes, status: int) -> None:
+    leased = job(
+        state=JobState.LEASED,
+        fencing_token=7,
+        lease_owner="agent-1",
+        lease_until=NOW + timedelta(minutes=1),
+    )
+    control = ControlPlane(agent(), (leased,))
+    store = ObjectStore()
+    store.objects[KEY] = existing
+    upload = RawUploadService(control, store, lambda: NOW)
+
+    response = client(control, upload=upload).put(
+        "/api/v1/edge/jobs/job-1/raw-object",
+        content=body,
+        headers={
+            "X-Fencing-Token": "7",
+            "X-Object-Key": KEY,
+            "Content-Type": "application/octet-stream",
+        },
+    )
+
+    assert response.status_code == status
+    assert store.objects[KEY] == existing
+    if status == 200:
+        assert response.json()["object_sha256"] == sha256(body).hexdigest()
+    else:
+        assert response.json() == {"detail": "object_conflict"}
+
+
+def test_create_app_continua_sem_rotas_edge() -> None:
+    paths = {route.path for route in create_app().routes}
+
+    assert all(not path.startswith("/api/v1/edge") for path in paths)

--- a/apps/central_api/tests/routes/test_raw_manifests.py
+++ b/apps/central_api/tests/routes/test_raw_manifests.py
@@ -1,0 +1,335 @@
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+from io import BytesIO
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from central_api.routes import raw_manifests
+from central_api.routes.raw_jobs import (
+    get_control_plane,
+    get_edge_identity,
+    get_raw_ingestion_service,
+)
+from central_api.routes.raw_manifests import router
+from central_api.schemas.raw_api import EdgeIdentity, RawManifestSubmission
+from central_api.services.delta_policy import DeltaPolicy, ResyncReason
+from central_api.services.raw_ingestion import RawIngestionService
+from cnes_contracts import RawManifest, SnapshotMode, SourceType, manifest_sha256
+from cnes_domain.control_plane.entities import (
+    Agent,
+    Job,
+    ManifestRef,
+    RawManifestRecord,
+    RawResyncState,
+)
+from cnes_domain.control_plane.enums import AgentState, JobState
+from cnes_domain.ports.object_store import ObjectStat
+
+NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
+FINGERPRINT = sha256(b"certificate").hexdigest()
+DATA = b"parquet"
+
+
+def raw_manifest(**updates: object) -> RawManifest:
+    values = {
+        "manifest_version": 1,
+        "manifest_id": "manifest-current",
+        "tenant_id": "354130",
+        "source_type": SourceType.CNES_LOCAL,
+        "file_subtype": "CNES_VINCULO",
+        "competencia": "2026-07",
+        "agent_id": "agent-1",
+        "agent_version": "1.0",
+        "schema_version": "v1",
+        "snapshot_mode": SnapshotMode.FULL,
+        "snapshot_id": "current",
+        "base_snapshot_id": None,
+        "sequence": 1,
+        "previous_manifest_sha256": None,
+        "object_sha256": sha256(DATA).hexdigest(),
+        "row_count": 1,
+        "size_bytes": len(DATA),
+        "object_key": "raw/354130/CNES_LOCAL/2026-07/current/data.parquet",
+        "created_at": NOW,
+    }
+    return RawManifest(**(values | updates))
+
+
+def job(mode: SnapshotMode = SnapshotMode.FULL) -> Job:
+    return Job(
+        tenant_id="354130",
+        job_id="job-1",
+        agent_id="agent-1",
+        source_type="CNES_LOCAL",
+        file_subtype="CNES_VINCULO",
+        competencia="2026-07",
+        requested_snapshot_mode=mode.value,
+        state=JobState.LEASED,
+        attempt=1,
+        fencing_token=7,
+        lease_owner="agent-1",
+        lease_until=NOW + timedelta(minutes=5),
+        result_manifest_id=None,
+        result_manifest_key=None,
+        error_code=None,
+        created_at=NOW,
+    )
+
+
+def record(raw: RawManifest) -> RawManifestRecord:
+    return RawManifestRecord(
+        tenant_id=raw.tenant_id,
+        manifest_id=raw.manifest_id,
+        manifest_key=raw.object_key.removesuffix("data.parquet") + "manifest.json",
+        agent_id=raw.agent_id,
+        source_type=raw.source_type.value,
+        file_subtype=raw.file_subtype,
+        competencia=raw.competencia,
+        snapshot_mode=raw.snapshot_mode.value,
+        snapshot_id=raw.snapshot_id,
+        base_snapshot_id=raw.base_snapshot_id,
+        sequence=raw.sequence,
+        previous_manifest_sha256=raw.previous_manifest_sha256,
+        manifest_sha256=manifest_sha256(raw),
+        created_at=raw.created_at,
+    )
+
+
+class ObjectStore:
+    def __init__(self, current: RawManifest, history: tuple[RawManifest, ...] = ()) -> None:
+        self.objects = {current.object_key: DATA}
+        for item in history:
+            self.objects[record(item).manifest_key] = canonical(item)
+
+    def stat(self, key: str) -> ObjectStat | None:
+        body = self.objects.get(key)
+        if body is None:
+            return None
+        return ObjectStat(key, len(body), sha256(body).hexdigest())
+
+    def put(self, key: str, body, expected_sha256: str) -> ObjectStat:
+        value = body.read()
+        current = self.objects.setdefault(key, value)
+        if current != value:
+            raise RuntimeError("object=immutable")
+        return ObjectStat(key, len(value), expected_sha256)
+
+    @contextmanager
+    def open(self, key: str):
+        yield BytesIO(self.objects[key])
+
+
+class ControlPlane:
+    def __init__(self, current: Job) -> None:
+        self.job = current
+        self.agent = Agent(
+            tenant_id="354130",
+            agent_id="agent-1",
+            state=AgentState.ACTIVE,
+            version="1.0",
+            certificate_fingerprint=FINGERPRINT,
+            last_seen_at=NOW,
+            created_at=NOW,
+        )
+        self.marker = None
+        self.latest = None
+        self.chain: tuple[ManifestRef, ...] = ()
+        self.records: dict[str, RawManifestRecord] = {}
+
+    def get_agent(self, tenant_id: str, agent_id: str) -> Agent | None:
+        return self.agent
+
+    def get_job(self, tenant_id: str, job_id: str) -> Job | None:
+        return self.job if (tenant_id, job_id) == (self.job.tenant_id, self.job.job_id) else None
+
+    def query_raw_resync_state(self, _query):
+        return self.marker
+
+    def query_latest_succeeded_job(self, _query):
+        return self.latest
+
+    def query_agent_raw_manifest_chain(self, _query):
+        return self.chain
+
+    def query_raw_manifest_by_id(self, query):
+        return self.records.get(query.manifest_id)
+
+    def fail_job(self, command, _event):
+        return self.job.model_copy(update={
+            "state": JobState.FAILED_FINAL,
+            "lease_owner": None,
+            "lease_until": None,
+            "error_code": command.error_code,
+            "rejected_manifest_sha256": command.rejected_manifest_sha256,
+        })
+
+    def complete_job(self, command, _event):
+        return self.job.model_copy(update={
+            "state": JobState.SUCCEEDED,
+            "lease_owner": None,
+            "lease_until": None,
+            "result_manifest_id": command.manifest.manifest_id,
+            "result_manifest_key": command.manifest.manifest_key,
+        })
+
+
+def canonical(raw: RawManifest) -> bytes:
+    return raw.model_dump_json(exclude_none=False, by_alias=False).encode()
+
+
+def api_client(control: ControlPlane, store: ObjectStore) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    identity = EdgeIdentity(
+        tenant_id="354130", agent_id="agent-1", certificate_fingerprint=FINGERPRINT
+    )
+    service = RawIngestionService(control, store, DeltaPolicy())
+    app.dependency_overrides[get_edge_identity] = lambda: identity
+    app.dependency_overrides[get_control_plane] = lambda: control
+    app.dependency_overrides[get_raw_ingestion_service] = lambda: service
+    return TestClient(app)
+
+
+def submission(raw: RawManifest) -> dict[str, object]:
+    return {"job_id": "job-1", "fencing_token": 7, "manifest": raw.model_dump(mode="json")}
+
+
+def test_schema_normaliza_objeto_json_preservando_contrato_estrito() -> None:
+    raw = raw_manifest()
+
+    parsed = RawManifestSubmission.model_validate(submission(raw))
+
+    assert parsed.manifest == raw
+    with pytest.raises(ValidationError):
+        parsed.job_id = "other"
+
+
+def test_manifesto_rejeita_tenant_do_corpo_divergente() -> None:
+    raw = raw_manifest().model_copy(update={
+        "tenant_id": "other",
+        "object_key": "raw/other/CNES_LOCAL/2026-07/current/data.parquet",
+    })
+    control = ControlPlane(job())
+    store = ObjectStore(raw)
+
+    response = api_client(control, store).post("/api/v1/edge/raw-manifests", json=submission(raw))
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "manifest_identity_conflict"}
+
+
+def test_manifesto_full_aceito_retorna_resposta_tipada(monkeypatch) -> None:
+    monkeypatch.setattr(raw_manifests, "_utc_now", lambda: NOW)
+    raw = raw_manifest()
+    response = api_client(ControlPlane(job()), ObjectStore(raw)).post(
+        "/api/v1/edge/raw-manifests", json=submission(raw)
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "accepted": True,
+        "manifest_id": raw.manifest_id,
+        "manifest_sha256": manifest_sha256(raw),
+        "full_resync_required": False,
+        "reason": None,
+    }
+
+
+def test_manifesto_distingue_job_ausente(monkeypatch) -> None:
+    monkeypatch.setattr(raw_manifests, "_utc_now", lambda: NOW)
+    raw = raw_manifest()
+    control = ControlPlane(job())
+    control.job = job().model_copy(update={"job_id": "other"})
+
+    response = api_client(control, ObjectStore(raw)).post(
+        "/api/v1/edge/raw-manifests", json=submission(raw)
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "job_missing"}
+
+
+def delta_from(previous: RawManifest, sequence: int, **updates: object) -> RawManifest:
+    values = {
+        "manifest_id": f"manifest-{sequence}",
+        "snapshot_mode": SnapshotMode.DELTA,
+        "snapshot_id": f"delta-{sequence}",
+        "base_snapshot_id": "base",
+        "sequence": sequence,
+        "previous_manifest_sha256": manifest_sha256(previous),
+        "object_key": f"raw/354130/CNES_LOCAL/2026-07/delta-{sequence}/data.parquet",
+    }
+    return raw_manifest(**(values | updates))
+
+
+def configure_resync(reason: ResyncReason):
+    base = raw_manifest(
+        manifest_id="manifest-base", snapshot_id="base",
+        object_key="raw/354130/CNES_LOCAL/2026-07/base/data.parquet",
+    )
+    history = [base]
+    current = delta_from(base, 2)
+    control = ControlPlane(job(SnapshotMode.DELTA))
+    if reason is ResyncReason.AGENT_RESYNC_REQUIRED:
+        control.marker = RawResyncState(
+            tenant_id="354130", agent_id="agent-1", source_type="CNES_LOCAL",
+            file_subtype="CNES_VINCULO", competencia="2026-07", required_since=NOW,
+        )
+        return current, control, tuple(history)
+    if reason is ResyncReason.BASE_UNKNOWN:
+        return current, control, tuple(history)
+    if reason is ResyncReason.SEQUENCE_GAP:
+        current = delta_from(base, 3)
+    elif reason is ResyncReason.HASH_CHAIN_MISMATCH:
+        current = delta_from(base, 2, previous_manifest_sha256="b" * 64)
+    elif reason is ResyncReason.SCHEMA_INCOMPATIBLE:
+        current = delta_from(base, 2, schema_version="v2")
+    elif reason is ResyncReason.BASE_TOO_OLD:
+        base = base.model_copy(update={"created_at": NOW - timedelta(days=8)})
+        history = [base]
+        current = delta_from(base, 2)
+    else:
+        for sequence in range(2, 32):
+            history.append(delta_from(history[-1], sequence))
+        current = delta_from(history[-1], 32)
+    refs = tuple(
+        ManifestRef(
+            manifest_id=item.manifest_id,
+            manifest_key=record(item).manifest_key,
+        )
+        for item in history
+    )
+    control.records = {item.manifest_id: record(item) for item in history}
+    control.chain = refs
+    head = history[-1]
+    control.latest = job().model_copy(update={
+        "state": JobState.SUCCEEDED,
+        "lease_owner": None,
+        "lease_until": None,
+        "result_manifest_id": head.manifest_id,
+        "result_manifest_key": record(head).manifest_key,
+    })
+    return current, control, tuple(history)
+
+
+@pytest.mark.parametrize("reason", list(ResyncReason))
+def test_resync_retorna_409_com_resposta_tipada(monkeypatch, reason: ResyncReason) -> None:
+    monkeypatch.setattr(raw_manifests, "_utc_now", lambda: NOW)
+    raw, control, history = configure_resync(reason)
+    store = ObjectStore(raw, history)
+
+    response = api_client(control, store).post("/api/v1/edge/raw-manifests", json=submission(raw))
+
+    digest = manifest_sha256(raw)
+    assert response.status_code == 409
+    assert response.json() == {
+        "accepted": False,
+        "manifest_id": raw.manifest_id,
+        "manifest_sha256": digest,
+        "full_resync_required": True,
+        "reason": reason.value,
+    }

--- a/apps/central_api/tests/services/test_raw_upload.py
+++ b/apps/central_api/tests/services/test_raw_upload.py
@@ -178,6 +178,25 @@ async def test_upload_publica_objeto_fora_da_thread_do_event_loop() -> None:
 
 
 @pytest.mark.anyio
+async def test_upload_consulta_control_plane_fora_da_thread_do_event_loop() -> None:
+    class ThreadRecordingControlPlane(ControlPlane):
+        def __init__(self, jobs: list[Job | None]) -> None:
+            super().__init__(jobs)
+            self.thread_ids: list[int] = []
+
+        def get_job(self, tenant_id: str, job_id: str) -> Job | None:
+            self.thread_ids.append(get_ident())
+            return super().get_job(tenant_id, job_id)
+
+    control = ThreadRecordingControlPlane([job()])
+    service = RawUploadService(control, ObjectStore(), lambda: NOW)
+
+    await service.upload(request(), chunks(b"payload"))
+
+    assert all(thread_id != get_ident() for thread_id in control.thread_ids)
+
+
+@pytest.mark.anyio
 async def test_upload_revalida_fence_antes_de_publicar() -> None:
     changed = job(fencing_token=8)
     store = ObjectStore()

--- a/apps/central_api/tests/services/test_raw_upload.py
+++ b/apps/central_api/tests/services/test_raw_upload.py
@@ -104,6 +104,7 @@ async def chunks(*values: bytes):
 @pytest.mark.anyio
 async def test_upload_faz_stream_sem_carregar_payload_inteiro(monkeypatch) -> None:
     writes: list[bytes] = []
+    write_threads: list[int] = []
     thresholds: list[int] = []
 
     class SpoolSpy(BytesIO):
@@ -115,6 +116,7 @@ async def test_upload_faz_stream_sem_carregar_payload_inteiro(monkeypatch) -> No
 
         def write(self, value: bytes) -> int:
             writes.append(value)
+            write_threads.append(get_ident())
             return super().write(value)
 
     def spool(*, max_size: int, mode: str):
@@ -129,6 +131,7 @@ async def test_upload_faz_stream_sem_carregar_payload_inteiro(monkeypatch) -> No
     result = await service.upload(request(), chunks(b"abc", b"def"))
 
     assert writes == [b"abc", b"def"]
+    assert all(thread_id != get_ident() for thread_id in write_threads)
     assert thresholds == [8 * 1024**2]
     assert result == ObjectStat(KEY, 6, sha256(b"abcdef").hexdigest())
 

--- a/apps/central_api/tests/services/test_raw_upload.py
+++ b/apps/central_api/tests/services/test_raw_upload.py
@@ -1,0 +1,249 @@
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+from io import BytesIO
+
+import pytest
+
+from central_api.services import raw_upload
+from central_api.services.raw_upload import (
+    RAW_UPLOAD_MAX_BYTES,
+    RawUploadConflict,
+    RawUploadFenceRejected,
+    RawUploadIdentityRejected,
+    RawUploadKeyRejected,
+    RawUploadLeaseRejected,
+    RawUploadNotFound,
+    RawUploadRequest,
+    RawUploadService,
+    RawUploadTooLarge,
+)
+from cnes_domain.control_plane.entities import Job
+from cnes_domain.control_plane.enums import JobState
+from cnes_domain.control_plane.errors import Conflict
+from cnes_domain.ports.object_store import ObjectStat
+
+NOW = datetime(2026, 7, 15, 12, tzinfo=UTC)
+KEY = "raw/354130/CNES_LOCAL/2026-07/snapshot-1/data.parquet"
+
+
+def job(**updates: object) -> Job:
+    values = {
+        "tenant_id": "354130",
+        "job_id": "job-1",
+        "agent_id": "agent-1",
+        "source_type": "CNES_LOCAL",
+        "file_subtype": "CNES_VINCULO",
+        "competencia": "2026-07",
+        "requested_snapshot_mode": "FULL",
+        "state": JobState.LEASED,
+        "attempt": 1,
+        "fencing_token": 7,
+        "lease_owner": "agent-1",
+        "lease_until": NOW + timedelta(minutes=5),
+        "result_manifest_id": None,
+        "result_manifest_key": None,
+        "error_code": None,
+        "created_at": NOW,
+    }
+    return Job(**(values | updates))
+
+
+class ControlPlane:
+    def __init__(self, jobs: list[Job | None]) -> None:
+        self.jobs = jobs
+        self.calls = 0
+
+    def get_job(self, tenant_id: str, job_id: str) -> Job | None:
+        self.calls += 1
+        current = self.jobs[min(self.calls - 1, len(self.jobs) - 1)]
+        if current is None:
+            return None
+        if (tenant_id, job_id) != (current.tenant_id, current.job_id):
+            return None
+        return current
+
+
+class ObjectStore:
+    def __init__(self, objects: dict[str, bytes] | None = None) -> None:
+        self.objects = dict(objects or {})
+        self.put_calls = 0
+
+    def stat(self, key: str) -> ObjectStat | None:
+        body = self.objects.get(key)
+        if body is None:
+            return None
+        return ObjectStat(key, len(body), sha256(body).hexdigest())
+
+    def put(self, key: str, body, expected_sha256: str) -> ObjectStat:
+        self.put_calls += 1
+        value = body.read()
+        current = self.objects.setdefault(key, value)
+        if current != value:
+            raise RuntimeError("object=immutable")
+        return ObjectStat(key, len(value), expected_sha256)
+
+
+def request(**updates: object) -> RawUploadRequest:
+    values = {
+        "tenant_id": "354130",
+        "agent_id": "agent-1",
+        "job_id": "job-1",
+        "fencing_token": 7,
+        "object_key": KEY,
+    }
+    return RawUploadRequest(**(values | updates))
+
+
+async def chunks(*values: bytes):
+    for value in values:
+        yield value
+
+
+@pytest.mark.anyio
+async def test_upload_faz_stream_sem_carregar_payload_inteiro(monkeypatch) -> None:
+    writes: list[bytes] = []
+    thresholds: list[int] = []
+
+    class SpoolSpy(BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.close()
+
+        def write(self, value: bytes) -> int:
+            writes.append(value)
+            return super().write(value)
+
+    def spool(*, max_size: int, mode: str):
+        thresholds.append(max_size)
+        assert mode == "w+b"
+        return SpoolSpy()
+
+    monkeypatch.setattr(raw_upload, "SpooledTemporaryFile", spool)
+    store = ObjectStore()
+    service = RawUploadService(ControlPlane([job()]), store, lambda: NOW)
+
+    result = await service.upload(request(), chunks(b"abc", b"def"))
+
+    assert writes == [b"abc", b"def"]
+    assert thresholds == [8 * 1024**2]
+    assert result == ObjectStat(KEY, 6, sha256(b"abcdef").hexdigest())
+
+
+@pytest.mark.anyio
+async def test_upload_rejeita_mais_de_um_gibibyte(monkeypatch) -> None:
+    assert RAW_UPLOAD_MAX_BYTES == 1024**3
+    monkeypatch.setattr(raw_upload, "RAW_UPLOAD_MAX_BYTES", 5)
+    store = ObjectStore()
+    service = RawUploadService(ControlPlane([job()]), store, lambda: NOW)
+
+    with pytest.raises(RawUploadTooLarge, match="payload_too_large"):
+        await service.upload(request(), chunks(b"123", b"456"))
+
+    assert store.put_calls == 0
+
+
+@pytest.mark.anyio
+async def test_upload_revalida_fence_antes_de_publicar() -> None:
+    changed = job(fencing_token=8)
+    store = ObjectStore()
+    service = RawUploadService(ControlPlane([job(), changed]), store, lambda: NOW)
+
+    with pytest.raises(RawUploadFenceRejected, match="job_fence_rejected"):
+        await service.upload(request(), chunks(b"payload"))
+
+    assert store.put_calls == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("current", "error"),
+    [
+        (None, RawUploadNotFound),
+        (job(agent_id="other"), RawUploadIdentityRejected),
+        (job(state=JobState.PENDING, lease_owner=None, lease_until=None), RawUploadLeaseRejected),
+        (job(lease_owner="other"), RawUploadLeaseRejected),
+        (job(lease_until=NOW), RawUploadLeaseRejected),
+        (job(fencing_token=8), RawUploadFenceRejected),
+    ],
+)
+async def test_job_invalido_rejeita_antes_do_primeiro_byte(current, error) -> None:
+    consumed = False
+
+    async def body():
+        nonlocal consumed
+        consumed = True
+        yield b"payload"
+
+    with pytest.raises(error):
+        await RawUploadService(ControlPlane([current]), ObjectStore(), lambda: NOW).upload(
+            request(), body()
+        )
+
+    assert not consumed
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "key",
+    [
+        "raw/other/CNES_LOCAL/2026-07/snapshot-1/data.parquet",
+        "raw/354130/SIHD/2026-07/snapshot-1/data.parquet",
+        "raw/354130/CNES_LOCAL/2026-08/snapshot-1/data.parquet",
+        "raw/354130/CNES_LOCAL/2026-07/../data.parquet",
+        "/raw/354130/CNES_LOCAL/2026-07/snapshot-1/data.parquet",
+        "raw/354130/CNES_LOCAL/2026-07/snapshot-1/other.parquet",
+    ],
+)
+async def test_upload_rejeita_chave_incompativel_antes_do_corpo(key: str) -> None:
+    with pytest.raises(RawUploadKeyRejected, match="object_key_invalid"):
+        await RawUploadService(ControlPlane([job()]), ObjectStore(), lambda: NOW).upload(
+            request(object_key=key), chunks(b"payload")
+        )
+
+
+@pytest.mark.anyio
+async def test_replay_identico_retorna_stat_sem_nova_escrita() -> None:
+    body = b"payload"
+    store = ObjectStore({KEY: body})
+    service = RawUploadService(ControlPlane([job()]), store, lambda: NOW)
+
+    result = await service.upload(request(), chunks(body))
+
+    assert result.sha256 == sha256(body).hexdigest()
+    assert store.put_calls == 0
+
+
+@pytest.mark.anyio
+async def test_replay_divergente_preserva_objeto_anterior() -> None:
+    store = ObjectStore({KEY: b"original"})
+    service = RawUploadService(ControlPlane([job()]), store, lambda: NOW)
+
+    with pytest.raises(RawUploadConflict, match="object_conflict"):
+        await service.upload(request(), chunks(b"different"))
+
+    assert store.objects[KEY] == b"original"
+    assert store.put_calls == 0
+
+
+@pytest.mark.anyio
+async def test_corrida_de_publicacao_identica_retorna_objeto_vencedor() -> None:
+    body = b"payload"
+
+    class RacingStore(ObjectStore):
+        def stat(self, key: str) -> ObjectStat | None:
+            if self.put_calls == 0:
+                return None
+            return ObjectStat(key, len(body), sha256(body).hexdigest())
+
+        def put(self, key: str, stream, expected_sha256: str) -> ObjectStat:
+            self.put_calls += 1
+            raise Conflict("object=immutable")
+
+    store = RacingStore()
+    service = RawUploadService(ControlPlane([job()]), store, lambda: NOW)
+
+    result = await service.upload(request(), chunks(body))
+
+    assert result == ObjectStat(KEY, len(body), sha256(body).hexdigest())

--- a/apps/central_api/tests/services/test_raw_upload.py
+++ b/apps/central_api/tests/services/test_raw_upload.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 from hashlib import sha256
 from io import BytesIO
+from threading import get_ident
 
 import pytest
 
@@ -8,6 +9,7 @@ from central_api.services import raw_upload
 from central_api.services.raw_upload import (
     RAW_UPLOAD_MAX_BYTES,
     RawUploadConflict,
+    RawUploadEmpty,
     RawUploadFenceRejected,
     RawUploadIdentityRejected,
     RawUploadKeyRejected,
@@ -145,6 +147,34 @@ async def test_upload_rejeita_mais_de_um_gibibyte(monkeypatch) -> None:
 
 
 @pytest.mark.anyio
+async def test_upload_rejeita_corpo_vazio_sem_publicar() -> None:
+    store = ObjectStore()
+    service = RawUploadService(ControlPlane([job()]), store, lambda: NOW)
+
+    with pytest.raises(RawUploadEmpty, match="payload_empty"):
+        await service.upload(request(), chunks())
+
+    assert store.put_calls == 0
+
+
+@pytest.mark.anyio
+async def test_upload_publica_objeto_fora_da_thread_do_event_loop() -> None:
+    class ThreadRecordingStore(ObjectStore):
+        thread_id: int | None = None
+
+        def put(self, key: str, body, expected_sha256: str) -> ObjectStat:
+            self.thread_id = get_ident()
+            return super().put(key, body, expected_sha256)
+
+    store = ThreadRecordingStore()
+    service = RawUploadService(ControlPlane([job()]), store, lambda: NOW)
+
+    await service.upload(request(), chunks(b"payload"))
+
+    assert store.thread_id != get_ident()
+
+
+@pytest.mark.anyio
 async def test_upload_revalida_fence_antes_de_publicar() -> None:
     changed = job(fencing_token=8)
     store = ObjectStore()
@@ -213,6 +243,67 @@ async def test_replay_identico_retorna_stat_sem_nova_escrita() -> None:
 
     assert result.sha256 == sha256(body).hexdigest()
     assert store.put_calls == 0
+
+
+@pytest.mark.anyio
+async def test_replay_terminal_identico_retorna_stat_sem_nova_escrita() -> None:
+    body = b"payload"
+    terminal = job(
+        state=JobState.SUCCEEDED,
+        lease_owner=None,
+        lease_until=None,
+        result_manifest_id="manifest-1",
+        result_manifest_key="raw/354130/CNES_LOCAL/2026-07/snapshot-1/manifest.json",
+    )
+    store = ObjectStore({KEY: body})
+    service = RawUploadService(ControlPlane([terminal]), store, lambda: NOW)
+
+    result = await service.upload(request(), chunks(body))
+
+    assert result.sha256 == sha256(body).hexdigest()
+    assert store.put_calls == 0
+
+
+@pytest.mark.anyio
+async def test_replay_resync_terminal_identico_retorna_stat() -> None:
+    body = b"payload"
+    terminal = job(
+        state=JobState.FAILED_FINAL,
+        lease_owner=None,
+        lease_until=None,
+        error_code="RAW_RESYNC_BASELINE_MISSING",
+        rejected_manifest_sha256="a" * 64,
+    )
+    store = ObjectStore({KEY: body})
+    service = RawUploadService(ControlPlane([terminal]), store, lambda: NOW)
+
+    result = await service.upload(request(), chunks(body))
+
+    assert result.sha256 == sha256(body).hexdigest()
+    assert store.put_calls == 0
+
+
+@pytest.mark.anyio
+async def test_job_terminal_sem_objeto_rejeita_antes_do_primeiro_byte() -> None:
+    consumed = False
+    terminal = job(
+        state=JobState.SUCCEEDED,
+        lease_owner=None,
+        lease_until=None,
+        result_manifest_id="manifest-1",
+        result_manifest_key="raw/354130/CNES_LOCAL/2026-07/snapshot-1/manifest.json",
+    )
+
+    async def body():
+        nonlocal consumed
+        consumed = True
+        yield b"payload"
+
+    service = RawUploadService(ControlPlane([terminal]), ObjectStore(), lambda: NOW)
+    with pytest.raises(RawUploadLeaseRejected, match="job_not_leased"):
+        await service.upload(request(), body())
+
+    assert not consumed
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Resumo

- expõe schemas e routers autenticados para claim, heartbeat, upload raw e manifesto
- adiciona upload streaming com spool de 8 MiB, limite de 1 GiB e revalidação de lease/fence
- mantém os routers desmontados até a composição mTLS da CND-034
- preserva replay terminal idêntico e move I/O bloqueante para worker threads

## Verificação

- 69 testes focados passaram
- cobertura focada: 96,04% com branches, gate de 90%
- Ruff focado e global passaram
- todos os checks obrigatórios do PR passaram
- Codex review do head 132be96: no major issues

Closes #141